### PR TITLE
[KYUUBI #1915] invoke tpcds from sql

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ embedded_zookeeper/
 **/operation_logs/
 **/server_operation_logs/
 **/engine_operation_logs/
+**/.idea/

--- a/dev/kyuubi-extension-spark-common/.rat-excludes
+++ b/dev/kyuubi-extension-spark-common/.rat-excludes
@@ -1,0 +1,49 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+**/.*/**
+**/*.json
+**/*.prefs
+**/*.log
+**/*.md
+**/*.iml
+**/target/**
+**/out/**
+**/spark-warehouse/**
+**/metastore_db/**
+**/licenses/LICENSE*
+**/licenses-binary/LICENSE*
+**/dependency-reduced-pom.xml
+**/scalastyle-output.xml
+NOTICE*
+docs/**
+build/apache-maven-*/**
+build/scala-*/**
+**/**/operation_logs/**/**
+**/**/server_operation_logs/**/**
+**/**/engine_operation_logs/**/**
+**/*.output.schema
+**/apache-kyuubi-*-bin*/**
+**/benchmarks/**
+**/jquery-*.min.js
+**/semantic.min.js
+**/semantic.min.css
+**/icon.png
+**/icon.min.css
+**/org/apache/kyuubi/ui/static/assets/**
+**/org/apache/kyuubi/ui/swagger/**
+**/org.apache.spark.status.AppHistoryServerPlugin

--- a/dev/kyuubi-extension-spark-common/.scalafmt.conf
+++ b/dev/kyuubi-extension-spark-common/.scalafmt.conf
@@ -1,0 +1,28 @@
+version = 3.1.1
+runner.dialect=scala212
+project.git=true
+
+align.preset = none
+align.openParenDefnSite = false
+align.openParenCallSite = false
+align.stripMargin = true
+align.tokens = []
+assumeStandardLibraryStripMargin = true
+danglingParentheses.preset = false
+docstrings.style = Asterisk
+docstrings.wrap = no
+importSelectors = singleLine
+indent.extendSite = 2
+literals.hexDigits = Upper
+maxColumn = 100
+newlines.source = keep
+newlines.topLevelStatementBlankLines = []
+optIn.configStyleArguments = false
+rewrite.imports.groups = [
+  ["javax?\\..*"],
+  ["scala\\..*"],
+  ["(?!org\\.apache\\.kyuubi\\.).*"],
+  ["org\\.apache\\.kyuubi\\..*"]
+]
+rewrite.imports.sort = scalastyle
+rewrite.rules = [Imports, SortModifiers]

--- a/dev/kyuubi-extension-spark-common/pom.xml
+++ b/dev/kyuubi-extension-spark-common/pom.xml
@@ -58,6 +58,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.reflections</groupId>
+            <artifactId>reflections</artifactId>
+            <version>0.9.9-RC1</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_${scala.binary.version}</artifactId>
             <type>test-jar</type>

--- a/dev/kyuubi-extension-spark-common/src/main/antlr4/org/apache/kyuubi/sql/zorder/ZorderSqlExtensions.g4
+++ b/dev/kyuubi-extension-spark-common/src/main/antlr4/org/apache/kyuubi/sql/zorder/ZorderSqlExtensions.g4
@@ -50,8 +50,9 @@ singleStatement
     ;
 
 statement
-    : OPTIMIZE multipartIdentifier whereClause? zorderClause        #optimizeZorder
-    | .*?                                                           #passThrough
+    : OPTIMIZE multipartIdentifier whereClause? zorderClause                    #optimizeZorder
+    | CALL multipartIdentifier '(' (callArgument (',' callArgument)*)? ')'      #call
+    | .*?                                                                       #passThrough
     ;
 
 whereClause
@@ -68,6 +69,11 @@ booleanExpression
     | left=booleanExpression operator=OR right=booleanExpression         #logicalBinary
     ;
 
+callArgument
+    : expression                    #positionalArgument
+    | identifier '=>' expression    #namedArgument
+    ;
+
 query
     : '('? multipartIdentifier comparisonOperator constant ')'?
     ;
@@ -76,12 +82,21 @@ comparisonOperator
     : EQ | NEQ | NEQJ | LT | LTE | GT | GTE | NSEQ
     ;
 
+expression
+    : constant
+    | stringMap
+    ;
+
 constant
     : NULL                     #nullLiteral
     | identifier STRING        #typeConstructor
     | number                   #numericLiteral
     | booleanValue             #booleanLiteral
     | STRING+                  #stringLiteral
+    ;
+
+stringMap
+    : MAP '(' constant (',' constant)* ')'
     ;
 
 multipartIdentifier
@@ -119,6 +134,7 @@ quotedIdentifier
 nonReserved
     : AND
     | BY
+    | CALL
     | FALSE
     | DATE
     | INTERVAL
@@ -133,6 +149,7 @@ nonReserved
 
 AND: 'AND';
 BY: 'BY';
+CALL: 'CALL';
 FALSE: 'FALSE';
 DATE: 'DATE';
 INTERVAL: 'INTERVAL';
@@ -153,6 +170,8 @@ LT  : '<';
 LTE : '<=' | '!>';
 GT  : '>';
 GTE : '>=' | '!<';
+
+MAP: 'MAP';
 
 MINUS: '-';
 

--- a/dev/kyuubi-extension-spark-common/src/main/java/org/apache/kyuubi/sql/call/procedure/Procedure.java
+++ b/dev/kyuubi-extension-spark-common/src/main/java/org/apache/kyuubi/sql/call/procedure/Procedure.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.kyuubi.sql.call.procedure;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.types.StructType;
+
+/** An interface representing a stored procedure available for execution. */
+public interface Procedure {
+  /** Returns the input parameters of this procedure. */
+  ProcedureParameter[] parameters();
+
+  /** Returns the type of rows produced by this procedure. */
+  StructType outputType();
+
+  /** @return the identfier name of the procedure */
+  Identifier getIdentifier();
+
+  /**
+   * Executes this procedure.
+   *
+   * <p>Spark will align the provided arguments according to the input parameters defined in {@link
+   * #parameters()} either by position or by name before execution.
+   *
+   * <p>Implementations may provide a summary of execution by returning one or many rows as a
+   * result. The schema of output rows must match the defined output type in {@link #outputType()}.
+   *
+   * @param args input arguments
+   * @return the result of executing this procedure with the given arguments
+   */
+  InternalRow[] call(InternalRow args);
+
+  /** Returns the description of this procedure. */
+  default String description() {
+    return this.getClass().toString();
+  }
+}

--- a/dev/kyuubi-extension-spark-common/src/main/java/org/apache/kyuubi/sql/call/procedure/ProcedureCatalog.java
+++ b/dev/kyuubi-extension-spark-common/src/main/java/org/apache/kyuubi/sql/call/procedure/ProcedureCatalog.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.kyuubi.sql.call.procedure;
+
+import org.apache.spark.sql.connector.catalog.CatalogPlugin;
+import org.apache.spark.sql.connector.catalog.Identifier;
+
+/**
+ * A catalog API for working with stored procedures.
+ *
+ * <p>Implementations should implement this interface if they expose stored procedures that can be
+ * called via CALL statements.
+ */
+public interface ProcedureCatalog extends CatalogPlugin {
+  /**
+   * Load a {@link Procedure stored procedure} by {@link Identifier identifier}.
+   *
+   * @param ident a stored procedure identifier
+   * @return the stored procedure's metadata
+   * @throws NoSuchMethodError if there is no matching stored procedure
+   */
+  Procedure loadProcedure(Identifier ident) throws NoSuchMethodError;
+}

--- a/dev/kyuubi-extension-spark-common/src/main/java/org/apache/kyuubi/sql/call/procedure/ProcedureParameter.java
+++ b/dev/kyuubi-extension-spark-common/src/main/java/org/apache/kyuubi/sql/call/procedure/ProcedureParameter.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.kyuubi.sql.call.procedure;
+
+import org.apache.spark.sql.types.DataType;
+
+/** An input parameter of a {@link Procedure stored procedure}. */
+public interface ProcedureParameter {
+
+  /**
+   * Creates a required input parameter.
+   *
+   * @param name the name of the parameter
+   * @param dataType the type of the parameter
+   * @return the constructed stored procedure parameter
+   */
+  static ProcedureParameter required(String name, DataType dataType) {
+    return new ProcedureParameterImpl(name, dataType, true);
+  }
+
+  /**
+   * Creates an optional input parameter.
+   *
+   * @param name the name of the parameter.
+   * @param dataType the type of the parameter.
+   * @return the constructed optional stored procedure parameter
+   */
+  static ProcedureParameter optional(String name, DataType dataType) {
+    return new ProcedureParameterImpl(name, dataType, false);
+  }
+
+  /** Returns the name of this parameter. */
+  String name();
+
+  /** Returns the type of this parameter. */
+  DataType dataType();
+
+  /** Returns true if this parameter is required. */
+  boolean required();
+}

--- a/dev/kyuubi-extension-spark-common/src/main/java/org/apache/kyuubi/sql/call/procedure/ProcedureParameterImpl.java
+++ b/dev/kyuubi-extension-spark-common/src/main/java/org/apache/kyuubi/sql/call/procedure/ProcedureParameterImpl.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.kyuubi.sql.call.procedure;
+
+import java.util.Objects;
+import org.apache.spark.sql.types.DataType;
+
+/** A {@link ProcedureParameter} implementation. */
+class ProcedureParameterImpl implements ProcedureParameter {
+  private final String name;
+  private final DataType dataType;
+  private final boolean required;
+
+  ProcedureParameterImpl(String name, DataType dataType, boolean required) {
+    this.name = name;
+    this.dataType = dataType;
+    this.required = required;
+  }
+
+  @Override
+  public String name() {
+    return name;
+  }
+
+  @Override
+  public DataType dataType() {
+    return dataType;
+  }
+
+  @Override
+  public boolean required() {
+    return required;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    } else if (other == null || getClass() != other.getClass()) {
+      return false;
+    }
+
+    ProcedureParameterImpl that = (ProcedureParameterImpl) other;
+    return required == that.required
+        && Objects.equals(name, that.name)
+        && Objects.equals(dataType, that.dataType);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, dataType, required);
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "ProcedureParameter(name='%s', type=%s, required=%b)", name, dataType, required);
+  }
+}

--- a/dev/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/call/CallCommand.scala
+++ b/dev/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/call/CallCommand.scala
@@ -1,20 +1,18 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.kyuubi.sql.call

--- a/dev/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/call/CallCommand.scala
+++ b/dev/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/call/CallCommand.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.kyuubi.sql.call
+
+import org.apache.spark.sql.{Row, SparkSession}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.command.LeafRunnableCommand
+
+import org.apache.kyuubi.sql.call.procedure.Procedure
+
+case class CallCommand(procedure: Procedure, args: InternalRow) extends LeafRunnableCommand {
+
+  override def run(session: SparkSession): Seq[Row] = {
+    procedure.call(args).map(Row(_))
+  }
+
+}

--- a/dev/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/call/KyuubiProcedureCatalog.scala
+++ b/dev/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/call/KyuubiProcedureCatalog.scala
@@ -1,21 +1,20 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.apache.kyuubi.sql.call
 
 import java.util.Locale
@@ -86,7 +85,7 @@ object KyuubiProcedureCatalog {
     params.sliding(2).foreach {
       case Seq(previousParam, currentParam) if !previousParam.required && currentParam.required =>
         throw new KyuubiSQLExtensionException(
-          s"Optional parameters must be after required ones but $currentParam is after $previousParam")
+          s"Optional params must after required ones but $currentParam is after $previousParam")
       case _ =>
     }
   }

--- a/dev/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/call/KyuubiProcedureCatalog.scala
+++ b/dev/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/call/KyuubiProcedureCatalog.scala
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.kyuubi.sql.call
+
+import java.util.Locale
+
+import scala.collection.{mutable, Seq}
+import scala.collection.convert.ImplicitConversions.`collection AsScalaIterable`
+
+import org.apache.spark.sql.catalyst.expressions.{Expression, Literal}
+import org.apache.spark.sql.connector.catalog.Identifier
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.reflections.Reflections
+
+import org.apache.kyuubi.sql.KyuubiSQLExtensionException
+import org.apache.kyuubi.sql.call.procedure.{Procedure, ProcedureCatalog, ProcedureParameter}
+
+case class KyuubiProcedureCatalog() extends ProcedureCatalog {
+  val procedureCatalog: mutable.Map[Identifier, Procedure] = mutable.Map.empty
+
+  override def loadProcedure(ident: Identifier): Procedure = {
+    procedureCatalog.get(ident) match {
+      case Some(proc) => proc
+      case _ => throw new KyuubiSQLExtensionException(s"Kyuubi procedure ${ident.name()} not found")
+    }
+  }
+
+  override def initialize(s: String, caseInsensitiveStringMap: CaseInsensitiveStringMap): Unit = {
+    val procedures = scanKyuubiProcs
+    procedures.foreach { proc =>
+      procedureCatalog.put(proc.getIdentifier, proc)
+    }
+  }
+
+  def scanKyuubiProcs: Seq[Procedure] = {
+    val reflections = new Reflections("org.apache.kyuubi")
+    val classInfos = reflections.getSubTypesOf(classOf[Procedure])
+    val procedures = classInfos.map { classInfo =>
+      Class.forName(classInfo.getCanonicalName).newInstance.asInstanceOf[Procedure]
+    }
+    procedures.toSeq
+  }
+
+  override def name(): String = classOf[KyuubiProcedureCatalog].getSimpleName
+}
+
+object KyuubiProcedureCatalog {
+  val kyuubiCatalog = new KyuubiProcedureCatalog
+  kyuubiCatalog.initialize("", CaseInsensitiveStringMap.empty())
+
+  def toIdentifier(names: Seq[String]): Identifier = {
+    val n = names.length
+    val ns = names.take(n - 1).toArray
+    val name = names.last
+    Identifier.of(ns, name)
+  }
+
+  def validateParams(params: Seq[ProcedureParameter]): Unit = {
+    // should not be any duplicate param names
+    val duplicateParamNames = params.groupBy(_.name).collect {
+      case (name, matchingParams) if matchingParams.length > 1 => name
+    }
+
+    if (duplicateParamNames.nonEmpty) {
+      throw new KyuubiSQLExtensionException(
+        s"Duplicate parameter names: ${duplicateParamNames.mkString("[", ",", "]")}")
+    }
+
+    // optional params should be at the end
+    params.sliding(2).foreach {
+      case Seq(previousParam, currentParam) if !previousParam.required && currentParam.required =>
+        throw new KyuubiSQLExtensionException(
+          s"Optional parameters must be after required ones but $currentParam is after $previousParam")
+      case _ =>
+    }
+  }
+
+  def normalizeParams(params: Seq[ProcedureParameter]): Seq[ProcedureParameter] = {
+    params.map {
+      case param if param.required =>
+        val normalizedName = param.name.toLowerCase(Locale.ROOT)
+        ProcedureParameter.required(normalizedName, param.dataType)
+      case param =>
+        val normalizedName = param.name.toLowerCase(Locale.ROOT)
+        ProcedureParameter.optional(normalizedName, param.dataType)
+    }
+  }
+
+  def normalizeArgs(args: Seq[CallArgument]): Seq[CallArgument] = {
+    args.map {
+      case a @ NamedArgument(name, _) => a.copy(name = name.toLowerCase(Locale.ROOT))
+      case other => other
+    }
+  }
+
+  def buildArgExprs(params: Seq[ProcedureParameter], args: Seq[CallArgument]): Seq[Expression] = {
+    // build a map of declared parameter names to their positions
+    val nameToPositionMap = params.map(_.name).zipWithIndex.toMap
+
+    // build a map of parameter names to args
+    val nameToArgMap = buildNameToArgMap(params, args, nameToPositionMap)
+
+    // verify all required parameters are provided
+    val missingParamNames = params.filter(_.required).collect {
+      case param if !nameToArgMap.contains(param.name) => param.name
+    }
+
+    if (missingParamNames.nonEmpty) {
+      throw new KyuubiSQLExtensionException(
+        s"Missing required parameters: ${missingParamNames.mkString("[", ",", "]")}")
+    }
+
+    val argExprs = new Array[Expression](params.size)
+
+    nameToArgMap.foreach { case (name, arg) =>
+      val position = nameToPositionMap(name)
+      argExprs(position) = arg.expr
+    }
+
+    // assign nulls to optional params that were not set
+    params.foreach {
+      case p if !p.required && !nameToArgMap.contains(p.name) =>
+        val position = nameToPositionMap(p.name)
+        argExprs(position) = Literal.create(null, p.dataType)
+      case _ =>
+    }
+
+    argExprs
+  }
+
+  private def buildNameToArgMap(
+      params: Seq[ProcedureParameter],
+      args: Seq[CallArgument],
+      nameToPositionMap: Map[String, Int]): Map[String, CallArgument] = {
+
+    val containsNamedArg = args.exists(_.isInstanceOf[NamedArgument])
+    val containsPositionalArg = args.exists(_.isInstanceOf[PositionalArgument])
+
+    if (containsNamedArg && containsPositionalArg) {
+      throw new KyuubiSQLExtensionException("Named and positional arguments cannot be mixed")
+    }
+
+    if (containsNamedArg) {
+      buildNameToArgMapUsingNames(args, nameToPositionMap)
+    } else {
+      buildNameToArgMapUsingPositions(args, params)
+    }
+  }
+
+  private def buildNameToArgMapUsingNames(
+      args: Seq[CallArgument],
+      nameToPositionMap: Map[String, Int]): Map[String, CallArgument] = {
+    val namedArgs = args.asInstanceOf[Seq[NamedArgument]]
+
+    val validationErrors = namedArgs.groupBy(_.name).collect {
+      case (name, matchingArgs) if matchingArgs.size > 1 => s"Duplicate procedure argument: $name"
+      case (name, _) if !nameToPositionMap.contains(name) => s"Unknown argument: $name"
+    }
+
+    if (validationErrors.nonEmpty) {
+      throw new KyuubiSQLExtensionException(
+        s"Could not build name to arg map: ${validationErrors.mkString(", ")}")
+    }
+
+    namedArgs.map(arg => arg.name -> arg).toMap
+  }
+
+  private def buildNameToArgMapUsingPositions(
+      args: Seq[CallArgument],
+      params: Seq[ProcedureParameter]): Map[String, CallArgument] = {
+
+    if (args.size > params.size) {
+      throw new KyuubiSQLExtensionException("Too many arguments for procedure")
+    }
+
+    args.zipWithIndex.map { case (arg, position) =>
+      val param = params(position)
+      param.name -> arg
+    }.toMap
+  }
+}

--- a/dev/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/call/Statements.scala
+++ b/dev/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/call/Statements.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.kyuubi.sql.call
+
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.plans.logical.LeafParsedStatement
+
+/**
+ * A CALL statement, as parsed from SQL.
+ */
+case class CallStatement(name: Seq[String], args: Seq[CallArgument]) extends LeafParsedStatement {}
+
+/**
+ * An argument in a CALL statement.
+ */
+sealed trait CallArgument {
+  def expr: Expression
+}
+
+/**
+ * An argument in a CALL statement identified by name.
+ */
+case class NamedArgument(name: String, expr: Expression) extends CallArgument
+
+/**
+ * An argument in a CALL statement identified by position.
+ */
+case class PositionalArgument(expr: Expression) extends CallArgument

--- a/dev/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/call/Statements.scala
+++ b/dev/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/call/Statements.scala
@@ -1,20 +1,18 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.kyuubi.sql.call

--- a/dev/kyuubi-extension-spark-common/src/test/scala/org/apache/kyuubi/sql/CreateTpcdsProcedure.scala
+++ b/dev/kyuubi-extension-spark-common/src/test/scala/org/apache/kyuubi/sql/CreateTpcdsProcedure.scala
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kyuubi.sql
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.connector.catalog.Identifier
+import org.apache.spark.sql.types.{DataTypes, Metadata, StructField, StructType}
+
+import org.apache.kyuubi.sql.call.procedure.{Procedure, ProcedureParameter}
+
+class CreateTpcdsProcedure extends Procedure {
+
+  override def parameters(): Array[ProcedureParameter] = Array(
+    ProcedureParameter.required("sf", DataTypes.IntegerType),
+    ProcedureParameter.required("db", DataTypes.StringType),
+    ProcedureParameter.required("format", DataTypes.StringType),
+    ProcedureParameter.optional("parallel", DataTypes.IntegerType))
+
+  override def outputType(): StructType = new StructType(Array[StructField](
+    new StructField("result", DataTypes.LongType, false, Metadata.empty)));
+
+  override def call(args: InternalRow): Array[InternalRow] = {
+    val config = new java.util.HashMap[String, String]()
+    val params = parameters()
+    config.put(params(0).name(), String.valueOf(args.getInt(0)))
+    config.put(params(1).name(), args.getString(1))
+    config.put(params(2).name(), args.getString(2))
+    config.put(params(3).name(), String.valueOf(args.getInt(3)))
+    Array.empty
+  }
+
+  override def getIdentifier: Identifier = Identifier.of(Array("spark", "kyuubi"), "create_tpcds")
+}

--- a/dev/kyuubi-extension-spark-common/src/test/scala/org/apache/spark/sql/ProcedureSuite.scala
+++ b/dev/kyuubi-extension-spark-common/src/test/scala/org/apache/spark/sql/ProcedureSuite.scala
@@ -30,7 +30,8 @@ class ProcedureSuite extends KyuubiSparkSQLExtensionTest with ExpressionEvalHelp
 
   test("parse call statements") {
     val p1 = sql(
-      "call spark.kyuubi.create_tpcds(db=>'tpcds_sf10', sf=>10, format=>'parquet')").queryExecution.analyzed
+      "call spark.kyuubi.create_tpcds(db=>'tpcds_sf10', sf=>10, format=>'parquet')"
+    ).queryExecution.analyzed
     assert(p1 != null)
   }
 

--- a/dev/kyuubi-extension-spark-common/src/test/scala/org/apache/spark/sql/ProcedureSuite.scala
+++ b/dev/kyuubi-extension-spark-common/src/test/scala/org/apache/spark/sql/ProcedureSuite.scala
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.catalyst.expressions.ExpressionEvalHelper
+import org.apache.spark.sql.internal.StaticSQLConf
+
+class ProcedureSuite extends KyuubiSparkSQLExtensionTest with ExpressionEvalHelper {
+  override def sparkConf(): SparkConf = {
+    super.sparkConf()
+      .set(
+        StaticSQLConf.SPARK_SESSION_EXTENSIONS.key,
+        "org.apache.kyuubi.sql.KyuubiSparkSQLCommonExtension")
+  }
+
+  test("parse call statements") {
+    val p1 = sql(
+      "call spark.kyuubi.create_tpcds(db=>'tpcds_sf10', sf=>10, format=>'parquet')").queryExecution.analyzed
+    assert(p1 != null)
+  }
+
+}

--- a/dev/kyuubi-tpcds/pom.xml
+++ b/dev/kyuubi-tpcds/pom.xml
@@ -54,6 +54,14 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.kyuubi</groupId>
+            <artifactId>kyuubi-extension-spark-common_${scala.binary.version}</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+
     </dependencies>
 
     <build>

--- a/dev/kyuubi-tpcds/src/main/scala/org/apache/kyuubi/tpcds/CreateTpcdsProcedure.scala
+++ b/dev/kyuubi-tpcds/src/main/scala/org/apache/kyuubi/tpcds/CreateTpcdsProcedure.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kyuubi.tpcds
+
+import org.apache.kyuubi.sql.call.procedure.{Procedure, ProcedureParameter}
+import org.apache.kyuubi.tpcds.DataGenerator.Config
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
+import org.apache.spark.sql.connector.catalog.Identifier
+import org.apache.spark.sql.types.{DataTypes, Metadata, StructField, StructType}
+
+
+class CreateTpcdsProcedure extends Procedure  {
+
+
+  override def parameters(): Array[ProcedureParameter] = Array(
+    ProcedureParameter.required("sf", DataTypes.IntegerType),
+    ProcedureParameter.required("db", DataTypes.StringType),
+    ProcedureParameter.required("format", DataTypes.StringType),
+    ProcedureParameter.optional("parallel", DataTypes.IntegerType)
+  )
+
+  override def outputType(): StructType = new StructType(Array[StructField](
+    new StructField("result", DataTypes.LongType, false, Metadata.empty)
+  ));
+
+  override def call(args: InternalRow): Array[InternalRow] = {
+    val sf = args.getInt(0)
+    val db = args.getString(1)
+    val format = args.getString(2)
+    val parallel = Option(args.getInt(3)).getOrElse(8)
+    val config = Config(db, sf, format, Some(parallel))
+    DataGenerator.run(config)
+    Array(new GenericInternalRow(0))
+  }
+
+  override def getIdentifier: Identifier = Identifier.of(Array("spark","kyuubi"), "create_tpcds")
+}
+
+

--- a/dev/kyuubi-tpcds/src/main/scala/org/apache/kyuubi/tpcds/CreateTpcdsProcedure.scala
+++ b/dev/kyuubi-tpcds/src/main/scala/org/apache/kyuubi/tpcds/CreateTpcdsProcedure.scala
@@ -16,27 +16,24 @@
  */
 package org.apache.kyuubi.tpcds
 
-import org.apache.kyuubi.sql.call.procedure.{Procedure, ProcedureParameter}
-import org.apache.kyuubi.tpcds.DataGenerator.Config
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
 import org.apache.spark.sql.connector.catalog.Identifier
 import org.apache.spark.sql.types.{DataTypes, Metadata, StructField, StructType}
 
+import org.apache.kyuubi.sql.call.procedure.{Procedure, ProcedureParameter}
+import org.apache.kyuubi.tpcds.DataGenerator.Config
 
-class CreateTpcdsProcedure extends Procedure  {
-
+class CreateTpcdsProcedure extends Procedure {
 
   override def parameters(): Array[ProcedureParameter] = Array(
     ProcedureParameter.required("sf", DataTypes.IntegerType),
     ProcedureParameter.required("db", DataTypes.StringType),
     ProcedureParameter.required("format", DataTypes.StringType),
-    ProcedureParameter.optional("parallel", DataTypes.IntegerType)
-  )
+    ProcedureParameter.optional("parallel", DataTypes.IntegerType))
 
   override def outputType(): StructType = new StructType(Array[StructField](
-    new StructField("result", DataTypes.LongType, false, Metadata.empty)
-  ));
+    new StructField("result", DataTypes.LongType, false, Metadata.empty)));
 
   override def call(args: InternalRow): Array[InternalRow] = {
     val sf = args.getInt(0)
@@ -48,7 +45,5 @@ class CreateTpcdsProcedure extends Procedure  {
     Array(new GenericInternalRow(0))
   }
 
-  override def getIdentifier: Identifier = Identifier.of(Array("spark","kyuubi"), "create_tpcds")
+  override def getIdentifier: Identifier = Identifier.of(Array("spark", "kyuubi"), "create_tpcds")
 }
-
-


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

#1915 invoke tpcds from sql

`call spark.kyuubi.create_tpcds(db=>'tpcds_sf10', sf=>10, format=>'parquet')`

In order to support calling functions from `sql` beeline. New syntax  `call`  store procedure is supported. This call syntax is similar to `iceberg`. Syntax module is added to the kyuubi-extension-spark-common extension. so spark kyuubi extension can recognize this syntax and pick up the call argument. 

When kyuubi procedure class is initialized, it will scan the java path for the  kyuubi procedure interface concrete implementations. and instantiation the procedures using reflections. after this initialization all kyuubi procedures under the class path will be registered to the procedure center.

when a `call` statement is invoked from beeline, it will check against all registered routines and calls will be dispatched correspondingly.


### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible
UT cases added
- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
