### PR TITLE
register java spark udfs through spark custom configurations

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/udf/KDFRegistry.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/udf/KDFRegistry.scala
@@ -21,16 +21,22 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.{SparkEnv, TaskContext}
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.api.java._
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions.udf
+import org.apache.spark.sql.types.{DataType, DataTypes}
 
 import org.apache.kyuubi.{KYUUBI_VERSION, Utils}
+import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiReservedKeys.KYUUBI_SESSION_USER_KEY
 
 object KDFRegistry {
 
   @transient
   val registeredFunctions = new ArrayBuffer[KyuubiDefinedFunction]()
+
+  lazy val udfs: Map[String, String] = new KyuubiConf().loadFileDefaults()
+    .getAllWithPrefix("kyuubi.spark.udf", "");
 
   lazy val appName = SparkEnv.get.conf.get("spark.app.name")
   lazy val appId = SparkEnv.get.conf.get("spark.app.id")
@@ -88,5 +94,313 @@ object KDFRegistry {
     for (func <- registeredFunctions) {
       spark.udf.register(func.name, func.udf)
     }
+
+    udfs.foreach(entry => {
+      val udfName = entry._1
+      val defParts = entry._2.split(",")
+      val udfFunc = Class.forName(defParts(0)).newInstance()
+      val numArgs = defParts(1).toInt
+      val field = classOf[DataTypes].getDeclaredField(defParts(2))
+      val returnedDataType: DataType = field.get(null).asInstanceOf[DataType]
+
+      numArgs match {
+        case 0 => spark.udf.register(udfName, udfFunc.asInstanceOf[UDF0[Any]], returnedDataType)
+        case 1 =>
+          spark.udf.register(udfName, udfFunc.asInstanceOf[UDF1[Any, Any]], returnedDataType)
+        case 2 =>
+          spark.udf.register(udfName, udfFunc.asInstanceOf[UDF2[Any, Any, Any]], returnedDataType)
+        case 3 =>
+          spark.udf.register(
+            udfName,
+            udfFunc.asInstanceOf[UDF3[Any, Any, Any, Any]],
+            returnedDataType)
+        case 4 => spark.udf.register(
+            udfName,
+            udfFunc.asInstanceOf[UDF4[Any, Any, Any, Any, Any]],
+            returnedDataType)
+        case 5 => spark.udf.register(
+            udfName,
+            udfFunc.asInstanceOf[UDF5[Any, Any, Any, Any, Any, Any]],
+            returnedDataType)
+        case 6 => spark.udf.register(
+            udfName,
+            udfFunc.asInstanceOf[UDF6[Any, Any, Any, Any, Any, Any, Any]],
+            returnedDataType)
+        case 7 => spark.udf.register(
+            udfName,
+            udfFunc.asInstanceOf[UDF7[Any, Any, Any, Any, Any, Any, Any, Any]],
+            returnedDataType)
+        case 8 => spark.udf.register(
+            udfName,
+            udfFunc.asInstanceOf[UDF8[Any, Any, Any, Any, Any, Any, Any, Any, Any]],
+            returnedDataType)
+        case 9 => spark.udf.register(
+            udfName,
+            udfFunc.asInstanceOf[UDF9[Any, Any, Any, Any, Any, Any, Any, Any, Any, Any]],
+            returnedDataType)
+        case 10 => spark.udf.register(
+            udfName,
+            udfFunc.asInstanceOf[UDF10[Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any]],
+            returnedDataType)
+        case 11 => spark.udf.register(
+            udfName,
+            udfFunc.asInstanceOf[UDF11[
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any]],
+            returnedDataType)
+        case 12 => spark.udf.register(
+            udfName,
+            udfFunc.asInstanceOf[UDF12[
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any]],
+            returnedDataType)
+        case 13 => spark.udf.register(
+            udfName,
+            udfFunc.asInstanceOf[UDF13[
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any]],
+            returnedDataType)
+        case 14 => spark.udf.register(
+            udfName,
+            udfFunc.asInstanceOf[UDF14[
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any]],
+            returnedDataType)
+        case 15 => spark.udf.register(
+            udfName,
+            udfFunc.asInstanceOf[UDF15[
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any]],
+            returnedDataType)
+        case 16 => spark.udf.register(
+            udfName,
+            udfFunc.asInstanceOf[UDF16[
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any]],
+            returnedDataType)
+        case 17 => spark.udf.register(
+            udfName,
+            udfFunc.asInstanceOf[UDF17[
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any]],
+            returnedDataType)
+        case 18 => spark.udf.register(
+            udfName,
+            udfFunc.asInstanceOf[UDF18[
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any]],
+            returnedDataType)
+        case 19 => spark.udf.register(
+            udfName,
+            udfFunc.asInstanceOf[UDF19[
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any]],
+            returnedDataType)
+        case 20 => spark.udf.register(
+            udfName,
+            udfFunc.asInstanceOf[UDF20[
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any]],
+            returnedDataType)
+        case 21 => spark.udf.register(
+            udfName,
+            udfFunc.asInstanceOf[UDF21[
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any]],
+            returnedDataType)
+        case 22 => spark.udf.register(
+            udfName,
+            udfFunc.asInstanceOf[UDF22[
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any,
+              Any]],
+            returnedDataType)
+      }
+    })
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
As far as I can tell there is no way to register spark java UDFs (through jars) through SQL commands the same way as hive UDFs. https://spark.apache.org/docs/latest/sql-ref-functions-udf-hive.html The create command passes without problem but when using the custom UDF it gives the error: **org.apache.spark.sql.AnalysisException: No handler for UDF/UDAF/UDTF** so as a workaround added number of custom kyuubi options as follow:

for each udf add an entry as follow
kyuubi.spark.udf.udfName=class,numArgs,returnTypes

return types have to be of type DataType defined in org.apache.spark.sql.types.DataTypes: possible values: StringType, BinaryType, BooleanType, DateType, TimestampType, CalendarIntervalType, DoubleType, ByteType, IntegerType, LongType, ShortType, NullType

Notes:

1. jars for the classes can be added using spark.jar option

example:
kyuubi.spark.udf.udfName1=com.exmaple.UDF1,2,DoubleType
kyuubi.spark.udf.udfName2=com.example.UDF2,5,StringType
kyuubi.spark.udf.udfName3=com.example.UDF3,8,BooleanType

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

Tried on 23 UDFs and they got loaded properly example is below

![Screenshot_20220602_143958](https://user-images.githubusercontent.com/900063/171631327-1567ca19-1dc7-42f8-9fe1-645818e96f44.png)
![Screenshot_20220602_151310](https://user-images.githubusercontent.com/900063/171638534-2e0b1006-2d52-4312-97ae-c8575415aaa9.png)



- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
