### PR TITLE
Kyuubi Hive JDBC: UGI-based delegation token authentication

### DIFF
--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/Utils.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/Utils.java
@@ -82,6 +82,7 @@ public class Utils {
     public static final String AUTH_QOP_DEPRECATED = "sasl.qop";
     public static final String AUTH_QOP = "saslQop";
     public static final String AUTH_SIMPLE = "noSasl";
+    public static final String AUTH_TOKEN = "delegationToken";
     public static final String AUTH_USER = "user";
     public static final String AUTH_PRINCIPAL = "principal";
     public static final String AUTH_KYUUBI_CLIENT_PRINCIPAL = "kyuubiClientPrincipal";

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/ZooKeeperHiveClientHelper.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/ZooKeeperHiveClientHelper.java
@@ -191,9 +191,11 @@ class ZooKeeperHiveClientHelper {
         /*
          * Note: this is pretty messy, but sticking to the current implementation. Set
          * authentication configs. Note that in JDBC driver, we have 3 auth modes: NOSASL, Kerberos
-         * and password based. The use of
+         * (including delegation token mechanism) and password based. The use of
          * JdbcConnectionParams.AUTH_TYPE==JdbcConnectionParams.AUTH_SIMPLE picks NOSASL. The
-         * presence of JdbcConnectionParams.AUTH_PRINCIPAL==<principal> picks Kerberos.
+         * presence of JdbcConnectionParams.AUTH_PRINCIPAL==<principal> picks Kerberos. If principal
+         * is absent, the presence of
+         * JdbcConnectionParams.AUTH_TYPE==JdbcConnectionParams.AUTH_TOKEN uses delegation token.
          * Otherwise password based (which includes NONE, PAM, LDAP, CUSTOM)
          */
         if (matcher.group(1).equals("hive.server2.authentication")) {
@@ -210,7 +212,13 @@ class ZooKeeperHiveClientHelper {
           }
         }
         // KERBEROS
+        // If delegation token is passed from the client side, do not set the principal
         if (matcher.group(1).equalsIgnoreCase("hive.server2.authentication.kerberos.principal")
+            && !(connParams.getSessionVars().containsKey(Utils.JdbcConnectionParams.AUTH_TYPE)
+                && connParams
+                    .getSessionVars()
+                    .get(Utils.JdbcConnectionParams.AUTH_TYPE)
+                    .equalsIgnoreCase(Utils.JdbcConnectionParams.AUTH_TOKEN))
             && !(connParams
                 .getSessionVars()
                 .containsKey(Utils.JdbcConnectionParams.AUTH_PRINCIPAL))) {

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/auth/HadoopShim.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/auth/HadoopShim.java
@@ -1,0 +1,350 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.jdbc.hive.auth;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Collection;
+import javax.security.auth.Subject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class HadoopShim {
+
+  public static final String KYUUBI_DELEGATION_TOKEN_KIND = "KYUUBI_DELEGATION_TOKEN";
+
+  private static final Logger LOG = LoggerFactory.getLogger(HadoopShim.class);
+
+  private static final String UGI_CLASS = "org.apache.hadoop.security.UserGroupInformation";
+  private static final String TEXT_CLASS = "org.apache.hadoop.io.Text";
+  private static final String TOKEN_CLASS = "org.apache.hadoop.security.token.Token";
+  private static final String ABSTRACT_DELEGATION_TOKEN_SELECTOR_CLASS =
+      "org.apache.hadoop.security.token.delegation.AbstractDelegationTokenSelector";
+
+  private static boolean hadoopClzAvailable;
+
+  private HadoopShim() {}
+
+  static {
+    try {
+      Class.forName(UGI_CLASS);
+      Class.forName(TEXT_CLASS);
+      Class.forName(TOKEN_CLASS);
+      Class.forName(ABSTRACT_DELEGATION_TOKEN_SELECTOR_CLASS);
+      hadoopClzAvailable = true;
+    } catch (ClassNotFoundException | NoClassDefFoundError e) {
+      hadoopClzAvailable = false;
+      LOG.info("Hadoop class is not available");
+    }
+  }
+
+  public static boolean hadoopClzAvailable() {
+    return hadoopClzAvailable;
+  }
+
+  private static void ensureHadoopClzAvailable() {
+    if (!hadoopClzAvailable) {
+      throw new IllegalStateException("Hadoop class is not available");
+    }
+  }
+
+  private static void requireClz(Object arg, String requiredClzName) {
+    String argClzName = arg.getClass().getName();
+    if (!requiredClzName.equals(argClzName)) {
+      throw new IllegalArgumentException("Require " + requiredClzName + " but got " + argClzName);
+    }
+  }
+
+  public static class UserGroupInformation {
+
+    private static Class<?> ugiClz;
+    private static Method getCurrentUserMethod;
+    private static Method getTokensMethod;
+    private static Field subjectField;
+
+    static {
+      if (hadoopClzAvailable) {
+        try {
+          ugiClz = Class.forName(UGI_CLASS);
+          getCurrentUserMethod = ugiClz.getDeclaredMethod("getCurrentUser");
+          getTokensMethod = ugiClz.getDeclaredMethod("getTokens");
+          subjectField = ugiClz.getDeclaredField("subject");
+          subjectField.setAccessible(true);
+        } catch (NoClassDefFoundError | ReflectiveOperationException e) {
+          throw new RuntimeException(e);
+        }
+      }
+    }
+
+    /**
+     * Forward to UserGroupInformation#getCurrentUser()
+     *
+     * @return UserGroupInformation
+     */
+    public static Object getCurrentUser() {
+      ensureHadoopClzAvailable();
+      try {
+        return getCurrentUserMethod.invoke(null);
+      } catch (ReflectiveOperationException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    public static Subject getCurrentSubject() {
+      return getSubject(getCurrentUser());
+    }
+
+    public static Subject getSubject(Object ugi) {
+      ensureHadoopClzAvailable();
+      requireClz(ugi, UGI_CLASS);
+      try {
+        return (Subject) subjectField.get(ugi);
+      } catch (ReflectiveOperationException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    /**
+     * Forward to UserGroupInformation#getTokens()
+     *
+     * @param ugi UserGroupInformation
+     * @return Collection<getTokens>
+     */
+    @SuppressWarnings("rawtypes")
+    public static Collection getTokens(Object ugi) {
+      ensureHadoopClzAvailable();
+      requireClz(ugi, UGI_CLASS);
+      try {
+        return (Collection) getTokensMethod.invoke(ugi);
+      } catch (ReflectiveOperationException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  public static class Token {
+    private static Class<?> tokenClz;
+    private static Constructor<?> tokenConstructor;
+    private static Method getIdentifierMethod;
+    private static Method getPasswordMethod;
+    private static Method encodeToUrlStringMethod;
+    private static Method decodeFromUrlStringMethod;
+
+    static {
+      if (hadoopClzAvailable) {
+        try {
+          tokenClz = Class.forName(TOKEN_CLASS);
+          tokenConstructor = tokenClz.getConstructor();
+          getIdentifierMethod = tokenClz.getDeclaredMethod("getIdentifier");
+          getPasswordMethod = tokenClz.getDeclaredMethod("getPassword");
+          encodeToUrlStringMethod = tokenClz.getDeclaredMethod("encodeToUrlString");
+          decodeFromUrlStringMethod =
+              tokenClz.getDeclaredMethod("decodeFromUrlString", String.class);
+        } catch (NoClassDefFoundError | ReflectiveOperationException e) {
+          throw new RuntimeException(e);
+        }
+      }
+    }
+
+    /**
+     * Forward to new Token()
+     *
+     * @return org.apache.hadoop.security.token.Token
+     */
+    public static Object newInstance() {
+      ensureHadoopClzAvailable();
+      try {
+        return tokenConstructor.newInstance();
+      } catch (ReflectiveOperationException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    /**
+     * Forward to Token#encodeToUrlString
+     *
+     * @param token org.apache.hadoop.security.token.Token
+     * @return encodeToUrlString
+     */
+    public static String encodeToUrlString(Object token) {
+      ensureHadoopClzAvailable();
+      requireClz(token, TOKEN_CLASS);
+      try {
+        return (String) encodeToUrlStringMethod.invoke(token);
+      } catch (ReflectiveOperationException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    public static void decodeFromUrlString(Object token, String newValue) {
+      ensureHadoopClzAvailable();
+      requireClz(token, TOKEN_CLASS);
+      try {
+        decodeFromUrlStringMethod.invoke(token, newValue);
+      } catch (ReflectiveOperationException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    public static byte[] getIdentifier(Object token) {
+      ensureHadoopClzAvailable();
+      requireClz(token, TOKEN_CLASS);
+      try {
+        return (byte[]) getIdentifierMethod.invoke(token);
+      } catch (ReflectiveOperationException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    public static byte[] getPassword(Object token) {
+      ensureHadoopClzAvailable();
+      requireClz(token, TOKEN_CLASS);
+      try {
+        return (byte[]) getPasswordMethod.invoke(token);
+      } catch (ReflectiveOperationException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  public static class AbstractDelegationTokenSelector {
+
+    private static Class<?> abstractDelegationTokenSelectorClz;
+    private static Constructor<?> abstractDelegationTokenSelectorConstructor;
+    private static Method selectTokenMethod;
+
+    static {
+      if (hadoopClzAvailable) {
+        try {
+          abstractDelegationTokenSelectorClz =
+              Class.forName(ABSTRACT_DELEGATION_TOKEN_SELECTOR_CLASS);
+          abstractDelegationTokenSelectorConstructor =
+              abstractDelegationTokenSelectorClz.getConstructor();
+          abstractDelegationTokenSelectorConstructor.setAccessible(true);
+          selectTokenMethod =
+              abstractDelegationTokenSelectorClz.getDeclaredMethod(
+                  "selectToken", Text.textClz, Collection.class);
+        } catch (NoClassDefFoundError | ReflectiveOperationException e) {
+          throw new RuntimeException(e);
+        }
+      }
+    }
+
+    /**
+     * Forward to new DelegationTokenSelector()
+     *
+     * @return org.apache.hadoop.hdfs.security.token.delegation.DelegationTokenSelector
+     */
+    public static Object newInstance(Object text) {
+      ensureHadoopClzAvailable();
+      requireClz(text, TEXT_CLASS);
+      try {
+        return abstractDelegationTokenSelectorConstructor.newInstance(text);
+      } catch (ReflectiveOperationException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    /**
+     * Forward to AbstractDelegationTokenSelector#selectToken( Text service, Collection<Token<?
+     * extends TokenIdentifier>> tokens)
+     *
+     * @return org.apache.hadoop.security.token
+     */
+    @SuppressWarnings("rawtypes")
+    public static Object selectToken(
+        Object delegationTokenSelector, Object service, Collection tokens) {
+      try {
+        return selectTokenMethod.invoke(delegationTokenSelector, service, tokens);
+      } catch (ReflectiveOperationException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  public static class Text {
+    private static Class<?> textClz;
+    private static Constructor<?> textConstructor;
+    private static Constructor<?> textStringConstructor;
+
+    static {
+      if (hadoopClzAvailable) {
+        try {
+          textClz = Class.forName(TEXT_CLASS);
+          textConstructor = textClz.getConstructor();
+          textStringConstructor = textClz.getConstructor(String.class);
+        } catch (NoClassDefFoundError | ReflectiveOperationException e) {
+          throw new RuntimeException(e);
+        }
+      }
+    }
+
+    /**
+     * Forward to new Text()
+     *
+     * @return org.apache.hadoop.io.Text
+     */
+    public static Object newInstance() {
+      ensureHadoopClzAvailable();
+      try {
+        return textConstructor.newInstance();
+      } catch (ReflectiveOperationException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    /**
+     * Forward to new Text(String text)
+     *
+     * @return org.apache.hadoop.io.Text
+     */
+    public static Object newInstance(String text) {
+      ensureHadoopClzAvailable();
+      try {
+        return textStringConstructor.newInstance(text);
+      } catch (ReflectiveOperationException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  /**
+   * Get the string form of the token given a token signature. The signature is used as the value of
+   * the "service" field in the token for lookup. Ref: AbstractDelegationTokenSelector in Hadoop. If
+   * there exists such a token in the token cache (credential store) of the job, the lookup returns
+   * that. This is relevant only when running against a "secure" hadoop release The method gets hold
+   * of the tokens if they are set up by hadoop - this should happen on the map/reduce tasks if the
+   * client added the tokens into hadoop's credential store in the front end during job submission.
+   * The method will select the hive delegation token among the set of tokens and return the string
+   * form of it
+   */
+  public static String getTokenStrForm(String tokenSignature) {
+    Object ugi = HadoopShim.UserGroupInformation.getCurrentUser();
+    Object kind = HadoopShim.Text.newInstance(KYUUBI_DELEGATION_TOKEN_KIND);
+    Object tokenSelector = AbstractDelegationTokenSelector.newInstance(kind);
+    Object service =
+        tokenSignature == null
+            ? HadoopShim.Text.newInstance()
+            : HadoopShim.Text.newInstance(tokenSignature);
+    Object token =
+        AbstractDelegationTokenSelector.selectToken(
+            tokenSelector, service, HadoopShim.UserGroupInformation.getTokens(ugi));
+    return token != null ? Token.encodeToUrlString(token) : null;
+  }
+}

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/auth/HttpAuthUtils.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/auth/HttpAuthUtils.java
@@ -32,8 +32,8 @@ public final class HttpAuthUtils {
 
   /** @return Stringified Base64 encoded kerberosAuthHeader on success */
   public static String getKerberosServiceTicket(
-      String serverPrinciple, String host, Subject loggedInSubject) throws Exception {
-    String spn = KerberosUtils.canonicalPrincipal(serverPrinciple, host);
+      String serverPrincipal, String host, Subject loggedInSubject) throws Exception {
+    String spn = KerberosUtils.canonicalPrincipal(serverPrincipal, host);
     return Subject.doAs(loggedInSubject, new HttpKerberosClientAction(spn));
   }
 

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/auth/HttpTokenAuthInterceptor.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/auth/HttpTokenAuthInterceptor.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.jdbc.hive.auth;
+
+import java.util.Map;
+import org.apache.http.HttpRequest;
+import org.apache.http.client.CookieStore;
+import org.apache.http.protocol.HttpContext;
+
+/**
+ * The class is instantiated with the username and password, it is then used to add header with
+ * these credentials to HTTP requests
+ */
+public class HttpTokenAuthInterceptor extends HttpRequestInterceptorBase {
+  private final String tokenStr;
+  private static final String HIVE_DELEGATION_TOKEN_HEADER = "X-Hive-Delegation-Token";
+
+  public HttpTokenAuthInterceptor(
+      String tokenStr,
+      CookieStore cookieStore,
+      String cn,
+      boolean isSSL,
+      Map<String, String> additionalHeaders,
+      Map<String, String> customCookies) {
+    super(cookieStore, cn, isSSL, additionalHeaders, customCookies);
+    this.tokenStr = tokenStr;
+  }
+
+  @Override
+  protected void addHttpAuthHeader(HttpRequest httpRequest, HttpContext httpContext)
+      throws Exception {
+    httpRequest.addHeader(HIVE_DELEGATION_TOKEN_HEADER, tokenStr);
+  }
+}

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/auth/KerberosSaslHelper.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/auth/KerberosSaslHelper.java
@@ -17,8 +17,12 @@
 
 package org.apache.kyuubi.jdbc.hive.auth;
 
+import java.util.Base64;
 import java.util.Map;
 import javax.security.auth.Subject;
+import javax.security.auth.callback.*;
+import javax.security.sasl.RealmCallback;
+import javax.security.sasl.RealmChoiceCallback;
 import javax.security.sasl.SaslException;
 import org.apache.thrift.transport.TSaslClientTransport;
 import org.apache.thrift.transport.TTransport;
@@ -39,6 +43,88 @@ public final class KerberosSaslHelper {
         new TSaslClientTransport(
             "GSSAPI", null, names[0], names[1], saslProps, null, underlyingTransport);
     return new TSubjectTransport(saslTransport, subject);
+  }
+
+  /**
+   * Create a client-side SASL transport that wraps an underlying transport.
+   *
+   * @param underlyingTransport The underlying transport mechanism, usually a TSocket.
+   * @param saslProps the sasl properties to create the client with
+   */
+  public static TTransport createTokenTransport(
+      String tokenStrForm,
+      final TTransport underlyingTransport,
+      final Map<String, String> saslProps)
+      throws SaslException {
+    try {
+      Object token = HadoopShim.Token.newInstance();
+      HadoopShim.Token.decodeFromUrlString(token, tokenStrForm);
+      byte[] identifier = HadoopShim.Token.getIdentifier(token);
+      byte[] password = HadoopShim.Token.getPassword(token);
+      TTransport saslTransport =
+          new TSaslClientTransport(
+              "DIGEST-MD5",
+              null,
+              null,
+              "default",
+              saslProps,
+              new SaslClientCallbackHandler(identifier, password),
+              underlyingTransport);
+      Subject subject = HadoopShim.UserGroupInformation.getCurrentSubject();
+      return new TSubjectTransport(saslTransport, subject);
+    } catch (Exception e) {
+      throw new SaslException("Failed to open client transport", e);
+    }
+  }
+
+  private static class SaslClientCallbackHandler implements CallbackHandler {
+    private final String userName;
+    private final char[] userPassword;
+
+    public SaslClientCallbackHandler(byte[] identifier, byte[] password) {
+      this.userName = encodeIdentifier(identifier);
+      this.userPassword = encodePassword(password);
+    }
+
+    @Override
+    public void handle(Callback[] callbacks) throws UnsupportedCallbackException {
+      NameCallback nc = null;
+      PasswordCallback pc = null;
+      RealmCallback rc = null;
+      for (Callback callback : callbacks) {
+        if (callback instanceof RealmChoiceCallback) {
+          continue;
+        } else if (callback instanceof NameCallback) {
+          nc = (NameCallback) callback;
+        } else if (callback instanceof PasswordCallback) {
+          pc = (PasswordCallback) callback;
+        } else if (callback instanceof RealmCallback) {
+          rc = (RealmCallback) callback;
+        } else {
+          throw new UnsupportedCallbackException(callback, "Unrecognized SASL client callback");
+        }
+      }
+      if (nc != null) {
+        LOG.debug("SASL client callback: setting username: {}", userName);
+        nc.setName(userName);
+      }
+      if (pc != null) {
+        LOG.debug("SASL client callback: setting userPassword");
+        pc.setPassword(userPassword);
+      }
+      if (rc != null) {
+        LOG.debug("SASL client callback: setting realm: {}", rc.getDefaultText());
+        rc.setText(rc.getDefaultText());
+      }
+    }
+
+    static String encodeIdentifier(byte[] identifier) {
+      return Base64.getEncoder().encodeToString(identifier);
+    }
+
+    static char[] encodePassword(byte[] password) {
+      return Base64.getEncoder().encodeToString(password).toCharArray();
+    }
   }
 
   private KerberosSaslHelper() {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This is a follow-up to #3023.

```
if (param.auth = 'delegationToken') {
  // delegation token
  ensure hadoopClassAvaiable, but maybe we can do it w/o hadoop classes in the future
  UGI-based delegation token authentication
}
```

To avoid depending on Hadoop classes in compile phase, this PR introduces a `HadoopShim` to use reflection to invoke Hadoop classes for delegation token authentication.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
