### PR TITLE
[KYUUBI #3359] Minor change LdapAuthenticationProviderImpl to adapt AD

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/LdapAuthenticationProviderImpl.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/LdapAuthenticationProviderImpl.scala
@@ -76,7 +76,6 @@ class LdapAuthenticationProviderImpl(conf: KyuubiConf) extends PasswdAuthenticat
 
     try {
       val ctx = new InitialDirContext(env)
-      ctx.close()
     } catch {
       case e: NamingException =>
         throw new AuthenticationException(s"Error validating LDAP user: $bindDn", e)


### PR DESCRIPTION
Compatible with the Microsoft Active Directory LDAP.
Currently, Apache Kyuubi support open LDAP, cannot support Microsoft Active Directory LDAP,I try much more times, So
I try to debug LdapAuthenticationProviderImpl class,I find something wrong with use Active Directory LDAP to connect to kyuubi authorized.it can be connect ,but close connect have something wrong,so I clear the close method,it can be very well。support Active Directory LDAP。

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
