### PR TITLE
[KYUUBI #3695] ADAPTIVE policy to dynamic expand or reduce engine pool size

### DIFF
--- a/docs/deployment/settings.md
+++ b/docs/deployment/settings.md
@@ -224,6 +224,7 @@ kyuubi.engine.deregister.exception.ttl|PT30M|Time to live(TTL) for exceptions pa
 kyuubi.engine.deregister.job.max.failures|4|Number of failures of job before deregistering the engine.|int|1.2.0
 kyuubi.engine.event.json.log.path|file:///tmp/kyuubi/events|The location of all the engine events go for the builtin JSON logger.<ul><li>Local Path: start with 'file://'</li><li>HDFS Path: start with 'hdfs://'</li></ul>|string|1.3.0
 kyuubi.engine.event.loggers|SPARK|A comma separated list of engine history loggers, where engine/session/operation etc events go.<ul> <li>SPARK: the events will be written to the spark listener bus.</li> <li>JSON: the events will be written to the location of kyuubi.engine.event.json.log.path</li> <li>JDBC: to be done</li> <li>CUSTOM: to be done.</li></ul>|seq|1.3.0
+kyuubi.engine.expand.threshold|3|engin expand threshold, when engin app over this value , new engin app will be launched|int|1.7.0
 kyuubi.engine.flink.extra.classpath|&lt;undefined&gt;|The extra classpath for the flink sql engine, for configuring location of hadoop client jars, etc|string|1.6.0
 kyuubi.engine.flink.java.options|&lt;undefined&gt;|The extra java options for the flink sql engine|string|1.6.0
 kyuubi.engine.flink.memory|1g|The heap memory for the flink sql engine|string|1.6.0

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -1626,7 +1626,7 @@ object KyuubiConf {
       .version("1.7.0")
       .stringConf
       .transform(_.toUpperCase(Locale.ROOT))
-      .checkValues(Set("RANDOM", "POLLING"))
+      .checkValues(Set("RANDOM", "POLLING", "ADAPTIVE"))
       .createWithDefault("RANDOM")
 
   val ENGINE_INITIALIZE_SQL: ConfigEntry[Seq[String]] =
@@ -2389,4 +2389,12 @@ object KyuubiConf {
       .version("1.7.0")
       .timeConf
       .createWithDefault(Duration.ofSeconds(60).toMillis)
+
+  val ENGINE_POOL_BALANCE_EXPAND_THRESHOLD: ConfigEntry[Int] =
+    buildConf("kyuubi.engine.expand.threshold")
+      .doc("engin expand threshold, when engin app over this value , " +
+        "new engin app will be launched")
+      .version("1.7.0")
+      .intConf
+      .createWithDefault(3)
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/reblance/RebalancedEnginePolicy.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/reblance/RebalancedEnginePolicy.scala
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kyuubi.engine.reblance
+
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
+
+import org.apache.commons.lang.StringUtils
+
+import org.apache.kyuubi.Logging
+import org.apache.kyuubi.config.KyuubiConf
+import org.apache.kyuubi.config.KyuubiConf.{ENGINE_INIT_TIMEOUT, ENGINE_POOL_BALANCE_EXPAND_THRESHOLD, ENGINE_POOL_BALANCE_POLICY}
+import org.apache.kyuubi.ha.client.{DiscoveryClient, DiscoveryPaths}
+import org.apache.kyuubi.ha.client.DiscoveryClientProvider.withDiscoveryClient
+import org.apache.kyuubi.session.SessionHandle
+
+object RebalancedEnginePolicy extends Logging {
+
+  private val sessionNodeSuffix = "-session"
+
+  def deleteCloseSessionHandleNode(
+      conf: KyuubiConf,
+      closedHandleSpace: String,
+      sessionSpace: UserSpaceInfo): Unit = {
+    if (StringUtils.isEmpty(closedHandleSpace)) {
+      warn(s"$closedHandleSpace not exists")
+    }
+    if (!conf.get(ENGINE_POOL_BALANCE_POLICY).equalsIgnoreCase("Rebalanced")) {
+      return
+    }
+    val timeout: Long = conf.get(ENGINE_INIT_TIMEOUT)
+    withDiscoveryClient(conf) { client =>
+      client.tryWithLock(sessionSpace.getLockZkPath, timeout) {
+        info(s"delete handle path $closedHandleSpace")
+        if (client.pathExists(closedHandleSpace)) {
+          client.delete(closedHandleSpace)
+        } else {
+          warn(s"delete handle path $closedHandleSpace not exists")
+        }
+      }
+    }
+  }
+
+  def getAdaptiveSpaceIndex(
+      conf: KyuubiConf,
+      userSpaceInfo: UserSpaceInfo,
+      clientPoolName: String,
+      handleId: String): Int = {
+    val engineExpandThreshold: Int = conf.get(ENGINE_POOL_BALANCE_EXPAND_THRESHOLD) + 1
+    val timeout: Long = conf.get(ENGINE_INIT_TIMEOUT)
+    val userPath = userSpaceInfo.getUserZkPath
+    val lockPath = userSpaceInfo.getLockZkPath
+
+    def groupOpenedSessionsByUserSpace(client: DiscoveryClient): Map[String, ListBuffer[String]] = {
+      val allSpaceSessions = mutable.Map[String, ListBuffer[String]]()
+      val allSessionNodes: List[String] =
+        client.getChildren(userPath).filter(_.endsWith(sessionNodeSuffix))
+      allSessionNodes.foreach { sessionNode =>
+        val userSpace = SessionNodeUtil.extractSpace(sessionNode)
+        val openedSessions = client.getChildren(DiscoveryPaths.makePath(userPath, sessionNode))
+        debug(s"$userSpace connected session are ${openedSessions.mkString(",")}")
+        allSpaceSessions.getOrElseUpdate(userSpace, new ListBuffer[String]()).appendAll(
+          openedSessions)
+      }
+      allSpaceSessions.toMap
+    }
+
+    withDiscoveryClient(conf) { client =>
+      if (client.pathNonExists(lockPath)) client.create(lockPath, "PERSISTENT")
+      client.tryWithLock(lockPath, timeout) {
+        val sessionsGroup = groupOpenedSessionsByUserSpace(client)
+        val chooseSpace = chooseAdaptiveSpace(
+          clientPoolName,
+          engineExpandThreshold,
+          sessionsGroup)
+        // record session node in zNode for for next space choose
+        recordOpenSession(handleId, userPath, client, chooseSpace)
+        chooseSpace.spaceIndex
+      }
+    }
+  }
+
+  private def recordOpenSession(
+      handleId: String,
+      userPath: String,
+      client: DiscoveryClient,
+      chooseSpace: AdaptiveSpace): Unit = {
+    val sessionNode = SessionNodeUtil
+      .combine2SessionNode(chooseSpace.adaptiveSpaceStr)
+    val sessionNodePath = DiscoveryPaths.makePath(userPath, sessionNode)
+    addOpenSessionHandleNode(
+      client,
+      sessionNodePath,
+      handleId,
+      chooseSpace.firstInit)
+  }
+
+  def chooseAdaptiveSpace(
+      subdomainPrefix: String,
+      engineExpandThreshold: Int,
+      sessionsGroup: Map[String, ListBuffer[String]]): AdaptiveSpace = {
+    val optionalGroup = sessionsGroup.filter(oneSpaceGroup =>
+      oneSpaceGroup._2.size < engineExpandThreshold)
+    val adaptiveSpace =
+      if (optionalGroup.isEmpty) {
+        info(s"All space connections are full, start expand a new space for new engine")
+        val newSpaceIndex = expandSpace(sessionsGroup.keys.toList, subdomainPrefix)
+        AdaptiveSpace(s"$subdomainPrefix-$newSpaceIndex", newSpaceIndex, firstInit = true)
+      } else {
+        val mostOpenSessionSpace = optionalGroup.maxBy(y => y._2.size)._1
+        val spaceIndex = mostOpenSessionSpace.split(s"$subdomainPrefix-").apply(1).toInt
+        AdaptiveSpace(mostOpenSessionSpace, spaceIndex, firstInit = false)
+      }
+    adaptiveSpace
+  }
+
+  private def expandSpace(allSpaces: List[String], subdomainPrefix: String): Int = {
+    val spaceIndexSeparator = "-"
+    if (allSpaces.isEmpty) {
+      val initSpace = s"$subdomainPrefix-1"
+      info(s"init space is $initSpace")
+      1
+    } else {
+      val lastSpace = allSpaces.max
+      info(s"max index space is $lastSpace")
+      val spaceSplitArray = lastSpace.split(spaceIndexSeparator)
+      val engine = spaceSplitArray.apply(0)
+      val pool = spaceSplitArray.apply(1)
+      val maxIndex = spaceSplitArray.apply(2).toInt
+      val newIndex = maxIndex + 1
+      val expandSpace = s"$engine-$pool-$newIndex"
+      info(s"expand space is $expandSpace")
+      newIndex
+    }
+  }
+
+  private def addOpenSessionHandleNode(
+      client: DiscoveryClient,
+      sessionNodePath: String,
+      handleId: String,
+      firstInit: Boolean): Unit = {
+    info(s"add handleId $handleId to engine space $sessionNodePath")
+
+    def createPath(client: DiscoveryClient, createNode: String): Unit = {
+      if (client.pathNonExists(createNode)) {
+        info(s"create zk path $createNode")
+        client.create(createNode, "PERSISTENT")
+      }
+    }
+
+    def createSeedHandlePath(): Unit = {
+      if (firstInit) {
+        val seedHandleId = SessionHandle().identifier.toString
+        val seedHandleNodePath = s"$sessionNodePath/$seedHandleId"
+        info(s"create seed handle path $seedHandleNodePath")
+        createPath(client, seedHandleNodePath)
+      }
+    }
+
+    createSeedHandlePath()
+    createPath(client, sessionNodePath)
+    createPath(client, s"$sessionNodePath/$handleId")
+  }
+
+  case class AdaptiveSpace(adaptiveSpaceStr: String, spaceIndex: Int, firstInit: Boolean)
+
+  case class UserSpaceInfo(commonParent: String, appUser: String) {
+    def getUserZkPath: String = DiscoveryPaths.makePath(commonParent, appUser)
+
+    def getLockZkPath: String = {
+      val lockPath = DiscoveryPaths.makePath(commonParent, appUser, Array("lock"))
+      lockPath
+    }
+  }
+
+  object SessionNodeUtil {
+    val spaceSessionSuffix = "-session"
+
+    def extractSpace(recordNode: String): String = {
+      recordNode.split(spaceSessionSuffix).apply(0)
+    }
+
+    def combine2SessionNode(engineNameSpace: String): String = {
+      s"$engineNameSpace$spaceSessionSuffix"
+    }
+  }
+}

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionManager.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionManager.scala
@@ -17,6 +17,8 @@
 
 package org.apache.kyuubi.session
 
+import java.util.concurrent.ConcurrentHashMap
+
 import scala.collection.JavaConverters._
 
 import com.codahale.metrics.MetricRegistry
@@ -43,6 +45,9 @@ class KyuubiSessionManager private (name: String) extends SessionManager(name) {
 
   val operationManager = new KyuubiOperationManager()
   val credentialsManager = new HadoopCredentialsManager()
+  val sessionHandleSpaceMap: ConcurrentHashMap[String, String] =
+    new ConcurrentHashMap[String, String]()
+
   val applicationManager = new KyuubiApplicationManager()
   private lazy val metadataManager: Option[MetadataManager] = {
     // Currently, the metadata manager is used by the REST frontend which provides batch job APIs,

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/reblance/RebalancedEnginePolicyTest.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/reblance/RebalancedEnginePolicyTest.scala
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kyuubi.engine.reblance
+
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
+
+import org.apache.kyuubi.KyuubiFunSuite
+
+class RebalancedEnginePolicyTest extends KyuubiFunSuite {
+
+  test("no expand init") {
+    val subdomainPrefix = "engine-pool"
+    val enginExpandThreshold = 3
+    val spaceSessions = mutable.Map[String, ListBuffer[String]]()
+    val res = RebalancedEnginePolicy.chooseAdaptiveSpace(
+      subdomainPrefix,
+      enginExpandThreshold,
+      spaceSessions.toMap)
+    assert(res.spaceIndex == 1)
+  }
+
+  test("do not need expand engin space") {
+    val subdomainPrefix = "engine-pool"
+    val enginExpandThreshold = 3
+    val spaceSessions = mutable.Map[String, ListBuffer[String]]()
+    val space1Handles = ListBuffer[String]()
+    val allSpaces = ListBuffer[String]()
+
+    allSpaces += "engine-pool-1"
+    space1Handles += "handle0"
+    space1Handles += "handle1"
+    spaceSessions += ("engine-pool-1" -> space1Handles)
+
+    val res = RebalancedEnginePolicy.chooseAdaptiveSpace(
+      subdomainPrefix,
+      enginExpandThreshold,
+      spaceSessions.toMap)
+    assert(res.adaptiveSpaceStr.equals("engine-pool-1"))
+  }
+
+  test("balance to max load space") {
+    val subdomainPrefix = "engine-pool"
+    val enginExpandThreshold = 3
+    val spaceSessions = mutable.Map[String, ListBuffer[String]]()
+    val space1Handles = ListBuffer[String]()
+    val space2Handles = ListBuffer[String]()
+    val allSpaces = ListBuffer[String]()
+
+    allSpaces += "engine-pool-1"
+    space1Handles += "handle0"
+    space1Handles += "handle1"
+    space1Handles += "handle2"
+    spaceSessions += ("engine-pool-1" -> space1Handles)
+
+    allSpaces += "engine-pool-2"
+    space2Handles += "handle0"
+    space2Handles += "handle1"
+    spaceSessions += ("engine-pool-2" -> space2Handles)
+
+    val res = RebalancedEnginePolicy.chooseAdaptiveSpace(
+      subdomainPrefix,
+      enginExpandThreshold,
+      spaceSessions.toMap)
+    assert(res.adaptiveSpaceStr.equals("engine-pool-2"))
+  }
+
+  test("expand new engin space suitcase 1") {
+    val subdomainPrefix = "engine-pool"
+    val enginExpandThreshold = 3
+    val spaceSessions = mutable.Map[String, ListBuffer[String]]()
+    val space1Handles = ListBuffer[String]()
+    val allSpaces = ListBuffer[String]()
+
+    allSpaces += "engine-pool-1"
+    space1Handles += "handle0"
+    space1Handles += "handle1"
+    space1Handles += "handle2"
+    spaceSessions += ("engine-pool-1" -> space1Handles)
+
+    val res = RebalancedEnginePolicy.chooseAdaptiveSpace(
+      subdomainPrefix,
+      enginExpandThreshold,
+      spaceSessions.toMap)
+    assert(res.adaptiveSpaceStr.equals("engine-pool-2"))
+  }
+
+  test("expand engin space suitcase 2") {
+    val subdomainPrefix = "engine-pool"
+    val enginExpandThreshold = 3
+    val spaceSessions = mutable.Map[String, ListBuffer[String]]()
+    val space1Handles = ListBuffer[String]()
+    val space2Handles = ListBuffer[String]()
+    val allSpaces = ListBuffer[String]()
+
+    allSpaces += "engine-pool-1"
+    space1Handles += "handle0"
+    space1Handles += "handle1"
+    space1Handles += "handle2"
+    spaceSessions += ("engine-pool-1" -> space1Handles)
+
+    allSpaces += "engine-pool-2"
+    space2Handles += "handle0"
+    space2Handles += "handle1"
+    space2Handles += "handle2"
+    spaceSessions += ("engine-pool-2" -> space2Handles)
+
+    val res = RebalancedEnginePolicy.chooseAdaptiveSpace(
+      subdomainPrefix,
+      enginExpandThreshold,
+      spaceSessions.toMap)
+    assert(res.adaptiveSpaceStr.equals("engine-pool-3"))
+  }
+
+}


### PR DESCRIPTION
### _Why are the changes needed?_
As described in issues #3695:  Kyuubi pool-share-level current policies can not dynamic expand or decrease engin according to engin load

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request