### PR TITLE
provide flexible scene of tenant

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -2030,22 +2030,6 @@ object KyuubiConf {
       .intConf
       .createOptional
 
-  val SERVER_LIMIT_CONNECTIONS_MANUAL_ENABLE: ConfigEntry[Boolean] =
-    buildConf("kyuubi.server.limit.connections.manual.enable")
-      .doc("Whether to enable custom limit. If it is enabled, Kyuubi will limit the" +
-        " conn's num according to user")
-      .version("1.7.0")
-      .booleanConf
-      .createWithDefault(false)
-
-  val ENGINE_SHARE_LEVEL_GROUP_MANUAL_ENABLE: ConfigEntry[Boolean] =
-    buildConf("kyuubi.engine.share.level.group.manual.enable")
-      .doc("Whether to enable custom group share. If it is enabled, Kyuubi will get the" +
-        " user's group by using relation configured in mysql.")
-      .version("1.7.0")
-      .booleanConf
-      .createWithDefault(false)
-
   val SESSION_PROGRESS_ENABLE: ConfigEntry[Boolean] =
     buildConf("kyuubi.operation.progress.enabled")
       .doc("Whether to enable the operation progress. When true," +

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -2030,6 +2030,22 @@ object KyuubiConf {
       .intConf
       .createOptional
 
+  val SERVER_LIMIT_CONNECTIONS_CUSTOM_ENABLE: ConfigEntry[Boolean] =
+    buildConf("kyuubi.server.limit.connections.custom.enable")
+      .doc("Whether to enable custom limit. If it is enabled, Kyuubi will limit the" +
+        " conn's num according to user")
+      .version("1.6.1")
+      .booleanConf
+      .createWithDefault(false)
+
+  val ENGINE_SHARE_LEVEL_GROUP_CUSTOM_ENABLE: ConfigEntry[Boolean] =
+    buildConf("kyuubi.engine.share.level.group.custom.enable")
+      .doc("Whether to enable custom group share. If it is enabled, Kyuubi will get the" +
+        " user's group by using relation configured in mysql.")
+      .version("1.6.1")
+      .booleanConf
+      .createWithDefault(false)
+
   val SESSION_PROGRESS_ENABLE: ConfigEntry[Boolean] =
     buildConf("kyuubi.operation.progress.enabled")
       .doc("Whether to enable the operation progress. When true," +

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -2030,19 +2030,19 @@ object KyuubiConf {
       .intConf
       .createOptional
 
-  val SERVER_LIMIT_CONNECTIONS_CUSTOM_ENABLE: ConfigEntry[Boolean] =
-    buildConf("kyuubi.server.limit.connections.custom.enable")
+  val SERVER_LIMIT_CONNECTIONS_MANUAL_ENABLE: ConfigEntry[Boolean] =
+    buildConf("kyuubi.server.limit.connections.manual.enable")
       .doc("Whether to enable custom limit. If it is enabled, Kyuubi will limit the" +
         " conn's num according to user")
-      .version("1.6.1")
+      .version("1.7.0")
       .booleanConf
       .createWithDefault(false)
 
-  val ENGINE_SHARE_LEVEL_GROUP_CUSTOM_ENABLE: ConfigEntry[Boolean] =
-    buildConf("kyuubi.engine.share.level.group.custom.enable")
+  val ENGINE_SHARE_LEVEL_GROUP_MANUAL_ENABLE: ConfigEntry[Boolean] =
+    buildConf("kyuubi.engine.share.level.group.manual.enable")
       .doc("Whether to enable custom group share. If it is enabled, Kyuubi will get the" +
         " user's group by using relation configured in mysql.")
-      .version("1.6.1")
+      .version("1.7.0")
       .booleanConf
       .createWithDefault(false)
 

--- a/kyuubi-server/src/main/resources/sql/mysql/metadata-store-schema-mysql.sql
+++ b/kyuubi-server/src/main/resources/sql/mysql/metadata-store-schema-mysql.sql
@@ -29,3 +29,29 @@ CREATE TABLE metadata(
     INDEX user_name_index(user_name),
     INDEX engine_type_index(engine_type)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE `t_sys_user` (
+                              `id` bigint(20) NOT NULL AUTO_INCREMENT,
+                              `group_id` bigint(20) DEFAULT NULL COMMENT '组ID',
+                              `name` varchar(255) NOT NULL COMMENT '用户名',
+                              `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+                              `is_del` tinyint(4) DEFAULT '0' COMMENT '是否软删除',
+                              PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE `t_limit_user` (
+                                `id` bigint(20) NOT NULL AUTO_INCREMENT,
+                                `user_id` bigint(20) NOT NULL COMMENT '用户ID',
+                                `num` int(20) NOT NULL COMMENT '最大连接数',
+                                `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+                                `is_del` tinyint(4) DEFAULT '0' COMMENT '是否软删除',
+                                PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE `t_sys_group` (
+                               `id` bigint(20) NOT NULL AUTO_INCREMENT,
+                               `name` varchar(255) NOT NULL COMMENT '组名，共享GROUP模式使用的名称',
+                               `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+                               `is_del` tinyint(4) DEFAULT '0' COMMENT '是否删除',
+                               PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/kyuubi-server/src/main/resources/sql/mysql/metadata-store-schema-mysql.sql
+++ b/kyuubi-server/src/main/resources/sql/mysql/metadata-store-schema-mysql.sql
@@ -32,26 +32,26 @@ CREATE TABLE metadata(
 
 CREATE TABLE `t_sys_user` (
                               `id` bigint(20) NOT NULL AUTO_INCREMENT,
-                              `group_id` bigint(20) DEFAULT NULL COMMENT '组ID',
-                              `name` varchar(255) NOT NULL COMMENT '用户名',
-                              `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
-                              `is_del` tinyint(4) DEFAULT '0' COMMENT '是否软删除',
+                              `group_id` bigint(20) DEFAULT NULL COMMENT 'group id',
+                              `name` varchar(255) NOT NULL COMMENT 'user name',
+                              `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'create time',
+                              `remark` varchar(500) NOT NULL COMMENT 'remark',
                               PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE `t_limit_user` (
                                 `id` bigint(20) NOT NULL AUTO_INCREMENT,
-                                `user_id` bigint(20) NOT NULL COMMENT '用户ID',
-                                `num` int(20) NOT NULL COMMENT '最大连接数',
-                                `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
-                                `is_del` tinyint(4) DEFAULT '0' COMMENT '是否软删除',
+                                `user_id` bigint(20) NOT NULL COMMENT 'user id',
+                                `num` int(20) NOT NULL COMMENT 'number of limit value',
+                                `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'create time',
+                                `remark` varchar(500) NOT NULL COMMENT 'remark',
                                 PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE `t_sys_group` (
                                `id` bigint(20) NOT NULL AUTO_INCREMENT,
-                               `name` varchar(255) NOT NULL COMMENT '组名，共享GROUP模式使用的名称',
-                               `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
-                               `is_del` tinyint(4) DEFAULT '0' COMMENT '是否删除',
+                               `name` varchar(255) NOT NULL COMMENT 'group name',
+                               `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'create time',
+                               `remark` varchar(500) NOT NULL COMMENT 'remark',
                                PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
@@ -74,8 +74,6 @@ private[kyuubi] class EngineRef(
 
   private val clientPoolName: String = conf.get(ENGINE_POOL_NAME)
 
-  private val isManualGroup: Boolean = conf.get(ENGINE_SHARE_LEVEL_GROUP_MANUAL_ENABLE)
-
   private val enginePoolBalancePolicy: String = conf.get(ENGINE_POOL_BALANCE_POLICY)
 
   // In case the multi kyuubi instances have the small gap of timeout, here we add
@@ -87,7 +85,7 @@ private[kyuubi] class EngineRef(
   // Launcher of the engine
   private[kyuubi] val appUser: String = shareLevel match {
     case SERVER => Utils.currentUser
-    case GROUP => if (isManualGroup) {
+    case GROUP => if (userGroupMap.nonEmpty) {
         userGroupMap.getOrElse(user, user)
       } else {
       val clientUGI = UserGroupInformation.createRemoteUser(user)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
@@ -74,7 +74,7 @@ private[kyuubi] class EngineRef(
 
   private val clientPoolName: String = conf.get(ENGINE_POOL_NAME)
 
-  private val isCustomGroup: Boolean = conf.get(ENGINE_SHARE_LEVEL_GROUP_CUSTOM_ENABLE)
+  private val isManualGroup: Boolean = conf.get(ENGINE_SHARE_LEVEL_GROUP_MANUAL_ENABLE)
 
   private val enginePoolBalancePolicy: String = conf.get(ENGINE_POOL_BALANCE_POLICY)
 
@@ -87,7 +87,7 @@ private[kyuubi] class EngineRef(
   // Launcher of the engine
   private[kyuubi] val appUser: String = shareLevel match {
     case SERVER => Utils.currentUser
-    case GROUP => if (isCustomGroup) {
+    case GROUP => if (isManualGroup) {
         userGroupMap.getOrElse(user, user)
       } else {
       val clientUGI = UserGroupInformation.createRemoteUser(user)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiServer.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiServer.scala
@@ -24,8 +24,7 @@ import org.apache.hadoop.security.UserGroupInformation
 
 import org.apache.kyuubi._
 import org.apache.kyuubi.config.KyuubiConf
-import org.apache.kyuubi.config.KyuubiConf.{FRONTEND_PROTOCOLS, FrontendProtocols,
-  SERVER_LIMIT_CONNECTIONS_MANUAL_ENABLE, ENGINE_SHARE_LEVEL_GROUP_MANUAL_ENABLE}
+import org.apache.kyuubi.config.KyuubiConf.{FRONTEND_PROTOCOLS, FrontendProtocols}
 import org.apache.kyuubi.config.KyuubiConf.FrontendProtocols._
 import org.apache.kyuubi.events.{EventBus, KyuubiServerInfoEvent, ServerEventHandlerRegister}
 import org.apache.kyuubi.ha.HighAvailabilityConf._
@@ -138,9 +137,7 @@ class KyuubiServer(name: String) extends Serverable(name) {
 
     // initialize meta source
     if (conf.get(FRONTEND_PROTOCOLS).map(FrontendProtocols.withName)
-      .contains(FrontendProtocols.REST)
-      || conf.get(SERVER_LIMIT_CONNECTIONS_MANUAL_ENABLE)
-      || conf.get(ENGINE_SHARE_LEVEL_GROUP_MANUAL_ENABLE)) {
+      .contains(FrontendProtocols.REST)) {
       new JDBCMetadataDatasource().initialize(conf)
     }
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiServer.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiServer.scala
@@ -24,12 +24,14 @@ import org.apache.hadoop.security.UserGroupInformation
 
 import org.apache.kyuubi._
 import org.apache.kyuubi.config.KyuubiConf
-import org.apache.kyuubi.config.KyuubiConf.{FRONTEND_PROTOCOLS, FrontendProtocols}
+import org.apache.kyuubi.config.KyuubiConf.{FRONTEND_PROTOCOLS, FrontendProtocols,
+  SERVER_LIMIT_CONNECTIONS_CUSTOM_ENABLE}
 import org.apache.kyuubi.config.KyuubiConf.FrontendProtocols._
 import org.apache.kyuubi.events.{EventBus, KyuubiServerInfoEvent, ServerEventHandlerRegister}
 import org.apache.kyuubi.ha.HighAvailabilityConf._
 import org.apache.kyuubi.ha.client.{AuthTypes, ServiceDiscovery}
 import org.apache.kyuubi.metrics.{MetricsConf, MetricsSystem}
+import org.apache.kyuubi.server.metadata.jdbc.JDBCMetadataDatasource
 import org.apache.kyuubi.service.{AbstractBackendService, AbstractFrontendService, Serverable, ServiceState}
 import org.apache.kyuubi.util.{KyuubiHadoopUtils, SignalRegister}
 import org.apache.kyuubi.zookeeper.EmbeddedZookeeper
@@ -133,6 +135,14 @@ class KyuubiServer(name: String) extends Serverable(name) {
     if (conf.get(MetricsConf.METRICS_ENABLED)) {
       addService(new MetricsSystem)
     }
+
+    // initialize meta source
+    if (conf.get(FRONTEND_PROTOCOLS).map(FrontendProtocols.withName)
+      .contains(FrontendProtocols.REST)
+      || conf.get(SERVER_LIMIT_CONNECTIONS_CUSTOM_ENABLE)) {
+      new JDBCMetadataDatasource().initialize(conf)
+    }
+
     super.initialize(conf)
   }
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiServer.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiServer.scala
@@ -25,7 +25,7 @@ import org.apache.hadoop.security.UserGroupInformation
 import org.apache.kyuubi._
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.{FRONTEND_PROTOCOLS, FrontendProtocols,
-  SERVER_LIMIT_CONNECTIONS_CUSTOM_ENABLE}
+  SERVER_LIMIT_CONNECTIONS_MANUAL_ENABLE, ENGINE_SHARE_LEVEL_GROUP_MANUAL_ENABLE}
 import org.apache.kyuubi.config.KyuubiConf.FrontendProtocols._
 import org.apache.kyuubi.events.{EventBus, KyuubiServerInfoEvent, ServerEventHandlerRegister}
 import org.apache.kyuubi.ha.HighAvailabilityConf._
@@ -139,7 +139,8 @@ class KyuubiServer(name: String) extends Serverable(name) {
     // initialize meta source
     if (conf.get(FRONTEND_PROTOCOLS).map(FrontendProtocols.withName)
       .contains(FrontendProtocols.REST)
-      || conf.get(SERVER_LIMIT_CONNECTIONS_CUSTOM_ENABLE)) {
+      || conf.get(SERVER_LIMIT_CONNECTIONS_MANUAL_ENABLE)
+      || conf.get(ENGINE_SHARE_LEVEL_GROUP_MANUAL_ENABLE)) {
       new JDBCMetadataDatasource().initialize(conf)
     }
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/UserCustomStore.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/UserCustomStore.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.server.metadata
+
+import java.io.Closeable
+
+trait UserCustomStore extends Closeable {
+
+  def getUserLimitList(): Seq[Tuple2[String, Int]]
+
+  def getUserGroupList(): Seq[Tuple2[String, String]]
+
+}

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/jdbc/JDBCMetadataDatasource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/jdbc/JDBCMetadataDatasource.scala
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.server.metadata.jdbc
+
+import com.zaxxer.hikari.{HikariConfig, HikariDataSource}
+
+import org.apache.kyuubi.config.KyuubiConf
+import org.apache.kyuubi.server.metadata.jdbc.DatabaseType._
+import org.apache.kyuubi.server.metadata.jdbc.JDBCMetadataDatasource.hikariDataSource
+import org.apache.kyuubi.server.metadata.jdbc.JDBCMetadataStoreConf._
+import org.apache.kyuubi.service.CompositeService
+
+class JDBCMetadataDatasource extends CompositeService("MetadataDatasource") {
+
+  override def initialize(conf: KyuubiConf): Unit = synchronized {
+    val dbType = DatabaseType.withName(conf.get(METADATA_STORE_JDBC_DATABASE_TYPE))
+    val driverClassOpt = conf.get(METADATA_STORE_JDBC_DRIVER)
+    val driverClass = dbType match {
+      case DERBY => driverClassOpt.getOrElse("org.apache.derby.jdbc.AutoloadedDriver")
+      case MYSQL => driverClassOpt.getOrElse("com.mysql.jdbc.Driver")
+      case CUSTOM => driverClassOpt.getOrElse(
+          throw new IllegalArgumentException("No jdbc driver defined"))
+    }
+    val datasourceProperties =
+      JDBCMetadataStoreConf.getMetadataStoreJDBCDataSourceProperties(conf)
+    val hikariConfig = new HikariConfig(datasourceProperties)
+    hikariConfig.setDriverClassName(driverClass)
+    hikariConfig.setJdbcUrl(conf.get(METADATA_STORE_JDBC_URL))
+    hikariConfig.setUsername(conf.get(METADATA_STORE_JDBC_USER))
+    hikariConfig.setPassword(conf.get(METADATA_STORE_JDBC_PASSWORD))
+    hikariConfig.setPoolName("jdbc-metadata-store-pool")
+    hikariDataSource = Option(new HikariDataSource(hikariConfig))
+    super.initialize(conf)
+  }
+
+  override def start(): Unit = synchronized {
+    super.start()
+  }
+
+  override def stop(): Unit = synchronized {
+    super.stop()
+  }
+
+}
+
+object JDBCMetadataDatasource {
+
+  @volatile var hikariDataSource: Option[HikariDataSource] = None
+
+}

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/jdbc/JDBCMetadataStore.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/jdbc/JDBCMetadataStore.scala
@@ -42,13 +42,6 @@ class JDBCMetadataStore(conf: KyuubiConf) extends MetadataStore with Logging {
   import JDBCMetadataStore._
 
   private val dbType = DatabaseType.withName(conf.get(METADATA_STORE_JDBC_DATABASE_TYPE))
-  private val driverClassOpt = conf.get(METADATA_STORE_JDBC_DRIVER)
-  private val driverClass = dbType match {
-    case DERBY => driverClassOpt.getOrElse("org.apache.derby.jdbc.AutoloadedDriver")
-    case MYSQL => driverClassOpt.getOrElse("com.mysql.jdbc.Driver")
-    case CUSTOM => driverClassOpt.getOrElse(
-        throw new IllegalArgumentException("No jdbc driver defined"))
-  }
 
   private val databaseAdaptor = dbType match {
     case DERBY => new DerbyDatabaseDialect
@@ -56,17 +49,6 @@ class JDBCMetadataStore(conf: KyuubiConf) extends MetadataStore with Logging {
     case CUSTOM => new GenericDatabaseDialect
   }
 
-  private val datasourceProperties =
-    JDBCMetadataStoreConf.getMetadataStoreJDBCDataSourceProperties(conf)
-  private val hikariConfig = new HikariConfig(datasourceProperties)
-  hikariConfig.setDriverClassName(driverClass)
-  hikariConfig.setJdbcUrl(conf.get(METADATA_STORE_JDBC_URL))
-  hikariConfig.setUsername(conf.get(METADATA_STORE_JDBC_USER))
-  hikariConfig.setPassword(conf.get(METADATA_STORE_JDBC_PASSWORD))
-  hikariConfig.setPoolName("jdbc-metadata-store-pool")
-
-  @VisibleForTesting
-  private[kyuubi] val hikariDataSource = new HikariDataSource(hikariConfig)
   private val mapper = new ObjectMapper().registerModule(DefaultScalaModule)
 
   private val terminalStates =
@@ -104,7 +86,6 @@ class JDBCMetadataStore(conf: KyuubiConf) extends MetadataStore with Logging {
   }
 
   override def close(): Unit = {
-    hikariDataSource.close()
   }
 
   override def insertMetadata(metadata: Metadata): Unit = {
@@ -440,7 +421,7 @@ class JDBCMetadataStore(conf: KyuubiConf) extends MetadataStore with Logging {
   private def withConnection[T](autoCommit: Boolean = true)(f: Connection => T): T = {
     var connection: Connection = null
     try {
-      connection = hikariDataSource.getConnection
+      connection = JDBCMetadataDatasource.hikariDataSource.get.getConnection
       connection.setAutoCommit(autoCommit)
       f(connection)
     } catch {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/jdbc/JDBCMetadataStore.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/jdbc/JDBCMetadataStore.scala
@@ -26,8 +26,6 @@ import scala.collection.mutable.ListBuffer
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import com.google.common.annotations.VisibleForTesting
-import com.zaxxer.hikari.{HikariConfig, HikariDataSource}
 
 import org.apache.kyuubi.{KyuubiException, Logging, Utils}
 import org.apache.kyuubi.config.KyuubiConf

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/jdbc/JDBCUserCustomStore.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/jdbc/JDBCUserCustomStore.scala
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.server.metadata.jdbc
+
+import java.sql.{Connection, PreparedStatement, ResultSet, SQLException}
+
+import scala.collection.mutable.ListBuffer
+
+import org.apache.kyuubi.{KyuubiException, Logging, Utils}
+import org.apache.kyuubi.server.metadata.UserCustomStore
+
+class JDBCUserCustomStore extends UserCustomStore with Logging {
+
+  override def close(): Unit = {}
+
+  override def getUserLimitList(): Seq[Tuple2[String, Int]] = {
+    val query =
+      s"""SELECT
+         |u.NAME AS userName,
+         |luser.num AS userLimit
+         |FROM
+         |t_sys_user u
+         |JOIN t_limit_user luser ON u.id = luser.user_id""".stripMargin
+    withConnection() { connection =>
+      withResultSet(connection, query, ListBuffer[Any](): _*) { rs =>
+        buildUserConfig(rs)
+      }
+    }
+  }
+
+  private def buildUserConfig(resultSet: ResultSet): Seq[Tuple2[String, Int]] = {
+    try {
+      val userMetaList = ListBuffer[Tuple2[String, Int]]()
+      while (resultSet.next()) {
+        val userName = resultSet.getString("userName")
+        val userLimit = resultSet.getInt("userLimit")
+        val userMeta = Tuple2(userName, userLimit)
+        userMetaList += userMeta
+      }
+      userMetaList
+    } finally {
+      Utils.tryLogNonFatalError(resultSet.close())
+    }
+  }
+
+  override def getUserGroupList(): Seq[Tuple2[String, String]] = {
+    val query =
+      s"""SELECT
+         |u.NAME AS userName,
+         |g.NAME AS groupName
+         |FROM
+         |t_sys_user u
+         |JOIN t_sys_group g ON u.group_id = g.id""".stripMargin
+    withConnection() { connection =>
+      withResultSet(connection, query, ListBuffer[Any](): _*) { rs =>
+        buildGroupConfig(rs)
+      }
+    }
+  }
+
+  private def buildGroupConfig(resultSet: ResultSet): Seq[Tuple2[String, String]] = {
+    try {
+      val groupMetaList = ListBuffer[Tuple2[String, String]]()
+      while (resultSet.next()) {
+        val userName = resultSet.getString("userName")
+        val groupName = resultSet.getString("groupName")
+        val groupMeta = Tuple2(userName, groupName)
+        groupMetaList += groupMeta
+      }
+      groupMetaList
+    } finally {
+      Utils.tryLogNonFatalError(resultSet.close())
+    }
+  }
+
+  private def withResultSet[T](
+      conn: Connection,
+      sql: String,
+      params: Any*)(f: ResultSet => T): T = {
+    debug(s"executing sql $sql with result set")
+    var statement: PreparedStatement = null
+    var resultSet: ResultSet = null
+    try {
+      statement = conn.prepareStatement(sql)
+      setStatementParams(statement, params: _*)
+      resultSet = statement.executeQuery()
+      f(resultSet)
+    } catch {
+      case e: SQLException =>
+        throw new KyuubiException(e.getMessage, e)
+    } finally {
+      if (resultSet != null) {
+        Utils.tryLogNonFatalError(resultSet.close())
+      }
+      if (statement != null) {
+        Utils.tryLogNonFatalError(statement.close())
+      }
+    }
+  }
+
+  private def setStatementParams(statement: PreparedStatement, params: Any*): Unit = {
+    params.zipWithIndex.foreach { case (param, index) =>
+      param match {
+        case null => statement.setObject(index + 1, null)
+        case s: String => statement.setString(index + 1, s)
+        case i: Int => statement.setInt(index + 1, i)
+        case l: Long => statement.setLong(index + 1, l)
+        case d: Double => statement.setDouble(index + 1, d)
+        case f: Float => statement.setFloat(index + 1, f)
+        case b: Boolean => statement.setBoolean(index + 1, b)
+        case _ => throw new KyuubiException(s"Unsupported param type ${param.getClass.getName}")
+      }
+    }
+  }
+
+  private def withConnection[T](autoCommit: Boolean = true)(f: Connection => T): T = {
+    var connection: Connection = null
+    try {
+      connection = JDBCMetadataDatasource.hikariDataSource.get.getConnection
+      connection.setAutoCommit(autoCommit)
+      f(connection)
+    } catch {
+      case e: SQLException =>
+        throw new KyuubiException(e.getMessage, e)
+    } finally {
+      if (connection != null) {
+        Utils.tryLogNonFatalError(connection.close())
+      }
+    }
+  }
+
+}
+
+object JDBCUserCustomStore extends Logging {
+  def apply(): JDBCUserCustomStore = {
+    new JDBCUserCustomStore()
+  }
+}

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/jdbc/JDBCUserCustomStore.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/jdbc/JDBCUserCustomStore.scala
@@ -44,18 +44,18 @@ class JDBCUserCustomStore extends UserCustomStore with Logging {
   }
 
   private def buildUserConfig(resultSet: ResultSet): Seq[Tuple2[String, Int]] = {
+    val userMetaList = ListBuffer[Tuple2[String, Int]]()
     try {
-      val userMetaList = ListBuffer[Tuple2[String, Int]]()
       while (resultSet.next()) {
         val userName = resultSet.getString("userName")
         val userLimit = resultSet.getInt("userLimit")
         val userMeta = Tuple2(userName, userLimit)
         userMetaList += userMeta
       }
-      userMetaList
     } finally {
       Utils.tryLogNonFatalError(resultSet.close())
     }
+    userMetaList
   }
 
   override def getUserGroupList(): Seq[Tuple2[String, String]] = {
@@ -74,18 +74,18 @@ class JDBCUserCustomStore extends UserCustomStore with Logging {
   }
 
   private def buildGroupConfig(resultSet: ResultSet): Seq[Tuple2[String, String]] = {
+    val groupMetaList = ListBuffer[Tuple2[String, String]]()
     try {
-      val groupMetaList = ListBuffer[Tuple2[String, String]]()
       while (resultSet.next()) {
         val userName = resultSet.getString("userName")
         val groupName = resultSet.getString("groupName")
         val groupMeta = Tuple2(userName, groupName)
         groupMetaList += groupMeta
       }
-      groupMetaList
     } finally {
       Utils.tryLogNonFatalError(resultSet.close())
     }
+    groupMetaList
   }
 
   private def withResultSet[T](

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionManager.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionManager.scala
@@ -269,10 +269,10 @@ class KyuubiSessionManager private (name: String) extends SessionManager(name) {
     val userLimit = conf.get(SERVER_LIMIT_CONNECTIONS_PER_USER).getOrElse(0)
     val ipAddressLimit = conf.get(SERVER_LIMIT_CONNECTIONS_PER_IPADDRESS).getOrElse(0)
     val userIpAddressLimit = conf.get(SERVER_LIMIT_CONNECTIONS_PER_USER_IPADDRESS).getOrElse(0)
-    val customEnable = conf.get(SERVER_LIMIT_CONNECTIONS_CUSTOM_ENABLE)
-    val userMap: Map[String, Int] = if (customEnable) JDBCUserCustomStore().getUserLimitList().toMap
+    val manualEnable = conf.get(SERVER_LIMIT_CONNECTIONS_MANUAL_ENABLE)
+    val userMap: Map[String, Int] = if (manualEnable) JDBCUserCustomStore().getUserLimitList().toMap
       else Map()
-    if (customEnable || userLimit > 0 || ipAddressLimit > 0 || userIpAddressLimit > 0) {
+    if (manualEnable || userLimit > 0 || ipAddressLimit > 0 || userIpAddressLimit > 0) {
       limiter = Some(SessionLimiter(userMap, userLimit, ipAddressLimit, userIpAddressLimit))
     }
   }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionManager.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionManager.scala
@@ -269,10 +269,12 @@ class KyuubiSessionManager private (name: String) extends SessionManager(name) {
     val userLimit = conf.get(SERVER_LIMIT_CONNECTIONS_PER_USER).getOrElse(0)
     val ipAddressLimit = conf.get(SERVER_LIMIT_CONNECTIONS_PER_IPADDRESS).getOrElse(0)
     val userIpAddressLimit = conf.get(SERVER_LIMIT_CONNECTIONS_PER_USER_IPADDRESS).getOrElse(0)
-    val manualEnable = conf.get(SERVER_LIMIT_CONNECTIONS_MANUAL_ENABLE)
-    val userMap: Map[String, Int] = if (manualEnable) JDBCUserCustomStore().getUserLimitList().toMap
-      else Map()
-    if (manualEnable || userLimit > 0 || ipAddressLimit > 0 || userIpAddressLimit > 0) {
+    val userMap: Map[String, Int] = try {
+      JDBCUserCustomStore().getUserLimitList.toMap
+    } catch {
+      case _: Throwable => Map()
+    }
+    if (userLimit > 0 || ipAddressLimit > 0 || userIpAddressLimit > 0) {
       limiter = Some(SessionLimiter(userMap, userLimit, ipAddressLimit, userIpAddressLimit))
     }
   }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/session/SessionLimiterSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/session/SessionLimiterSuite.scala
@@ -31,12 +31,14 @@ class SessionLimiterSuite extends KyuubiFunSuite {
     val userLimit = 30
     val ipAddressLimit = 20
     val userIpAddressLimit = 10
+    val userCustomLimit = 5
+    val userMap: Map[String, Int] = Map({ "user001" -> 5 })
     val threadPool = Executors.newFixedThreadPool(10)
     def checkLimit(
         userIpAddress: UserIpAddress,
         expectedIndex: Int,
         expectedErrorMsg: String): Unit = {
-      val limiter = SessionLimiter(userLimit, ipAddressLimit, userIpAddressLimit)
+      val limiter = SessionLimiter(userMap, userLimit, ipAddressLimit, userIpAddressLimit)
       val successAdder = new LongAdder
       val expectedErrorAdder = new LongAdder
       val count = 50
@@ -78,6 +80,13 @@ class SessionLimiterSuite extends KyuubiFunSuite {
       userIpAddressLimit,
       s"Connection limit per user:ipaddress reached" +
         s" (user:ipaddress: $user:$ipAddress limit: $userIpAddressLimit)")
+
+    // user custom limit
+    checkLimit(
+      UserIpAddress(user, null),
+      userCustomLimit,
+      s"Connection limit per user custom reached (user: $user limit: $userCustomLimit)")
+
     threadPool.shutdown()
   }
 
@@ -87,7 +96,8 @@ class SessionLimiterSuite extends KyuubiFunSuite {
     val userLimit = 30
     val ipAddressLimit = 20
     val userIpAddressLimit = 10
-    val limiter = SessionLimiter(userLimit, ipAddressLimit, userIpAddressLimit)
+    val userMap: Map[String, Int] = Map({ "user001" -> 5 })
+    val limiter = SessionLimiter(userMap, userLimit, ipAddressLimit, userIpAddressLimit)
     for (i <- 0 until 50) {
       val userIpAddress = UserIpAddress(user, ipAddress)
       limiter.increment(userIpAddress)


### PR DESCRIPTION
### Why are the changes needed?
1. To close #3809

- [ ] Adding an accurate connection limit in SessionLimiter class. It will limit connection by using different number which configed in database
- [ ] At Group's share level, The EngineRef class providing a new method of fetching group's name
- [ ] Adjusting the MetadataStore module by extracting the datasource poll 
- [ ] the two fetures is not enabled by default in the KyuubiConf class



### According test
- [ ]  Test case of connection limit in SessionLimiterSuite class
- [ ]  Group's share level is small change and it was testing in the project of myself
