### PR TITLE
[KYUUBI #3242] First stop server and then interrupt thread when stopping the frontend service

### DIFF
--- a/docs/deployment/settings.md
+++ b/docs/deployment/settings.md
@@ -331,7 +331,7 @@ kyuubi.frontend.thrift.login.timeout|PT20S|Timeout for Thrift clients during log
 kyuubi.frontend.thrift.max.message.size|104857600|Maximum message size in bytes a Kyuubi server will accept.|int|1.4.0
 kyuubi.frontend.thrift.max.worker.threads|999|Maximum number of threads in the of frontend worker thread pool for the thrift frontend service|int|1.4.0
 kyuubi.frontend.thrift.min.worker.threads|9|Minimum number of threads in the of frontend worker thread pool for the thrift frontend service|int|1.4.0
-kyuubi.frontend.thrift.stop.timeout|PT60S|Timeout for stop the thrift frontend service.|int|1.7.0
+kyuubi.frontend.thrift.stop.timeout|PT1M|Timeout for stop the thrift frontend service.|duration|1.7.0
 kyuubi.frontend.thrift.worker.keepalive.time|PT1M|Keep-alive time (in milliseconds) for an idle worker thread|duration|1.4.0
 kyuubi.frontend.worker.keepalive.time|PT1M|(deprecated) Keep-alive time (in milliseconds) for an idle worker thread|duration|1.0.0
 

--- a/docs/deployment/settings.md
+++ b/docs/deployment/settings.md
@@ -331,7 +331,7 @@ kyuubi.frontend.thrift.login.timeout|PT20S|Timeout for Thrift clients during log
 kyuubi.frontend.thrift.max.message.size|104857600|Maximum message size in bytes a Kyuubi server will accept.|int|1.4.0
 kyuubi.frontend.thrift.max.worker.threads|999|Maximum number of threads in the of frontend worker thread pool for the thrift frontend service|int|1.4.0
 kyuubi.frontend.thrift.min.worker.threads|9|Minimum number of threads in the of frontend worker thread pool for the thrift frontend service|int|1.4.0
-kyuubi.frontend.thrift.stop.timeout|PT0.06S|Timeout seconds for stop the thrift frontend service.|duration|1.7.0
+kyuubi.frontend.thrift.stop.timeout|PT60S|Timeout for stop the thrift frontend service.|int|1.7.0
 kyuubi.frontend.thrift.worker.keepalive.time|PT1M|Keep-alive time (in milliseconds) for an idle worker thread|duration|1.4.0
 kyuubi.frontend.worker.keepalive.time|PT1M|(deprecated) Keep-alive time (in milliseconds) for an idle worker thread|duration|1.0.0
 

--- a/docs/deployment/settings.md
+++ b/docs/deployment/settings.md
@@ -331,6 +331,7 @@ kyuubi.frontend.thrift.login.timeout|PT20S|Timeout for Thrift clients during log
 kyuubi.frontend.thrift.max.message.size|104857600|Maximum message size in bytes a Kyuubi server will accept.|int|1.4.0
 kyuubi.frontend.thrift.max.worker.threads|999|Maximum number of threads in the of frontend worker thread pool for the thrift frontend service|int|1.4.0
 kyuubi.frontend.thrift.min.worker.threads|9|Minimum number of threads in the of frontend worker thread pool for the thrift frontend service|int|1.4.0
+kyuubi.frontend.thrift.stop.timeout|PT0.06S|Timeout seconds for stop the thrift frontend service.|duration|1.7.0
 kyuubi.frontend.thrift.worker.keepalive.time|PT1M|Keep-alive time (in milliseconds) for an idle worker thread|duration|1.4.0
 kyuubi.frontend.worker.keepalive.time|PT1M|(deprecated) Keep-alive time (in milliseconds) for an idle worker thread|duration|1.0.0
 

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -671,6 +671,13 @@ object KyuubiConf {
       .booleanConf
       .createWithDefault(true)
 
+  val FRONTEND_THRIFT_STOP_TIMEOUT: ConfigEntry[Long] =
+    buildConf("kyuubi.frontend.thrift.stop.timeout")
+      .doc("Timeout seconds for stop the thrift frontend service.")
+      .version("1.7.0")
+      .timeConf
+      .createWithDefault(60)
+
   val FRONTEND_PROXY_HTTP_CLIENT_IP_HEADER: ConfigEntry[String] =
     buildConf("kyuubi.frontend.proxy.http.client.ip.header")
       .doc("The http header to record the real client ip address. If your server is behind a load" +

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -673,10 +673,10 @@ object KyuubiConf {
 
   val FRONTEND_THRIFT_STOP_TIMEOUT: ConfigEntry[Long] =
     buildConf("kyuubi.frontend.thrift.stop.timeout")
-      .doc("Timeout seconds for stop the thrift frontend service.")
+      .doc("Timeout for stop the thrift frontend service.")
       .version("1.7.0")
       .timeConf
-      .createWithDefault(60)
+      .createWithDefault(Duration.ofSeconds(60).toMillis)
 
   val FRONTEND_PROXY_HTTP_CLIENT_IP_HEADER: ConfigEntry[String] =
     buildConf("kyuubi.frontend.proxy.http.client.ip.header")

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/TBinaryFrontendService.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/TBinaryFrontendService.scala
@@ -112,7 +112,7 @@ abstract class TBinaryFrontendService(name: String)
         .beBackoffSlotLength(beBackoffSlotLength)
         .beBackoffSlotLengthUnit(TimeUnit.MILLISECONDS)
         .executorService(executor)
-        .stopTimeoutVal(stopTimeout)
+        .stopTimeoutVal(stopTimeout / 1000)
       // TCP Server
       server = Some(new TThreadPoolServer(args))
       server.foreach(_.setServerEventHandler(new FeTServerEventHandler))

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/TBinaryFrontendService.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/TBinaryFrontendService.scala
@@ -49,6 +49,8 @@ abstract class TBinaryFrontendService(name: String)
     conf.get(FRONTEND_THRIFT_BINARY_BIND_HOST)
   final override protected lazy val portNum: Int = conf.get(FRONTEND_THRIFT_BINARY_BIND_PORT)
 
+  private lazy val stopTimeout = conf.get(FRONTEND_THRIFT_STOP_TIMEOUT).toInt
+
   protected var server: Option[TServer] = None
 
   // Removed OOM hook since Kyuubi #1800 to respect the hive server2 #2383
@@ -110,6 +112,7 @@ abstract class TBinaryFrontendService(name: String)
         .beBackoffSlotLength(beBackoffSlotLength)
         .beBackoffSlotLengthUnit(TimeUnit.MILLISECONDS)
         .executorService(executor)
+        .stopTimeoutVal(stopTimeout)
       // TCP Server
       server = Some(new TThreadPoolServer(args))
       server.foreach(_.setServerEventHandler(new FeTServerEventHandler))
@@ -180,7 +183,16 @@ abstract class TBinaryFrontendService(name: String)
     }
 
   override protected def stopServer(): Unit = {
-    server.foreach(_.stop())
+    server.foreach { s =>
+      {
+        s.stop()
+        // wait for the server to stop until timeout
+        val startTime = System.currentTimeMillis()
+        while (System.currentTimeMillis() - startTime < stopTimeout && s.isServing) {
+          Thread.sleep(500)
+        }
+      }
+    }
     server = None
   }
 }

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/TFrontendService.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/TFrontendService.scala
@@ -91,8 +91,8 @@ abstract class TFrontendService(name: String)
    */
   private def stopInternal(): Unit = {
     if (started.compareAndSet(true, false)) {
-      serverThread.interrupt()
       stopServer()
+      serverThread.interrupt()
       info(getName + " has stopped")
     }
   }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
@@ -220,6 +220,7 @@ class KyuubiOperationPerConnectionSuite extends WithKyuubiServer with HiveJDBCTe
   test("transfer the TGetInfoReq to kyuubi engine side to verify the connection valid") {
     withSessionConf(Map.empty)(Map(
       KyuubiConf.SERVER_INFO_PROVIDER.key -> "ENGINE",
+      KyuubiConf.FRONTEND_THRIFT_STOP_TIMEOUT.key -> "1000",
       KyuubiConf.SESSION_ENGINE_LAUNCH_ASYNC.key -> "false"))() {
       withJdbcStatement() { statement =>
         val conn = statement.getConnection.asInstanceOf[KyuubiConnection]


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

close #3242

First stop server and then interrupt service thread When stopping Frontend Service, in order to avoid kyuubi server exit hang.

### _How was this patch tested?_
- [X] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [X] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
