### PR TITLE
[KYUUBI #3851][SPARK] Support auto set up `spark.master` when Kyuubi running inside Pod

### DIFF
--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/HiveJDBCTestHelper.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/HiveJDBCTestHelper.scala
@@ -88,6 +88,18 @@ trait HiveJDBCTestHelper extends JDBCTestHelper {
       user)(f)
   }
 
+  def withThriftClientAndConnectionConf[T](f: (TCLIService.Iface, Map[String, String]) => T): T = {
+    withThriftClientAndConnectionConf()(f)
+  }
+
+  def withThriftClientAndConnectionConf[T](user: Option[String] = None)(f: (
+      TCLIService.Iface,
+      Map[String, String]) => T): T = {
+    TClientTestUtils.withThriftClientAndConnectionConf(
+      jdbcUrl.stripPrefix(URL_PREFIX),
+      user)(f)
+  }
+
   def withSessionHandle[T](f: (TCLIService.Iface, TSessionHandle) => T): T = {
     val hostAndPort = jdbcUrl.stripPrefix(URL_PREFIX).split("/;").head
     TClientTestUtils.withSessionHandle(hostAndPort, sessionConfigs)(f)

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/SparkQueryTests.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/SparkQueryTests.scala
@@ -52,7 +52,7 @@ trait SparkQueryTests extends SparkDataTypeTests with HiveJDBCTestHelper {
   test("execute statement - select with variable substitution") {
     assume(!httpMode)
 
-    withThriftClient { client =>
+    withThriftClientAndConnectionConf { (client, connectionConf) =>
       val req = new TOpenSessionReq()
       req.setUsername("chengpan")
       req.setPassword("123")
@@ -62,7 +62,7 @@ trait SparkQueryTests extends SparkDataTypeTests with HiveJDBCTestHelper {
         "set:hivevar:b" -> "y",
         "set:metaconf:c" -> "z",
         "set:system:s" -> "s")
-      req.setConfiguration(conf.asJava)
+      req.setConfiguration((conf ++ connectionConf).asJava)
       val tOpenSessionResp = client.OpenSession(req)
       val status = tOpenSessionResp.getStatus
       assert(status.getStatusCode === TStatusCode.SUCCESS_STATUS)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
@@ -138,6 +138,8 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
 object KubernetesApplicationOperation extends Logging {
   val LABEL_KYUUBI_UNIQUE_KEY = "kyuubi-unique-tag"
   val SPARK_APP_ID_LABEL = "spark-app-selector"
+  val KUBERNETES_SERVICE_HOST = "KUBERNETES_SERVICE_HOST"
+  val KUBERNETES_SERVICE_PORT = "KUBERNETES_SERVICE_PORT"
 
   def toApplicationState(state: String): ApplicationState = state match {
     // https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/core/types.go#L2396

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ProcBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ProcBuilder.scala
@@ -106,6 +106,14 @@ trait ProcBuilder {
 
   protected val extraEngineLog: Option[OperationLog]
 
+  /**
+   * Add `engine.master` if KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT
+   * are defined. So we can deploy engine on kubernetes without setting `engine.master`
+   * explicitly when kyuubi-servers are on kubernetes, which also helps in case that
+   * api-server is not exposed to us.
+   */
+  protected def completeMasterUrl(conf: KyuubiConf) = {}
+
   protected val workingDir: Path = {
     env.get("KYUUBI_WORK_DIR_ROOT").map { root =>
       val workingRoot = Paths.get(root).toAbsolutePath

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkBatchProcessBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkBatchProcessBuilder.scala
@@ -45,6 +45,8 @@ class SparkBatchProcessBuilder(
     }
 
     val batchKyuubiConf = new KyuubiConf(false)
+    // complete `spark.master` if absent on kubernetes
+    completeMasterUrl(batchKyuubiConf)
     batchConf.foreach(entry => { batchKyuubiConf.set(entry._1, entry._2) })
     // tag batch application
     KyuubiApplicationManager.tagApplication(batchId, "spark", clusterManager(), batchKyuubiConf)


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
to close https://github.com/apache/incubator-kyuubi/issues/3851 .
We can deploy spark on kubernetes without configure spark.master explicitly when api-server url is not exposed for us.


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x]  Add screenshots for manual tests if appropriate
we do not set `spark.master`:
![企业微信截图_16692948916568](https://user-images.githubusercontent.com/76927591/203790820-75373068-c407-4d31-9860-a13b136a084e.png)

kyuubi add `spark.master` when setting `kyuubi.kubernetes.engine.master.override` to true.
![企业微信截图_16692948189845](https://user-images.githubusercontent.com/76927591/203790634-03fa0181-8405-4551-9af8-f394c58747a8.png)


- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
