### PR TITLE
Binding python/sql spark session

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/resources/python/execute_python.py
+++ b/externals/kyuubi-spark-sql-engine/src/main/resources/python/execute_python.py
@@ -240,7 +240,9 @@ def execute_request(content):
 
 
 # get or create spark session
-spark_session = kyuubi_util.get_spark_session(os.environ.get("KYUUBI_SPARK_SESSION_UUID"))
+spark_session = kyuubi_util.get_spark_session(
+    os.environ.get("KYUUBI_SPARK_SESSION_UUID")
+)
 global_dict["spark"] = spark_session
 
 

--- a/externals/kyuubi-spark-sql-engine/src/main/resources/python/execute_python.py
+++ b/externals/kyuubi-spark-sql-engine/src/main/resources/python/execute_python.py
@@ -240,7 +240,7 @@ def execute_request(content):
 
 
 # get or create spark session
-spark_session = kyuubi_util.get_spark_session()
+spark_session = kyuubi_util.get_spark_session(os.environ.get("KYUUBI_SPARK_SESSION_UUID"))
 global_dict["spark"] = spark_session
 
 

--- a/externals/kyuubi-spark-sql-engine/src/main/resources/python/kyuubi_util.py
+++ b/externals/kyuubi-spark-sql-engine/src/main/resources/python/kyuubi_util.py
@@ -76,7 +76,9 @@ def get_spark_session(uuid=None) -> "SparkSession":
             SparkSession.builder.master("dummy").appName("kyuubi-python").getOrCreate()
         )
     else:
-        session = gateway.jvm.org.apache.kyuubi.engine.spark.session.SparkSQLSessionManager.getSparkSession(
-            uuid
+        session = (
+            gateway.jvm.org.apache.kyuubi.engine.spark.SparkSQLEngine.getSparkSession(
+                uuid
+            )
         )
         return SparkSession(sparkContext=sc, jsparkSession=session)

--- a/externals/kyuubi-spark-sql-engine/src/main/resources/python/kyuubi_util.py
+++ b/externals/kyuubi-spark-sql-engine/src/main/resources/python/kyuubi_util.py
@@ -70,9 +70,13 @@ def _get_exist_spark_context(self, jconf):
     )
 
 
-def get_spark_session() -> "SparkSession":
+def get_spark_session(uuid=None) -> "SparkSession":
     SparkContext._initialize_context = _get_exist_spark_context
     gateway = connect_to_exist_gateway()
     SparkContext._ensure_initialized(gateway=gateway)
-    spark = SparkSession.builder.master("local").appName("test").getOrCreate()
-    return spark
+    if uuid is None:
+        return SparkSession.builder.master("dummy").appName("kyuubi-python").getOrCreate()
+    else:
+        session = SparkContext._jvm.org.apache.kyuubi.engine.spark.session.SparkSQLSessionManager.getSparkSession(uuid)
+        sc = SparkContext.getOrCreate()
+        return SparkSession(sparkContext=sc, jsparkSession=session)

--- a/externals/kyuubi-spark-sql-engine/src/main/resources/python/kyuubi_util.py
+++ b/externals/kyuubi-spark-sql-engine/src/main/resources/python/kyuubi_util.py
@@ -61,6 +61,7 @@ def connect_to_exist_gateway() -> "JavaGateway":
 
     return gateway
 
+
 def get_spark_session(uuid=None) -> "SparkSession":
     gateway = connect_to_exist_gateway()
     jjsc = gateway.jvm.JavaSparkContext(
@@ -71,7 +72,11 @@ def get_spark_session(uuid=None) -> "SparkSession":
     sc = SparkContext(conf=conf, gateway=gateway, jsc=jjsc)
     if uuid is None:
         # note that in this mode, all the python's spark sessions share the root spark session.
-        return SparkSession.builder.master("dummy").appName("kyuubi-python").getOrCreate()
+        return (
+            SparkSession.builder.master("dummy").appName("kyuubi-python").getOrCreate()
+        )
     else:
-        session = gateway.jvm.org.apache.kyuubi.engine.spark.session.SparkSQLSessionManager.getSparkSession(uuid)
+        session = gateway.jvm.org.apache.kyuubi.engine.spark.session.SparkSQLSessionManager.getSparkSession(
+            uuid
+        )
         return SparkSession(sparkContext=sc, jsparkSession=session)

--- a/externals/kyuubi-spark-sql-engine/src/main/resources/python/kyuubi_util.py
+++ b/externals/kyuubi-spark-sql-engine/src/main/resources/python/kyuubi_util.py
@@ -66,12 +66,12 @@ def get_spark_session(uuid=None) -> "SparkSession":
     jjsc = gateway.jvm.JavaSparkContext(
         gateway.jvm.org.apache.spark.SparkContext.getOrCreate()
     )
+    conf = SparkConf()
+    conf.setMaster("dummy").setAppName("kyuubi-python")
+    sc = SparkContext(conf=conf, gateway=gateway, jsc=jjsc)
     if uuid is None:
         # note that in this mode, all the python's spark sessions share the root spark session.
         return SparkSession.builder.master("dummy").appName("kyuubi-python").getOrCreate()
     else:
         session = gateway.jvm.org.apache.kyuubi.engine.spark.session.SparkSQLSessionManager.getSparkSession(uuid)
-        conf = SparkConf()
-        conf.setMaster("dummy").setAppName("kyuubi-python")
-        sc = SparkContext(conf=conf, gateway=gateway, jsc=jjsc)
         return SparkSession(sparkContext=sc, jsparkSession=session)

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
@@ -29,7 +29,6 @@ import scala.collection.JavaConverters._
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import org.apache.commons.lang3.StringUtils
 import org.apache.spark.SparkFiles
 import org.apache.spark.api.python.KyuubiPythonGatewayServer
 import org.apache.spark.sql.{Row, SparkSession}

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
@@ -29,6 +29,7 @@ import scala.collection.JavaConverters._
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import org.apache.commons.lang3.StringUtils
 import org.apache.spark.SparkFiles
 import org.apache.spark.api.python.KyuubiPythonGatewayServer
 import org.apache.spark.sql.{Row, SparkSession}

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
@@ -243,6 +243,7 @@ object ExecutePython extends Logging {
           "SPARK_HOME",
           getSparkPythonHomeFromArchive(spark, session).getOrElse(defaultSparkHome)))
     }
+    env.put("KYUUBI_SPARK_SESSION_UUID", session.handle.identifier.toString)
     env.put("PYTHON_GATEWAY_CONNECTION_INFO", KyuubiPythonGatewayServer.CONNECTION_FILE_PATH)
     logger.info(
       s"""

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/session/SparkSQLSessionManager.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/session/SparkSQLSessionManager.scala
@@ -18,7 +18,6 @@
 package org.apache.kyuubi.engine.spark.session
 
 import java.util.concurrent.{ScheduledExecutorService, TimeUnit}
-import java.util.concurrent.atomic.AtomicReference
 
 import org.apache.hive.service.rpc.thrift.TProtocolVersion
 import org.apache.spark.sql.SparkSession
@@ -43,10 +42,7 @@ import org.apache.kyuubi.util.ThreadUtils
 class SparkSQLSessionManager private (name: String, spark: SparkSession)
   extends SessionManager(name) {
 
-  def this(spark: SparkSession) = {
-    this(classOf[SparkSQLSessionManager].getSimpleName, spark)
-    SparkSQLSessionManager.setSessionManager(this)
-  }
+  def this(spark: SparkSession) = this(classOf[SparkSQLSessionManager].getSimpleName, spark)
 
   val operationManager = new SparkSQLOperationManager()
 
@@ -180,19 +176,4 @@ class SparkSQLSessionManager private (name: String, spark: SparkSession)
   }
 
   override protected def isServer: Boolean = false
-}
-
-object SparkSQLSessionManager {
-  private val sessionManager = new AtomicReference[SparkSQLSessionManager]
-
-  private def setSessionManager(manager: SparkSQLSessionManager): Unit = {
-    sessionManager.set(manager)
-  }
-
-  def getSparkSession(uuid: String): SparkSession = {
-    sessionManager.get()
-      .getSession(SessionHandle.fromUUID(uuid))
-      .asInstanceOf[SparkSessionImpl]
-      .spark
-  }
 }

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/PySparkTests.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/PySparkTests.scala
@@ -93,26 +93,44 @@ class PySparkTests extends WithSparkSQLEngine with HiveJDBCTestHelper {
   test("binding python/sql spark session") {
     checkPythonRuntimeAndVersion()
     withMultipleConnectionJdbcStatement()({ statement =>
-      statement.executeQuery("SET kyuubi.operation.language=python")
-      val setPy =
+      statement.executeQuery("SET kyuubi.operation.language=PYTHON")
+
+      // set hello=kyuubi in python
+      val set1 =
         """
           |spark.sql("set hello=kyuubi").show()
           |""".stripMargin
-      val output =
+      val output1 =
         """|+-----+------+
            ||  key| value|
            |+-----+------+
            ||hello|kyuubi|
            |+-----+------+""".stripMargin
-      val resultSet = statement.executeQuery(setPy)
-      assert(resultSet.next())
-      assert(resultSet.getString("output") === output)
-      assert(resultSet.getString("status") === "ok")
+      val resultSet1 = statement.executeQuery(set1)
+      assert(resultSet1.next())
+      assert(resultSet1.getString("status") === "ok")
+      assert(resultSet1.getString("output") === output1)
 
-      val resultSetSql = statement.executeQuery("set hello")
-      assert(resultSetSql.next())
-      assert(resultSetSql.getString("key") === "hello")
-      assert(resultSetSql.getString("value") === "kyuubi")
+      val set2 =
+        """
+          |spark.sql("SET kyuubi.operation.language=SQL").show(truncate = False)
+          |""".stripMargin
+      val output2 =
+        """|+-------------------------+-----+
+           ||key                      |value|
+           |+-------------------------+-----+
+           ||kyuubi.operation.language|SQL  |
+           |+-------------------------+-----+""".stripMargin
+      val resultSet2 = statement.executeQuery(set2)
+      assert(resultSet2.next())
+      assert(resultSet2.getString("status") === "ok")
+      assert(resultSet2.getString("output") === output2)
+
+      // get hello value in sql
+      val resultSet3 = statement.executeQuery("set hello")
+      assert(resultSet3.next())
+      assert(resultSet3.getString("key") === "hello")
+      assert(resultSet3.getString("value") === "kyuubi")
     })
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Bind python and SQL spark session, then the variables we set on the python side can be visited on the SQL side

After this PR, we can change the execution mode from python to sql by running

```python
spark.sql("SET kyuubi.operation.language=SQL").show()
```

![5091671606960_ pic_hd](https://user-images.githubusercontent.com/8537877/208873580-bf6d8a09-63ad-4788-bce7-c1fe2705f0b2.jpg)


### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
