### PR TITLE
Tidy up the `Are you willing to submit PR` option in the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -128,7 +128,6 @@ body:
         especially if you already know a good understanding of how to implement the fix.
         Kyuubi is a community-driven project and we love to bring new contributors in.
       options:
-        - label: Yes. I can submit a PR independently to fix.
         - label: Yes. I would be willing to submit a PR with guidance from the Kyuubi community to fix.
         - label: No. I cannot submit a PR at this time.
 

--- a/.github/ISSUE_TEMPLATE/doc-improvement-report.yml
+++ b/.github/ISSUE_TEMPLATE/doc-improvement-report.yml
@@ -90,7 +90,6 @@ body:
         especially if you already know a good understanding of how to implement the fix.
         Kyuubi is a community-driven project and we love to bring new contributors in.
       options:
-        - label: Yes. I can submit a PR independently to improve.
         - label: Yes. I would be willing to submit a PR with guidance from the Kyuubi community to improve.
         - label: No. I cannot submit a PR at this time.
 

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -86,7 +86,6 @@ body:
         especially if you already have a grip on how to implement the new feature.
         Kyuubi is a community-driven project and we love to bring new contributors in.
       options:
-        - label: Yes. I can submit a PR independently to improve.
         - label: Yes. I would be willing to submit a PR with guidance from the Kyuubi community to improve.
         - label: No. I cannot submit a PR at this time.
 

--- a/.github/ISSUE_TEMPLATE/improve-test.yml
+++ b/.github/ISSUE_TEMPLATE/improve-test.yml
@@ -69,7 +69,6 @@ body:
         especially if you already know a good understanding of how to implement the fix.
         Kyuubi is a community-driven project and we love to bring new contributors in.
       options:
-        - label: Yes. I can submit a PR independently to improve.
         - label: Yes. I would be willing to submit a PR with guidance from the Kyuubi community to improve.
         - label: No. I cannot submit a PR at this time.
 

--- a/.github/ISSUE_TEMPLATE/improvement.yml
+++ b/.github/ISSUE_TEMPLATE/improvement.yml
@@ -69,7 +69,6 @@ body:
         especially if you already know a good understanding of how to implement the fix.
         Kyuubi is a community-driven project and we love to bring new contributors in.
       options:
-        - label: Yes. I can submit a PR independently to improve.
         - label: Yes. I would be willing to submit a PR with guidance from the Kyuubi community to improve.
         - label: No. I cannot submit a PR at this time.
 

--- a/.github/ISSUE_TEMPLATE/subtask.yml
+++ b/.github/ISSUE_TEMPLATE/subtask.yml
@@ -63,7 +63,6 @@ body:
         especially if you already have a grip on how to implement the new feature.
         Kyuubi is a community-driven project and we love to bring new contributors in.
       options:
-        - label: Yes. I can submit a PR independently to improve.
         - label: Yes. I would be willing to submit a PR with guidance from the Kyuubi community to improve.
         - label: No. I cannot submit a PR at this time.
 

--- a/.github/ISSUE_TEMPLATE/umbrella.yml
+++ b/.github/ISSUE_TEMPLATE/umbrella.yml
@@ -73,7 +73,6 @@ body:
         especially if you already have a grip on how to implement the new feature.
         Kyuubi is a community-driven project and we love to bring new contributors in.
       options:
-        - label: Yes. I can submit a PR independently to improve.
         - label: Yes. I would be willing to submit a PR with guidance from the Kyuubi community to improve.
         - label: No. I cannot submit a PR at this time.
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This pr aims to tidy up the `Are you willing to submit PR` option in the issue template.
  

Currently, The `Are you willing to submit PR` option of some Apache kyuubi issue templates has three options as follow:
 - [ ] Yes. I can submit a PR independently to improve.
 - [ ] Yes. I would be willing to submit a PR with guidance from the Kyuubi community to improve.
 - [ ] No. I cannot submit a PR at this time.

The intent of `Are you willing to submit PR` option is to confirm whether the questioner can submit PR at now, So two options are enough.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
