### PR TITLE
[PYSPARK] Fix internal python code issue

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
@@ -175,8 +175,11 @@ case class SessionPythonWorker(
     stdin.println(input)
     // scalastyle:on
     stdin.flush()
-    Option(stdout.readLine())
-      .map(ExecutePython.fromJson[PythonResponse](_))
+    val output = stdout.readLine()
+    // scalastyle:off println
+    println(s"$input -> $output")
+    // scalastyle:on
+    Option(output).map(ExecutePython.fromJson[PythonResponse](_))
   }
 
   def close(): Unit = {

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
@@ -135,7 +135,7 @@ class ExecutePython(
 
   override protected def withLocalProperties[T](f: => T): T = {
     try {
-      val jobDesc = redactedStatement.replaceAll("\\'", "\\\\'").replaceAll("\\s*", " ").trim
+      val jobDesc = redactedStatement.replaceAll("\\'", "\\\\'").replaceAll("\\s", " ").trim
       // for python, the boolean value is capitalized
       val pythonForceCancel = forceCancel.toString.capitalize
       worker.runCode("spark.sparkContext.setJobGroup" +

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
@@ -124,13 +124,6 @@ class ExecutePython(
       executePython()
     }
   }
-
-  override def setSparkLocalProperty: (String, String) => Unit =
-    (key: String, value: String) => {
-      val valueStr = if (value == null) "None" else s"'$value'"
-      worker.runCode(s"spark.sparkContext.setLocalProperty('$key', $valueStr)")
-      ()
-    }
 }
 
 case class SessionPythonWorker(

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
@@ -135,8 +135,10 @@ class ExecutePython(
 
   override protected def withLocalProperties[T](f: => T): T = {
     try {
+      // for python, the boolean value is capitalized
+      val pythonForceCancel = forceCancel.toString.capitalize
       worker.runCode("spark.sparkContext.setJobGroup" +
-        s"('$statementId', '$redactedStatement', $forceCancel)")
+        s"('$statementId', '${redactedStatement.replaceAll("\\'", "\\\\'")}', $pythonForceCancel)")
       setSparkLocalProperty(KYUUBI_SESSION_USER_KEY, session.user)
       setSparkLocalProperty(KYUUBI_STATEMENT_ID_KEY, statementId)
       schedulerPool match {

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
@@ -189,11 +189,8 @@ case class SessionPythonWorker(
     stdin.println(input)
     // scalastyle:on
     stdin.flush()
-    val output = stdout.readLine()
-    // scalastyle:off println
-    println(s"$input -> $output")
-    // scalastyle:on
-    Option(output).map(ExecutePython.fromJson[PythonResponse](_))
+    Option(stdout.readLine())
+      .map(ExecutePython.fromJson[PythonResponse](_))
   }
 
   def close(): Unit = {

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
@@ -155,7 +155,8 @@ class ExecutePython(
       setSparkLocalProperty(KYUUBI_SESSION_USER_KEY, "")
       setSparkLocalProperty(KYUUBI_STATEMENT_ID_KEY, "")
       setSparkLocalProperty(SPARK_SCHEDULER_POOL_KEY, "")
-      worker.runCode("spark.sparkContext.clearJobGroup()")
+      // using cancelJobGroup for pyspark, see details in pyspark/context.py
+      worker.runCode(s"spark.sparkContext.cancelJobGroup('$statementId')")
       if (isSessionUserSignEnabled) {
         clearSessionUserSign()
       }

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
@@ -195,7 +195,7 @@ case class SessionPythonWorker(
     Option(output).map(ExecutePython.fromJson[PythonResponse](_))
   }
 
-  def close(): Unit = withLockRequired {
+  def close(): Unit = {
     val exitCmd = ExecutePython.toJson(Map("cmd" -> "exit_worker"))
     // scalastyle:off println
     stdin.println(exitCmd)

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
@@ -136,7 +136,8 @@ class ExecutePython(
 
   override protected def withLocalProperties[T](f: => T): T = {
     try {
-      val jobDesc = redactedStatement.replaceAll("\\'", "\\\\'").replaceAll("\\s", " ").trim
+      // to prevent the transferred set job group python code broken
+      val jobDesc = s"Python statement: $statementId"
       // for python, the boolean value is capitalized
       val pythonForceCancel = forceCancel.toString.capitalize
       worker.runCode("spark.sparkContext.setJobGroup" +

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
@@ -37,7 +37,6 @@ import org.apache.spark.sql.types.StructType
 
 import org.apache.kyuubi.{KyuubiSQLException, Logging, Utils}
 import org.apache.kyuubi.config.KyuubiConf.{ENGINE_SPARK_PYTHON_ENV_ARCHIVE, ENGINE_SPARK_PYTHON_ENV_ARCHIVE_EXEC_PATH, ENGINE_SPARK_PYTHON_HOME_ARCHIVE}
-import org.apache.kyuubi.config.KyuubiReservedKeys.{KYUUBI_SESSION_USER_KEY, KYUUBI_STATEMENT_ID_KEY}
 import org.apache.kyuubi.engine.spark.KyuubiSparkUtil._
 import org.apache.kyuubi.operation.{ArrayFetchIterator, OperationState}
 import org.apache.kyuubi.operation.log.OperationLog
@@ -99,7 +98,7 @@ class ExecutePython(
     }
   }
 
-  override protected def runInternal(): Unit = withLocalProperties {
+  override protected def runInternal(): Unit = {
     addTimeoutMonitor(queryTimeout)
     if (shouldRunAsync) {
       val asyncOperation = new Runnable {
@@ -132,33 +131,6 @@ class ExecutePython(
       worker.runCode(s"spark.sparkContext.setLocalProperty('$key', $valueStr)")
       ()
     }
-
-  override protected def withLocalProperties[T](f: => T): T = {
-    try {
-      worker.runCode("spark.sparkContext.setJobGroup" +
-        s"($statementId, $redactedStatement, $forceCancel)")
-      setSparkLocalProperty(KYUUBI_SESSION_USER_KEY, session.user)
-      setSparkLocalProperty(KYUUBI_STATEMENT_ID_KEY, statementId)
-      schedulerPool match {
-        case Some(pool) =>
-          setSparkLocalProperty(SPARK_SCHEDULER_POOL_KEY, pool)
-        case None =>
-      }
-      if (isSessionUserSignEnabled) {
-        setSessionUserSign()
-      }
-
-      f
-    } finally {
-      setSparkLocalProperty(KYUUBI_SESSION_USER_KEY, "")
-      setSparkLocalProperty(KYUUBI_STATEMENT_ID_KEY, "")
-      setSparkLocalProperty(SPARK_SCHEDULER_POOL_KEY, "")
-      worker.runCode("spark.sparkContext.clearJobGroup()")
-      if (isSessionUserSignEnabled) {
-        clearSessionUserSign()
-      }
-    }
-  }
 }
 
 case class SessionPythonWorker(

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
@@ -30,7 +30,6 @@ import scala.collection.JavaConverters._
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import org.apache.commons.lang3.StringUtils
-import org.apache.commons.text.StringEscapeUtils
 import org.apache.spark.SparkFiles
 import org.apache.spark.api.python.KyuubiPythonGatewayServer
 import org.apache.spark.sql.{Row, SparkSession}
@@ -136,12 +135,11 @@ class ExecutePython(
 
   override protected def withLocalProperties[T](f: => T): T = {
     try {
-      val escapedStatement = redactedStatement.replaceAll("\\'", "\\\\'")
-        .replaceAll("\\n", "\\\\n")
+      val jobDesc = redactedStatement.replaceAll("\\'", "\\\\'").replaceAll("\\s*", " ").trim
       // for python, the boolean value is capitalized
       val pythonForceCancel = forceCancel.toString.capitalize
       worker.runCode("spark.sparkContext.setJobGroup" +
-        s"('$statementId', '$escapedStatement', $pythonForceCancel)")
+        s"('$statementId', '$jobDesc', $pythonForceCancel)")
       setSparkLocalProperty(KYUUBI_SESSION_USER_KEY, session.user)
       setSparkLocalProperty(KYUUBI_STATEMENT_ID_KEY, statementId)
       schedulerPool match {

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
@@ -140,8 +140,10 @@ class ExecutePython(
       val jobDesc = s"Python statement: $statementId"
       // for python, the boolean value is capitalized
       val pythonForceCancel = forceCancel.toString.capitalize
-      worker.runCode("spark.sparkContext.setJobGroup" +
-        s"('$statementId', '$jobDesc', $pythonForceCancel)", internal = true)
+      worker.runCode(
+        "spark.sparkContext.setJobGroup" +
+          s"('$statementId', '$jobDesc', $pythonForceCancel)",
+        internal = true)
       setSparkLocalProperty(KYUUBI_SESSION_USER_KEY, session.user)
       setSparkLocalProperty(KYUUBI_STATEMENT_ID_KEY, statementId)
       schedulerPool match {
@@ -191,7 +193,7 @@ case class SessionPythonWorker(
    * internal python code failure.
    *
    * @param code the python code
-   * @param internal whether is an internal invoke
+   * @param internal whether is internal python code
    * @return the python response
    */
   def runCode(code: String, internal: Boolean = false): Option[PythonResponse] = withLockRequired {

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
@@ -139,7 +139,7 @@ class ExecutePython(
       // to prevent the transferred set job group python code broken
       val jobDesc = s"Python statement: $statementId"
       // for python, the boolean value is capitalized
-      val pythonForceCancel = forceCancel.toString.capitalize
+      val pythonForceCancel = if (forceCancel) "True" else "False"
       worker.runCode(
         "spark.sparkContext.setJobGroup" +
           s"('$statementId', '$jobDesc', $pythonForceCancel)",
@@ -187,9 +187,9 @@ case class SessionPythonWorker(
 
   /**
    * Run the python code and return the response. This method maybe invoked internally,
-   * such as setJobGroup and cancelJobGroup, if the internal python is not formatted correct,
-   * it might impact the code correctness and even cause result out of sequence. To prevent that,
-   * please make sure the internal python code simple and set internal flay, to be aware of the
+   * such as setJobGroup and cancelJobGroup, if the internal python code is not formatted correctly,
+   * it might impact the correctness and even cause result out of sequence. To prevent that,
+   * please make sure the internal python code simple and set internal flag, to be aware of the
    * internal python code failure.
    *
    * @param code the python code

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkOperation.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkOperation.scala
@@ -62,8 +62,11 @@ abstract class SparkOperation(session: Session)
   override def cleanup(targetState: OperationState): Unit = state.synchronized {
     if (!isTerminalState(state)) {
       setState(targetState)
+      // scalastyle:off println
+      println(s"before cleaning up: " + statement)
       Option(getBackgroundHandle).foreach(_.cancel(true))
       if (!spark.sparkContext.isStopped) spark.sparkContext.cancelJobGroup(statementId)
+      println(s"after cleaning up: " + statement)
     }
   }
 

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkOperation.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkOperation.scala
@@ -62,11 +62,8 @@ abstract class SparkOperation(session: Session)
   override def cleanup(targetState: OperationState): Unit = state.synchronized {
     if (!isTerminalState(state)) {
       setState(targetState)
-      // scalastyle:off println
-      println(s"before cleaning up: " + statement)
       Option(getBackgroundHandle).foreach(_.cancel(true))
       if (!spark.sparkContext.isStopped) spark.sparkContext.cancelJobGroup(statementId)
-      println(s"after cleaning up: " + statement)
     }
   }
 

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/PySparkTests.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/PySparkTests.scala
@@ -77,6 +77,7 @@ class PySparkTests extends WithSparkSQLEngine with HiveJDBCTestHelper {
         statement.executePython(code)
       }.getMessage
       assert(e.contains("Query timed out"))
+      statement.setQueryTimeout(20)
       code = "bad_code"
       e = intercept[KyuubiSQLException](statement.executePython(code)).getMessage
       assert(e.contains("Interpret error"))

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/PySparkTests.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/PySparkTests.scala
@@ -72,11 +72,7 @@ class PySparkTests extends WithSparkSQLEngine with HiveJDBCTestHelper {
     val statement = connection.createStatement().asInstanceOf[KyuubiStatement]
     statement.setQueryTimeout(5)
     try {
-      var code =
-        """
-          |import time
-          |time.sleep(10)
-          |""".stripMargin
+      var code = "spark.sql(\"select java_method('java.lang.Thread', 'sleep', 10000L)\").show()"
       var e = intercept[SQLTimeoutException] {
         statement.executePython(code)
       }.getMessage

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/PySparkTests.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/PySparkTests.scala
@@ -77,7 +77,6 @@ class PySparkTests extends WithSparkSQLEngine with HiveJDBCTestHelper {
         statement.executePython(code)
       }.getMessage
       assert(e.contains("Query timed out"))
-      statement.setQueryTimeout(20)
       code = "bad_code"
       e = intercept[KyuubiSQLException](statement.executePython(code)).getMessage
       assert(e.contains("Interpret error"))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

1. wrap the code with correct delimiter

Before:
```
{"code":"spark.sparkContext.setJobGroup(07753dd9-804e-478f-b84f-bf0735732334, ..., true)","cmd":"run_code"}
```

After:
```
{"code":"spark.sparkContext.setJobGroup('07753dd9-804e-478f-b84f-bf0735732334', '...', True)","cmd":"run_code"}
```

2. using cancelJobGroup for pyspark

Before:
```
'SparkContext' object has no attribute 'clearJobGroup'
```
After:
Using SparkContext.cancelJobGroup

3. Simplify the internal python code and throw exception on failure
We can not trust the user code is formatted correctly and we shall ensure the internal python code is simple and correct to prevent code correctness and even cause result out of sequence.
Such as, the user code might be below(maybe user invoke executePython api)
```
spark.sql('123\'\n\b\t'
```

It is difficult to escape the user code and set the job description as the statement as.
So, in this pr, I simplify the job description, just record its statementId, user can check the original code from log or on UI I think.
### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
