### PR TITLE
[K8S][LOG]Improve print diagnostics info in kubernetes cluster deploy-mode case

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/KyuubiSparkUtil.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/KyuubiSparkUtil.scala
@@ -57,6 +57,13 @@ object KyuubiSparkUtil extends Logging {
   def engineUrl: String = globalSparkContext.getConf.getOption(
     "spark.org.apache.hadoop.yarn.server.webproxy.amfilter.AmIpFilter.param.PROXY_URI_BASES")
     .orElse(globalSparkContext.uiWebUrl).getOrElse("")
+  def deployMode(sc: SparkContext): String = {
+    if (sc.getConf.getBoolean("spark.kubernetes.submitInDriver", false)) {
+      "cluster"
+    } else {
+      sc.deployMode
+    }
+  }
 
   lazy val diagnostics: String = {
     val sc = globalSparkContext
@@ -67,7 +74,7 @@ object KyuubiSparkUtil extends Logging {
        |                 application ID: $engineId
        |                 application web UI: $engineUrl
        |                 master: ${sc.master}
-       |                 deploy mode: ${sc.deployMode}
+       |                 deploy mode: ${deployMode(sc)}
        |                 version: ${sc.version}
        |           Start time: ${LocalDateTime.ofInstant(Instant.ofEpochMilli(sc.startTime), ZoneId.systemDefault)}
        |           User: ${sc.sparkUser}""".stripMargin


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
For Spark On Kubernetes Cluster Deploy-Mode, spark will set `spark.submit.deployMode=client` and `spark.kubernetes.submitInDriver=true`.

Kyuubi print diagnostics about deploy-mode for spark sql engine should not only dependence on `spark.submit.deployMode`.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
