### PR TITLE
[K8S][HELM] Add volumes and volumeMounts support to helm chart

### DIFF
--- a/charts/kyuubi/templates/kyuubi-deployment.yaml
+++ b/charts/kyuubi/templates/kyuubi-deployment.yaml
@@ -83,10 +83,16 @@ spec:
           volumeMounts:
             - name: conf
               mountPath: {{ .Values.server.confDir }}
+            {{- with .Values.volumeMounts }}
+              {{- tpl (toYaml .) $ | nindent 12 }}
+            {{- end }}
       volumes:
         - name: conf
           configMap:
             name: {{ .Release.Name }}
+        {{- with .Values.volumes }}
+          {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/kyuubi/values.yaml
+++ b/charts/kyuubi/values.yaml
@@ -79,6 +79,11 @@ server:
 env: []
 envFrom: []
 
+# Additional volumes for Kyuubi pod (templated)
+volumes: []
+# Additional volumeMounts for Kyuubi container (templated)
+volumeMounts: []
+
 service:
   type: NodePort
   # The default port limit of kubernetes is 30000-32767


### PR DESCRIPTION
### _Why are the changes needed?_
The changes allow to add volumes to Kyuubi server pod and volumeMounts to  Kyuubi server container.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
