### PR TITLE
[KYUUBI #4035][FOLLOWUP] Add eventEnabled method for KyuubiOperation and SparkOperation

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/GetTypeInfo.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/GetTypeInfo.scala
@@ -27,6 +27,7 @@ import org.apache.kyuubi.operation.meta.ResultSetSchemaConstant._
 import org.apache.kyuubi.session.Session
 
 class GetTypeInfo(session: Session) extends SparkOperation(session) {
+  override protected def eventEnabled: Boolean = false
   override protected def resultSchema: StructType = {
     new StructType()
       .add(TYPE_NAME, "string", nullable = false, "Type name")

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkOperation.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkOperation.scala
@@ -120,11 +120,15 @@ abstract class SparkOperation(session: Session)
     s"spark.${SESSION_USER_SIGN_ENABLED.key}",
     SESSION_USER_SIGN_ENABLED.defaultVal.get)
 
-  EventBus.post(SparkOperationEvent(this))
+  protected def eventEnabled: Boolean = true
+
+  if (eventEnabled) EventBus.post(SparkOperationEvent(this))
 
   override protected def setState(newState: OperationState): Unit = {
     super.setState(newState)
-    EventBus.post(SparkOperationEvent(this, operationListener.flatMap(_.getExecutionId)))
+    if (eventEnabled) {
+      EventBus.post(SparkOperationEvent(this, operationListener.flatMap(_.getExecutionId)))
+    }
   }
 
   protected def setSparkLocalProperty: (String, String) => Unit =

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
@@ -29,7 +29,6 @@ import org.apache.kyuubi.{KyuubiException, KyuubiSQLException}
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.engine.{ApplicationInfo, ApplicationState, KillResponse, ProcBuilder}
 import org.apache.kyuubi.engine.spark.SparkBatchProcessBuilder
-import org.apache.kyuubi.events.{EventBus, KyuubiOperationEvent}
 import org.apache.kyuubi.metrics.MetricsConstants.OPERATION_OPEN
 import org.apache.kyuubi.metrics.MetricsSystem
 import org.apache.kyuubi.operation.FetchOrientation.FetchOrientation
@@ -61,7 +60,6 @@ class BatchJobSubmission(
     recoveryMetadata: Option[Metadata])
   extends KyuubiApplicationOperation(session) {
   import BatchJobSubmission._
-  EventBus.post(KyuubiOperationEvent(this))
 
   override def shouldRunAsync: Boolean = true
 
@@ -151,7 +149,6 @@ class BatchJobSubmission(
       if (newState == RUNNING) {
         session.onEngineOpened()
       }
-      EventBus.post(KyuubiOperationEvent(this))
     }
   }
 
@@ -345,6 +342,8 @@ class BatchJobSubmission(
   }
 
   override def isTimedOut: Boolean = false
+
+  override protected def eventEnabled: Boolean = true
 }
 
 object BatchJobSubmission {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/ExecuteStatement.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/ExecuteStatement.scala
@@ -24,9 +24,7 @@ import org.apache.hive.service.rpc.thrift.TOperationState._
 
 import org.apache.kyuubi.KyuubiSQLException
 import org.apache.kyuubi.config.KyuubiConf
-import org.apache.kyuubi.events.{EventBus, KyuubiOperationEvent}
 import org.apache.kyuubi.operation.FetchOrientation.FETCH_NEXT
-import org.apache.kyuubi.operation.OperationState.OperationState
 import org.apache.kyuubi.operation.log.OperationLog
 import org.apache.kyuubi.session.Session
 
@@ -37,7 +35,6 @@ class ExecuteStatement(
     override val shouldRunAsync: Boolean,
     queryTimeout: Long)
   extends KyuubiOperation(session) {
-  EventBus.post(KyuubiOperationEvent(this))
 
   final private val _operationLog: OperationLog =
     if (shouldRunAsync) {
@@ -162,8 +159,5 @@ class ExecuteStatement(
     if (!shouldRunAsync) getBackgroundHandle.get()
   }
 
-  override def setState(newState: OperationState): Unit = {
-    super.setState(newState)
-    EventBus.post(KyuubiOperationEvent(this))
-  }
+  override protected def eventEnabled: Boolean = true
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/KyuubiOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/KyuubiOperation.scala
@@ -26,6 +26,7 @@ import org.apache.thrift.TException
 import org.apache.thrift.transport.TTransportException
 
 import org.apache.kyuubi.{KyuubiSQLException, Utils}
+import org.apache.kyuubi.events.{EventBus, KyuubiOperationEvent}
 import org.apache.kyuubi.metrics.MetricsConstants.{OPERATION_FAIL, OPERATION_OPEN, OPERATION_STATE, OPERATION_TOTAL}
 import org.apache.kyuubi.metrics.MetricsSystem
 import org.apache.kyuubi.operation.FetchOrientation.FetchOrientation
@@ -169,6 +170,10 @@ abstract class KyuubiOperation(session: Session) extends AbstractOperation(sessi
 
   override def shouldRunAsync: Boolean = false
 
+  protected def eventEnabled: Boolean = false
+
+  if (eventEnabled) EventBus.post(KyuubiOperationEvent(this))
+
   override def setState(newState: OperationState): Unit = {
     MetricsSystem.tracing { ms =>
       ms.markMeter(MetricRegistry.name(OPERATION_STATE, opType, state.toString.toLowerCase), -1)
@@ -176,5 +181,6 @@ abstract class KyuubiOperation(session: Session) extends AbstractOperation(sessi
       ms.markMeter(MetricRegistry.name(OPERATION_STATE, newState.toString.toLowerCase))
     }
     super.setState(newState)
+    if (eventEnabled) EventBus.post(KyuubiOperationEvent(this))
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Followup for #4035
Add `eventEnabled` method for KyuubiOperation and SparkOperation.

For `KyuubiOperation`, enable below operations as before
- ExecuteStatement
- BatchJobSubmission

For `SparkOperation`, disable
- GetTypeInfo
   -  because it is used by `KyuubiConnection::isValid` and might be called with interval to check session alive
### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
