### PR TITLE
Register the session information of the engine in zookeeper

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/session/SparkSQLSessionManager.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/session/SparkSQLSessionManager.scala
@@ -62,7 +62,7 @@ class SparkSQLSessionManager private (name: String, spark: SparkSession)
     new java.util.HashMap[String, (Integer, java.lang.Long)]()
   private var userIsolatedSparkSessionThread: Option[ScheduledExecutorService] = None
 
-  private var discoveryClient: Option[DiscoveryClient] = _
+  private var discoveryClient: Option[DiscoveryClient] = None
   private var sessionsPath: String = _
 
   private def startUserIsolatedCacheChecker(): Unit = {

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/ExposeSparkEngineSessionsSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/ExposeSparkEngineSessionsSuite.scala
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.engine.spark
+
+import java.util.UUID
+import java.util.concurrent.Executors
+
+import org.scalatest.concurrent.PatienceConfiguration.Timeout
+import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
+
+import org.apache.kyuubi.operation.HiveJDBCTestHelper
+import org.apache.kyuubi.service.ServiceState
+
+class ExposeSparkEngineSessionsSuite
+  extends WithDiscoverySparkSQLEngine with HiveJDBCTestHelper with WithEmbeddedZookeeper {
+
+  override protected def jdbcUrl: String = getJdbcUrl
+
+  override val namespace: String = {
+    s"/kyuubi/tom/${UUID.randomUUID().toString}"
+  }
+
+  override def withKyuubiConf: Map[String, String] = {
+    super.withKyuubiConf ++ zookeeperConf
+  }
+
+  test("engine session info") {
+    withDiscoveryClient { discoveryClient =>
+      assert(engine.getServiceState == ServiceState.STARTED)
+      assert(discoveryClient.pathExists(namespace))
+
+      val sessionsPath = namespace.split("/", 3).drop(1).mkString("/", "/sessions/", "")
+      assert(discoveryClient.getChildrenCount(sessionsPath) == 0)
+
+      val threads = Executors.newFixedThreadPool(3)
+      threads.execute(() => {
+        withJdbcStatement() { statement =>
+          statement.execute("SELECT java_method('java.lang.Thread', 'sleep', 5000l)")
+        }
+      })
+      eventually(Timeout(2.seconds)) {
+        assert(discoveryClient.getChildrenCount(sessionsPath) == 1)
+      }
+
+      threads.execute(() => {
+        withJdbcStatement() { statement =>
+          statement.execute("SELECT java_method('java.lang.Thread', 'sleep', 5000l)")
+        }
+      })
+      threads.execute(() => {
+        withJdbcStatement() { statement =>
+          statement.execute("SELECT java_method('java.lang.Thread', 'sleep', 5000l)")
+        }
+      })
+
+      eventually(Timeout(2.seconds)) {
+        assert(discoveryClient.getChildrenCount(sessionsPath) == 3)
+      }
+
+      threads.shutdown()
+      eventually(Timeout(20.seconds)) {
+        assert(discoveryClient.getChildrenCount(sessionsPath) == 0)
+      }
+    }
+  }
+}

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/DiscoveryClient.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/DiscoveryClient.scala
@@ -57,6 +57,13 @@ trait DiscoveryClient extends Logging {
   def getChildren(path: String): List[String]
 
   /**
+   * Get the number of children under the given path.
+   *
+   * @return number of children
+   */
+  def getChildrenCount(path: String): Int
+
+  /**
    * Check if the path is exists.
    */
   def pathExists(path: String): Boolean

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/etcd/EtcdDiscoveryClient.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/etcd/EtcdDiscoveryClient.scala
@@ -142,6 +142,10 @@ class EtcdDiscoveryClient(conf: KyuubiConf) extends DiscoveryClient {
     }
   }
 
+  def getChildrenCount(path: String): Int = {
+    getChildren(path).size
+  }
+
   def pathExists(path: String): Boolean = {
     !pathNonExists(path)
   }

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/zookeeper/ZookeeperDiscoveryClient.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/zookeeper/ZookeeperDiscoveryClient.scala
@@ -96,6 +96,10 @@ class ZookeeperDiscoveryClient(conf: KyuubiConf) extends DiscoveryClient {
     zkClient.getChildren.forPath(path).asScala.toList
   }
 
+  def getChildrenCount(path: String): Int = {
+    zkClient.checkExists.forPath(path).getNumChildren
+  }
+
   def pathExists(path: String): Boolean = {
     zkClient.checkExists().forPath(path) != null
   }


### PR DESCRIPTION
### _Why are the changes needed?_
Egnine registers the information of the currently opened session, and the server can select the engine based on this information when selecting the engine.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
