### PR TITLE
[K8S][HELM] Add initContainers and containers support to helm chart

### DIFF
--- a/charts/kyuubi/templates/kyuubi-deployment.yaml
+++ b/charts/kyuubi/templates/kyuubi-deployment.yaml
@@ -43,6 +43,9 @@ spec:
       imagePullSecrets: {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ .Values.serviceAccount.name | default .Release.Name }}
+      {{- with .Values.initContainers }}
+      initContainers: {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
       containers:
         - name: kyuubi-server
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -86,6 +89,9 @@ spec:
             {{- with .Values.volumeMounts }}
               {{- tpl (toYaml .) $ | nindent 12 }}
             {{- end }}
+        {{- with .Values.containers }}
+          {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
       volumes:
         - name: conf
           configMap:

--- a/charts/kyuubi/values.yaml
+++ b/charts/kyuubi/values.yaml
@@ -84,6 +84,11 @@ volumes: []
 # Additional volumeMounts for Kyuubi container (templated)
 volumeMounts: []
 
+# Additional init containers for Kyuubi pod (templated)
+initContainers: []
+# Additional containers for Kyuubi pod (templated)
+containers: []
+
 service:
   type: NodePort
   # The default port limit of kubernetes is 30000-32767


### PR DESCRIPTION
### _Why are the changes needed?_
The changes allow to add initContainers and containers to Kyuubi server pod.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
