### PR TITLE
Reset the operation log before fetching new one

### DIFF
--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/log/LogBatchCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/log/LogBatchCommand.scala
@@ -48,7 +48,6 @@ class LogBatchCommand(
       var from = math.max(normalizedCliConfig.batchOpts.from, 0)
       val size = normalizedCliConfig.batchOpts.size
 
-      var log: OperationLog = null
       var done = false
       var batch = this.batch.getOrElse(batchRestApi.getBatchById(batchId))
       val kyuubiInstance = batch.getKyuubiInstance
@@ -64,7 +63,7 @@ class LogBatchCommand(
         }
 
         while (!done) {
-          log = null
+          var log: OperationLog = null
           try {
             log = retrieveOperationLog()
             val (latestBatch, shouldFinishLog) =

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/log/LogBatchCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/log/LogBatchCommand.scala
@@ -104,6 +104,7 @@ class LogBatchCommand(
               }
             } catch {
               case e: Exception => error(s"Error fetching batch logs: ${e.getMessage}")
+                hasRemainingLogs = false
             }
           }
           if (hasRemainingLogs) {

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/log/LogBatchCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/log/LogBatchCommand.scala
@@ -103,7 +103,8 @@ class LogBatchCommand(
                 hasRemainingLogs = false
               }
             } catch {
-              case e: Exception => error(s"Error fetching batch logs: ${e.getMessage}")
+              case e: Exception =>
+                error(s"Error fetching batch logs: ${e.getMessage}")
                 hasRemainingLogs = false
             }
           }

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/log/LogBatchCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/log/LogBatchCommand.scala
@@ -64,6 +64,7 @@ class LogBatchCommand(
         }
 
         while (!done) {
+          log = null
           try {
             log = retrieveOperationLog()
             val (latestBatch, shouldFinishLog) =


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
https://github.com/apache/kyuubi/blob/9342a29284234e21c73f96024a740c6e93e7cb33/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/log/LogBatchCommand.scala#L134-L141

We need to reset the operation log before fetching new operation log, otherwise, we might meet corner case.

- The last operation log is not empty
- we meet log not found exception
- we can not terminate the loop because the `shouldFinishLog` is always false

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
