### PR TITLE
[Authz] Implicitly extracting name of Extractors and OperationType in spec file generation preventing use class name String directly

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/util/AuthZUtils.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/util/AuthZUtils.scala
@@ -86,6 +86,10 @@ private[authz] object AuthZUtils {
     method.invoke(obj, values: _*)
   }
 
+  def getClassSimpleName[T]: String = {
+    classOf[T].getClass.getSimpleName
+  }
+
   /**
    * Get the active session user
    * @param spark spark context instance

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/util/AuthZUtils.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/util/AuthZUtils.scala
@@ -23,7 +23,6 @@ import java.security.interfaces.ECPublicKey
 import java.security.spec.X509EncodedKeySpec
 import java.util.Base64
 
-import scala.reflect.ClassTag
 import scala.util.{Failure, Success, Try}
 
 import org.apache.commons.lang3.StringUtils
@@ -32,7 +31,6 @@ import org.apache.spark.{SPARK_VERSION, SparkContext}
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, View}
 
 import org.apache.kyuubi.plugin.spark.authz.AccessControlException
-import org.apache.kyuubi.plugin.spark.authz.serde.Extractor
 import org.apache.kyuubi.plugin.spark.authz.util.ReservedKeys._
 
 private[authz] object AuthZUtils {
@@ -86,17 +84,6 @@ private[authz] object AuthZUtils {
     val method = obj.getMethod(methodName, types: _*)
     method.setAccessible(true)
     method.invoke(obj, values: _*)
-  }
-
-  /**
-   * return the key of [[org.apache.kyuubi.plugin.spark.authz.serde.Extractor]]
-   * extracting class simple name as in [[org.apache.kyuubi.plugin.spark.authz.serde.Extractor.key]]
-   *
-   * @tparam T class of Extractor
-   * @return key of Extractor
-   */
-  def extractorKey[T <: Extractor](implicit ct: ClassTag[T]): String = {
-    ct.runtimeClass.getSimpleName
   }
 
   /**

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/util/AuthZUtils.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/util/AuthZUtils.scala
@@ -23,6 +23,7 @@ import java.security.interfaces.ECPublicKey
 import java.security.spec.X509EncodedKeySpec
 import java.util.Base64
 
+import scala.reflect.ClassTag
 import scala.util.{Failure, Success, Try}
 
 import org.apache.commons.lang3.StringUtils
@@ -31,6 +32,7 @@ import org.apache.spark.{SPARK_VERSION, SparkContext}
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, View}
 
 import org.apache.kyuubi.plugin.spark.authz.AccessControlException
+import org.apache.kyuubi.plugin.spark.authz.serde.Extractor
 import org.apache.kyuubi.plugin.spark.authz.util.ReservedKeys._
 
 private[authz] object AuthZUtils {
@@ -86,8 +88,8 @@ private[authz] object AuthZUtils {
     method.invoke(obj, values: _*)
   }
 
-  def getClassSimpleName[T]: String = {
-    classOf[T].getClass.getSimpleName
+  def extractorName[T <: Extractor](implicit ct: ClassTag[T]): String = {
+    ct.runtimeClass.getSimpleName
   }
 
   /**

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/util/AuthZUtils.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/util/AuthZUtils.scala
@@ -88,7 +88,14 @@ private[authz] object AuthZUtils {
     method.invoke(obj, values: _*)
   }
 
-  def extractorName[T <: Extractor](implicit ct: ClassTag[T]): String = {
+  /**
+   * return the key of [[org.apache.kyuubi.plugin.spark.authz.serde.Extractor]]
+   * extracting class simple name as in [[org.apache.kyuubi.plugin.spark.authz.serde.Extractor.key]]
+   *
+   * @tparam T class of Extractor
+   * @return key of Extractor
+   */
+  def extractorKey[T <: Extractor](implicit ct: ClassTag[T]): String = {
     ct.runtimeClass.getSimpleName
   }
 

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/DatabaseCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/DatabaseCommands.scala
@@ -26,28 +26,28 @@ object DatabaseCommands {
     DatabaseCommandSpec(
       "org.apache.spark.sql.execution.command.AlterDatabasePropertiesCommand",
       Seq(DatabaseDesc("databaseName", classSimpleName[StringDatabaseExtractor])),
-      operationTypeStr(ALTERDATABASE))
+      ALTERDATABASE)
   }
 
   val CommentOnNamespace = {
     DatabaseCommandSpec(
       "org.apache.spark.sql.catalyst.plans.logical.CommentOnNamespace",
       Seq(DatabaseDesc("child", classSimpleName[ResolvedNamespaceDatabaseExtractor])),
-      operationTypeStr(ALTERDATABASE))
+      ALTERDATABASE)
   }
 
   val SetNamespaceProperties = {
     DatabaseCommandSpec(
       "org.apache.spark.sql.catalyst.plans.logical.SetNamespaceProperties",
       Seq(DatabaseDesc("namespace", classSimpleName[ResolvedNamespaceDatabaseExtractor])),
-      operationTypeStr(ALTERDATABASE))
+      ALTERDATABASE)
   }
 
   val SetNamespaceLocation = {
     DatabaseCommandSpec(
       "org.apache.spark.sql.catalyst.plans.logical.SetNamespaceLocation",
       Seq(DatabaseDesc("namespace", classSimpleName[ResolvedNamespaceDatabaseExtractor])),
-      operationTypeStr(ALTERDATABASE_LOCATION))
+      ALTERDATABASE_LOCATION)
   }
 
   val CreateNamespace = {
@@ -61,7 +61,7 @@ object DatabaseCommands {
     DatabaseCommandSpec(
       "org.apache.spark.sql.catalyst.plans.logical.CreateNamespace",
       Seq(databaseDesc1, databaseDesc2),
-      operationTypeStr(CREATEDATABASE))
+      CREATEDATABASE)
   }
 
   val DropNamespace = {

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/DatabaseCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/DatabaseCommands.scala
@@ -18,45 +18,44 @@
 package org.apache.kyuubi.plugin.spark.authz.gen
 
 import org.apache.kyuubi.plugin.spark.authz.serde._
-import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils.extractorKey
 
 object DatabaseCommands {
 
   val AlterDatabaseProperties = {
     DatabaseCommandSpec(
       "org.apache.spark.sql.execution.command.AlterDatabasePropertiesCommand",
-      Seq(DatabaseDesc("databaseName", extractorKey[StringDatabaseExtractor])),
+      Seq(DatabaseDesc("databaseName", classSimpleName[StringDatabaseExtractor])),
       "ALTERDATABASE")
   }
 
   val CommentOnNamespace = {
     DatabaseCommandSpec(
       "org.apache.spark.sql.catalyst.plans.logical.CommentOnNamespace",
-      Seq(DatabaseDesc("child", extractorKey[ResolvedNamespaceDatabaseExtractor])),
+      Seq(DatabaseDesc("child", classSimpleName[ResolvedNamespaceDatabaseExtractor])),
       "ALTERDATABASE")
   }
 
   val SetNamespaceProperties = {
     DatabaseCommandSpec(
       "org.apache.spark.sql.catalyst.plans.logical.SetNamespaceProperties",
-      Seq(DatabaseDesc("namespace", extractorKey[ResolvedNamespaceDatabaseExtractor])),
+      Seq(DatabaseDesc("namespace", classSimpleName[ResolvedNamespaceDatabaseExtractor])),
       "ALTERDATABASE")
   }
 
   val SetNamespaceLocation = {
     DatabaseCommandSpec(
       "org.apache.spark.sql.catalyst.plans.logical.SetNamespaceLocation",
-      Seq(DatabaseDesc("namespace", extractorKey[ResolvedNamespaceDatabaseExtractor])),
+      Seq(DatabaseDesc("namespace", classSimpleName[ResolvedNamespaceDatabaseExtractor])),
       "ALTERDATABASE_LOCATION")
   }
 
   val CreateNamespace = {
     val databaseDesc1 =
-      DatabaseDesc("name", extractorKey[ResolvedDBObjectNameDatabaseExtractor])
+      DatabaseDesc("name", classSimpleName[ResolvedDBObjectNameDatabaseExtractor])
     val databaseDesc2 =
       DatabaseDesc(
         "namespace",
-        extractorKey[StringSeqDatabaseExtractor],
+        classSimpleName[StringSeqDatabaseExtractor],
         catalogDesc = Some(CatalogDesc()))
     DatabaseCommandSpec(
       "org.apache.spark.sql.catalyst.plans.logical.CreateNamespace",
@@ -67,7 +66,7 @@ object DatabaseCommands {
   val DropNamespace = {
     DatabaseCommandSpec(
       "org.apache.spark.sql.catalyst.plans.logical.DropNamespace",
-      Seq(DatabaseDesc("namespace", extractorKey[ResolvedNamespaceDatabaseExtractor])),
+      Seq(DatabaseDesc("namespace", classSimpleName[ResolvedNamespaceDatabaseExtractor])),
       "DROPDATABASE")
   }
 
@@ -76,7 +75,7 @@ object DatabaseCommands {
       "org.apache.spark.sql.execution.command.AnalyzeTablesCommand",
       Seq(DatabaseDesc(
         "databaseName",
-        extractorKey[StringOptionDatabaseExtractor],
+        classSimpleName[StringOptionDatabaseExtractor],
         isInput = true)),
       "ANALYZE_TABLE")
   }
@@ -84,14 +83,14 @@ object DatabaseCommands {
   val SetDatabase = {
     val cmd = "org.apache.spark.sql.execution.command.SetDatabaseCommand"
     val databaseDesc =
-      DatabaseDesc("databaseName", extractorKey[StringDatabaseExtractor], isInput = true)
+      DatabaseDesc("databaseName", classSimpleName[StringDatabaseExtractor], isInput = true)
     DatabaseCommandSpec(cmd, Seq(databaseDesc), "SWITCHDATABASE")
   }
 
   val DescribeDatabase = {
     val cmd = "org.apache.spark.sql.execution.command.DescribeDatabaseCommand"
     val databaseDesc =
-      DatabaseDesc("databaseName", extractorKey[StringDatabaseExtractor], isInput = true)
+      DatabaseDesc("databaseName", classSimpleName[StringDatabaseExtractor], isInput = true)
     DatabaseCommandSpec(cmd, Seq(databaseDesc), "DESCDATABASE")
   }
 
@@ -100,15 +99,15 @@ object DatabaseCommands {
     val databaseDesc1 =
       DatabaseDesc(
         "child",
-        extractorKey[ResolvedDBObjectNameDatabaseExtractor],
+        classSimpleName[ResolvedDBObjectNameDatabaseExtractor],
         isInput = true)
     val databaseDesc2 =
       DatabaseDesc(
         "namespace",
-        extractorKey[StringSeqOptionDatabaseExtractor],
+        classSimpleName[StringSeqOptionDatabaseExtractor],
         catalogDesc = Some(CatalogDesc(
           fieldName = "catalogName",
-          fieldExtractor = extractorKey[StringOptionCatalogExtractor])),
+          fieldExtractor = classSimpleName[StringOptionCatalogExtractor])),
         isInput = true)
     DatabaseCommandSpec(cmd, Seq(databaseDesc1, databaseDesc2), "SWITCHDATABASE")
   }
@@ -117,7 +116,7 @@ object DatabaseCommands {
     val cmd = "org.apache.spark.sql.execution.command.SetNamespaceCommand"
     val databaseDesc = DatabaseDesc(
       "namespace",
-      extractorKey[StringSeqDatabaseExtractor],
+      classSimpleName[StringSeqDatabaseExtractor],
       isInput = true)
     DatabaseCommandSpec(cmd, Seq(databaseDesc), "SWITCHDATABASE")
   }
@@ -127,7 +126,7 @@ object DatabaseCommands {
     val databaseDesc =
       DatabaseDesc(
         "namespace",
-        extractorKey[ResolvedNamespaceDatabaseExtractor],
+        classSimpleName[ResolvedNamespaceDatabaseExtractor],
         isInput = true)
     DatabaseCommandSpec(cmd, Seq(databaseDesc), "DESCDATABASE")
   }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/DatabaseCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/DatabaseCommands.scala
@@ -17,42 +17,47 @@
 
 package org.apache.kyuubi.plugin.spark.authz.gen
 
-import org.apache.kyuubi.plugin.spark.authz.serde.{CatalogDesc, DatabaseCommandSpec, DatabaseDesc}
+import org.apache.kyuubi.plugin.spark.authz.serde._
+import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils.getClassSimpleName
 
 object DatabaseCommands {
 
   val AlterDatabaseProperties = {
     DatabaseCommandSpec(
       "org.apache.spark.sql.execution.command.AlterDatabasePropertiesCommand",
-      Seq(DatabaseDesc("databaseName", "StringDatabaseExtractor")),
+      Seq(DatabaseDesc("databaseName", getClassSimpleName[StringDatabaseExtractor])),
       "ALTERDATABASE")
   }
 
   val CommentOnNamespace = {
     DatabaseCommandSpec(
       "org.apache.spark.sql.catalyst.plans.logical.CommentOnNamespace",
-      Seq(DatabaseDesc("child", "ResolvedNamespaceDatabaseExtractor")),
+      Seq(DatabaseDesc("child", getClassSimpleName[ResolvedNamespaceDatabaseExtractor])),
       "ALTERDATABASE")
   }
 
   val SetNamespaceProperties = {
     DatabaseCommandSpec(
       "org.apache.spark.sql.catalyst.plans.logical.SetNamespaceProperties",
-      Seq(DatabaseDesc("namespace", "ResolvedNamespaceDatabaseExtractor")),
+      Seq(DatabaseDesc("namespace", getClassSimpleName[ResolvedNamespaceDatabaseExtractor])),
       "ALTERDATABASE")
   }
 
   val SetNamespaceLocation = {
     DatabaseCommandSpec(
       "org.apache.spark.sql.catalyst.plans.logical.SetNamespaceLocation",
-      Seq(DatabaseDesc("namespace", "ResolvedNamespaceDatabaseExtractor")),
+      Seq(DatabaseDesc("namespace", getClassSimpleName[ResolvedNamespaceDatabaseExtractor])),
       "ALTERDATABASE_LOCATION")
   }
 
   val CreateNamespace = {
-    val databaseDesc1 = DatabaseDesc("name", "ResolvedDBObjectNameDatabaseExtractor")
+    val databaseDesc1 =
+      DatabaseDesc("name", getClassSimpleName[ResolvedDBObjectNameDatabaseExtractor])
     val databaseDesc2 =
-      DatabaseDesc("namespace", "StringSeqDatabaseExtractor", catalogDesc = Some(CatalogDesc()))
+      DatabaseDesc(
+        "namespace",
+        getClassSimpleName[StringSeqDatabaseExtractor],
+        catalogDesc = Some(CatalogDesc()))
     DatabaseCommandSpec(
       "org.apache.spark.sql.catalyst.plans.logical.CreateNamespace",
       Seq(databaseDesc1, databaseDesc2),
@@ -62,40 +67,48 @@ object DatabaseCommands {
   val DropNamespace = {
     DatabaseCommandSpec(
       "org.apache.spark.sql.catalyst.plans.logical.DropNamespace",
-      Seq(DatabaseDesc("namespace", "ResolvedNamespaceDatabaseExtractor")),
+      Seq(DatabaseDesc("namespace", getClassSimpleName[ResolvedNamespaceDatabaseExtractor])),
       "DROPDATABASE")
   }
 
   val AnalyzeTables = {
     DatabaseCommandSpec(
       "org.apache.spark.sql.execution.command.AnalyzeTablesCommand",
-      Seq(DatabaseDesc("databaseName", "StringOptionDatabaseExtractor", isInput = true)),
+      Seq(DatabaseDesc(
+        "databaseName",
+        getClassSimpleName[StringOptionDatabaseExtractor],
+        isInput = true)),
       "ANALYZE_TABLE")
   }
 
   val SetDatabase = {
     val cmd = "org.apache.spark.sql.execution.command.SetDatabaseCommand"
-    val databaseDesc = DatabaseDesc("databaseName", "StringDatabaseExtractor", isInput = true)
+    val databaseDesc =
+      DatabaseDesc("databaseName", getClassSimpleName[StringDatabaseExtractor], isInput = true)
     DatabaseCommandSpec(cmd, Seq(databaseDesc), "SWITCHDATABASE")
   }
 
   val DescribeDatabase = {
     val cmd = "org.apache.spark.sql.execution.command.DescribeDatabaseCommand"
-    val databaseDesc = DatabaseDesc("databaseName", "StringDatabaseExtractor", isInput = true)
+    val databaseDesc =
+      DatabaseDesc("databaseName", getClassSimpleName[StringDatabaseExtractor], isInput = true)
     DatabaseCommandSpec(cmd, Seq(databaseDesc), "DESCDATABASE")
   }
 
   val SetCatalogAndNamespace = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.SetCatalogAndNamespace"
     val databaseDesc1 =
-      DatabaseDesc("child", "ResolvedDBObjectNameDatabaseExtractor", isInput = true)
+      DatabaseDesc(
+        "child",
+        getClassSimpleName[ResolvedDBObjectNameDatabaseExtractor],
+        isInput = true)
     val databaseDesc2 =
       DatabaseDesc(
         "namespace",
-        "StringSeqOptionDatabaseExtractor",
+        getClassSimpleName[StringSeqOptionDatabaseExtractor],
         catalogDesc = Some(CatalogDesc(
           fieldName = "catalogName",
-          fieldExtractor = "StringOptionCatalogExtractor")),
+          fieldExtractor = getClassSimpleName[StringOptionCatalogExtractor])),
         isInput = true)
     DatabaseCommandSpec(cmd, Seq(databaseDesc1, databaseDesc2), "SWITCHDATABASE")
   }
@@ -104,7 +117,7 @@ object DatabaseCommands {
     val cmd = "org.apache.spark.sql.execution.command.SetNamespaceCommand"
     val databaseDesc = DatabaseDesc(
       "namespace",
-      "StringSeqDatabaseExtractor",
+      getClassSimpleName[StringSeqDatabaseExtractor],
       isInput = true)
     DatabaseCommandSpec(cmd, Seq(databaseDesc), "SWITCHDATABASE")
   }
@@ -112,7 +125,10 @@ object DatabaseCommands {
   val DescribeNamespace = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.DescribeNamespace"
     val databaseDesc =
-      DatabaseDesc("namespace", "ResolvedNamespaceDatabaseExtractor", isInput = true)
+      DatabaseDesc(
+        "namespace",
+        getClassSimpleName[ResolvedNamespaceDatabaseExtractor],
+        isInput = true)
     DatabaseCommandSpec(cmd, Seq(databaseDesc), "DESCDATABASE")
   }
 

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/DatabaseCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/DatabaseCommands.scala
@@ -18,45 +18,45 @@
 package org.apache.kyuubi.plugin.spark.authz.gen
 
 import org.apache.kyuubi.plugin.spark.authz.serde._
-import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils.extractorName
+import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils.extractorKey
 
 object DatabaseCommands {
 
   val AlterDatabaseProperties = {
     DatabaseCommandSpec(
       "org.apache.spark.sql.execution.command.AlterDatabasePropertiesCommand",
-      Seq(DatabaseDesc("databaseName", extractorName[StringDatabaseExtractor])),
+      Seq(DatabaseDesc("databaseName", extractorKey[StringDatabaseExtractor])),
       "ALTERDATABASE")
   }
 
   val CommentOnNamespace = {
     DatabaseCommandSpec(
       "org.apache.spark.sql.catalyst.plans.logical.CommentOnNamespace",
-      Seq(DatabaseDesc("child", extractorName[ResolvedNamespaceDatabaseExtractor])),
+      Seq(DatabaseDesc("child", extractorKey[ResolvedNamespaceDatabaseExtractor])),
       "ALTERDATABASE")
   }
 
   val SetNamespaceProperties = {
     DatabaseCommandSpec(
       "org.apache.spark.sql.catalyst.plans.logical.SetNamespaceProperties",
-      Seq(DatabaseDesc("namespace", extractorName[ResolvedNamespaceDatabaseExtractor])),
+      Seq(DatabaseDesc("namespace", extractorKey[ResolvedNamespaceDatabaseExtractor])),
       "ALTERDATABASE")
   }
 
   val SetNamespaceLocation = {
     DatabaseCommandSpec(
       "org.apache.spark.sql.catalyst.plans.logical.SetNamespaceLocation",
-      Seq(DatabaseDesc("namespace", extractorName[ResolvedNamespaceDatabaseExtractor])),
+      Seq(DatabaseDesc("namespace", extractorKey[ResolvedNamespaceDatabaseExtractor])),
       "ALTERDATABASE_LOCATION")
   }
 
   val CreateNamespace = {
     val databaseDesc1 =
-      DatabaseDesc("name", extractorName[ResolvedDBObjectNameDatabaseExtractor])
+      DatabaseDesc("name", extractorKey[ResolvedDBObjectNameDatabaseExtractor])
     val databaseDesc2 =
       DatabaseDesc(
         "namespace",
-        extractorName[StringSeqDatabaseExtractor],
+        extractorKey[StringSeqDatabaseExtractor],
         catalogDesc = Some(CatalogDesc()))
     DatabaseCommandSpec(
       "org.apache.spark.sql.catalyst.plans.logical.CreateNamespace",
@@ -67,7 +67,7 @@ object DatabaseCommands {
   val DropNamespace = {
     DatabaseCommandSpec(
       "org.apache.spark.sql.catalyst.plans.logical.DropNamespace",
-      Seq(DatabaseDesc("namespace", extractorName[ResolvedNamespaceDatabaseExtractor])),
+      Seq(DatabaseDesc("namespace", extractorKey[ResolvedNamespaceDatabaseExtractor])),
       "DROPDATABASE")
   }
 
@@ -76,7 +76,7 @@ object DatabaseCommands {
       "org.apache.spark.sql.execution.command.AnalyzeTablesCommand",
       Seq(DatabaseDesc(
         "databaseName",
-        extractorName[StringOptionDatabaseExtractor],
+        extractorKey[StringOptionDatabaseExtractor],
         isInput = true)),
       "ANALYZE_TABLE")
   }
@@ -84,14 +84,14 @@ object DatabaseCommands {
   val SetDatabase = {
     val cmd = "org.apache.spark.sql.execution.command.SetDatabaseCommand"
     val databaseDesc =
-      DatabaseDesc("databaseName", extractorName[StringDatabaseExtractor], isInput = true)
+      DatabaseDesc("databaseName", extractorKey[StringDatabaseExtractor], isInput = true)
     DatabaseCommandSpec(cmd, Seq(databaseDesc), "SWITCHDATABASE")
   }
 
   val DescribeDatabase = {
     val cmd = "org.apache.spark.sql.execution.command.DescribeDatabaseCommand"
     val databaseDesc =
-      DatabaseDesc("databaseName", extractorName[StringDatabaseExtractor], isInput = true)
+      DatabaseDesc("databaseName", extractorKey[StringDatabaseExtractor], isInput = true)
     DatabaseCommandSpec(cmd, Seq(databaseDesc), "DESCDATABASE")
   }
 
@@ -100,15 +100,15 @@ object DatabaseCommands {
     val databaseDesc1 =
       DatabaseDesc(
         "child",
-        extractorName[ResolvedDBObjectNameDatabaseExtractor],
+        extractorKey[ResolvedDBObjectNameDatabaseExtractor],
         isInput = true)
     val databaseDesc2 =
       DatabaseDesc(
         "namespace",
-        extractorName[StringSeqOptionDatabaseExtractor],
+        extractorKey[StringSeqOptionDatabaseExtractor],
         catalogDesc = Some(CatalogDesc(
           fieldName = "catalogName",
-          fieldExtractor = extractorName[StringOptionCatalogExtractor])),
+          fieldExtractor = extractorKey[StringOptionCatalogExtractor])),
         isInput = true)
     DatabaseCommandSpec(cmd, Seq(databaseDesc1, databaseDesc2), "SWITCHDATABASE")
   }
@@ -117,7 +117,7 @@ object DatabaseCommands {
     val cmd = "org.apache.spark.sql.execution.command.SetNamespaceCommand"
     val databaseDesc = DatabaseDesc(
       "namespace",
-      extractorName[StringSeqDatabaseExtractor],
+      extractorKey[StringSeqDatabaseExtractor],
       isInput = true)
     DatabaseCommandSpec(cmd, Seq(databaseDesc), "SWITCHDATABASE")
   }
@@ -127,7 +127,7 @@ object DatabaseCommands {
     val databaseDesc =
       DatabaseDesc(
         "namespace",
-        extractorName[ResolvedNamespaceDatabaseExtractor],
+        extractorKey[ResolvedNamespaceDatabaseExtractor],
         isInput = true)
     DatabaseCommandSpec(cmd, Seq(databaseDesc), "DESCDATABASE")
   }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/DatabaseCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/DatabaseCommands.scala
@@ -18,45 +18,45 @@
 package org.apache.kyuubi.plugin.spark.authz.gen
 
 import org.apache.kyuubi.plugin.spark.authz.serde._
-import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils.getClassSimpleName
+import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils.extractorName
 
 object DatabaseCommands {
 
   val AlterDatabaseProperties = {
     DatabaseCommandSpec(
       "org.apache.spark.sql.execution.command.AlterDatabasePropertiesCommand",
-      Seq(DatabaseDesc("databaseName", getClassSimpleName[StringDatabaseExtractor])),
+      Seq(DatabaseDesc("databaseName", extractorName[StringDatabaseExtractor])),
       "ALTERDATABASE")
   }
 
   val CommentOnNamespace = {
     DatabaseCommandSpec(
       "org.apache.spark.sql.catalyst.plans.logical.CommentOnNamespace",
-      Seq(DatabaseDesc("child", getClassSimpleName[ResolvedNamespaceDatabaseExtractor])),
+      Seq(DatabaseDesc("child", extractorName[ResolvedNamespaceDatabaseExtractor])),
       "ALTERDATABASE")
   }
 
   val SetNamespaceProperties = {
     DatabaseCommandSpec(
       "org.apache.spark.sql.catalyst.plans.logical.SetNamespaceProperties",
-      Seq(DatabaseDesc("namespace", getClassSimpleName[ResolvedNamespaceDatabaseExtractor])),
+      Seq(DatabaseDesc("namespace", extractorName[ResolvedNamespaceDatabaseExtractor])),
       "ALTERDATABASE")
   }
 
   val SetNamespaceLocation = {
     DatabaseCommandSpec(
       "org.apache.spark.sql.catalyst.plans.logical.SetNamespaceLocation",
-      Seq(DatabaseDesc("namespace", getClassSimpleName[ResolvedNamespaceDatabaseExtractor])),
+      Seq(DatabaseDesc("namespace", extractorName[ResolvedNamespaceDatabaseExtractor])),
       "ALTERDATABASE_LOCATION")
   }
 
   val CreateNamespace = {
     val databaseDesc1 =
-      DatabaseDesc("name", getClassSimpleName[ResolvedDBObjectNameDatabaseExtractor])
+      DatabaseDesc("name", extractorName[ResolvedDBObjectNameDatabaseExtractor])
     val databaseDesc2 =
       DatabaseDesc(
         "namespace",
-        getClassSimpleName[StringSeqDatabaseExtractor],
+        extractorName[StringSeqDatabaseExtractor],
         catalogDesc = Some(CatalogDesc()))
     DatabaseCommandSpec(
       "org.apache.spark.sql.catalyst.plans.logical.CreateNamespace",
@@ -67,7 +67,7 @@ object DatabaseCommands {
   val DropNamespace = {
     DatabaseCommandSpec(
       "org.apache.spark.sql.catalyst.plans.logical.DropNamespace",
-      Seq(DatabaseDesc("namespace", getClassSimpleName[ResolvedNamespaceDatabaseExtractor])),
+      Seq(DatabaseDesc("namespace", extractorName[ResolvedNamespaceDatabaseExtractor])),
       "DROPDATABASE")
   }
 
@@ -76,7 +76,7 @@ object DatabaseCommands {
       "org.apache.spark.sql.execution.command.AnalyzeTablesCommand",
       Seq(DatabaseDesc(
         "databaseName",
-        getClassSimpleName[StringOptionDatabaseExtractor],
+        extractorName[StringOptionDatabaseExtractor],
         isInput = true)),
       "ANALYZE_TABLE")
   }
@@ -84,14 +84,14 @@ object DatabaseCommands {
   val SetDatabase = {
     val cmd = "org.apache.spark.sql.execution.command.SetDatabaseCommand"
     val databaseDesc =
-      DatabaseDesc("databaseName", getClassSimpleName[StringDatabaseExtractor], isInput = true)
+      DatabaseDesc("databaseName", extractorName[StringDatabaseExtractor], isInput = true)
     DatabaseCommandSpec(cmd, Seq(databaseDesc), "SWITCHDATABASE")
   }
 
   val DescribeDatabase = {
     val cmd = "org.apache.spark.sql.execution.command.DescribeDatabaseCommand"
     val databaseDesc =
-      DatabaseDesc("databaseName", getClassSimpleName[StringDatabaseExtractor], isInput = true)
+      DatabaseDesc("databaseName", extractorName[StringDatabaseExtractor], isInput = true)
     DatabaseCommandSpec(cmd, Seq(databaseDesc), "DESCDATABASE")
   }
 
@@ -100,15 +100,15 @@ object DatabaseCommands {
     val databaseDesc1 =
       DatabaseDesc(
         "child",
-        getClassSimpleName[ResolvedDBObjectNameDatabaseExtractor],
+        extractorName[ResolvedDBObjectNameDatabaseExtractor],
         isInput = true)
     val databaseDesc2 =
       DatabaseDesc(
         "namespace",
-        getClassSimpleName[StringSeqOptionDatabaseExtractor],
+        extractorName[StringSeqOptionDatabaseExtractor],
         catalogDesc = Some(CatalogDesc(
           fieldName = "catalogName",
-          fieldExtractor = getClassSimpleName[StringOptionCatalogExtractor])),
+          fieldExtractor = extractorName[StringOptionCatalogExtractor])),
         isInput = true)
     DatabaseCommandSpec(cmd, Seq(databaseDesc1, databaseDesc2), "SWITCHDATABASE")
   }
@@ -117,7 +117,7 @@ object DatabaseCommands {
     val cmd = "org.apache.spark.sql.execution.command.SetNamespaceCommand"
     val databaseDesc = DatabaseDesc(
       "namespace",
-      getClassSimpleName[StringSeqDatabaseExtractor],
+      extractorName[StringSeqDatabaseExtractor],
       isInput = true)
     DatabaseCommandSpec(cmd, Seq(databaseDesc), "SWITCHDATABASE")
   }
@@ -127,7 +127,7 @@ object DatabaseCommands {
     val databaseDesc =
       DatabaseDesc(
         "namespace",
-        getClassSimpleName[ResolvedNamespaceDatabaseExtractor],
+        extractorName[ResolvedNamespaceDatabaseExtractor],
         isInput = true)
     DatabaseCommandSpec(cmd, Seq(databaseDesc), "DESCDATABASE")
   }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/DatabaseCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/DatabaseCommands.scala
@@ -17,6 +17,7 @@
 
 package org.apache.kyuubi.plugin.spark.authz.gen
 
+import org.apache.kyuubi.plugin.spark.authz.OperationType._
 import org.apache.kyuubi.plugin.spark.authz.serde._
 
 object DatabaseCommands {
@@ -25,28 +26,28 @@ object DatabaseCommands {
     DatabaseCommandSpec(
       "org.apache.spark.sql.execution.command.AlterDatabasePropertiesCommand",
       Seq(DatabaseDesc("databaseName", classSimpleName[StringDatabaseExtractor])),
-      "ALTERDATABASE")
+      operationTypeStr(ALTERDATABASE))
   }
 
   val CommentOnNamespace = {
     DatabaseCommandSpec(
       "org.apache.spark.sql.catalyst.plans.logical.CommentOnNamespace",
       Seq(DatabaseDesc("child", classSimpleName[ResolvedNamespaceDatabaseExtractor])),
-      "ALTERDATABASE")
+      operationTypeStr(ALTERDATABASE))
   }
 
   val SetNamespaceProperties = {
     DatabaseCommandSpec(
       "org.apache.spark.sql.catalyst.plans.logical.SetNamespaceProperties",
       Seq(DatabaseDesc("namespace", classSimpleName[ResolvedNamespaceDatabaseExtractor])),
-      "ALTERDATABASE")
+      operationTypeStr(ALTERDATABASE))
   }
 
   val SetNamespaceLocation = {
     DatabaseCommandSpec(
       "org.apache.spark.sql.catalyst.plans.logical.SetNamespaceLocation",
       Seq(DatabaseDesc("namespace", classSimpleName[ResolvedNamespaceDatabaseExtractor])),
-      "ALTERDATABASE_LOCATION")
+      operationTypeStr(ALTERDATABASE_LOCATION))
   }
 
   val CreateNamespace = {
@@ -60,7 +61,7 @@ object DatabaseCommands {
     DatabaseCommandSpec(
       "org.apache.spark.sql.catalyst.plans.logical.CreateNamespace",
       Seq(databaseDesc1, databaseDesc2),
-      "CREATEDATABASE")
+      operationTypeStr(CREATEDATABASE))
   }
 
   val DropNamespace = {

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/DatabaseCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/DatabaseCommands.scala
@@ -68,7 +68,7 @@ object DatabaseCommands {
     DatabaseCommandSpec(
       "org.apache.spark.sql.catalyst.plans.logical.DropNamespace",
       Seq(DatabaseDesc("namespace", classOf[ResolvedNamespaceDatabaseExtractor])),
-      "DROPDATABASE")
+      DROPDATABASE)
   }
 
   val AnalyzeTables = {
@@ -78,21 +78,21 @@ object DatabaseCommands {
         "databaseName",
         classOf[StringOptionDatabaseExtractor],
         isInput = true)),
-      "ANALYZE_TABLE")
+      ANALYZE_TABLE)
   }
 
   val SetDatabase = {
     val cmd = "org.apache.spark.sql.execution.command.SetDatabaseCommand"
     val databaseDesc =
       DatabaseDesc("databaseName", classOf[StringDatabaseExtractor], isInput = true)
-    DatabaseCommandSpec(cmd, Seq(databaseDesc), "SWITCHDATABASE")
+    DatabaseCommandSpec(cmd, Seq(databaseDesc), SWITCHDATABASE)
   }
 
   val DescribeDatabase = {
     val cmd = "org.apache.spark.sql.execution.command.DescribeDatabaseCommand"
     val databaseDesc =
       DatabaseDesc("databaseName", classOf[StringDatabaseExtractor], isInput = true)
-    DatabaseCommandSpec(cmd, Seq(databaseDesc), "DESCDATABASE")
+    DatabaseCommandSpec(cmd, Seq(databaseDesc), DESCDATABASE)
   }
 
   val SetCatalogAndNamespace = {
@@ -110,7 +110,7 @@ object DatabaseCommands {
           fieldName = "catalogName",
           fieldExtractor = classOf[StringOptionCatalogExtractor])),
         isInput = true)
-    DatabaseCommandSpec(cmd, Seq(databaseDesc1, databaseDesc2), "SWITCHDATABASE")
+    DatabaseCommandSpec(cmd, Seq(databaseDesc1, databaseDesc2), SWITCHDATABASE)
   }
 
   val SetNamespace = {
@@ -119,7 +119,7 @@ object DatabaseCommands {
       "namespace",
       classOf[StringSeqDatabaseExtractor],
       isInput = true)
-    DatabaseCommandSpec(cmd, Seq(databaseDesc), "SWITCHDATABASE")
+    DatabaseCommandSpec(cmd, Seq(databaseDesc), SWITCHDATABASE)
   }
 
   val DescribeNamespace = {
@@ -129,20 +129,20 @@ object DatabaseCommands {
         "namespace",
         classOf[ResolvedNamespaceDatabaseExtractor],
         isInput = true)
-    DatabaseCommandSpec(cmd, Seq(databaseDesc), "DESCDATABASE")
+    DatabaseCommandSpec(cmd, Seq(databaseDesc), DESCDATABASE)
   }
 
   val data = Array(
     AlterDatabaseProperties,
     AlterDatabaseProperties.copy(
       classname = "org.apache.spark.sql.execution.command.AlterDatabaseSetLocationCommand",
-      opType = "ALTERDATABASE_LOCATION"),
+      opType = ALTERDATABASE_LOCATION),
     AlterDatabaseProperties.copy(
       classname = "org.apache.spark.sql.execution.command.CreateDatabaseCommand",
-      opType = "CREATEDATABASE"),
+      opType = CREATEDATABASE),
     AlterDatabaseProperties.copy(
       classname = "org.apache.spark.sql.execution.command.DropDatabaseCommand",
-      opType = "DROPDATABASE"),
+      opType = DROPDATABASE),
     AnalyzeTables,
     CreateNamespace,
     CommentOnNamespace,

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/DatabaseCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/DatabaseCommands.scala
@@ -25,38 +25,38 @@ object DatabaseCommands {
   val AlterDatabaseProperties = {
     DatabaseCommandSpec(
       "org.apache.spark.sql.execution.command.AlterDatabasePropertiesCommand",
-      Seq(DatabaseDesc("databaseName", classSimpleName[StringDatabaseExtractor])),
+      Seq(DatabaseDesc("databaseName", classOf[StringDatabaseExtractor])),
       ALTERDATABASE)
   }
 
   val CommentOnNamespace = {
     DatabaseCommandSpec(
       "org.apache.spark.sql.catalyst.plans.logical.CommentOnNamespace",
-      Seq(DatabaseDesc("child", classSimpleName[ResolvedNamespaceDatabaseExtractor])),
+      Seq(DatabaseDesc("child", classOf[ResolvedNamespaceDatabaseExtractor])),
       ALTERDATABASE)
   }
 
   val SetNamespaceProperties = {
     DatabaseCommandSpec(
       "org.apache.spark.sql.catalyst.plans.logical.SetNamespaceProperties",
-      Seq(DatabaseDesc("namespace", classSimpleName[ResolvedNamespaceDatabaseExtractor])),
+      Seq(DatabaseDesc("namespace", classOf[ResolvedNamespaceDatabaseExtractor])),
       ALTERDATABASE)
   }
 
   val SetNamespaceLocation = {
     DatabaseCommandSpec(
       "org.apache.spark.sql.catalyst.plans.logical.SetNamespaceLocation",
-      Seq(DatabaseDesc("namespace", classSimpleName[ResolvedNamespaceDatabaseExtractor])),
+      Seq(DatabaseDesc("namespace", classOf[ResolvedNamespaceDatabaseExtractor])),
       ALTERDATABASE_LOCATION)
   }
 
   val CreateNamespace = {
     val databaseDesc1 =
-      DatabaseDesc("name", classSimpleName[ResolvedDBObjectNameDatabaseExtractor])
+      DatabaseDesc("name", classOf[ResolvedDBObjectNameDatabaseExtractor])
     val databaseDesc2 =
       DatabaseDesc(
         "namespace",
-        classSimpleName[StringSeqDatabaseExtractor],
+        classOf[StringSeqDatabaseExtractor],
         catalogDesc = Some(CatalogDesc()))
     DatabaseCommandSpec(
       "org.apache.spark.sql.catalyst.plans.logical.CreateNamespace",
@@ -67,7 +67,7 @@ object DatabaseCommands {
   val DropNamespace = {
     DatabaseCommandSpec(
       "org.apache.spark.sql.catalyst.plans.logical.DropNamespace",
-      Seq(DatabaseDesc("namespace", classSimpleName[ResolvedNamespaceDatabaseExtractor])),
+      Seq(DatabaseDesc("namespace", classOf[ResolvedNamespaceDatabaseExtractor])),
       "DROPDATABASE")
   }
 
@@ -76,7 +76,7 @@ object DatabaseCommands {
       "org.apache.spark.sql.execution.command.AnalyzeTablesCommand",
       Seq(DatabaseDesc(
         "databaseName",
-        classSimpleName[StringOptionDatabaseExtractor],
+        classOf[StringOptionDatabaseExtractor],
         isInput = true)),
       "ANALYZE_TABLE")
   }
@@ -84,14 +84,14 @@ object DatabaseCommands {
   val SetDatabase = {
     val cmd = "org.apache.spark.sql.execution.command.SetDatabaseCommand"
     val databaseDesc =
-      DatabaseDesc("databaseName", classSimpleName[StringDatabaseExtractor], isInput = true)
+      DatabaseDesc("databaseName", classOf[StringDatabaseExtractor], isInput = true)
     DatabaseCommandSpec(cmd, Seq(databaseDesc), "SWITCHDATABASE")
   }
 
   val DescribeDatabase = {
     val cmd = "org.apache.spark.sql.execution.command.DescribeDatabaseCommand"
     val databaseDesc =
-      DatabaseDesc("databaseName", classSimpleName[StringDatabaseExtractor], isInput = true)
+      DatabaseDesc("databaseName", classOf[StringDatabaseExtractor], isInput = true)
     DatabaseCommandSpec(cmd, Seq(databaseDesc), "DESCDATABASE")
   }
 
@@ -100,15 +100,15 @@ object DatabaseCommands {
     val databaseDesc1 =
       DatabaseDesc(
         "child",
-        classSimpleName[ResolvedDBObjectNameDatabaseExtractor],
+        classOf[ResolvedDBObjectNameDatabaseExtractor],
         isInput = true)
     val databaseDesc2 =
       DatabaseDesc(
         "namespace",
-        classSimpleName[StringSeqOptionDatabaseExtractor],
+        classOf[StringSeqOptionDatabaseExtractor],
         catalogDesc = Some(CatalogDesc(
           fieldName = "catalogName",
-          fieldExtractor = classSimpleName[StringOptionCatalogExtractor])),
+          fieldExtractor = classOf[StringOptionCatalogExtractor])),
         isInput = true)
     DatabaseCommandSpec(cmd, Seq(databaseDesc1, databaseDesc2), "SWITCHDATABASE")
   }
@@ -117,7 +117,7 @@ object DatabaseCommands {
     val cmd = "org.apache.spark.sql.execution.command.SetNamespaceCommand"
     val databaseDesc = DatabaseDesc(
       "namespace",
-      classSimpleName[StringSeqDatabaseExtractor],
+      classOf[StringSeqDatabaseExtractor],
       isInput = true)
     DatabaseCommandSpec(cmd, Seq(databaseDesc), "SWITCHDATABASE")
   }
@@ -127,7 +127,7 @@ object DatabaseCommands {
     val databaseDesc =
       DatabaseDesc(
         "namespace",
-        classSimpleName[ResolvedNamespaceDatabaseExtractor],
+        classOf[ResolvedNamespaceDatabaseExtractor],
         isInput = true)
     DatabaseCommandSpec(cmd, Seq(databaseDesc), "DESCDATABASE")
   }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/FunctionCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/FunctionCommands.scala
@@ -26,13 +26,13 @@ object FunctionCommands {
     val cmd = "org.apache.spark.sql.execution.command.CreateFunctionCommand"
     val functionTypeDesc = FunctionTypeDesc(
       "isTemp",
-      classSimpleName[TempMarkerFunctionTypeExtractor],
+      classOf[TempMarkerFunctionTypeExtractor],
       Seq("TEMP"))
     val databaseDesc =
-      DatabaseDesc("databaseName", classSimpleName[StringOptionDatabaseExtractor])
+      DatabaseDesc("databaseName", classOf[StringOptionDatabaseExtractor])
     val functionDesc = FunctionDesc(
       "functionName",
-      classSimpleName[StringFunctionExtractor],
+      classOf[StringFunctionExtractor],
       Some(databaseDesc),
       Some(functionTypeDesc))
     FunctionCommandSpec(cmd, Seq(functionDesc), CREATEFUNCTION)
@@ -42,21 +42,21 @@ object FunctionCommands {
     val cmd = "org.apache.spark.sql.execution.command.DescribeFunctionCommand"
     val skips = Seq("TEMP", "SYSTEM")
     val functionTypeDesc1 =
-      FunctionTypeDesc("info", classSimpleName[ExpressionInfoFunctionTypeExtractor], skips)
+      FunctionTypeDesc("info", classOf[ExpressionInfoFunctionTypeExtractor], skips)
     val functionDesc1 = FunctionDesc(
       "info",
-      classSimpleName[ExpressionInfoFunctionExtractor],
+      classOf[ExpressionInfoFunctionExtractor],
       functionTypeDesc = Some(functionTypeDesc1),
       isInput = true)
 
     val functionTypeDesc2 =
       FunctionTypeDesc(
         "functionName",
-        classSimpleName[FunctionIdentifierFunctionTypeExtractor],
+        classOf[FunctionIdentifierFunctionTypeExtractor],
         skips)
     val functionDesc2 = FunctionDesc(
       "functionName",
-      classSimpleName[FunctionIdentifierFunctionExtractor],
+      classOf[FunctionIdentifierFunctionExtractor],
       functionTypeDesc = Some(functionTypeDesc2),
       isInput = true)
     FunctionCommandSpec(cmd, Seq(functionDesc1, functionDesc2), DESCFUNCTION)
@@ -70,10 +70,10 @@ object FunctionCommands {
   val RefreshFunction = {
     val cmd = "org.apache.spark.sql.execution.command.RefreshFunctionCommand"
     val databaseDesc =
-      DatabaseDesc("databaseName", classSimpleName[StringOptionDatabaseExtractor])
+      DatabaseDesc("databaseName", classOf[StringOptionDatabaseExtractor])
     val functionDesc = FunctionDesc(
       "functionName",
-      classSimpleName[StringFunctionExtractor],
+      classOf[StringFunctionExtractor],
       Some(databaseDesc))
     FunctionCommandSpec(cmd, Seq(functionDesc), RELOADFUNCTION)
   }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/FunctionCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/FunctionCommands.scala
@@ -17,6 +17,7 @@
 
 package org.apache.kyuubi.plugin.spark.authz.gen
 
+import org.apache.kyuubi.plugin.spark.authz.OperationType._
 import org.apache.kyuubi.plugin.spark.authz.serde._
 
 object FunctionCommands {
@@ -34,7 +35,7 @@ object FunctionCommands {
       classSimpleName[StringFunctionExtractor],
       Some(databaseDesc),
       Some(functionTypeDesc))
-    FunctionCommandSpec(cmd, Seq(functionDesc), "CREATEFUNCTION")
+    FunctionCommandSpec(cmd, Seq(functionDesc), operationTypeStr(CREATEFUNCTION))
   }
 
   val DescribeFunction = {
@@ -58,12 +59,12 @@ object FunctionCommands {
       classSimpleName[FunctionIdentifierFunctionExtractor],
       functionTypeDesc = Some(functionTypeDesc2),
       isInput = true)
-    FunctionCommandSpec(cmd, Seq(functionDesc1, functionDesc2), "DESCFUNCTION")
+    FunctionCommandSpec(cmd, Seq(functionDesc1, functionDesc2), operationTypeStr(DESCFUNCTION))
   }
 
   val DropFunction = {
     val cmd = "org.apache.spark.sql.execution.command.DropFunctionCommand"
-    CreateFunction.copy(cmd, opType = "DROPFUNCTION")
+    CreateFunction.copy(cmd, opType = operationTypeStr(DROPFUNCTION))
   }
 
   val RefreshFunction = {
@@ -74,7 +75,7 @@ object FunctionCommands {
       "functionName",
       classSimpleName[StringFunctionExtractor],
       Some(databaseDesc))
-    FunctionCommandSpec(cmd, Seq(functionDesc), "RELOADFUNCTION")
+    FunctionCommandSpec(cmd, Seq(functionDesc), operationTypeStr(RELOADFUNCTION))
   }
 
   val data = Array(

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/FunctionCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/FunctionCommands.scala
@@ -35,7 +35,7 @@ object FunctionCommands {
       classSimpleName[StringFunctionExtractor],
       Some(databaseDesc),
       Some(functionTypeDesc))
-    FunctionCommandSpec(cmd, Seq(functionDesc), operationTypeStr(CREATEFUNCTION))
+    FunctionCommandSpec(cmd, Seq(functionDesc), CREATEFUNCTION)
   }
 
   val DescribeFunction = {
@@ -59,12 +59,12 @@ object FunctionCommands {
       classSimpleName[FunctionIdentifierFunctionExtractor],
       functionTypeDesc = Some(functionTypeDesc2),
       isInput = true)
-    FunctionCommandSpec(cmd, Seq(functionDesc1, functionDesc2), operationTypeStr(DESCFUNCTION))
+    FunctionCommandSpec(cmd, Seq(functionDesc1, functionDesc2), DESCFUNCTION)
   }
 
   val DropFunction = {
     val cmd = "org.apache.spark.sql.execution.command.DropFunctionCommand"
-    CreateFunction.copy(cmd, opType = operationTypeStr(DROPFUNCTION))
+    CreateFunction.copy(cmd, opType = DROPFUNCTION)
   }
 
   val RefreshFunction = {
@@ -75,7 +75,7 @@ object FunctionCommands {
       "functionName",
       classSimpleName[StringFunctionExtractor],
       Some(databaseDesc))
-    FunctionCommandSpec(cmd, Seq(functionDesc), operationTypeStr(RELOADFUNCTION))
+    FunctionCommandSpec(cmd, Seq(functionDesc), RELOADFUNCTION)
   }
 
   val data = Array(

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/FunctionCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/FunctionCommands.scala
@@ -18,7 +18,6 @@
 package org.apache.kyuubi.plugin.spark.authz.gen
 
 import org.apache.kyuubi.plugin.spark.authz.serde._
-import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils.extractorKey
 
 object FunctionCommands {
 
@@ -26,13 +25,13 @@ object FunctionCommands {
     val cmd = "org.apache.spark.sql.execution.command.CreateFunctionCommand"
     val functionTypeDesc = FunctionTypeDesc(
       "isTemp",
-      extractorKey[TempMarkerFunctionTypeExtractor],
+      classSimpleName[TempMarkerFunctionTypeExtractor],
       Seq("TEMP"))
     val databaseDesc =
-      DatabaseDesc("databaseName", extractorKey[StringOptionDatabaseExtractor])
+      DatabaseDesc("databaseName", classSimpleName[StringOptionDatabaseExtractor])
     val functionDesc = FunctionDesc(
       "functionName",
-      extractorKey[StringFunctionExtractor],
+      classSimpleName[StringFunctionExtractor],
       Some(databaseDesc),
       Some(functionTypeDesc))
     FunctionCommandSpec(cmd, Seq(functionDesc), "CREATEFUNCTION")
@@ -42,21 +41,21 @@ object FunctionCommands {
     val cmd = "org.apache.spark.sql.execution.command.DescribeFunctionCommand"
     val skips = Seq("TEMP", "SYSTEM")
     val functionTypeDesc1 =
-      FunctionTypeDesc("info", extractorKey[ExpressionInfoFunctionTypeExtractor], skips)
+      FunctionTypeDesc("info", classSimpleName[ExpressionInfoFunctionTypeExtractor], skips)
     val functionDesc1 = FunctionDesc(
       "info",
-      extractorKey[ExpressionInfoFunctionExtractor],
+      classSimpleName[ExpressionInfoFunctionExtractor],
       functionTypeDesc = Some(functionTypeDesc1),
       isInput = true)
 
     val functionTypeDesc2 =
       FunctionTypeDesc(
         "functionName",
-        extractorKey[FunctionIdentifierFunctionTypeExtractor],
+        classSimpleName[FunctionIdentifierFunctionTypeExtractor],
         skips)
     val functionDesc2 = FunctionDesc(
       "functionName",
-      extractorKey[FunctionIdentifierFunctionExtractor],
+      classSimpleName[FunctionIdentifierFunctionExtractor],
       functionTypeDesc = Some(functionTypeDesc2),
       isInput = true)
     FunctionCommandSpec(cmd, Seq(functionDesc1, functionDesc2), "DESCFUNCTION")
@@ -70,10 +69,10 @@ object FunctionCommands {
   val RefreshFunction = {
     val cmd = "org.apache.spark.sql.execution.command.RefreshFunctionCommand"
     val databaseDesc =
-      DatabaseDesc("databaseName", extractorKey[StringOptionDatabaseExtractor])
+      DatabaseDesc("databaseName", classSimpleName[StringOptionDatabaseExtractor])
     val functionDesc = FunctionDesc(
       "functionName",
-      extractorKey[StringFunctionExtractor],
+      classSimpleName[StringFunctionExtractor],
       Some(databaseDesc))
     FunctionCommandSpec(cmd, Seq(functionDesc), "RELOADFUNCTION")
   }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/FunctionCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/FunctionCommands.scala
@@ -17,7 +17,8 @@
 
 package org.apache.kyuubi.plugin.spark.authz.gen
 
-import org.apache.kyuubi.plugin.spark.authz.serde.{DatabaseDesc, FunctionCommandSpec, FunctionDesc, FunctionTypeDesc, StringOptionDatabaseExtractor, TempMarkerFunctionTypeExtractor}
+import org.apache.kyuubi.plugin.spark.authz.serde._
+import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils.getClassSimpleName
 
 object FunctionCommands {
 
@@ -25,13 +26,13 @@ object FunctionCommands {
     val cmd = "org.apache.spark.sql.execution.command.CreateFunctionCommand"
     val functionTypeDesc = FunctionTypeDesc(
       "isTemp",
-      classOf[TempMarkerFunctionTypeExtractor].getSimpleName,
+      getClassSimpleName[TempMarkerFunctionTypeExtractor],
       Seq("TEMP"))
     val databaseDesc =
-      DatabaseDesc("databaseName", classOf[StringOptionDatabaseExtractor].getSimpleName)
+      DatabaseDesc("databaseName", getClassSimpleName[StringOptionDatabaseExtractor])
     val functionDesc = FunctionDesc(
       "functionName",
-      "StringFunctionExtractor",
+      getClassSimpleName[StringFunctionExtractor],
       Some(databaseDesc),
       Some(functionTypeDesc))
     FunctionCommandSpec(cmd, Seq(functionDesc), "CREATEFUNCTION")
@@ -40,18 +41,22 @@ object FunctionCommands {
   val DescribeFunction = {
     val cmd = "org.apache.spark.sql.execution.command.DescribeFunctionCommand"
     val skips = Seq("TEMP", "SYSTEM")
-    val functionTypeDesc1 = FunctionTypeDesc("info", "ExpressionInfoFunctionTypeExtractor", skips)
+    val functionTypeDesc1 =
+      FunctionTypeDesc("info", getClassSimpleName[ExpressionInfoFunctionTypeExtractor], skips)
     val functionDesc1 = FunctionDesc(
       "info",
-      "ExpressionInfoFunctionExtractor",
+      getClassSimpleName[ExpressionInfoFunctionExtractor],
       functionTypeDesc = Some(functionTypeDesc1),
       isInput = true)
 
     val functionTypeDesc2 =
-      FunctionTypeDesc("functionName", "FunctionIdentifierFunctionTypeExtractor", skips)
+      FunctionTypeDesc(
+        "functionName",
+        getClassSimpleName[FunctionIdentifierFunctionTypeExtractor],
+        skips)
     val functionDesc2 = FunctionDesc(
       "functionName",
-      "FunctionIdentifierFunctionExtractor",
+      getClassSimpleName[FunctionIdentifierFunctionExtractor],
       functionTypeDesc = Some(functionTypeDesc2),
       isInput = true)
     FunctionCommandSpec(cmd, Seq(functionDesc1, functionDesc2), "DESCFUNCTION")
@@ -64,10 +69,11 @@ object FunctionCommands {
 
   val RefreshFunction = {
     val cmd = "org.apache.spark.sql.execution.command.RefreshFunctionCommand"
-    val databaseDesc = DatabaseDesc("databaseName", "StringOptionDatabaseExtractor")
+    val databaseDesc =
+      DatabaseDesc("databaseName", getClassSimpleName[StringOptionDatabaseExtractor])
     val functionDesc = FunctionDesc(
       "functionName",
-      "StringFunctionExtractor",
+      getClassSimpleName[StringFunctionExtractor],
       Some(databaseDesc))
     FunctionCommandSpec(cmd, Seq(functionDesc), "RELOADFUNCTION")
   }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/FunctionCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/FunctionCommands.scala
@@ -18,7 +18,7 @@
 package org.apache.kyuubi.plugin.spark.authz.gen
 
 import org.apache.kyuubi.plugin.spark.authz.serde._
-import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils.extractorName
+import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils.extractorKey
 
 object FunctionCommands {
 
@@ -26,13 +26,13 @@ object FunctionCommands {
     val cmd = "org.apache.spark.sql.execution.command.CreateFunctionCommand"
     val functionTypeDesc = FunctionTypeDesc(
       "isTemp",
-      extractorName[TempMarkerFunctionTypeExtractor],
+      extractorKey[TempMarkerFunctionTypeExtractor],
       Seq("TEMP"))
     val databaseDesc =
-      DatabaseDesc("databaseName", extractorName[StringOptionDatabaseExtractor])
+      DatabaseDesc("databaseName", extractorKey[StringOptionDatabaseExtractor])
     val functionDesc = FunctionDesc(
       "functionName",
-      extractorName[StringFunctionExtractor],
+      extractorKey[StringFunctionExtractor],
       Some(databaseDesc),
       Some(functionTypeDesc))
     FunctionCommandSpec(cmd, Seq(functionDesc), "CREATEFUNCTION")
@@ -42,21 +42,21 @@ object FunctionCommands {
     val cmd = "org.apache.spark.sql.execution.command.DescribeFunctionCommand"
     val skips = Seq("TEMP", "SYSTEM")
     val functionTypeDesc1 =
-      FunctionTypeDesc("info", extractorName[ExpressionInfoFunctionTypeExtractor], skips)
+      FunctionTypeDesc("info", extractorKey[ExpressionInfoFunctionTypeExtractor], skips)
     val functionDesc1 = FunctionDesc(
       "info",
-      extractorName[ExpressionInfoFunctionExtractor],
+      extractorKey[ExpressionInfoFunctionExtractor],
       functionTypeDesc = Some(functionTypeDesc1),
       isInput = true)
 
     val functionTypeDesc2 =
       FunctionTypeDesc(
         "functionName",
-        extractorName[FunctionIdentifierFunctionTypeExtractor],
+        extractorKey[FunctionIdentifierFunctionTypeExtractor],
         skips)
     val functionDesc2 = FunctionDesc(
       "functionName",
-      extractorName[FunctionIdentifierFunctionExtractor],
+      extractorKey[FunctionIdentifierFunctionExtractor],
       functionTypeDesc = Some(functionTypeDesc2),
       isInput = true)
     FunctionCommandSpec(cmd, Seq(functionDesc1, functionDesc2), "DESCFUNCTION")
@@ -70,10 +70,10 @@ object FunctionCommands {
   val RefreshFunction = {
     val cmd = "org.apache.spark.sql.execution.command.RefreshFunctionCommand"
     val databaseDesc =
-      DatabaseDesc("databaseName", extractorName[StringOptionDatabaseExtractor])
+      DatabaseDesc("databaseName", extractorKey[StringOptionDatabaseExtractor])
     val functionDesc = FunctionDesc(
       "functionName",
-      extractorName[StringFunctionExtractor],
+      extractorKey[StringFunctionExtractor],
       Some(databaseDesc))
     FunctionCommandSpec(cmd, Seq(functionDesc), "RELOADFUNCTION")
   }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/FunctionCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/FunctionCommands.scala
@@ -18,7 +18,7 @@
 package org.apache.kyuubi.plugin.spark.authz.gen
 
 import org.apache.kyuubi.plugin.spark.authz.serde._
-import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils.getClassSimpleName
+import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils.extractorName
 
 object FunctionCommands {
 
@@ -26,13 +26,13 @@ object FunctionCommands {
     val cmd = "org.apache.spark.sql.execution.command.CreateFunctionCommand"
     val functionTypeDesc = FunctionTypeDesc(
       "isTemp",
-      getClassSimpleName[TempMarkerFunctionTypeExtractor],
+      extractorName[TempMarkerFunctionTypeExtractor],
       Seq("TEMP"))
     val databaseDesc =
-      DatabaseDesc("databaseName", getClassSimpleName[StringOptionDatabaseExtractor])
+      DatabaseDesc("databaseName", extractorName[StringOptionDatabaseExtractor])
     val functionDesc = FunctionDesc(
       "functionName",
-      getClassSimpleName[StringFunctionExtractor],
+      extractorName[StringFunctionExtractor],
       Some(databaseDesc),
       Some(functionTypeDesc))
     FunctionCommandSpec(cmd, Seq(functionDesc), "CREATEFUNCTION")
@@ -42,21 +42,21 @@ object FunctionCommands {
     val cmd = "org.apache.spark.sql.execution.command.DescribeFunctionCommand"
     val skips = Seq("TEMP", "SYSTEM")
     val functionTypeDesc1 =
-      FunctionTypeDesc("info", getClassSimpleName[ExpressionInfoFunctionTypeExtractor], skips)
+      FunctionTypeDesc("info", extractorName[ExpressionInfoFunctionTypeExtractor], skips)
     val functionDesc1 = FunctionDesc(
       "info",
-      getClassSimpleName[ExpressionInfoFunctionExtractor],
+      extractorName[ExpressionInfoFunctionExtractor],
       functionTypeDesc = Some(functionTypeDesc1),
       isInput = true)
 
     val functionTypeDesc2 =
       FunctionTypeDesc(
         "functionName",
-        getClassSimpleName[FunctionIdentifierFunctionTypeExtractor],
+        extractorName[FunctionIdentifierFunctionTypeExtractor],
         skips)
     val functionDesc2 = FunctionDesc(
       "functionName",
-      getClassSimpleName[FunctionIdentifierFunctionExtractor],
+      extractorName[FunctionIdentifierFunctionExtractor],
       functionTypeDesc = Some(functionTypeDesc2),
       isInput = true)
     FunctionCommandSpec(cmd, Seq(functionDesc1, functionDesc2), "DESCFUNCTION")
@@ -70,10 +70,10 @@ object FunctionCommands {
   val RefreshFunction = {
     val cmd = "org.apache.spark.sql.execution.command.RefreshFunctionCommand"
     val databaseDesc =
-      DatabaseDesc("databaseName", getClassSimpleName[StringOptionDatabaseExtractor])
+      DatabaseDesc("databaseName", extractorName[StringOptionDatabaseExtractor])
     val functionDesc = FunctionDesc(
       "functionName",
-      getClassSimpleName[StringFunctionExtractor],
+      extractorName[StringFunctionExtractor],
       Some(databaseDesc))
     FunctionCommandSpec(cmd, Seq(functionDesc), "RELOADFUNCTION")
   }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/IcebergCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/IcebergCommands.scala
@@ -18,7 +18,7 @@
 package org.apache.kyuubi.plugin.spark.authz.gen
 
 import org.apache.kyuubi.plugin.spark.authz.serde._
-import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils.extractorName
+import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils.extractorKey
 
 object IcebergCommands {
 
@@ -28,7 +28,7 @@ object IcebergCommands {
     val tableDesc =
       TableDesc(
         "table",
-        extractorName[DataSourceV2RelationTableExtractor],
+        extractorKey[DataSourceV2RelationTableExtractor],
         actionTypeDesc = Some(actionTypeDesc))
     TableCommandSpec(cmd, Seq(tableDesc), queryDescs = Seq(QueryDesc("query")))
   }
@@ -43,7 +43,7 @@ object IcebergCommands {
     val actionTypeDesc = ActionTypeDesc(null, null, Some("UPDATE"))
     val tableDesc = TableDesc(
       "targetTable",
-      extractorName[DataSourceV2RelationTableExtractor],
+      extractorKey[DataSourceV2RelationTableExtractor],
       actionTypeDesc = Some(actionTypeDesc))
     val queryDesc = QueryDesc("sourceTable")
     TableCommandSpec(cmd, Seq(tableDesc), queryDescs = Seq(queryDesc))

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/IcebergCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/IcebergCommands.scala
@@ -27,7 +27,7 @@ object IcebergCommands {
     val tableDesc =
       TableDesc(
         "table",
-        classSimpleName[DataSourceV2RelationTableExtractor],
+        classOf[DataSourceV2RelationTableExtractor],
         actionTypeDesc = Some(actionTypeDesc))
     TableCommandSpec(cmd, Seq(tableDesc), queryDescs = Seq(QueryDesc("query")))
   }
@@ -42,7 +42,7 @@ object IcebergCommands {
     val actionTypeDesc = ActionTypeDesc(null, null, Some("UPDATE"))
     val tableDesc = TableDesc(
       "targetTable",
-      classSimpleName[DataSourceV2RelationTableExtractor],
+      classOf[DataSourceV2RelationTableExtractor],
       actionTypeDesc = Some(actionTypeDesc))
     val queryDesc = QueryDesc("sourceTable")
     TableCommandSpec(cmd, Seq(tableDesc), queryDescs = Seq(queryDesc))

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/IcebergCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/IcebergCommands.scala
@@ -18,6 +18,7 @@
 package org.apache.kyuubi.plugin.spark.authz.gen
 
 import org.apache.kyuubi.plugin.spark.authz.serde._
+import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils.getClassSimpleName
 
 object IcebergCommands {
 
@@ -27,7 +28,7 @@ object IcebergCommands {
     val tableDesc =
       TableDesc(
         "table",
-        "DataSourceV2RelationTableExtractor",
+        getClassSimpleName[DataSourceV2RelationTableExtractor],
         actionTypeDesc = Some(actionTypeDesc))
     TableCommandSpec(cmd, Seq(tableDesc), queryDescs = Seq(QueryDesc("query")))
   }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/IcebergCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/IcebergCommands.scala
@@ -43,7 +43,7 @@ object IcebergCommands {
     val actionTypeDesc = ActionTypeDesc(null, null, Some("UPDATE"))
     val tableDesc = TableDesc(
       "targetTable",
-      "DataSourceV2RelationTableExtractor",
+      getClassSimpleName[DataSourceV2RelationTableExtractor],
       actionTypeDesc = Some(actionTypeDesc))
     val queryDesc = QueryDesc("sourceTable")
     TableCommandSpec(cmd, Seq(tableDesc), queryDescs = Seq(queryDesc))

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/IcebergCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/IcebergCommands.scala
@@ -18,7 +18,7 @@
 package org.apache.kyuubi.plugin.spark.authz.gen
 
 import org.apache.kyuubi.plugin.spark.authz.serde._
-import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils.getClassSimpleName
+import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils.extractorName
 
 object IcebergCommands {
 
@@ -28,7 +28,7 @@ object IcebergCommands {
     val tableDesc =
       TableDesc(
         "table",
-        getClassSimpleName[DataSourceV2RelationTableExtractor],
+        extractorName[DataSourceV2RelationTableExtractor],
         actionTypeDesc = Some(actionTypeDesc))
     TableCommandSpec(cmd, Seq(tableDesc), queryDescs = Seq(QueryDesc("query")))
   }
@@ -43,7 +43,7 @@ object IcebergCommands {
     val actionTypeDesc = ActionTypeDesc(null, null, Some("UPDATE"))
     val tableDesc = TableDesc(
       "targetTable",
-      getClassSimpleName[DataSourceV2RelationTableExtractor],
+      extractorName[DataSourceV2RelationTableExtractor],
       actionTypeDesc = Some(actionTypeDesc))
     val queryDesc = QueryDesc("sourceTable")
     TableCommandSpec(cmd, Seq(tableDesc), queryDescs = Seq(queryDesc))

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/IcebergCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/IcebergCommands.scala
@@ -18,7 +18,6 @@
 package org.apache.kyuubi.plugin.spark.authz.gen
 
 import org.apache.kyuubi.plugin.spark.authz.serde._
-import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils.extractorKey
 
 object IcebergCommands {
 
@@ -28,7 +27,7 @@ object IcebergCommands {
     val tableDesc =
       TableDesc(
         "table",
-        extractorKey[DataSourceV2RelationTableExtractor],
+        classSimpleName[DataSourceV2RelationTableExtractor],
         actionTypeDesc = Some(actionTypeDesc))
     TableCommandSpec(cmd, Seq(tableDesc), queryDescs = Seq(QueryDesc("query")))
   }
@@ -43,7 +42,7 @@ object IcebergCommands {
     val actionTypeDesc = ActionTypeDesc(null, null, Some("UPDATE"))
     val tableDesc = TableDesc(
       "targetTable",
-      extractorKey[DataSourceV2RelationTableExtractor],
+      classSimpleName[DataSourceV2RelationTableExtractor],
       actionTypeDesc = Some(actionTypeDesc))
     val queryDesc = QueryDesc("sourceTable")
     TableCommandSpec(cmd, Seq(tableDesc), queryDescs = Seq(queryDesc))

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/Scans.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/Scans.scala
@@ -18,7 +18,7 @@
 package org.apache.kyuubi.plugin.spark.authz.gen
 
 import org.apache.kyuubi.plugin.spark.authz.serde.{CatalogTableOptionTableExtractor, CatalogTableTableExtractor, DataSourceV2RelationTableExtractor, ScanDesc, ScanSpec}
-import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils.getClassSimpleName
+import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils.extractorName
 
 object Scans {
 
@@ -27,7 +27,7 @@ object Scans {
     val tableDesc =
       ScanDesc(
         "tableMeta",
-        getClassSimpleName[CatalogTableTableExtractor])
+        extractorName[CatalogTableTableExtractor])
     ScanSpec(r, Seq(tableDesc))
   }
 
@@ -36,7 +36,7 @@ object Scans {
     val tableDesc =
       ScanDesc(
         "catalogTable",
-        getClassSimpleName[CatalogTableOptionTableExtractor])
+        extractorName[CatalogTableOptionTableExtractor])
     ScanSpec(r, Seq(tableDesc))
   }
 
@@ -45,7 +45,7 @@ object Scans {
     val tableDesc =
       ScanDesc(
         null,
-        getClassSimpleName[DataSourceV2RelationTableExtractor])
+        extractorName[DataSourceV2RelationTableExtractor])
     ScanSpec(r, Seq(tableDesc))
   }
 
@@ -54,7 +54,7 @@ object Scans {
     val tableDesc =
       ScanDesc(
         "catalogTable",
-        getClassSimpleName[CatalogTableTableExtractor])
+        extractorName[CatalogTableTableExtractor])
     ScanSpec(r, Seq(tableDesc))
   }
 

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/Scans.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/Scans.scala
@@ -26,7 +26,7 @@ object Scans {
     val tableDesc =
       ScanDesc(
         "tableMeta",
-        classSimpleName[CatalogTableTableExtractor])
+        classOf[CatalogTableTableExtractor])
     ScanSpec(r, Seq(tableDesc))
   }
 
@@ -35,7 +35,7 @@ object Scans {
     val tableDesc =
       ScanDesc(
         "catalogTable",
-        classSimpleName[CatalogTableOptionTableExtractor])
+        classOf[CatalogTableOptionTableExtractor])
     ScanSpec(r, Seq(tableDesc))
   }
 
@@ -44,7 +44,7 @@ object Scans {
     val tableDesc =
       ScanDesc(
         null,
-        classSimpleName[DataSourceV2RelationTableExtractor])
+        classOf[DataSourceV2RelationTableExtractor])
     ScanSpec(r, Seq(tableDesc))
   }
 
@@ -53,7 +53,7 @@ object Scans {
     val tableDesc =
       ScanDesc(
         "catalogTable",
-        classSimpleName[CatalogTableTableExtractor])
+        classOf[CatalogTableTableExtractor])
     ScanSpec(r, Seq(tableDesc))
   }
 

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/Scans.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/Scans.scala
@@ -18,7 +18,7 @@
 package org.apache.kyuubi.plugin.spark.authz.gen
 
 import org.apache.kyuubi.plugin.spark.authz.serde.{CatalogTableOptionTableExtractor, CatalogTableTableExtractor, DataSourceV2RelationTableExtractor, ScanDesc, ScanSpec}
-import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils.extractorName
+import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils.extractorKey
 
 object Scans {
 
@@ -27,7 +27,7 @@ object Scans {
     val tableDesc =
       ScanDesc(
         "tableMeta",
-        extractorName[CatalogTableTableExtractor])
+        extractorKey[CatalogTableTableExtractor])
     ScanSpec(r, Seq(tableDesc))
   }
 
@@ -36,7 +36,7 @@ object Scans {
     val tableDesc =
       ScanDesc(
         "catalogTable",
-        extractorName[CatalogTableOptionTableExtractor])
+        extractorKey[CatalogTableOptionTableExtractor])
     ScanSpec(r, Seq(tableDesc))
   }
 
@@ -45,7 +45,7 @@ object Scans {
     val tableDesc =
       ScanDesc(
         null,
-        extractorName[DataSourceV2RelationTableExtractor])
+        extractorKey[DataSourceV2RelationTableExtractor])
     ScanSpec(r, Seq(tableDesc))
   }
 
@@ -54,7 +54,7 @@ object Scans {
     val tableDesc =
       ScanDesc(
         "catalogTable",
-        extractorName[CatalogTableTableExtractor])
+        extractorKey[CatalogTableTableExtractor])
     ScanSpec(r, Seq(tableDesc))
   }
 

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/Scans.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/Scans.scala
@@ -18,6 +18,7 @@
 package org.apache.kyuubi.plugin.spark.authz.gen
 
 import org.apache.kyuubi.plugin.spark.authz.serde.{CatalogTableOptionTableExtractor, CatalogTableTableExtractor, DataSourceV2RelationTableExtractor, ScanDesc, ScanSpec}
+import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils.getClassSimpleName
 
 object Scans {
 
@@ -26,7 +27,7 @@ object Scans {
     val tableDesc =
       ScanDesc(
         "tableMeta",
-        classOf[CatalogTableTableExtractor].getSimpleName)
+        getClassSimpleName[CatalogTableTableExtractor])
     ScanSpec(r, Seq(tableDesc))
   }
 
@@ -35,7 +36,7 @@ object Scans {
     val tableDesc =
       ScanDesc(
         "catalogTable",
-        classOf[CatalogTableOptionTableExtractor].getSimpleName)
+        getClassSimpleName[CatalogTableOptionTableExtractor])
     ScanSpec(r, Seq(tableDesc))
   }
 
@@ -44,7 +45,7 @@ object Scans {
     val tableDesc =
       ScanDesc(
         null,
-        classOf[DataSourceV2RelationTableExtractor].getSimpleName)
+        getClassSimpleName[DataSourceV2RelationTableExtractor])
     ScanSpec(r, Seq(tableDesc))
   }
 
@@ -53,7 +54,7 @@ object Scans {
     val tableDesc =
       ScanDesc(
         "catalogTable",
-        classOf[CatalogTableTableExtractor].getSimpleName)
+        getClassSimpleName[CatalogTableTableExtractor])
     ScanSpec(r, Seq(tableDesc))
   }
 

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/Scans.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/Scans.scala
@@ -17,8 +17,7 @@
 
 package org.apache.kyuubi.plugin.spark.authz.gen
 
-import org.apache.kyuubi.plugin.spark.authz.serde.{CatalogTableOptionTableExtractor, CatalogTableTableExtractor, DataSourceV2RelationTableExtractor, ScanDesc, ScanSpec}
-import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils.extractorKey
+import org.apache.kyuubi.plugin.spark.authz.serde._
 
 object Scans {
 
@@ -27,7 +26,7 @@ object Scans {
     val tableDesc =
       ScanDesc(
         "tableMeta",
-        extractorKey[CatalogTableTableExtractor])
+        classSimpleName[CatalogTableTableExtractor])
     ScanSpec(r, Seq(tableDesc))
   }
 
@@ -36,7 +35,7 @@ object Scans {
     val tableDesc =
       ScanDesc(
         "catalogTable",
-        extractorKey[CatalogTableOptionTableExtractor])
+        classSimpleName[CatalogTableOptionTableExtractor])
     ScanSpec(r, Seq(tableDesc))
   }
 
@@ -45,7 +44,7 @@ object Scans {
     val tableDesc =
       ScanDesc(
         null,
-        extractorKey[DataSourceV2RelationTableExtractor])
+        classSimpleName[DataSourceV2RelationTableExtractor])
     ScanSpec(r, Seq(tableDesc))
   }
 
@@ -54,7 +53,7 @@ object Scans {
     val tableDesc =
       ScanDesc(
         "catalogTable",
-        extractorKey[CatalogTableTableExtractor])
+        classSimpleName[CatalogTableTableExtractor])
     ScanSpec(r, Seq(tableDesc))
   }
 

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/TableCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/TableCommands.scala
@@ -18,29 +18,29 @@
 package org.apache.kyuubi.plugin.spark.authz.gen
 
 import org.apache.kyuubi.plugin.spark.authz.serde._
-import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils.extractorName
+import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils.extractorKey
 
 object TableCommands {
   // table extractors
-  val tite = extractorName[TableIdentifierTableExtractor]
+  val tite = extractorKey[TableIdentifierTableExtractor]
   val tableNameDesc = TableDesc("tableName", tite)
   val tableIdentDesc = TableDesc("tableIdent", tite)
-  val resolvedTableDesc = TableDesc("child", extractorName[ResolvedTableTableExtractor])
+  val resolvedTableDesc = TableDesc("child", extractorKey[ResolvedTableTableExtractor])
   val resolvedDbObjectNameDesc =
-    TableDesc("child", extractorName[ResolvedDbObjectNameTableExtractor])
+    TableDesc("child", extractorKey[ResolvedDbObjectNameTableExtractor])
 
   val overwriteActionTypeDesc =
-    ActionTypeDesc("overwrite", extractorName[OverwriteOrInsertActionTypeExtractor])
+    ActionTypeDesc("overwrite", extractorKey[OverwriteOrInsertActionTypeExtractor])
 
   val AlterTable = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.AlterTable"
-    val tableDesc = TableDesc("ident", extractorName[IdentifierTableExtractor])
+    val tableDesc = TableDesc("ident", extractorKey[IdentifierTableExtractor])
     TableCommandSpec(cmd, Seq(tableDesc), "ALTERTABLE_PROPERTIES")
   }
 
   val AlterTableAddColumns = {
     val cmd = "org.apache.spark.sql.execution.command.AlterTableAddColumnsCommand"
-    val columnDesc = ColumnDesc("colsToAdd", extractorName[StructFieldSeqColumnExtractor])
+    val columnDesc = ColumnDesc("colsToAdd", extractorKey[StructFieldSeqColumnExtractor])
     val tableDesc = TableDesc("table", tite, Some(columnDesc))
     TableCommandSpec(cmd, Seq(tableDesc), "ALTERTABLE_ADDCOLS")
   }
@@ -73,7 +73,7 @@ object TableCommands {
   val AlterTableAddPartition = {
     val cmd = "org.apache.spark.sql.execution.command.AlterTableAddPartitionCommand"
     val columnDesc =
-      ColumnDesc("partitionSpecsAndLocs", extractorName[PartitionLocsSeqColumnExtractor])
+      ColumnDesc("partitionSpecsAndLocs", extractorKey[PartitionLocsSeqColumnExtractor])
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
@@ -82,7 +82,7 @@ object TableCommands {
 
   val AlterTableChangeColumn = {
     val cmd = "org.apache.spark.sql.execution.command.AlterTableChangeColumnCommand"
-    val columnDesc = ColumnDesc("columnName", extractorName[StringColumnExtractor])
+    val columnDesc = ColumnDesc("columnName", extractorKey[StringColumnExtractor])
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
@@ -91,7 +91,7 @@ object TableCommands {
 
   val AlterTableDropPartition = {
     val cmd = "org.apache.spark.sql.execution.command.AlterTableDropPartitionCommand"
-    val columnDesc = ColumnDesc("specs", extractorName[PartitionSeqColumnExtractor])
+    val columnDesc = ColumnDesc("specs", extractorKey[PartitionSeqColumnExtractor])
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
@@ -105,7 +105,7 @@ object TableCommands {
     val oldTableTableTypeDesc =
       TableTypeDesc(
         "oldName",
-        extractorName[TableIdentifierTableTypeExtractor],
+        extractorKey[TableIdentifierTableTypeExtractor],
         Seq("TEMP_VIEW"))
     val oldTableD = TableDesc(
       "oldName",
@@ -131,7 +131,7 @@ object TableCommands {
 
   val AlterTableRenamePartition = {
     val cmd = "org.apache.spark.sql.execution.command.AlterTableRenamePartitionCommand"
-    val columnDesc = ColumnDesc("oldPartition", extractorName[PartitionColumnExtractor])
+    val columnDesc = ColumnDesc("oldPartition", extractorKey[PartitionColumnExtractor])
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
@@ -140,7 +140,7 @@ object TableCommands {
 
   val AlterTableSerDeProperties = {
     val cmd = "org.apache.spark.sql.execution.command.AlterTableSerDePropertiesCommand"
-    val columnDesc = ColumnDesc("partSpec", extractorName[PartitionOptionColumnExtractor])
+    val columnDesc = ColumnDesc("partSpec", extractorKey[PartitionOptionColumnExtractor])
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
@@ -149,7 +149,7 @@ object TableCommands {
 
   val AlterTableSetLocation = {
     val cmd = "org.apache.spark.sql.execution.command.AlterTableSetLocationCommand"
-    val columnDesc = ColumnDesc("partitionSpec", extractorName[PartitionOptionColumnExtractor])
+    val columnDesc = ColumnDesc("partitionSpec", extractorKey[PartitionOptionColumnExtractor])
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
@@ -166,7 +166,7 @@ object TableCommands {
 
   val AlterViewAs = {
     val tableTypeDesc =
-      TableTypeDesc("name", extractorName[TableIdentifierTableTypeExtractor], Seq("TEMP_VIEW"))
+      TableTypeDesc("name", extractorKey[TableIdentifierTableTypeExtractor], Seq("TEMP_VIEW"))
 
     TableCommandSpec(
       "org.apache.spark.sql.execution.command.AlterViewAsCommand",
@@ -177,8 +177,8 @@ object TableCommands {
 
   val AnalyzeColumn = {
     val cmd = "org.apache.spark.sql.execution.command.AnalyzeColumnCommand"
-    val cd1 = ColumnDesc("columnNames", extractorName[StringSeqColumnExtractor])
-    val cd2 = cd1.copy(fieldExtractor = extractorName[StringSeqOptionColumnExtractor])
+    val cd1 = ColumnDesc("columnNames", extractorKey[StringSeqColumnExtractor])
+    val cd2 = cd1.copy(fieldExtractor = extractorKey[StringSeqOptionColumnExtractor])
     val td1 = tableIdentDesc.copy(columnDesc = Some(cd1), isInput = true)
     val td2 = td1.copy(columnDesc = Some(cd2))
     TableCommandSpec(cmd, Seq(td1, td2), "ANALYZE_TABLE")
@@ -186,7 +186,7 @@ object TableCommands {
 
   val AnalyzePartition = {
     val cmd = "org.apache.spark.sql.execution.command.AnalyzePartitionCommand"
-    val columnDesc = ColumnDesc("partitionSpec", extractorName[PartitionColumnExtractor])
+    val columnDesc = ColumnDesc("partitionSpec", extractorKey[PartitionColumnExtractor])
     TableCommandSpec(
       cmd,
       Seq(tableIdentDesc.copy(columnDesc = Some(columnDesc), isInput = true)),
@@ -205,7 +205,7 @@ object TableCommands {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.CreateTable"
     val tableDesc = TableDesc(
       "tableName",
-      extractorName[IdentifierTableExtractor],
+      extractorKey[IdentifierTableExtractor],
       catalogDesc = Some(CatalogDesc()))
     TableCommandSpec(cmd, Seq(tableDesc, resolvedDbObjectNameDesc), "CREATETABLE")
   }
@@ -214,7 +214,7 @@ object TableCommands {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.CreateV2Table"
     val tableDesc = TableDesc(
       "tableName",
-      extractorName[IdentifierTableExtractor],
+      extractorKey[IdentifierTableExtractor],
       catalogDesc = Some(CatalogDesc()))
     TableCommandSpec(cmd, Seq(tableDesc), "CREATETABLE")
   }
@@ -223,7 +223,7 @@ object TableCommands {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.CreateTableAsSelect"
     val tableDesc = TableDesc(
       "tableName",
-      extractorName[IdentifierTableExtractor],
+      extractorKey[IdentifierTableExtractor],
       catalogDesc = Some(CatalogDesc()))
     TableCommandSpec(
       cmd,
@@ -243,7 +243,7 @@ object TableCommands {
     val tableDesc =
       TableDesc(
         "table",
-        extractorName[DataSourceV2RelationTableExtractor],
+        extractorKey[DataSourceV2RelationTableExtractor],
         actionTypeDesc = Some(actionTypeDesc))
     TableCommandSpec(cmd, Seq(tableDesc), queryDescs = Seq(QueryDesc("query")))
   }
@@ -254,7 +254,7 @@ object TableCommands {
     val tableDesc =
       TableDesc(
         "table",
-        extractorName[DataSourceV2RelationTableExtractor],
+        extractorKey[DataSourceV2RelationTableExtractor],
         actionTypeDesc = Some(actionTypeDesc))
     TableCommandSpec(cmd, Seq(tableDesc), queryDescs = Seq(QueryDesc("query")))
   }
@@ -270,7 +270,7 @@ object TableCommands {
     val tableDesc =
       TableDesc(
         "table",
-        extractorName[DataSourceV2RelationTableExtractor],
+        extractorKey[DataSourceV2RelationTableExtractor],
         actionTypeDesc = Some(actionTypeDesc))
     TableCommandSpec(cmd, Seq(tableDesc), queryDescs = Seq(QueryDesc("query")))
   }
@@ -283,28 +283,28 @@ object TableCommands {
   val AddPartitions = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.AddPartitions"
     // TODO: add column desc
-    val tableDesc = TableDesc("table", extractorName[DataSourceV2RelationTableExtractor])
+    val tableDesc = TableDesc("table", extractorKey[DataSourceV2RelationTableExtractor])
     TableCommandSpec(cmd, Seq(tableDesc), "ALTERTABLE_ADDPARTS")
   }
 
   val DropPartitions = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.DropPartitions"
     // TODO: add column desc
-    val tableDesc = TableDesc("table", extractorName[DataSourceV2RelationTableExtractor])
+    val tableDesc = TableDesc("table", extractorKey[DataSourceV2RelationTableExtractor])
     TableCommandSpec(cmd, Seq(tableDesc), "ALTERTABLE_DROPPARTS")
   }
 
   val RenamePartitions = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.RenamePartitions"
     // TODO: add column desc
-    val tableDesc = TableDesc("table", extractorName[DataSourceV2RelationTableExtractor])
+    val tableDesc = TableDesc("table", extractorKey[DataSourceV2RelationTableExtractor])
     TableCommandSpec(cmd, Seq(tableDesc), "ALTERTABLE_RENAMEPART")
   }
 
   val TruncatePartition = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.TruncatePartition"
     // TODO: add column desc
-    val tableDesc = TableDesc("table", extractorName[DataSourceV2RelationTableExtractor])
+    val tableDesc = TableDesc("table", extractorKey[DataSourceV2RelationTableExtractor])
     TableCommandSpec(cmd, Seq(tableDesc), "ALTERTABLE_DROPPARTS")
   }
 
@@ -315,7 +315,7 @@ object TableCommands {
 
   val CacheTable = {
     val cmd = "org.apache.spark.sql.execution.command.CacheTableCommand"
-    val queryDesc = QueryDesc("plan", extractorName[LogicalPlanOptionQueryExtractor])
+    val queryDesc = QueryDesc("plan", extractorKey[LogicalPlanOptionQueryExtractor])
     TableCommandSpec(cmd, Nil, "CREATEVIEW", queryDescs = Seq(queryDesc))
   }
 
@@ -328,11 +328,11 @@ object TableCommands {
     val cmd = "org.apache.spark.sql.execution.command.CreateViewCommand"
     val tableTypeDesc = TableTypeDesc(
       "viewType",
-      extractorName[ViewTypeTableTypeExtractor],
+      extractorKey[ViewTypeTableTypeExtractor],
       Seq("TEMP_VIEW", "GLOBAL_TEMP_VIEW"))
     val tableDesc = TableDesc(
       "name",
-      extractorName[TableIdentifierTableExtractor],
+      extractorKey[TableIdentifierTableExtractor],
       tableTypeDesc = Some(tableTypeDesc))
     val queryDesc1 = QueryDesc("plan")
     val queryDesc2 = QueryDesc("child")
@@ -346,7 +346,7 @@ object TableCommands {
 
   val CreateDataSourceTable = {
     val cmd = "org.apache.spark.sql.execution.command.CreateDataSourceTableCommand"
-    val tableDesc = TableDesc("table", extractorName[CatalogTableTableExtractor])
+    val tableDesc = TableDesc("table", extractorKey[CatalogTableTableExtractor])
     TableCommandSpec(cmd, Seq(tableDesc), "CREATETABLE")
   }
 
@@ -360,9 +360,9 @@ object TableCommands {
 
   val CreateHiveTableAsSelect = {
     val cmd = "org.apache.spark.sql.hive.execution.CreateHiveTableAsSelectCommand"
-    val columnDesc = ColumnDesc("outputColumnNames", extractorName[StringSeqColumnExtractor])
+    val columnDesc = ColumnDesc("outputColumnNames", extractorKey[StringSeqColumnExtractor])
     val tableDesc =
-      TableDesc("tableDesc", extractorName[CatalogTableTableExtractor], Some(columnDesc))
+      TableDesc("tableDesc", extractorKey[CatalogTableTableExtractor], Some(columnDesc))
     val queryDesc = QueryDesc("query")
     TableCommandSpec(cmd, Seq(tableDesc), "CREATETABLE_AS_SELECT", queryDescs = Seq(queryDesc))
   }
@@ -371,11 +371,11 @@ object TableCommands {
     val cmd = "org.apache.spark.sql.execution.command.CreateTableLikeCommand"
     val tableDesc1 = TableDesc(
       "targetTable",
-      extractorName[TableIdentifierTableExtractor],
+      extractorKey[TableIdentifierTableExtractor],
       setCurrentDatabaseIfMissing = true)
     val tableDesc2 = TableDesc(
       "sourceTable",
-      extractorName[TableIdentifierTableExtractor],
+      extractorKey[TableIdentifierTableExtractor],
       isInput = true,
       setCurrentDatabaseIfMissing = true)
     TableCommandSpec(cmd, Seq(tableDesc1, tableDesc2), "CREATETABLE")
@@ -383,10 +383,10 @@ object TableCommands {
 
   val DescribeColumn = {
     val cmd = "org.apache.spark.sql.execution.command.DescribeColumnCommand"
-    val columnDesc = ColumnDesc("colNameParts", extractorName[StringSeqLastColumnExtractor])
+    val columnDesc = ColumnDesc("colNameParts", extractorKey[StringSeqLastColumnExtractor])
     val tableDesc = TableDesc(
       "table",
-      extractorName[TableIdentifierTableExtractor],
+      extractorKey[TableIdentifierTableExtractor],
       Some(columnDesc),
       isInput = true)
     TableCommandSpec(cmd, Seq(tableDesc), "DESCTABLE")
@@ -394,10 +394,10 @@ object TableCommands {
 
   val DescribeTable = {
     val cmd = "org.apache.spark.sql.execution.command.DescribeTableCommand"
-    val columnDesc = ColumnDesc("partitionSpec", extractorName[PartitionColumnExtractor])
+    val columnDesc = ColumnDesc("partitionSpec", extractorKey[PartitionColumnExtractor])
     val tableDesc = TableDesc(
       "table",
-      extractorName[TableIdentifierTableExtractor],
+      extractorKey[TableIdentifierTableExtractor],
       Some(columnDesc),
       isInput = true,
       setCurrentDatabaseIfMissing = true)
@@ -409,7 +409,7 @@ object TableCommands {
     val tableTypeDesc =
       TableTypeDesc(
         "tableName",
-        extractorName[TableIdentifierTableTypeExtractor],
+        extractorKey[TableIdentifierTableTypeExtractor],
         Seq("TEMP_VIEW"))
     TableCommandSpec(
       cmd,
@@ -428,7 +428,7 @@ object TableCommands {
     val actionTypeDesc = ActionTypeDesc(null, null, Some("UPDATE"))
     val tableDesc = TableDesc(
       "targetTable",
-      extractorName[DataSourceV2RelationTableExtractor],
+      extractorKey[DataSourceV2RelationTableExtractor],
       actionTypeDesc = Some(actionTypeDesc))
     val queryDesc = QueryDesc("sourceTable")
     TableCommandSpec(cmd, Seq(tableDesc), queryDescs = Seq(queryDesc))
@@ -455,27 +455,27 @@ object TableCommands {
   val ShowCreateTableV2 = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.ShowCreateTable"
     val tableDesc =
-      TableDesc("child", extractorName[ResolvedTableTableExtractor], isInput = true)
+      TableDesc("child", extractorKey[ResolvedTableTableExtractor], isInput = true)
     TableCommandSpec(cmd, Seq(tableDesc), "SHOW_CREATETABLE")
   }
 
   val ShowTablePropertiesV2 = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.ShowTableProperties"
     val tableDesc =
-      TableDesc("table", extractorName[ResolvedTableTableExtractor], isInput = true)
+      TableDesc("table", extractorKey[ResolvedTableTableExtractor], isInput = true)
     TableCommandSpec(cmd, Seq(tableDesc), "SHOW_TBLPROPERTIES")
   }
 
   val ShowPartitions = {
     val cmd = "org.apache.spark.sql.execution.command.ShowPartitionsCommand"
-    val columnDesc = ColumnDesc("spec", extractorName[PartitionOptionColumnExtractor])
+    val columnDesc = ColumnDesc("spec", extractorKey[PartitionOptionColumnExtractor])
     val tableDesc = tableNameDesc.copy(isInput = true, columnDesc = Some(columnDesc))
     TableCommandSpec(cmd, Seq(tableDesc), "SHOWPARTITIONS")
   }
 
   val TruncateTable = {
     val cmd = "org.apache.spark.sql.execution.command.TruncateTableCommand"
-    val columnDesc = ColumnDesc("partitionSpec", extractorName[PartitionOptionColumnExtractor])
+    val columnDesc = ColumnDesc("partitionSpec", extractorKey[PartitionOptionColumnExtractor])
     val tableDesc = tableNameDesc.copy(columnDesc = Some(columnDesc))
     TableCommandSpec(cmd, Seq(tableDesc), "TRUNCATETABLE")
   }
@@ -490,7 +490,7 @@ object TableCommands {
     val actionTypeDesc = overwriteActionTypeDesc
     val tableDesc = TableDesc(
       "logicalRelation",
-      extractorName[LogicalRelationTableExtractor],
+      extractorKey[LogicalRelationTableExtractor],
       actionTypeDesc = Some(actionTypeDesc))
     TableCommandSpec(cmd, Seq(tableDesc), queryDescs = Seq(QueryDesc("query")))
   }
@@ -498,10 +498,10 @@ object TableCommands {
   val InsertIntoHiveTable = {
     val cmd = "org.apache.spark.sql.hive.execution.InsertIntoHiveTable"
     val actionTypeDesc = overwriteActionTypeDesc
-    val columnDesc = ColumnDesc("outputColumnNames", extractorName[StringSeqColumnExtractor])
+    val columnDesc = ColumnDesc("outputColumnNames", extractorKey[StringSeqColumnExtractor])
     val tableDesc = TableDesc(
       "table",
-      extractorName[CatalogTableTableExtractor],
+      extractorKey[CatalogTableTableExtractor],
       Some(columnDesc),
       Some(actionTypeDesc))
     val queryDesc = QueryDesc("query")
@@ -517,7 +517,7 @@ object TableCommands {
   val LoadData = {
     val cmd = "org.apache.spark.sql.execution.command.LoadDataCommand"
     val actionTypeDesc = overwriteActionTypeDesc.copy(fieldName = "isOverwrite")
-    val columnDesc = ColumnDesc("partition", extractorName[PartitionOptionColumnExtractor])
+    val columnDesc = ColumnDesc("partition", extractorKey[PartitionOptionColumnExtractor])
     val tableDesc = tableIdentDesc.copy(
       fieldName = "table",
       columnDesc = Some(columnDesc),

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/TableCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/TableCommands.scala
@@ -153,7 +153,7 @@ object TableCommands {
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
-      "ALTERTABLE_LOCATION")
+      ALTERTABLE_LOCATION)
   }
 
   val AlterTableSetProperties = TableCommandSpec(
@@ -228,7 +228,7 @@ object TableCommands {
     TableCommandSpec(
       cmd,
       Seq(tableDesc, resolvedDbObjectNameDesc.copy(fieldName = "left")),
-      "CREATETABLE_AS_SELECT",
+      CREATETABLE_AS_SELECT,
       Seq(QueryDesc("query")))
   }
 
@@ -358,7 +358,7 @@ object TableCommands {
     val cmd = "org.apache.spark.sql.execution.command.CreateDataSourceTableAsSelectCommand"
     CreateDataSourceTable.copy(
       classname = cmd,
-      opType = "CREATETABLE_AS_SELECT",
+      opType = CREATETABLE_AS_SELECT,
       queryDescs = Seq(QueryDesc("query")))
   }
 

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/TableCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/TableCommands.scala
@@ -18,29 +18,29 @@
 package org.apache.kyuubi.plugin.spark.authz.gen
 
 import org.apache.kyuubi.plugin.spark.authz.serde._
-import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils.getClassSimpleName
+import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils.extractorName
 
 object TableCommands {
   // table extractors
-  val tite = getClassSimpleName[TableIdentifierTableExtractor]
+  val tite = extractorName[TableIdentifierTableExtractor]
   val tableNameDesc = TableDesc("tableName", tite)
   val tableIdentDesc = TableDesc("tableIdent", tite)
-  val resolvedTableDesc = TableDesc("child", getClassSimpleName[ResolvedTableTableExtractor])
+  val resolvedTableDesc = TableDesc("child", extractorName[ResolvedTableTableExtractor])
   val resolvedDbObjectNameDesc =
-    TableDesc("child", getClassSimpleName[ResolvedDbObjectNameTableExtractor])
+    TableDesc("child", extractorName[ResolvedDbObjectNameTableExtractor])
 
   val overwriteActionTypeDesc =
-    ActionTypeDesc("overwrite", getClassSimpleName[OverwriteOrInsertActionTypeExtractor])
+    ActionTypeDesc("overwrite", extractorName[OverwriteOrInsertActionTypeExtractor])
 
   val AlterTable = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.AlterTable"
-    val tableDesc = TableDesc("ident", getClassSimpleName[IdentifierTableExtractor])
+    val tableDesc = TableDesc("ident", extractorName[IdentifierTableExtractor])
     TableCommandSpec(cmd, Seq(tableDesc), "ALTERTABLE_PROPERTIES")
   }
 
   val AlterTableAddColumns = {
     val cmd = "org.apache.spark.sql.execution.command.AlterTableAddColumnsCommand"
-    val columnDesc = ColumnDesc("colsToAdd", getClassSimpleName[StructFieldSeqColumnExtractor])
+    val columnDesc = ColumnDesc("colsToAdd", extractorName[StructFieldSeqColumnExtractor])
     val tableDesc = TableDesc("table", tite, Some(columnDesc))
     TableCommandSpec(cmd, Seq(tableDesc), "ALTERTABLE_ADDCOLS")
   }
@@ -73,7 +73,7 @@ object TableCommands {
   val AlterTableAddPartition = {
     val cmd = "org.apache.spark.sql.execution.command.AlterTableAddPartitionCommand"
     val columnDesc =
-      ColumnDesc("partitionSpecsAndLocs", getClassSimpleName[PartitionLocsSeqColumnExtractor])
+      ColumnDesc("partitionSpecsAndLocs", extractorName[PartitionLocsSeqColumnExtractor])
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
@@ -82,7 +82,7 @@ object TableCommands {
 
   val AlterTableChangeColumn = {
     val cmd = "org.apache.spark.sql.execution.command.AlterTableChangeColumnCommand"
-    val columnDesc = ColumnDesc("columnName", getClassSimpleName[StringColumnExtractor])
+    val columnDesc = ColumnDesc("columnName", extractorName[StringColumnExtractor])
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
@@ -91,7 +91,7 @@ object TableCommands {
 
   val AlterTableDropPartition = {
     val cmd = "org.apache.spark.sql.execution.command.AlterTableDropPartitionCommand"
-    val columnDesc = ColumnDesc("specs", getClassSimpleName[PartitionSeqColumnExtractor])
+    val columnDesc = ColumnDesc("specs", extractorName[PartitionSeqColumnExtractor])
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
@@ -105,7 +105,7 @@ object TableCommands {
     val oldTableTableTypeDesc =
       TableTypeDesc(
         "oldName",
-        getClassSimpleName[TableIdentifierTableTypeExtractor],
+        extractorName[TableIdentifierTableTypeExtractor],
         Seq("TEMP_VIEW"))
     val oldTableD = TableDesc(
       "oldName",
@@ -131,7 +131,7 @@ object TableCommands {
 
   val AlterTableRenamePartition = {
     val cmd = "org.apache.spark.sql.execution.command.AlterTableRenamePartitionCommand"
-    val columnDesc = ColumnDesc("oldPartition", getClassSimpleName[PartitionColumnExtractor])
+    val columnDesc = ColumnDesc("oldPartition", extractorName[PartitionColumnExtractor])
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
@@ -140,7 +140,7 @@ object TableCommands {
 
   val AlterTableSerDeProperties = {
     val cmd = "org.apache.spark.sql.execution.command.AlterTableSerDePropertiesCommand"
-    val columnDesc = ColumnDesc("partSpec", getClassSimpleName[PartitionOptionColumnExtractor])
+    val columnDesc = ColumnDesc("partSpec", extractorName[PartitionOptionColumnExtractor])
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
@@ -149,7 +149,7 @@ object TableCommands {
 
   val AlterTableSetLocation = {
     val cmd = "org.apache.spark.sql.execution.command.AlterTableSetLocationCommand"
-    val columnDesc = ColumnDesc("partitionSpec", getClassSimpleName[PartitionOptionColumnExtractor])
+    val columnDesc = ColumnDesc("partitionSpec", extractorName[PartitionOptionColumnExtractor])
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
@@ -166,7 +166,7 @@ object TableCommands {
 
   val AlterViewAs = {
     val tableTypeDesc =
-      TableTypeDesc("name", getClassSimpleName[TableIdentifierTableTypeExtractor], Seq("TEMP_VIEW"))
+      TableTypeDesc("name", extractorName[TableIdentifierTableTypeExtractor], Seq("TEMP_VIEW"))
 
     TableCommandSpec(
       "org.apache.spark.sql.execution.command.AlterViewAsCommand",
@@ -177,8 +177,8 @@ object TableCommands {
 
   val AnalyzeColumn = {
     val cmd = "org.apache.spark.sql.execution.command.AnalyzeColumnCommand"
-    val cd1 = ColumnDesc("columnNames", getClassSimpleName[StringSeqColumnExtractor])
-    val cd2 = cd1.copy(fieldExtractor = getClassSimpleName[StringSeqOptionColumnExtractor])
+    val cd1 = ColumnDesc("columnNames", extractorName[StringSeqColumnExtractor])
+    val cd2 = cd1.copy(fieldExtractor = extractorName[StringSeqOptionColumnExtractor])
     val td1 = tableIdentDesc.copy(columnDesc = Some(cd1), isInput = true)
     val td2 = td1.copy(columnDesc = Some(cd2))
     TableCommandSpec(cmd, Seq(td1, td2), "ANALYZE_TABLE")
@@ -186,7 +186,7 @@ object TableCommands {
 
   val AnalyzePartition = {
     val cmd = "org.apache.spark.sql.execution.command.AnalyzePartitionCommand"
-    val columnDesc = ColumnDesc("partitionSpec", getClassSimpleName[PartitionColumnExtractor])
+    val columnDesc = ColumnDesc("partitionSpec", extractorName[PartitionColumnExtractor])
     TableCommandSpec(
       cmd,
       Seq(tableIdentDesc.copy(columnDesc = Some(columnDesc), isInput = true)),
@@ -205,7 +205,7 @@ object TableCommands {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.CreateTable"
     val tableDesc = TableDesc(
       "tableName",
-      getClassSimpleName[IdentifierTableExtractor],
+      extractorName[IdentifierTableExtractor],
       catalogDesc = Some(CatalogDesc()))
     TableCommandSpec(cmd, Seq(tableDesc, resolvedDbObjectNameDesc), "CREATETABLE")
   }
@@ -214,7 +214,7 @@ object TableCommands {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.CreateV2Table"
     val tableDesc = TableDesc(
       "tableName",
-      getClassSimpleName[IdentifierTableExtractor],
+      extractorName[IdentifierTableExtractor],
       catalogDesc = Some(CatalogDesc()))
     TableCommandSpec(cmd, Seq(tableDesc), "CREATETABLE")
   }
@@ -223,7 +223,7 @@ object TableCommands {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.CreateTableAsSelect"
     val tableDesc = TableDesc(
       "tableName",
-      getClassSimpleName[IdentifierTableExtractor],
+      extractorName[IdentifierTableExtractor],
       catalogDesc = Some(CatalogDesc()))
     TableCommandSpec(
       cmd,
@@ -243,7 +243,7 @@ object TableCommands {
     val tableDesc =
       TableDesc(
         "table",
-        getClassSimpleName[DataSourceV2RelationTableExtractor],
+        extractorName[DataSourceV2RelationTableExtractor],
         actionTypeDesc = Some(actionTypeDesc))
     TableCommandSpec(cmd, Seq(tableDesc), queryDescs = Seq(QueryDesc("query")))
   }
@@ -254,7 +254,7 @@ object TableCommands {
     val tableDesc =
       TableDesc(
         "table",
-        getClassSimpleName[DataSourceV2RelationTableExtractor],
+        extractorName[DataSourceV2RelationTableExtractor],
         actionTypeDesc = Some(actionTypeDesc))
     TableCommandSpec(cmd, Seq(tableDesc), queryDescs = Seq(QueryDesc("query")))
   }
@@ -270,7 +270,7 @@ object TableCommands {
     val tableDesc =
       TableDesc(
         "table",
-        getClassSimpleName[DataSourceV2RelationTableExtractor],
+        extractorName[DataSourceV2RelationTableExtractor],
         actionTypeDesc = Some(actionTypeDesc))
     TableCommandSpec(cmd, Seq(tableDesc), queryDescs = Seq(QueryDesc("query")))
   }
@@ -283,28 +283,28 @@ object TableCommands {
   val AddPartitions = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.AddPartitions"
     // TODO: add column desc
-    val tableDesc = TableDesc("table", getClassSimpleName[DataSourceV2RelationTableExtractor])
+    val tableDesc = TableDesc("table", extractorName[DataSourceV2RelationTableExtractor])
     TableCommandSpec(cmd, Seq(tableDesc), "ALTERTABLE_ADDPARTS")
   }
 
   val DropPartitions = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.DropPartitions"
     // TODO: add column desc
-    val tableDesc = TableDesc("table", getClassSimpleName[DataSourceV2RelationTableExtractor])
+    val tableDesc = TableDesc("table", extractorName[DataSourceV2RelationTableExtractor])
     TableCommandSpec(cmd, Seq(tableDesc), "ALTERTABLE_DROPPARTS")
   }
 
   val RenamePartitions = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.RenamePartitions"
     // TODO: add column desc
-    val tableDesc = TableDesc("table", getClassSimpleName[DataSourceV2RelationTableExtractor])
+    val tableDesc = TableDesc("table", extractorName[DataSourceV2RelationTableExtractor])
     TableCommandSpec(cmd, Seq(tableDesc), "ALTERTABLE_RENAMEPART")
   }
 
   val TruncatePartition = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.TruncatePartition"
     // TODO: add column desc
-    val tableDesc = TableDesc("table", getClassSimpleName[DataSourceV2RelationTableExtractor])
+    val tableDesc = TableDesc("table", extractorName[DataSourceV2RelationTableExtractor])
     TableCommandSpec(cmd, Seq(tableDesc), "ALTERTABLE_DROPPARTS")
   }
 
@@ -315,7 +315,7 @@ object TableCommands {
 
   val CacheTable = {
     val cmd = "org.apache.spark.sql.execution.command.CacheTableCommand"
-    val queryDesc = QueryDesc("plan", getClassSimpleName[LogicalPlanOptionQueryExtractor])
+    val queryDesc = QueryDesc("plan", extractorName[LogicalPlanOptionQueryExtractor])
     TableCommandSpec(cmd, Nil, "CREATEVIEW", queryDescs = Seq(queryDesc))
   }
 
@@ -328,11 +328,11 @@ object TableCommands {
     val cmd = "org.apache.spark.sql.execution.command.CreateViewCommand"
     val tableTypeDesc = TableTypeDesc(
       "viewType",
-      getClassSimpleName[ViewTypeTableTypeExtractor],
+      extractorName[ViewTypeTableTypeExtractor],
       Seq("TEMP_VIEW", "GLOBAL_TEMP_VIEW"))
     val tableDesc = TableDesc(
       "name",
-      getClassSimpleName[TableIdentifierTableExtractor],
+      extractorName[TableIdentifierTableExtractor],
       tableTypeDesc = Some(tableTypeDesc))
     val queryDesc1 = QueryDesc("plan")
     val queryDesc2 = QueryDesc("child")
@@ -346,7 +346,7 @@ object TableCommands {
 
   val CreateDataSourceTable = {
     val cmd = "org.apache.spark.sql.execution.command.CreateDataSourceTableCommand"
-    val tableDesc = TableDesc("table", getClassSimpleName[CatalogTableTableExtractor])
+    val tableDesc = TableDesc("table", extractorName[CatalogTableTableExtractor])
     TableCommandSpec(cmd, Seq(tableDesc), "CREATETABLE")
   }
 
@@ -360,9 +360,9 @@ object TableCommands {
 
   val CreateHiveTableAsSelect = {
     val cmd = "org.apache.spark.sql.hive.execution.CreateHiveTableAsSelectCommand"
-    val columnDesc = ColumnDesc("outputColumnNames", getClassSimpleName[StringSeqColumnExtractor])
+    val columnDesc = ColumnDesc("outputColumnNames", extractorName[StringSeqColumnExtractor])
     val tableDesc =
-      TableDesc("tableDesc", getClassSimpleName[CatalogTableTableExtractor], Some(columnDesc))
+      TableDesc("tableDesc", extractorName[CatalogTableTableExtractor], Some(columnDesc))
     val queryDesc = QueryDesc("query")
     TableCommandSpec(cmd, Seq(tableDesc), "CREATETABLE_AS_SELECT", queryDescs = Seq(queryDesc))
   }
@@ -371,11 +371,11 @@ object TableCommands {
     val cmd = "org.apache.spark.sql.execution.command.CreateTableLikeCommand"
     val tableDesc1 = TableDesc(
       "targetTable",
-      getClassSimpleName[TableIdentifierTableExtractor],
+      extractorName[TableIdentifierTableExtractor],
       setCurrentDatabaseIfMissing = true)
     val tableDesc2 = TableDesc(
       "sourceTable",
-      getClassSimpleName[TableIdentifierTableExtractor],
+      extractorName[TableIdentifierTableExtractor],
       isInput = true,
       setCurrentDatabaseIfMissing = true)
     TableCommandSpec(cmd, Seq(tableDesc1, tableDesc2), "CREATETABLE")
@@ -383,10 +383,10 @@ object TableCommands {
 
   val DescribeColumn = {
     val cmd = "org.apache.spark.sql.execution.command.DescribeColumnCommand"
-    val columnDesc = ColumnDesc("colNameParts", getClassSimpleName[StringSeqLastColumnExtractor])
+    val columnDesc = ColumnDesc("colNameParts", extractorName[StringSeqLastColumnExtractor])
     val tableDesc = TableDesc(
       "table",
-      getClassSimpleName[TableIdentifierTableExtractor],
+      extractorName[TableIdentifierTableExtractor],
       Some(columnDesc),
       isInput = true)
     TableCommandSpec(cmd, Seq(tableDesc), "DESCTABLE")
@@ -394,10 +394,10 @@ object TableCommands {
 
   val DescribeTable = {
     val cmd = "org.apache.spark.sql.execution.command.DescribeTableCommand"
-    val columnDesc = ColumnDesc("partitionSpec", getClassSimpleName[PartitionColumnExtractor])
+    val columnDesc = ColumnDesc("partitionSpec", extractorName[PartitionColumnExtractor])
     val tableDesc = TableDesc(
       "table",
-      getClassSimpleName[TableIdentifierTableExtractor],
+      extractorName[TableIdentifierTableExtractor],
       Some(columnDesc),
       isInput = true,
       setCurrentDatabaseIfMissing = true)
@@ -409,7 +409,7 @@ object TableCommands {
     val tableTypeDesc =
       TableTypeDesc(
         "tableName",
-        getClassSimpleName[TableIdentifierTableTypeExtractor],
+        extractorName[TableIdentifierTableTypeExtractor],
         Seq("TEMP_VIEW"))
     TableCommandSpec(
       cmd,
@@ -428,7 +428,7 @@ object TableCommands {
     val actionTypeDesc = ActionTypeDesc(null, null, Some("UPDATE"))
     val tableDesc = TableDesc(
       "targetTable",
-      getClassSimpleName[DataSourceV2RelationTableExtractor],
+      extractorName[DataSourceV2RelationTableExtractor],
       actionTypeDesc = Some(actionTypeDesc))
     val queryDesc = QueryDesc("sourceTable")
     TableCommandSpec(cmd, Seq(tableDesc), queryDescs = Seq(queryDesc))
@@ -455,27 +455,27 @@ object TableCommands {
   val ShowCreateTableV2 = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.ShowCreateTable"
     val tableDesc =
-      TableDesc("child", getClassSimpleName[ResolvedTableTableExtractor], isInput = true)
+      TableDesc("child", extractorName[ResolvedTableTableExtractor], isInput = true)
     TableCommandSpec(cmd, Seq(tableDesc), "SHOW_CREATETABLE")
   }
 
   val ShowTablePropertiesV2 = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.ShowTableProperties"
     val tableDesc =
-      TableDesc("table", getClassSimpleName[ResolvedTableTableExtractor], isInput = true)
+      TableDesc("table", extractorName[ResolvedTableTableExtractor], isInput = true)
     TableCommandSpec(cmd, Seq(tableDesc), "SHOW_TBLPROPERTIES")
   }
 
   val ShowPartitions = {
     val cmd = "org.apache.spark.sql.execution.command.ShowPartitionsCommand"
-    val columnDesc = ColumnDesc("spec", getClassSimpleName[PartitionOptionColumnExtractor])
+    val columnDesc = ColumnDesc("spec", extractorName[PartitionOptionColumnExtractor])
     val tableDesc = tableNameDesc.copy(isInput = true, columnDesc = Some(columnDesc))
     TableCommandSpec(cmd, Seq(tableDesc), "SHOWPARTITIONS")
   }
 
   val TruncateTable = {
     val cmd = "org.apache.spark.sql.execution.command.TruncateTableCommand"
-    val columnDesc = ColumnDesc("partitionSpec", getClassSimpleName[PartitionOptionColumnExtractor])
+    val columnDesc = ColumnDesc("partitionSpec", extractorName[PartitionOptionColumnExtractor])
     val tableDesc = tableNameDesc.copy(columnDesc = Some(columnDesc))
     TableCommandSpec(cmd, Seq(tableDesc), "TRUNCATETABLE")
   }
@@ -490,7 +490,7 @@ object TableCommands {
     val actionTypeDesc = overwriteActionTypeDesc
     val tableDesc = TableDesc(
       "logicalRelation",
-      getClassSimpleName[LogicalRelationTableExtractor],
+      extractorName[LogicalRelationTableExtractor],
       actionTypeDesc = Some(actionTypeDesc))
     TableCommandSpec(cmd, Seq(tableDesc), queryDescs = Seq(QueryDesc("query")))
   }
@@ -498,10 +498,10 @@ object TableCommands {
   val InsertIntoHiveTable = {
     val cmd = "org.apache.spark.sql.hive.execution.InsertIntoHiveTable"
     val actionTypeDesc = overwriteActionTypeDesc
-    val columnDesc = ColumnDesc("outputColumnNames", getClassSimpleName[StringSeqColumnExtractor])
+    val columnDesc = ColumnDesc("outputColumnNames", extractorName[StringSeqColumnExtractor])
     val tableDesc = TableDesc(
       "table",
-      getClassSimpleName[CatalogTableTableExtractor],
+      extractorName[CatalogTableTableExtractor],
       Some(columnDesc),
       Some(actionTypeDesc))
     val queryDesc = QueryDesc("query")
@@ -517,7 +517,7 @@ object TableCommands {
   val LoadData = {
     val cmd = "org.apache.spark.sql.execution.command.LoadDataCommand"
     val actionTypeDesc = overwriteActionTypeDesc.copy(fieldName = "isOverwrite")
-    val columnDesc = ColumnDesc("partition", getClassSimpleName[PartitionOptionColumnExtractor])
+    val columnDesc = ColumnDesc("partition", extractorName[PartitionOptionColumnExtractor])
     val tableDesc = tableIdentDesc.copy(
       fieldName = "table",
       columnDesc = Some(columnDesc),

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/TableCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/TableCommands.scala
@@ -35,19 +35,19 @@ object TableCommands {
   val AlterTable = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.AlterTable"
     val tableDesc = TableDesc("ident", classSimpleName[IdentifierTableExtractor])
-    TableCommandSpec(cmd, Seq(tableDesc), operationTypeStr(ALTERTABLE_PROPERTIES))
+    TableCommandSpec(cmd, Seq(tableDesc), ALTERTABLE_PROPERTIES)
   }
 
   val AlterTableAddColumns = {
     val cmd = "org.apache.spark.sql.execution.command.AlterTableAddColumnsCommand"
     val columnDesc = ColumnDesc("colsToAdd", classSimpleName[StructFieldSeqColumnExtractor])
     val tableDesc = TableDesc("table", tite, Some(columnDesc))
-    TableCommandSpec(cmd, Seq(tableDesc), operationTypeStr(ALTERTABLE_ADDCOLS))
+    TableCommandSpec(cmd, Seq(tableDesc), ALTERTABLE_ADDCOLS)
   }
 
   val AddColumns = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.AddColumns"
-    TableCommandSpec(cmd, Seq(resolvedTableDesc), operationTypeStr(ALTERTABLE_ADDCOLS))
+    TableCommandSpec(cmd, Seq(resolvedTableDesc), ALTERTABLE_ADDCOLS)
   }
 
   val AlterColumn = {
@@ -62,12 +62,12 @@ object TableCommands {
 
   val ReplaceColumns = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.ReplaceColumns"
-    TableCommandSpec(cmd, Seq(resolvedTableDesc), operationTypeStr(ALTERTABLE_REPLACECOLS))
+    TableCommandSpec(cmd, Seq(resolvedTableDesc), ALTERTABLE_REPLACECOLS)
   }
 
   val RenameColumn = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.RenameColumn"
-    TableCommandSpec(cmd, Seq(resolvedTableDesc), operationTypeStr(ALTERTABLE_RENAMECOL))
+    TableCommandSpec(cmd, Seq(resolvedTableDesc), ALTERTABLE_RENAMECOL)
   }
 
   val AlterTableAddPartition = {
@@ -77,7 +77,7 @@ object TableCommands {
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
-      operationTypeStr(ALTERTABLE_ADDPARTS))
+      ALTERTABLE_ADDPARTS)
   }
 
   val AlterTableChangeColumn = {
@@ -86,7 +86,7 @@ object TableCommands {
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
-      operationTypeStr(ALTERTABLE_REPLACECOLS))
+      ALTERTABLE_REPLACECOLS)
   }
 
   val AlterTableDropPartition = {
@@ -95,7 +95,7 @@ object TableCommands {
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
-      operationTypeStr(ALTERTABLE_DROPPARTS))
+      ALTERTABLE_DROPPARTS)
   }
 
   val AlterTableRename = {
@@ -115,18 +115,18 @@ object TableCommands {
 
     val newTableD =
       TableDesc("newName", tite, tableTypeDesc = Some(oldTableTableTypeDesc))
-    TableCommandSpec(cmd, Seq(oldTableD, newTableD), operationTypeStr(ALTERTABLE_RENAME))
+    TableCommandSpec(cmd, Seq(oldTableD, newTableD), ALTERTABLE_RENAME)
   }
 
   // this is for spark 3.1 or below
   val AlterTableRecoverPartitions = {
     val cmd = "org.apache.spark.sql.execution.command.AlterTableRecoverPartitionsCommand"
-    TableCommandSpec(cmd, Seq(tableNameDesc), operationTypeStr(MSCK))
+    TableCommandSpec(cmd, Seq(tableNameDesc), MSCK)
   }
 
   val RepairTable = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.RepairTable"
-    TableCommandSpec(cmd, Seq(resolvedTableDesc), operationTypeStr(MSCK))
+    TableCommandSpec(cmd, Seq(resolvedTableDesc), MSCK)
   }
 
   val AlterTableRenamePartition = {
@@ -135,7 +135,7 @@ object TableCommands {
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
-      operationTypeStr(ALTERTABLE_RENAMEPART))
+      ALTERTABLE_RENAMEPART)
   }
 
   val AlterTableSerDeProperties = {
@@ -144,7 +144,7 @@ object TableCommands {
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
-      operationTypeStr(ALTERTABLE_SERDEPROPERTIES))
+      ALTERTABLE_SERDEPROPERTIES)
   }
 
   val AlterTableSetLocation = {
@@ -159,7 +159,7 @@ object TableCommands {
   val AlterTableSetProperties = TableCommandSpec(
     "org.apache.spark.sql.execution.command.AlterTableSetPropertiesCommand",
     Seq(tableNameDesc),
-    operationTypeStr(ALTERTABLE_PROPERTIES))
+    ALTERTABLE_PROPERTIES)
 
   val AlterTableUnsetProperties = AlterTableSetProperties.copy(classname =
     "org.apache.spark.sql.execution.command.AlterTableUnsetPropertiesCommand")
@@ -171,7 +171,7 @@ object TableCommands {
     TableCommandSpec(
       "org.apache.spark.sql.execution.command.AlterViewAsCommand",
       Seq(TableDesc("name", tite, tableTypeDesc = Some(tableTypeDesc))),
-      operationTypeStr(ALTERVIEW_AS),
+      ALTERVIEW_AS,
       Seq(QueryDesc("query")))
   }
 
@@ -181,7 +181,7 @@ object TableCommands {
     val cd2 = cd1.copy(fieldExtractor = classSimpleName[StringSeqOptionColumnExtractor])
     val td1 = tableIdentDesc.copy(columnDesc = Some(cd1), isInput = true)
     val td2 = td1.copy(columnDesc = Some(cd2))
-    TableCommandSpec(cmd, Seq(td1, td2), operationTypeStr(ANALYZE_TABLE))
+    TableCommandSpec(cmd, Seq(td1, td2), ANALYZE_TABLE)
   }
 
   val AnalyzePartition = {
@@ -190,7 +190,7 @@ object TableCommands {
     TableCommandSpec(
       cmd,
       Seq(tableIdentDesc.copy(columnDesc = Some(columnDesc), isInput = true)),
-      operationTypeStr(ANALYZE_TABLE))
+      ANALYZE_TABLE)
   }
 
   val AnalyzeTable = {
@@ -198,7 +198,7 @@ object TableCommands {
     TableCommandSpec(
       cmd,
       Seq(tableIdentDesc.copy(isInput = true)),
-      operationTypeStr(ANALYZE_TABLE))
+      ANALYZE_TABLE)
   }
 
   val CreateTableV2 = {
@@ -207,7 +207,7 @@ object TableCommands {
       "tableName",
       classSimpleName[IdentifierTableExtractor],
       catalogDesc = Some(CatalogDesc()))
-    TableCommandSpec(cmd, Seq(tableDesc, resolvedDbObjectNameDesc), operationTypeStr(CREATETABLE))
+    TableCommandSpec(cmd, Seq(tableDesc, resolvedDbObjectNameDesc), CREATETABLE)
   }
 
   val CreateV2Table = {
@@ -216,7 +216,7 @@ object TableCommands {
       "tableName",
       classSimpleName[IdentifierTableExtractor],
       catalogDesc = Some(CatalogDesc()))
-    TableCommandSpec(cmd, Seq(tableDesc), operationTypeStr(CREATETABLE))
+    TableCommandSpec(cmd, Seq(tableDesc), CREATETABLE)
   }
 
   val CreateTableAsSelectV2 = {
@@ -234,7 +234,7 @@ object TableCommands {
 
   val CommentOnTable = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.CommentOnTable"
-    TableCommandSpec(cmd, Seq(resolvedTableDesc), operationTypeStr(ALTERTABLE_PROPERTIES))
+    TableCommandSpec(cmd, Seq(resolvedTableDesc), ALTERTABLE_PROPERTIES)
   }
 
   val AppendDataV2 = {
@@ -284,44 +284,44 @@ object TableCommands {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.AddPartitions"
     // TODO: add column desc
     val tableDesc = TableDesc("table", classSimpleName[DataSourceV2RelationTableExtractor])
-    TableCommandSpec(cmd, Seq(tableDesc), operationTypeStr(ALTERTABLE_ADDPARTS))
+    TableCommandSpec(cmd, Seq(tableDesc), ALTERTABLE_ADDPARTS)
   }
 
   val DropPartitions = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.DropPartitions"
     // TODO: add column desc
     val tableDesc = TableDesc("table", classSimpleName[DataSourceV2RelationTableExtractor])
-    TableCommandSpec(cmd, Seq(tableDesc), operationTypeStr(ALTERTABLE_DROPPARTS))
+    TableCommandSpec(cmd, Seq(tableDesc), ALTERTABLE_DROPPARTS)
   }
 
   val RenamePartitions = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.RenamePartitions"
     // TODO: add column desc
     val tableDesc = TableDesc("table", classSimpleName[DataSourceV2RelationTableExtractor])
-    TableCommandSpec(cmd, Seq(tableDesc), operationTypeStr(ALTERTABLE_RENAMEPART))
+    TableCommandSpec(cmd, Seq(tableDesc), ALTERTABLE_RENAMEPART)
   }
 
   val TruncatePartition = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.TruncatePartition"
     // TODO: add column desc
     val tableDesc = TableDesc("table", classSimpleName[DataSourceV2RelationTableExtractor])
-    TableCommandSpec(cmd, Seq(tableDesc), operationTypeStr(ALTERTABLE_DROPPARTS))
+    TableCommandSpec(cmd, Seq(tableDesc), ALTERTABLE_DROPPARTS)
   }
 
   val CacheTableAsSelect = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.CacheTableAsSelect"
-    TableCommandSpec(cmd, Nil, operationTypeStr(CREATEVIEW), queryDescs = Seq(QueryDesc("plan")))
+    TableCommandSpec(cmd, Nil, CREATEVIEW, queryDescs = Seq(QueryDesc("plan")))
   }
 
   val CacheTable = {
     val cmd = "org.apache.spark.sql.execution.command.CacheTableCommand"
     val queryDesc = QueryDesc("plan", classSimpleName[LogicalPlanOptionQueryExtractor])
-    TableCommandSpec(cmd, Nil, operationTypeStr(CREATEVIEW), queryDescs = Seq(queryDesc))
+    TableCommandSpec(cmd, Nil, CREATEVIEW, queryDescs = Seq(queryDesc))
   }
 
   val CacheTableV2 = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.CacheTable"
-    TableCommandSpec(cmd, Nil, operationTypeStr(CREATEVIEW), Seq(QueryDesc("table")))
+    TableCommandSpec(cmd, Nil, CREATEVIEW, Seq(QueryDesc("table")))
   }
 
   val CreateView = {
@@ -339,19 +339,19 @@ object TableCommands {
     TableCommandSpec(
       cmd,
       Seq(tableDesc),
-      operationTypeStr(CREATEVIEW),
+      CREATEVIEW,
       queryDescs = Seq(queryDesc1, queryDesc2))
   }
 
   val CreateTempViewUsing = {
     val cmd = "org.apache.spark.sql.execution.datasources.CreateTempViewUsing"
-    TableCommandSpec(cmd, Nil, operationTypeStr(CREATEVIEW))
+    TableCommandSpec(cmd, Nil, CREATEVIEW)
   }
 
   val CreateDataSourceTable = {
     val cmd = "org.apache.spark.sql.execution.command.CreateDataSourceTableCommand"
     val tableDesc = TableDesc("table", classSimpleName[CatalogTableTableExtractor])
-    TableCommandSpec(cmd, Seq(tableDesc), operationTypeStr(CREATETABLE))
+    TableCommandSpec(cmd, Seq(tableDesc), CREATETABLE)
   }
 
   val CreateDataSourceTableAsSelect = {
@@ -382,7 +382,7 @@ object TableCommands {
       classSimpleName[TableIdentifierTableExtractor],
       isInput = true,
       setCurrentDatabaseIfMissing = true)
-    TableCommandSpec(cmd, Seq(tableDesc1, tableDesc2), operationTypeStr(CREATETABLE))
+    TableCommandSpec(cmd, Seq(tableDesc1, tableDesc2), CREATETABLE)
   }
 
   val DescribeColumn = {
@@ -393,7 +393,7 @@ object TableCommands {
       classSimpleName[TableIdentifierTableExtractor],
       Some(columnDesc),
       isInput = true)
-    TableCommandSpec(cmd, Seq(tableDesc), operationTypeStr(DESCTABLE))
+    TableCommandSpec(cmd, Seq(tableDesc), DESCTABLE)
   }
 
   val DescribeTable = {
@@ -405,7 +405,7 @@ object TableCommands {
       Some(columnDesc),
       isInput = true,
       setCurrentDatabaseIfMissing = true)
-    TableCommandSpec(cmd, Seq(tableDesc), operationTypeStr(DESCTABLE))
+    TableCommandSpec(cmd, Seq(tableDesc), DESCTABLE)
   }
 
   val DropTable = {
@@ -418,13 +418,13 @@ object TableCommands {
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(tableTypeDesc = Some(tableTypeDesc))),
-      operationTypeStr(DROPTABLE))
+      DROPTABLE)
   }
 
   val DropTableV2 = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.DropTable"
     val tableDesc1 = resolvedTableDesc
-    TableCommandSpec(cmd, Seq(tableDesc1), operationTypeStr(DROPTABLE))
+    TableCommandSpec(cmd, Seq(tableDesc1), DROPTABLE)
   }
 
   val MergeIntoTable = {
@@ -441,52 +441,52 @@ object TableCommands {
   val ShowColumns = {
     val cmd = "org.apache.spark.sql.execution.command.ShowColumnsCommand"
     val tableDesc = tableNameDesc.copy(isInput = true)
-    TableCommandSpec(cmd, Seq(tableDesc), operationTypeStr(SHOWCOLUMNS))
+    TableCommandSpec(cmd, Seq(tableDesc), SHOWCOLUMNS)
   }
 
   val ShowCreateTable = {
     val cmd = "org.apache.spark.sql.execution.command.ShowCreateTableCommand"
     val tableDesc = tableNameDesc.copy(fieldName = "table", isInput = true)
-    TableCommandSpec(cmd, Seq(tableDesc), operationTypeStr(SHOW_CREATETABLE))
+    TableCommandSpec(cmd, Seq(tableDesc), SHOW_CREATETABLE)
   }
 
   val ShowTableProperties = {
     val cmd = "org.apache.spark.sql.execution.command.ShowTablePropertiesCommand"
     val tableDesc = tableNameDesc.copy(fieldName = "table", isInput = true)
-    TableCommandSpec(cmd, Seq(tableDesc), operationTypeStr(SHOW_TBLPROPERTIES))
+    TableCommandSpec(cmd, Seq(tableDesc), SHOW_TBLPROPERTIES)
   }
 
   val ShowCreateTableV2 = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.ShowCreateTable"
     val tableDesc =
       TableDesc("child", classSimpleName[ResolvedTableTableExtractor], isInput = true)
-    TableCommandSpec(cmd, Seq(tableDesc), operationTypeStr(SHOW_CREATETABLE))
+    TableCommandSpec(cmd, Seq(tableDesc), SHOW_CREATETABLE)
   }
 
   val ShowTablePropertiesV2 = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.ShowTableProperties"
     val tableDesc =
       TableDesc("table", classSimpleName[ResolvedTableTableExtractor], isInput = true)
-    TableCommandSpec(cmd, Seq(tableDesc), operationTypeStr(SHOW_TBLPROPERTIES))
+    TableCommandSpec(cmd, Seq(tableDesc), SHOW_TBLPROPERTIES)
   }
 
   val ShowPartitions = {
     val cmd = "org.apache.spark.sql.execution.command.ShowPartitionsCommand"
     val columnDesc = ColumnDesc("spec", classSimpleName[PartitionOptionColumnExtractor])
     val tableDesc = tableNameDesc.copy(isInput = true, columnDesc = Some(columnDesc))
-    TableCommandSpec(cmd, Seq(tableDesc), operationTypeStr(SHOWPARTITIONS))
+    TableCommandSpec(cmd, Seq(tableDesc), SHOWPARTITIONS)
   }
 
   val TruncateTable = {
     val cmd = "org.apache.spark.sql.execution.command.TruncateTableCommand"
     val columnDesc = ColumnDesc("partitionSpec", classSimpleName[PartitionOptionColumnExtractor])
     val tableDesc = tableNameDesc.copy(columnDesc = Some(columnDesc))
-    TableCommandSpec(cmd, Seq(tableDesc), operationTypeStr(TRUNCATETABLE))
+    TableCommandSpec(cmd, Seq(tableDesc), TRUNCATETABLE)
   }
 
   val TruncateTableV2 = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.TruncateTable"
-    TableCommandSpec(cmd, Seq(resolvedTableDesc), operationTypeStr(TRUNCATETABLE))
+    TableCommandSpec(cmd, Seq(resolvedTableDesc), TRUNCATETABLE)
   }
 
   val InsertIntoDataSource = {

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/TableCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/TableCommands.scala
@@ -18,27 +18,29 @@
 package org.apache.kyuubi.plugin.spark.authz.gen
 
 import org.apache.kyuubi.plugin.spark.authz.serde._
+import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils.getClassSimpleName
 
 object TableCommands {
   // table extractors
-  val tite = classOf[TableIdentifierTableExtractor].getSimpleName
+  val tite = getClassSimpleName[TableIdentifierTableExtractor]
   val tableNameDesc = TableDesc("tableName", tite)
   val tableIdentDesc = TableDesc("tableIdent", tite)
-  val resolvedTableDesc = TableDesc("child", "ResolvedTableTableExtractor")
-  val resolvedDbObjectNameDesc = TableDesc("child", "ResolvedDbObjectNameTableExtractor")
+  val resolvedTableDesc = TableDesc("child", getClassSimpleName[ResolvedTableTableExtractor])
+  val resolvedDbObjectNameDesc =
+    TableDesc("child", getClassSimpleName[ResolvedDbObjectNameTableExtractor])
 
   val overwriteActionTypeDesc =
-    ActionTypeDesc("overwrite", "OverwriteOrInsertActionTypeExtractor")
+    ActionTypeDesc("overwrite", getClassSimpleName[OverwriteOrInsertActionTypeExtractor])
 
   val AlterTable = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.AlterTable"
-    val tableDesc = TableDesc("ident", classOf[IdentifierTableExtractor].getSimpleName)
+    val tableDesc = TableDesc("ident", getClassSimpleName[IdentifierTableExtractor])
     TableCommandSpec(cmd, Seq(tableDesc), "ALTERTABLE_PROPERTIES")
   }
 
   val AlterTableAddColumns = {
     val cmd = "org.apache.spark.sql.execution.command.AlterTableAddColumnsCommand"
-    val columnDesc = ColumnDesc("colsToAdd", "StructFieldSeqColumnExtractor")
+    val columnDesc = ColumnDesc("colsToAdd", getClassSimpleName[StructFieldSeqColumnExtractor])
     val tableDesc = TableDesc("table", tite, Some(columnDesc))
     TableCommandSpec(cmd, Seq(tableDesc), "ALTERTABLE_ADDCOLS")
   }
@@ -70,7 +72,8 @@ object TableCommands {
 
   val AlterTableAddPartition = {
     val cmd = "org.apache.spark.sql.execution.command.AlterTableAddPartitionCommand"
-    val columnDesc = ColumnDesc("partitionSpecsAndLocs", "PartitionLocsSeqColumnExtractor")
+    val columnDesc =
+      ColumnDesc("partitionSpecsAndLocs", getClassSimpleName[PartitionLocsSeqColumnExtractor])
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
@@ -79,7 +82,7 @@ object TableCommands {
 
   val AlterTableChangeColumn = {
     val cmd = "org.apache.spark.sql.execution.command.AlterTableChangeColumnCommand"
-    val columnDesc = ColumnDesc("columnName", "StringColumnExtractor")
+    val columnDesc = ColumnDesc("columnName", getClassSimpleName[StringColumnExtractor])
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
@@ -88,7 +91,7 @@ object TableCommands {
 
   val AlterTableDropPartition = {
     val cmd = "org.apache.spark.sql.execution.command.AlterTableDropPartitionCommand"
-    val columnDesc = ColumnDesc("specs", "PartitionSeqColumnExtractor")
+    val columnDesc = ColumnDesc("specs", getClassSimpleName[PartitionSeqColumnExtractor])
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
@@ -100,7 +103,10 @@ object TableCommands {
     val actionTypeDesc = ActionTypeDesc(null, null, Some("DELETE"))
 
     val oldTableTableTypeDesc =
-      TableTypeDesc("oldName", "TableIdentifierTableTypeExtractor", Seq("TEMP_VIEW"))
+      TableTypeDesc(
+        "oldName",
+        getClassSimpleName[TableIdentifierTableTypeExtractor],
+        Seq("TEMP_VIEW"))
     val oldTableD = TableDesc(
       "oldName",
       tite,
@@ -125,7 +131,7 @@ object TableCommands {
 
   val AlterTableRenamePartition = {
     val cmd = "org.apache.spark.sql.execution.command.AlterTableRenamePartitionCommand"
-    val columnDesc = ColumnDesc("oldPartition", "PartitionColumnExtractor")
+    val columnDesc = ColumnDesc("oldPartition", getClassSimpleName[PartitionColumnExtractor])
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
@@ -134,7 +140,7 @@ object TableCommands {
 
   val AlterTableSerDeProperties = {
     val cmd = "org.apache.spark.sql.execution.command.AlterTableSerDePropertiesCommand"
-    val columnDesc = ColumnDesc("partSpec", "PartitionOptionColumnExtractor")
+    val columnDesc = ColumnDesc("partSpec", getClassSimpleName[PartitionOptionColumnExtractor])
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
@@ -143,7 +149,7 @@ object TableCommands {
 
   val AlterTableSetLocation = {
     val cmd = "org.apache.spark.sql.execution.command.AlterTableSetLocationCommand"
-    val columnDesc = ColumnDesc("partitionSpec", "PartitionOptionColumnExtractor")
+    val columnDesc = ColumnDesc("partitionSpec", getClassSimpleName[PartitionOptionColumnExtractor])
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
@@ -160,7 +166,7 @@ object TableCommands {
 
   val AlterViewAs = {
     val tableTypeDesc =
-      TableTypeDesc("name", "TableIdentifierTableTypeExtractor", Seq("TEMP_VIEW"))
+      TableTypeDesc("name", getClassSimpleName[TableIdentifierTableTypeExtractor], Seq("TEMP_VIEW"))
 
     TableCommandSpec(
       "org.apache.spark.sql.execution.command.AlterViewAsCommand",
@@ -171,8 +177,8 @@ object TableCommands {
 
   val AnalyzeColumn = {
     val cmd = "org.apache.spark.sql.execution.command.AnalyzeColumnCommand"
-    val cd1 = ColumnDesc("columnNames", "StringSeqColumnExtractor")
-    val cd2 = cd1.copy(fieldExtractor = "StringSeqOptionColumnExtractor")
+    val cd1 = ColumnDesc("columnNames", getClassSimpleName[StringSeqColumnExtractor])
+    val cd2 = cd1.copy(fieldExtractor = getClassSimpleName[StringSeqOptionColumnExtractor])
     val td1 = tableIdentDesc.copy(columnDesc = Some(cd1), isInput = true)
     val td2 = td1.copy(columnDesc = Some(cd2))
     TableCommandSpec(cmd, Seq(td1, td2), "ANALYZE_TABLE")
@@ -180,7 +186,7 @@ object TableCommands {
 
   val AnalyzePartition = {
     val cmd = "org.apache.spark.sql.execution.command.AnalyzePartitionCommand"
-    val columnDesc = ColumnDesc("partitionSpec", "PartitionColumnExtractor")
+    val columnDesc = ColumnDesc("partitionSpec", getClassSimpleName[PartitionColumnExtractor])
     TableCommandSpec(
       cmd,
       Seq(tableIdentDesc.copy(columnDesc = Some(columnDesc), isInput = true)),
@@ -199,7 +205,7 @@ object TableCommands {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.CreateTable"
     val tableDesc = TableDesc(
       "tableName",
-      "IdentifierTableExtractor",
+      getClassSimpleName[IdentifierTableExtractor],
       catalogDesc = Some(CatalogDesc()))
     TableCommandSpec(cmd, Seq(tableDesc, resolvedDbObjectNameDesc), "CREATETABLE")
   }
@@ -208,7 +214,7 @@ object TableCommands {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.CreateV2Table"
     val tableDesc = TableDesc(
       "tableName",
-      "IdentifierTableExtractor",
+      getClassSimpleName[IdentifierTableExtractor],
       catalogDesc = Some(CatalogDesc()))
     TableCommandSpec(cmd, Seq(tableDesc), "CREATETABLE")
   }
@@ -217,7 +223,7 @@ object TableCommands {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.CreateTableAsSelect"
     val tableDesc = TableDesc(
       "tableName",
-      "IdentifierTableExtractor",
+      getClassSimpleName[IdentifierTableExtractor],
       catalogDesc = Some(CatalogDesc()))
     TableCommandSpec(
       cmd,
@@ -237,7 +243,7 @@ object TableCommands {
     val tableDesc =
       TableDesc(
         "table",
-        "DataSourceV2RelationTableExtractor",
+        getClassSimpleName[DataSourceV2RelationTableExtractor],
         actionTypeDesc = Some(actionTypeDesc))
     TableCommandSpec(cmd, Seq(tableDesc), queryDescs = Seq(QueryDesc("query")))
   }
@@ -248,7 +254,7 @@ object TableCommands {
     val tableDesc =
       TableDesc(
         "table",
-        "DataSourceV2RelationTableExtractor",
+        getClassSimpleName[DataSourceV2RelationTableExtractor],
         actionTypeDesc = Some(actionTypeDesc))
     TableCommandSpec(cmd, Seq(tableDesc), queryDescs = Seq(QueryDesc("query")))
   }
@@ -264,7 +270,7 @@ object TableCommands {
     val tableDesc =
       TableDesc(
         "table",
-        "DataSourceV2RelationTableExtractor",
+        getClassSimpleName[DataSourceV2RelationTableExtractor],
         actionTypeDesc = Some(actionTypeDesc))
     TableCommandSpec(cmd, Seq(tableDesc), queryDescs = Seq(QueryDesc("query")))
   }
@@ -277,28 +283,28 @@ object TableCommands {
   val AddPartitions = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.AddPartitions"
     // TODO: add column desc
-    val tableDesc = TableDesc("table", "DataSourceV2RelationTableExtractor")
+    val tableDesc = TableDesc("table", getClassSimpleName[DataSourceV2RelationTableExtractor])
     TableCommandSpec(cmd, Seq(tableDesc), "ALTERTABLE_ADDPARTS")
   }
 
   val DropPartitions = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.DropPartitions"
     // TODO: add column desc
-    val tableDesc = TableDesc("table", "DataSourceV2RelationTableExtractor")
+    val tableDesc = TableDesc("table", getClassSimpleName[DataSourceV2RelationTableExtractor])
     TableCommandSpec(cmd, Seq(tableDesc), "ALTERTABLE_DROPPARTS")
   }
 
   val RenamePartitions = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.RenamePartitions"
     // TODO: add column desc
-    val tableDesc = TableDesc("table", "DataSourceV2RelationTableExtractor")
+    val tableDesc = TableDesc("table", getClassSimpleName[DataSourceV2RelationTableExtractor])
     TableCommandSpec(cmd, Seq(tableDesc), "ALTERTABLE_RENAMEPART")
   }
 
   val TruncatePartition = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.TruncatePartition"
     // TODO: add column desc
-    val tableDesc = TableDesc("table", "DataSourceV2RelationTableExtractor")
+    val tableDesc = TableDesc("table", getClassSimpleName[DataSourceV2RelationTableExtractor])
     TableCommandSpec(cmd, Seq(tableDesc), "ALTERTABLE_DROPPARTS")
   }
 
@@ -309,7 +315,7 @@ object TableCommands {
 
   val CacheTable = {
     val cmd = "org.apache.spark.sql.execution.command.CacheTableCommand"
-    val queryDesc = QueryDesc("plan", "LogicalPlanOptionQueryExtractor")
+    val queryDesc = QueryDesc("plan", getClassSimpleName[LogicalPlanOptionQueryExtractor])
     TableCommandSpec(cmd, Nil, "CREATEVIEW", queryDescs = Seq(queryDesc))
   }
 
@@ -322,11 +328,11 @@ object TableCommands {
     val cmd = "org.apache.spark.sql.execution.command.CreateViewCommand"
     val tableTypeDesc = TableTypeDesc(
       "viewType",
-      "ViewTypeTableTypeExtractor",
+      getClassSimpleName[ViewTypeTableTypeExtractor],
       Seq("TEMP_VIEW", "GLOBAL_TEMP_VIEW"))
     val tableDesc = TableDesc(
       "name",
-      "TableIdentifierTableExtractor",
+      getClassSimpleName[TableIdentifierTableExtractor],
       tableTypeDesc = Some(tableTypeDesc))
     val queryDesc1 = QueryDesc("plan")
     val queryDesc2 = QueryDesc("child")
@@ -340,7 +346,7 @@ object TableCommands {
 
   val CreateDataSourceTable = {
     val cmd = "org.apache.spark.sql.execution.command.CreateDataSourceTableCommand"
-    val tableDesc = TableDesc("table", "CatalogTableTableExtractor")
+    val tableDesc = TableDesc("table", getClassSimpleName[CatalogTableTableExtractor])
     TableCommandSpec(cmd, Seq(tableDesc), "CREATETABLE")
   }
 
@@ -354,8 +360,9 @@ object TableCommands {
 
   val CreateHiveTableAsSelect = {
     val cmd = "org.apache.spark.sql.hive.execution.CreateHiveTableAsSelectCommand"
-    val columnDesc = ColumnDesc("outputColumnNames", "StringSeqColumnExtractor")
-    val tableDesc = TableDesc("tableDesc", "CatalogTableTableExtractor", Some(columnDesc))
+    val columnDesc = ColumnDesc("outputColumnNames", getClassSimpleName[StringSeqColumnExtractor])
+    val tableDesc =
+      TableDesc("tableDesc", getClassSimpleName[CatalogTableTableExtractor], Some(columnDesc))
     val queryDesc = QueryDesc("query")
     TableCommandSpec(cmd, Seq(tableDesc), "CREATETABLE_AS_SELECT", queryDescs = Seq(queryDesc))
   }
@@ -364,11 +371,11 @@ object TableCommands {
     val cmd = "org.apache.spark.sql.execution.command.CreateTableLikeCommand"
     val tableDesc1 = TableDesc(
       "targetTable",
-      "TableIdentifierTableExtractor",
+      getClassSimpleName[TableIdentifierTableExtractor],
       setCurrentDatabaseIfMissing = true)
     val tableDesc2 = TableDesc(
       "sourceTable",
-      "TableIdentifierTableExtractor",
+      getClassSimpleName[TableIdentifierTableExtractor],
       isInput = true,
       setCurrentDatabaseIfMissing = true)
     TableCommandSpec(cmd, Seq(tableDesc1, tableDesc2), "CREATETABLE")
@@ -376,10 +383,10 @@ object TableCommands {
 
   val DescribeColumn = {
     val cmd = "org.apache.spark.sql.execution.command.DescribeColumnCommand"
-    val columnDesc = ColumnDesc("colNameParts", "StringSeqLastColumnExtractor")
+    val columnDesc = ColumnDesc("colNameParts", getClassSimpleName[StringSeqLastColumnExtractor])
     val tableDesc = TableDesc(
       "table",
-      "TableIdentifierTableExtractor",
+      getClassSimpleName[TableIdentifierTableExtractor],
       Some(columnDesc),
       isInput = true)
     TableCommandSpec(cmd, Seq(tableDesc), "DESCTABLE")
@@ -387,10 +394,10 @@ object TableCommands {
 
   val DescribeTable = {
     val cmd = "org.apache.spark.sql.execution.command.DescribeTableCommand"
-    val columnDesc = ColumnDesc("partitionSpec", "PartitionColumnExtractor")
+    val columnDesc = ColumnDesc("partitionSpec", getClassSimpleName[PartitionColumnExtractor])
     val tableDesc = TableDesc(
       "table",
-      "TableIdentifierTableExtractor",
+      getClassSimpleName[TableIdentifierTableExtractor],
       Some(columnDesc),
       isInput = true,
       setCurrentDatabaseIfMissing = true)
@@ -400,7 +407,10 @@ object TableCommands {
   val DropTable = {
     val cmd = "org.apache.spark.sql.execution.command.DropTableCommand"
     val tableTypeDesc =
-      TableTypeDesc("tableName", "TableIdentifierTableTypeExtractor", Seq("TEMP_VIEW"))
+      TableTypeDesc(
+        "tableName",
+        getClassSimpleName[TableIdentifierTableTypeExtractor],
+        Seq("TEMP_VIEW"))
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(tableTypeDesc = Some(tableTypeDesc))),
@@ -418,7 +428,7 @@ object TableCommands {
     val actionTypeDesc = ActionTypeDesc(null, null, Some("UPDATE"))
     val tableDesc = TableDesc(
       "targetTable",
-      "DataSourceV2RelationTableExtractor",
+      getClassSimpleName[DataSourceV2RelationTableExtractor],
       actionTypeDesc = Some(actionTypeDesc))
     val queryDesc = QueryDesc("sourceTable")
     TableCommandSpec(cmd, Seq(tableDesc), queryDescs = Seq(queryDesc))
@@ -444,26 +454,28 @@ object TableCommands {
 
   val ShowCreateTableV2 = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.ShowCreateTable"
-    val tableDesc = TableDesc("child", "ResolvedTableTableExtractor", isInput = true)
+    val tableDesc =
+      TableDesc("child", getClassSimpleName[ResolvedTableTableExtractor], isInput = true)
     TableCommandSpec(cmd, Seq(tableDesc), "SHOW_CREATETABLE")
   }
 
   val ShowTablePropertiesV2 = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.ShowTableProperties"
-    val tableDesc = TableDesc("table", "ResolvedTableTableExtractor", isInput = true)
+    val tableDesc =
+      TableDesc("table", getClassSimpleName[ResolvedTableTableExtractor], isInput = true)
     TableCommandSpec(cmd, Seq(tableDesc), "SHOW_TBLPROPERTIES")
   }
 
   val ShowPartitions = {
     val cmd = "org.apache.spark.sql.execution.command.ShowPartitionsCommand"
-    val columnDesc = ColumnDesc("spec", "PartitionOptionColumnExtractor")
+    val columnDesc = ColumnDesc("spec", getClassSimpleName[PartitionOptionColumnExtractor])
     val tableDesc = tableNameDesc.copy(isInput = true, columnDesc = Some(columnDesc))
     TableCommandSpec(cmd, Seq(tableDesc), "SHOWPARTITIONS")
   }
 
   val TruncateTable = {
     val cmd = "org.apache.spark.sql.execution.command.TruncateTableCommand"
-    val columnDesc = ColumnDesc("partitionSpec", "PartitionOptionColumnExtractor")
+    val columnDesc = ColumnDesc("partitionSpec", getClassSimpleName[PartitionOptionColumnExtractor])
     val tableDesc = tableNameDesc.copy(columnDesc = Some(columnDesc))
     TableCommandSpec(cmd, Seq(tableDesc), "TRUNCATETABLE")
   }
@@ -478,7 +490,7 @@ object TableCommands {
     val actionTypeDesc = overwriteActionTypeDesc
     val tableDesc = TableDesc(
       "logicalRelation",
-      "LogicalRelationTableExtractor",
+      getClassSimpleName[LogicalRelationTableExtractor],
       actionTypeDesc = Some(actionTypeDesc))
     TableCommandSpec(cmd, Seq(tableDesc), queryDescs = Seq(QueryDesc("query")))
   }
@@ -486,10 +498,10 @@ object TableCommands {
   val InsertIntoHiveTable = {
     val cmd = "org.apache.spark.sql.hive.execution.InsertIntoHiveTable"
     val actionTypeDesc = overwriteActionTypeDesc
-    val columnDesc = ColumnDesc("outputColumnNames", "StringSeqColumnExtractor")
+    val columnDesc = ColumnDesc("outputColumnNames", getClassSimpleName[StringSeqColumnExtractor])
     val tableDesc = TableDesc(
       "table",
-      "CatalogTableTableExtractor",
+      getClassSimpleName[CatalogTableTableExtractor],
       Some(columnDesc),
       Some(actionTypeDesc))
     val queryDesc = QueryDesc("query")
@@ -505,7 +517,7 @@ object TableCommands {
   val LoadData = {
     val cmd = "org.apache.spark.sql.execution.command.LoadDataCommand"
     val actionTypeDesc = overwriteActionTypeDesc.copy(fieldName = "isOverwrite")
-    val columnDesc = ColumnDesc("partition", "PartitionOptionColumnExtractor")
+    val columnDesc = ColumnDesc("partition", getClassSimpleName[PartitionOptionColumnExtractor])
     val tableDesc = tableIdentDesc.copy(
       fieldName = "table",
       columnDesc = Some(columnDesc),

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/TableCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/TableCommands.scala
@@ -18,29 +18,28 @@
 package org.apache.kyuubi.plugin.spark.authz.gen
 
 import org.apache.kyuubi.plugin.spark.authz.serde._
-import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils.extractorKey
 
 object TableCommands {
   // table extractors
-  val tite = extractorKey[TableIdentifierTableExtractor]
+  val tite = classSimpleName[TableIdentifierTableExtractor]
   val tableNameDesc = TableDesc("tableName", tite)
   val tableIdentDesc = TableDesc("tableIdent", tite)
-  val resolvedTableDesc = TableDesc("child", extractorKey[ResolvedTableTableExtractor])
+  val resolvedTableDesc = TableDesc("child", classSimpleName[ResolvedTableTableExtractor])
   val resolvedDbObjectNameDesc =
-    TableDesc("child", extractorKey[ResolvedDbObjectNameTableExtractor])
+    TableDesc("child", classSimpleName[ResolvedDbObjectNameTableExtractor])
 
   val overwriteActionTypeDesc =
-    ActionTypeDesc("overwrite", extractorKey[OverwriteOrInsertActionTypeExtractor])
+    ActionTypeDesc("overwrite", classSimpleName[OverwriteOrInsertActionTypeExtractor])
 
   val AlterTable = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.AlterTable"
-    val tableDesc = TableDesc("ident", extractorKey[IdentifierTableExtractor])
+    val tableDesc = TableDesc("ident", classSimpleName[IdentifierTableExtractor])
     TableCommandSpec(cmd, Seq(tableDesc), "ALTERTABLE_PROPERTIES")
   }
 
   val AlterTableAddColumns = {
     val cmd = "org.apache.spark.sql.execution.command.AlterTableAddColumnsCommand"
-    val columnDesc = ColumnDesc("colsToAdd", extractorKey[StructFieldSeqColumnExtractor])
+    val columnDesc = ColumnDesc("colsToAdd", classSimpleName[StructFieldSeqColumnExtractor])
     val tableDesc = TableDesc("table", tite, Some(columnDesc))
     TableCommandSpec(cmd, Seq(tableDesc), "ALTERTABLE_ADDCOLS")
   }
@@ -73,7 +72,7 @@ object TableCommands {
   val AlterTableAddPartition = {
     val cmd = "org.apache.spark.sql.execution.command.AlterTableAddPartitionCommand"
     val columnDesc =
-      ColumnDesc("partitionSpecsAndLocs", extractorKey[PartitionLocsSeqColumnExtractor])
+      ColumnDesc("partitionSpecsAndLocs", classSimpleName[PartitionLocsSeqColumnExtractor])
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
@@ -82,7 +81,7 @@ object TableCommands {
 
   val AlterTableChangeColumn = {
     val cmd = "org.apache.spark.sql.execution.command.AlterTableChangeColumnCommand"
-    val columnDesc = ColumnDesc("columnName", extractorKey[StringColumnExtractor])
+    val columnDesc = ColumnDesc("columnName", classSimpleName[StringColumnExtractor])
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
@@ -91,7 +90,7 @@ object TableCommands {
 
   val AlterTableDropPartition = {
     val cmd = "org.apache.spark.sql.execution.command.AlterTableDropPartitionCommand"
-    val columnDesc = ColumnDesc("specs", extractorKey[PartitionSeqColumnExtractor])
+    val columnDesc = ColumnDesc("specs", classSimpleName[PartitionSeqColumnExtractor])
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
@@ -105,7 +104,7 @@ object TableCommands {
     val oldTableTableTypeDesc =
       TableTypeDesc(
         "oldName",
-        extractorKey[TableIdentifierTableTypeExtractor],
+        classSimpleName[TableIdentifierTableTypeExtractor],
         Seq("TEMP_VIEW"))
     val oldTableD = TableDesc(
       "oldName",
@@ -131,7 +130,7 @@ object TableCommands {
 
   val AlterTableRenamePartition = {
     val cmd = "org.apache.spark.sql.execution.command.AlterTableRenamePartitionCommand"
-    val columnDesc = ColumnDesc("oldPartition", extractorKey[PartitionColumnExtractor])
+    val columnDesc = ColumnDesc("oldPartition", classSimpleName[PartitionColumnExtractor])
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
@@ -140,7 +139,7 @@ object TableCommands {
 
   val AlterTableSerDeProperties = {
     val cmd = "org.apache.spark.sql.execution.command.AlterTableSerDePropertiesCommand"
-    val columnDesc = ColumnDesc("partSpec", extractorKey[PartitionOptionColumnExtractor])
+    val columnDesc = ColumnDesc("partSpec", classSimpleName[PartitionOptionColumnExtractor])
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
@@ -149,7 +148,7 @@ object TableCommands {
 
   val AlterTableSetLocation = {
     val cmd = "org.apache.spark.sql.execution.command.AlterTableSetLocationCommand"
-    val columnDesc = ColumnDesc("partitionSpec", extractorKey[PartitionOptionColumnExtractor])
+    val columnDesc = ColumnDesc("partitionSpec", classSimpleName[PartitionOptionColumnExtractor])
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
@@ -166,7 +165,7 @@ object TableCommands {
 
   val AlterViewAs = {
     val tableTypeDesc =
-      TableTypeDesc("name", extractorKey[TableIdentifierTableTypeExtractor], Seq("TEMP_VIEW"))
+      TableTypeDesc("name", classSimpleName[TableIdentifierTableTypeExtractor], Seq("TEMP_VIEW"))
 
     TableCommandSpec(
       "org.apache.spark.sql.execution.command.AlterViewAsCommand",
@@ -177,8 +176,8 @@ object TableCommands {
 
   val AnalyzeColumn = {
     val cmd = "org.apache.spark.sql.execution.command.AnalyzeColumnCommand"
-    val cd1 = ColumnDesc("columnNames", extractorKey[StringSeqColumnExtractor])
-    val cd2 = cd1.copy(fieldExtractor = extractorKey[StringSeqOptionColumnExtractor])
+    val cd1 = ColumnDesc("columnNames", classSimpleName[StringSeqColumnExtractor])
+    val cd2 = cd1.copy(fieldExtractor = classSimpleName[StringSeqOptionColumnExtractor])
     val td1 = tableIdentDesc.copy(columnDesc = Some(cd1), isInput = true)
     val td2 = td1.copy(columnDesc = Some(cd2))
     TableCommandSpec(cmd, Seq(td1, td2), "ANALYZE_TABLE")
@@ -186,7 +185,7 @@ object TableCommands {
 
   val AnalyzePartition = {
     val cmd = "org.apache.spark.sql.execution.command.AnalyzePartitionCommand"
-    val columnDesc = ColumnDesc("partitionSpec", extractorKey[PartitionColumnExtractor])
+    val columnDesc = ColumnDesc("partitionSpec", classSimpleName[PartitionColumnExtractor])
     TableCommandSpec(
       cmd,
       Seq(tableIdentDesc.copy(columnDesc = Some(columnDesc), isInput = true)),
@@ -205,7 +204,7 @@ object TableCommands {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.CreateTable"
     val tableDesc = TableDesc(
       "tableName",
-      extractorKey[IdentifierTableExtractor],
+      classSimpleName[IdentifierTableExtractor],
       catalogDesc = Some(CatalogDesc()))
     TableCommandSpec(cmd, Seq(tableDesc, resolvedDbObjectNameDesc), "CREATETABLE")
   }
@@ -214,7 +213,7 @@ object TableCommands {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.CreateV2Table"
     val tableDesc = TableDesc(
       "tableName",
-      extractorKey[IdentifierTableExtractor],
+      classSimpleName[IdentifierTableExtractor],
       catalogDesc = Some(CatalogDesc()))
     TableCommandSpec(cmd, Seq(tableDesc), "CREATETABLE")
   }
@@ -223,7 +222,7 @@ object TableCommands {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.CreateTableAsSelect"
     val tableDesc = TableDesc(
       "tableName",
-      extractorKey[IdentifierTableExtractor],
+      classSimpleName[IdentifierTableExtractor],
       catalogDesc = Some(CatalogDesc()))
     TableCommandSpec(
       cmd,
@@ -243,7 +242,7 @@ object TableCommands {
     val tableDesc =
       TableDesc(
         "table",
-        extractorKey[DataSourceV2RelationTableExtractor],
+        classSimpleName[DataSourceV2RelationTableExtractor],
         actionTypeDesc = Some(actionTypeDesc))
     TableCommandSpec(cmd, Seq(tableDesc), queryDescs = Seq(QueryDesc("query")))
   }
@@ -254,7 +253,7 @@ object TableCommands {
     val tableDesc =
       TableDesc(
         "table",
-        extractorKey[DataSourceV2RelationTableExtractor],
+        classSimpleName[DataSourceV2RelationTableExtractor],
         actionTypeDesc = Some(actionTypeDesc))
     TableCommandSpec(cmd, Seq(tableDesc), queryDescs = Seq(QueryDesc("query")))
   }
@@ -270,7 +269,7 @@ object TableCommands {
     val tableDesc =
       TableDesc(
         "table",
-        extractorKey[DataSourceV2RelationTableExtractor],
+        classSimpleName[DataSourceV2RelationTableExtractor],
         actionTypeDesc = Some(actionTypeDesc))
     TableCommandSpec(cmd, Seq(tableDesc), queryDescs = Seq(QueryDesc("query")))
   }
@@ -283,28 +282,28 @@ object TableCommands {
   val AddPartitions = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.AddPartitions"
     // TODO: add column desc
-    val tableDesc = TableDesc("table", extractorKey[DataSourceV2RelationTableExtractor])
+    val tableDesc = TableDesc("table", classSimpleName[DataSourceV2RelationTableExtractor])
     TableCommandSpec(cmd, Seq(tableDesc), "ALTERTABLE_ADDPARTS")
   }
 
   val DropPartitions = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.DropPartitions"
     // TODO: add column desc
-    val tableDesc = TableDesc("table", extractorKey[DataSourceV2RelationTableExtractor])
+    val tableDesc = TableDesc("table", classSimpleName[DataSourceV2RelationTableExtractor])
     TableCommandSpec(cmd, Seq(tableDesc), "ALTERTABLE_DROPPARTS")
   }
 
   val RenamePartitions = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.RenamePartitions"
     // TODO: add column desc
-    val tableDesc = TableDesc("table", extractorKey[DataSourceV2RelationTableExtractor])
+    val tableDesc = TableDesc("table", classSimpleName[DataSourceV2RelationTableExtractor])
     TableCommandSpec(cmd, Seq(tableDesc), "ALTERTABLE_RENAMEPART")
   }
 
   val TruncatePartition = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.TruncatePartition"
     // TODO: add column desc
-    val tableDesc = TableDesc("table", extractorKey[DataSourceV2RelationTableExtractor])
+    val tableDesc = TableDesc("table", classSimpleName[DataSourceV2RelationTableExtractor])
     TableCommandSpec(cmd, Seq(tableDesc), "ALTERTABLE_DROPPARTS")
   }
 
@@ -315,7 +314,7 @@ object TableCommands {
 
   val CacheTable = {
     val cmd = "org.apache.spark.sql.execution.command.CacheTableCommand"
-    val queryDesc = QueryDesc("plan", extractorKey[LogicalPlanOptionQueryExtractor])
+    val queryDesc = QueryDesc("plan", classSimpleName[LogicalPlanOptionQueryExtractor])
     TableCommandSpec(cmd, Nil, "CREATEVIEW", queryDescs = Seq(queryDesc))
   }
 
@@ -328,11 +327,11 @@ object TableCommands {
     val cmd = "org.apache.spark.sql.execution.command.CreateViewCommand"
     val tableTypeDesc = TableTypeDesc(
       "viewType",
-      extractorKey[ViewTypeTableTypeExtractor],
+      classSimpleName[ViewTypeTableTypeExtractor],
       Seq("TEMP_VIEW", "GLOBAL_TEMP_VIEW"))
     val tableDesc = TableDesc(
       "name",
-      extractorKey[TableIdentifierTableExtractor],
+      classSimpleName[TableIdentifierTableExtractor],
       tableTypeDesc = Some(tableTypeDesc))
     val queryDesc1 = QueryDesc("plan")
     val queryDesc2 = QueryDesc("child")
@@ -346,7 +345,7 @@ object TableCommands {
 
   val CreateDataSourceTable = {
     val cmd = "org.apache.spark.sql.execution.command.CreateDataSourceTableCommand"
-    val tableDesc = TableDesc("table", extractorKey[CatalogTableTableExtractor])
+    val tableDesc = TableDesc("table", classSimpleName[CatalogTableTableExtractor])
     TableCommandSpec(cmd, Seq(tableDesc), "CREATETABLE")
   }
 
@@ -360,9 +359,9 @@ object TableCommands {
 
   val CreateHiveTableAsSelect = {
     val cmd = "org.apache.spark.sql.hive.execution.CreateHiveTableAsSelectCommand"
-    val columnDesc = ColumnDesc("outputColumnNames", extractorKey[StringSeqColumnExtractor])
+    val columnDesc = ColumnDesc("outputColumnNames", classSimpleName[StringSeqColumnExtractor])
     val tableDesc =
-      TableDesc("tableDesc", extractorKey[CatalogTableTableExtractor], Some(columnDesc))
+      TableDesc("tableDesc", classSimpleName[CatalogTableTableExtractor], Some(columnDesc))
     val queryDesc = QueryDesc("query")
     TableCommandSpec(cmd, Seq(tableDesc), "CREATETABLE_AS_SELECT", queryDescs = Seq(queryDesc))
   }
@@ -371,11 +370,11 @@ object TableCommands {
     val cmd = "org.apache.spark.sql.execution.command.CreateTableLikeCommand"
     val tableDesc1 = TableDesc(
       "targetTable",
-      extractorKey[TableIdentifierTableExtractor],
+      classSimpleName[TableIdentifierTableExtractor],
       setCurrentDatabaseIfMissing = true)
     val tableDesc2 = TableDesc(
       "sourceTable",
-      extractorKey[TableIdentifierTableExtractor],
+      classSimpleName[TableIdentifierTableExtractor],
       isInput = true,
       setCurrentDatabaseIfMissing = true)
     TableCommandSpec(cmd, Seq(tableDesc1, tableDesc2), "CREATETABLE")
@@ -383,10 +382,10 @@ object TableCommands {
 
   val DescribeColumn = {
     val cmd = "org.apache.spark.sql.execution.command.DescribeColumnCommand"
-    val columnDesc = ColumnDesc("colNameParts", extractorKey[StringSeqLastColumnExtractor])
+    val columnDesc = ColumnDesc("colNameParts", classSimpleName[StringSeqLastColumnExtractor])
     val tableDesc = TableDesc(
       "table",
-      extractorKey[TableIdentifierTableExtractor],
+      classSimpleName[TableIdentifierTableExtractor],
       Some(columnDesc),
       isInput = true)
     TableCommandSpec(cmd, Seq(tableDesc), "DESCTABLE")
@@ -394,10 +393,10 @@ object TableCommands {
 
   val DescribeTable = {
     val cmd = "org.apache.spark.sql.execution.command.DescribeTableCommand"
-    val columnDesc = ColumnDesc("partitionSpec", extractorKey[PartitionColumnExtractor])
+    val columnDesc = ColumnDesc("partitionSpec", classSimpleName[PartitionColumnExtractor])
     val tableDesc = TableDesc(
       "table",
-      extractorKey[TableIdentifierTableExtractor],
+      classSimpleName[TableIdentifierTableExtractor],
       Some(columnDesc),
       isInput = true,
       setCurrentDatabaseIfMissing = true)
@@ -409,7 +408,7 @@ object TableCommands {
     val tableTypeDesc =
       TableTypeDesc(
         "tableName",
-        extractorKey[TableIdentifierTableTypeExtractor],
+        classSimpleName[TableIdentifierTableTypeExtractor],
         Seq("TEMP_VIEW"))
     TableCommandSpec(
       cmd,
@@ -428,7 +427,7 @@ object TableCommands {
     val actionTypeDesc = ActionTypeDesc(null, null, Some("UPDATE"))
     val tableDesc = TableDesc(
       "targetTable",
-      extractorKey[DataSourceV2RelationTableExtractor],
+      classSimpleName[DataSourceV2RelationTableExtractor],
       actionTypeDesc = Some(actionTypeDesc))
     val queryDesc = QueryDesc("sourceTable")
     TableCommandSpec(cmd, Seq(tableDesc), queryDescs = Seq(queryDesc))
@@ -455,27 +454,27 @@ object TableCommands {
   val ShowCreateTableV2 = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.ShowCreateTable"
     val tableDesc =
-      TableDesc("child", extractorKey[ResolvedTableTableExtractor], isInput = true)
+      TableDesc("child", classSimpleName[ResolvedTableTableExtractor], isInput = true)
     TableCommandSpec(cmd, Seq(tableDesc), "SHOW_CREATETABLE")
   }
 
   val ShowTablePropertiesV2 = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.ShowTableProperties"
     val tableDesc =
-      TableDesc("table", extractorKey[ResolvedTableTableExtractor], isInput = true)
+      TableDesc("table", classSimpleName[ResolvedTableTableExtractor], isInput = true)
     TableCommandSpec(cmd, Seq(tableDesc), "SHOW_TBLPROPERTIES")
   }
 
   val ShowPartitions = {
     val cmd = "org.apache.spark.sql.execution.command.ShowPartitionsCommand"
-    val columnDesc = ColumnDesc("spec", extractorKey[PartitionOptionColumnExtractor])
+    val columnDesc = ColumnDesc("spec", classSimpleName[PartitionOptionColumnExtractor])
     val tableDesc = tableNameDesc.copy(isInput = true, columnDesc = Some(columnDesc))
     TableCommandSpec(cmd, Seq(tableDesc), "SHOWPARTITIONS")
   }
 
   val TruncateTable = {
     val cmd = "org.apache.spark.sql.execution.command.TruncateTableCommand"
-    val columnDesc = ColumnDesc("partitionSpec", extractorKey[PartitionOptionColumnExtractor])
+    val columnDesc = ColumnDesc("partitionSpec", classSimpleName[PartitionOptionColumnExtractor])
     val tableDesc = tableNameDesc.copy(columnDesc = Some(columnDesc))
     TableCommandSpec(cmd, Seq(tableDesc), "TRUNCATETABLE")
   }
@@ -490,7 +489,7 @@ object TableCommands {
     val actionTypeDesc = overwriteActionTypeDesc
     val tableDesc = TableDesc(
       "logicalRelation",
-      extractorKey[LogicalRelationTableExtractor],
+      classSimpleName[LogicalRelationTableExtractor],
       actionTypeDesc = Some(actionTypeDesc))
     TableCommandSpec(cmd, Seq(tableDesc), queryDescs = Seq(QueryDesc("query")))
   }
@@ -498,10 +497,10 @@ object TableCommands {
   val InsertIntoHiveTable = {
     val cmd = "org.apache.spark.sql.hive.execution.InsertIntoHiveTable"
     val actionTypeDesc = overwriteActionTypeDesc
-    val columnDesc = ColumnDesc("outputColumnNames", extractorKey[StringSeqColumnExtractor])
+    val columnDesc = ColumnDesc("outputColumnNames", classSimpleName[StringSeqColumnExtractor])
     val tableDesc = TableDesc(
       "table",
-      extractorKey[CatalogTableTableExtractor],
+      classSimpleName[CatalogTableTableExtractor],
       Some(columnDesc),
       Some(actionTypeDesc))
     val queryDesc = QueryDesc("query")
@@ -517,7 +516,7 @@ object TableCommands {
   val LoadData = {
     val cmd = "org.apache.spark.sql.execution.command.LoadDataCommand"
     val actionTypeDesc = overwriteActionTypeDesc.copy(fieldName = "isOverwrite")
-    val columnDesc = ColumnDesc("partition", extractorKey[PartitionOptionColumnExtractor])
+    val columnDesc = ColumnDesc("partition", classSimpleName[PartitionOptionColumnExtractor])
     val tableDesc = tableIdentDesc.copy(
       fieldName = "table",
       columnDesc = Some(columnDesc),

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/TableCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/TableCommands.scala
@@ -17,6 +17,7 @@
 
 package org.apache.kyuubi.plugin.spark.authz.gen
 
+import org.apache.kyuubi.plugin.spark.authz.OperationType._
 import org.apache.kyuubi.plugin.spark.authz.serde._
 
 object TableCommands {
@@ -34,19 +35,19 @@ object TableCommands {
   val AlterTable = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.AlterTable"
     val tableDesc = TableDesc("ident", classSimpleName[IdentifierTableExtractor])
-    TableCommandSpec(cmd, Seq(tableDesc), "ALTERTABLE_PROPERTIES")
+    TableCommandSpec(cmd, Seq(tableDesc), operationTypeStr(ALTERTABLE_PROPERTIES))
   }
 
   val AlterTableAddColumns = {
     val cmd = "org.apache.spark.sql.execution.command.AlterTableAddColumnsCommand"
     val columnDesc = ColumnDesc("colsToAdd", classSimpleName[StructFieldSeqColumnExtractor])
     val tableDesc = TableDesc("table", tite, Some(columnDesc))
-    TableCommandSpec(cmd, Seq(tableDesc), "ALTERTABLE_ADDCOLS")
+    TableCommandSpec(cmd, Seq(tableDesc), operationTypeStr(ALTERTABLE_ADDCOLS))
   }
 
   val AddColumns = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.AddColumns"
-    TableCommandSpec(cmd, Seq(resolvedTableDesc), "ALTERTABLE_ADDCOLS")
+    TableCommandSpec(cmd, Seq(resolvedTableDesc), operationTypeStr(ALTERTABLE_ADDCOLS))
   }
 
   val AlterColumn = {
@@ -61,12 +62,12 @@ object TableCommands {
 
   val ReplaceColumns = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.ReplaceColumns"
-    TableCommandSpec(cmd, Seq(resolvedTableDesc), "ALTERTABLE_REPLACECOLS")
+    TableCommandSpec(cmd, Seq(resolvedTableDesc), operationTypeStr(ALTERTABLE_REPLACECOLS))
   }
 
   val RenameColumn = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.RenameColumn"
-    TableCommandSpec(cmd, Seq(resolvedTableDesc), "ALTERTABLE_RENAMECOL")
+    TableCommandSpec(cmd, Seq(resolvedTableDesc), operationTypeStr(ALTERTABLE_RENAMECOL))
   }
 
   val AlterTableAddPartition = {
@@ -76,7 +77,7 @@ object TableCommands {
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
-      "ALTERTABLE_ADDPARTS")
+      operationTypeStr(ALTERTABLE_ADDPARTS))
   }
 
   val AlterTableChangeColumn = {
@@ -85,7 +86,7 @@ object TableCommands {
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
-      "ALTERTABLE_REPLACECOLS")
+      operationTypeStr(ALTERTABLE_REPLACECOLS))
   }
 
   val AlterTableDropPartition = {
@@ -94,7 +95,7 @@ object TableCommands {
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
-      "ALTERTABLE_DROPPARTS")
+      operationTypeStr(ALTERTABLE_DROPPARTS))
   }
 
   val AlterTableRename = {
@@ -114,18 +115,18 @@ object TableCommands {
 
     val newTableD =
       TableDesc("newName", tite, tableTypeDesc = Some(oldTableTableTypeDesc))
-    TableCommandSpec(cmd, Seq(oldTableD, newTableD), "ALTERTABLE_RENAME")
+    TableCommandSpec(cmd, Seq(oldTableD, newTableD), operationTypeStr(ALTERTABLE_RENAME))
   }
 
   // this is for spark 3.1 or below
   val AlterTableRecoverPartitions = {
     val cmd = "org.apache.spark.sql.execution.command.AlterTableRecoverPartitionsCommand"
-    TableCommandSpec(cmd, Seq(tableNameDesc), "MSCK")
+    TableCommandSpec(cmd, Seq(tableNameDesc), operationTypeStr(MSCK))
   }
 
   val RepairTable = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.RepairTable"
-    TableCommandSpec(cmd, Seq(resolvedTableDesc), "MSCK")
+    TableCommandSpec(cmd, Seq(resolvedTableDesc), operationTypeStr(MSCK))
   }
 
   val AlterTableRenamePartition = {
@@ -134,7 +135,7 @@ object TableCommands {
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
-      "ALTERTABLE_RENAMEPART")
+      operationTypeStr(ALTERTABLE_RENAMEPART))
   }
 
   val AlterTableSerDeProperties = {
@@ -143,7 +144,7 @@ object TableCommands {
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
-      "ALTERTABLE_SERDEPROPERTIES")
+      operationTypeStr(ALTERTABLE_SERDEPROPERTIES))
   }
 
   val AlterTableSetLocation = {
@@ -158,7 +159,7 @@ object TableCommands {
   val AlterTableSetProperties = TableCommandSpec(
     "org.apache.spark.sql.execution.command.AlterTableSetPropertiesCommand",
     Seq(tableNameDesc),
-    "ALTERTABLE_PROPERTIES")
+    operationTypeStr(ALTERTABLE_PROPERTIES))
 
   val AlterTableUnsetProperties = AlterTableSetProperties.copy(classname =
     "org.apache.spark.sql.execution.command.AlterTableUnsetPropertiesCommand")
@@ -170,7 +171,7 @@ object TableCommands {
     TableCommandSpec(
       "org.apache.spark.sql.execution.command.AlterViewAsCommand",
       Seq(TableDesc("name", tite, tableTypeDesc = Some(tableTypeDesc))),
-      "ALTERVIEW_AS",
+      operationTypeStr(ALTERVIEW_AS),
       Seq(QueryDesc("query")))
   }
 
@@ -180,7 +181,7 @@ object TableCommands {
     val cd2 = cd1.copy(fieldExtractor = classSimpleName[StringSeqOptionColumnExtractor])
     val td1 = tableIdentDesc.copy(columnDesc = Some(cd1), isInput = true)
     val td2 = td1.copy(columnDesc = Some(cd2))
-    TableCommandSpec(cmd, Seq(td1, td2), "ANALYZE_TABLE")
+    TableCommandSpec(cmd, Seq(td1, td2), operationTypeStr(ANALYZE_TABLE))
   }
 
   val AnalyzePartition = {
@@ -189,7 +190,7 @@ object TableCommands {
     TableCommandSpec(
       cmd,
       Seq(tableIdentDesc.copy(columnDesc = Some(columnDesc), isInput = true)),
-      "ANALYZE_TABLE")
+      operationTypeStr(ANALYZE_TABLE))
   }
 
   val AnalyzeTable = {
@@ -197,7 +198,7 @@ object TableCommands {
     TableCommandSpec(
       cmd,
       Seq(tableIdentDesc.copy(isInput = true)),
-      "ANALYZE_TABLE")
+      operationTypeStr(ANALYZE_TABLE))
   }
 
   val CreateTableV2 = {
@@ -206,7 +207,7 @@ object TableCommands {
       "tableName",
       classSimpleName[IdentifierTableExtractor],
       catalogDesc = Some(CatalogDesc()))
-    TableCommandSpec(cmd, Seq(tableDesc, resolvedDbObjectNameDesc), "CREATETABLE")
+    TableCommandSpec(cmd, Seq(tableDesc, resolvedDbObjectNameDesc), operationTypeStr(CREATETABLE))
   }
 
   val CreateV2Table = {
@@ -215,7 +216,7 @@ object TableCommands {
       "tableName",
       classSimpleName[IdentifierTableExtractor],
       catalogDesc = Some(CatalogDesc()))
-    TableCommandSpec(cmd, Seq(tableDesc), "CREATETABLE")
+    TableCommandSpec(cmd, Seq(tableDesc), operationTypeStr(CREATETABLE))
   }
 
   val CreateTableAsSelectV2 = {
@@ -233,7 +234,7 @@ object TableCommands {
 
   val CommentOnTable = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.CommentOnTable"
-    TableCommandSpec(cmd, Seq(resolvedTableDesc), "ALTERTABLE_PROPERTIES")
+    TableCommandSpec(cmd, Seq(resolvedTableDesc), operationTypeStr(ALTERTABLE_PROPERTIES))
   }
 
   val AppendDataV2 = {
@@ -283,44 +284,44 @@ object TableCommands {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.AddPartitions"
     // TODO: add column desc
     val tableDesc = TableDesc("table", classSimpleName[DataSourceV2RelationTableExtractor])
-    TableCommandSpec(cmd, Seq(tableDesc), "ALTERTABLE_ADDPARTS")
+    TableCommandSpec(cmd, Seq(tableDesc), operationTypeStr(ALTERTABLE_ADDPARTS))
   }
 
   val DropPartitions = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.DropPartitions"
     // TODO: add column desc
     val tableDesc = TableDesc("table", classSimpleName[DataSourceV2RelationTableExtractor])
-    TableCommandSpec(cmd, Seq(tableDesc), "ALTERTABLE_DROPPARTS")
+    TableCommandSpec(cmd, Seq(tableDesc), operationTypeStr(ALTERTABLE_DROPPARTS))
   }
 
   val RenamePartitions = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.RenamePartitions"
     // TODO: add column desc
     val tableDesc = TableDesc("table", classSimpleName[DataSourceV2RelationTableExtractor])
-    TableCommandSpec(cmd, Seq(tableDesc), "ALTERTABLE_RENAMEPART")
+    TableCommandSpec(cmd, Seq(tableDesc), operationTypeStr(ALTERTABLE_RENAMEPART))
   }
 
   val TruncatePartition = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.TruncatePartition"
     // TODO: add column desc
     val tableDesc = TableDesc("table", classSimpleName[DataSourceV2RelationTableExtractor])
-    TableCommandSpec(cmd, Seq(tableDesc), "ALTERTABLE_DROPPARTS")
+    TableCommandSpec(cmd, Seq(tableDesc), operationTypeStr(ALTERTABLE_DROPPARTS))
   }
 
   val CacheTableAsSelect = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.CacheTableAsSelect"
-    TableCommandSpec(cmd, Nil, "CREATEVIEW", queryDescs = Seq(QueryDesc("plan")))
+    TableCommandSpec(cmd, Nil, operationTypeStr(CREATEVIEW), queryDescs = Seq(QueryDesc("plan")))
   }
 
   val CacheTable = {
     val cmd = "org.apache.spark.sql.execution.command.CacheTableCommand"
     val queryDesc = QueryDesc("plan", classSimpleName[LogicalPlanOptionQueryExtractor])
-    TableCommandSpec(cmd, Nil, "CREATEVIEW", queryDescs = Seq(queryDesc))
+    TableCommandSpec(cmd, Nil, operationTypeStr(CREATEVIEW), queryDescs = Seq(queryDesc))
   }
 
   val CacheTableV2 = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.CacheTable"
-    TableCommandSpec(cmd, Nil, "CREATEVIEW", Seq(QueryDesc("table")))
+    TableCommandSpec(cmd, Nil, operationTypeStr(CREATEVIEW), Seq(QueryDesc("table")))
   }
 
   val CreateView = {
@@ -335,18 +336,22 @@ object TableCommands {
       tableTypeDesc = Some(tableTypeDesc))
     val queryDesc1 = QueryDesc("plan")
     val queryDesc2 = QueryDesc("child")
-    TableCommandSpec(cmd, Seq(tableDesc), "CREATEVIEW", queryDescs = Seq(queryDesc1, queryDesc2))
+    TableCommandSpec(
+      cmd,
+      Seq(tableDesc),
+      operationTypeStr(CREATEVIEW),
+      queryDescs = Seq(queryDesc1, queryDesc2))
   }
 
   val CreateTempViewUsing = {
     val cmd = "org.apache.spark.sql.execution.datasources.CreateTempViewUsing"
-    TableCommandSpec(cmd, Nil, "CREATEVIEW")
+    TableCommandSpec(cmd, Nil, operationTypeStr(CREATEVIEW))
   }
 
   val CreateDataSourceTable = {
     val cmd = "org.apache.spark.sql.execution.command.CreateDataSourceTableCommand"
     val tableDesc = TableDesc("table", classSimpleName[CatalogTableTableExtractor])
-    TableCommandSpec(cmd, Seq(tableDesc), "CREATETABLE")
+    TableCommandSpec(cmd, Seq(tableDesc), operationTypeStr(CREATETABLE))
   }
 
   val CreateDataSourceTableAsSelect = {
@@ -377,7 +382,7 @@ object TableCommands {
       classSimpleName[TableIdentifierTableExtractor],
       isInput = true,
       setCurrentDatabaseIfMissing = true)
-    TableCommandSpec(cmd, Seq(tableDesc1, tableDesc2), "CREATETABLE")
+    TableCommandSpec(cmd, Seq(tableDesc1, tableDesc2), operationTypeStr(CREATETABLE))
   }
 
   val DescribeColumn = {
@@ -388,7 +393,7 @@ object TableCommands {
       classSimpleName[TableIdentifierTableExtractor],
       Some(columnDesc),
       isInput = true)
-    TableCommandSpec(cmd, Seq(tableDesc), "DESCTABLE")
+    TableCommandSpec(cmd, Seq(tableDesc), operationTypeStr(DESCTABLE))
   }
 
   val DescribeTable = {
@@ -400,7 +405,7 @@ object TableCommands {
       Some(columnDesc),
       isInput = true,
       setCurrentDatabaseIfMissing = true)
-    TableCommandSpec(cmd, Seq(tableDesc), "DESCTABLE")
+    TableCommandSpec(cmd, Seq(tableDesc), operationTypeStr(DESCTABLE))
   }
 
   val DropTable = {
@@ -413,13 +418,13 @@ object TableCommands {
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(tableTypeDesc = Some(tableTypeDesc))),
-      "DROPTABLE")
+      operationTypeStr(DROPTABLE))
   }
 
   val DropTableV2 = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.DropTable"
     val tableDesc1 = resolvedTableDesc
-    TableCommandSpec(cmd, Seq(tableDesc1), "DROPTABLE")
+    TableCommandSpec(cmd, Seq(tableDesc1), operationTypeStr(DROPTABLE))
   }
 
   val MergeIntoTable = {
@@ -436,52 +441,52 @@ object TableCommands {
   val ShowColumns = {
     val cmd = "org.apache.spark.sql.execution.command.ShowColumnsCommand"
     val tableDesc = tableNameDesc.copy(isInput = true)
-    TableCommandSpec(cmd, Seq(tableDesc), "SHOWCOLUMNS")
+    TableCommandSpec(cmd, Seq(tableDesc), operationTypeStr(SHOWCOLUMNS))
   }
 
   val ShowCreateTable = {
     val cmd = "org.apache.spark.sql.execution.command.ShowCreateTableCommand"
     val tableDesc = tableNameDesc.copy(fieldName = "table", isInput = true)
-    TableCommandSpec(cmd, Seq(tableDesc), "SHOW_CREATETABLE")
+    TableCommandSpec(cmd, Seq(tableDesc), operationTypeStr(SHOW_CREATETABLE))
   }
 
   val ShowTableProperties = {
     val cmd = "org.apache.spark.sql.execution.command.ShowTablePropertiesCommand"
     val tableDesc = tableNameDesc.copy(fieldName = "table", isInput = true)
-    TableCommandSpec(cmd, Seq(tableDesc), "SHOW_TBLPROPERTIES")
+    TableCommandSpec(cmd, Seq(tableDesc), operationTypeStr(SHOW_TBLPROPERTIES))
   }
 
   val ShowCreateTableV2 = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.ShowCreateTable"
     val tableDesc =
       TableDesc("child", classSimpleName[ResolvedTableTableExtractor], isInput = true)
-    TableCommandSpec(cmd, Seq(tableDesc), "SHOW_CREATETABLE")
+    TableCommandSpec(cmd, Seq(tableDesc), operationTypeStr(SHOW_CREATETABLE))
   }
 
   val ShowTablePropertiesV2 = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.ShowTableProperties"
     val tableDesc =
       TableDesc("table", classSimpleName[ResolvedTableTableExtractor], isInput = true)
-    TableCommandSpec(cmd, Seq(tableDesc), "SHOW_TBLPROPERTIES")
+    TableCommandSpec(cmd, Seq(tableDesc), operationTypeStr(SHOW_TBLPROPERTIES))
   }
 
   val ShowPartitions = {
     val cmd = "org.apache.spark.sql.execution.command.ShowPartitionsCommand"
     val columnDesc = ColumnDesc("spec", classSimpleName[PartitionOptionColumnExtractor])
     val tableDesc = tableNameDesc.copy(isInput = true, columnDesc = Some(columnDesc))
-    TableCommandSpec(cmd, Seq(tableDesc), "SHOWPARTITIONS")
+    TableCommandSpec(cmd, Seq(tableDesc), operationTypeStr(SHOWPARTITIONS))
   }
 
   val TruncateTable = {
     val cmd = "org.apache.spark.sql.execution.command.TruncateTableCommand"
     val columnDesc = ColumnDesc("partitionSpec", classSimpleName[PartitionOptionColumnExtractor])
     val tableDesc = tableNameDesc.copy(columnDesc = Some(columnDesc))
-    TableCommandSpec(cmd, Seq(tableDesc), "TRUNCATETABLE")
+    TableCommandSpec(cmd, Seq(tableDesc), operationTypeStr(TRUNCATETABLE))
   }
 
   val TruncateTableV2 = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.TruncateTable"
-    TableCommandSpec(cmd, Seq(resolvedTableDesc), "TRUNCATETABLE")
+    TableCommandSpec(cmd, Seq(resolvedTableDesc), operationTypeStr(TRUNCATETABLE))
   }
 
   val InsertIntoDataSource = {

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/TableCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/TableCommands.scala
@@ -22,25 +22,25 @@ import org.apache.kyuubi.plugin.spark.authz.serde._
 
 object TableCommands {
   // table extractors
-  val tite = classSimpleName[TableIdentifierTableExtractor]
+  val tite = classOf[TableIdentifierTableExtractor]
   val tableNameDesc = TableDesc("tableName", tite)
   val tableIdentDesc = TableDesc("tableIdent", tite)
-  val resolvedTableDesc = TableDesc("child", classSimpleName[ResolvedTableTableExtractor])
+  val resolvedTableDesc = TableDesc("child", classOf[ResolvedTableTableExtractor])
   val resolvedDbObjectNameDesc =
-    TableDesc("child", classSimpleName[ResolvedDbObjectNameTableExtractor])
+    TableDesc("child", classOf[ResolvedDbObjectNameTableExtractor])
 
   val overwriteActionTypeDesc =
-    ActionTypeDesc("overwrite", classSimpleName[OverwriteOrInsertActionTypeExtractor])
+    ActionTypeDesc("overwrite", classOf[OverwriteOrInsertActionTypeExtractor])
 
   val AlterTable = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.AlterTable"
-    val tableDesc = TableDesc("ident", classSimpleName[IdentifierTableExtractor])
+    val tableDesc = TableDesc("ident", classOf[IdentifierTableExtractor])
     TableCommandSpec(cmd, Seq(tableDesc), ALTERTABLE_PROPERTIES)
   }
 
   val AlterTableAddColumns = {
     val cmd = "org.apache.spark.sql.execution.command.AlterTableAddColumnsCommand"
-    val columnDesc = ColumnDesc("colsToAdd", classSimpleName[StructFieldSeqColumnExtractor])
+    val columnDesc = ColumnDesc("colsToAdd", classOf[StructFieldSeqColumnExtractor])
     val tableDesc = TableDesc("table", tite, Some(columnDesc))
     TableCommandSpec(cmd, Seq(tableDesc), ALTERTABLE_ADDCOLS)
   }
@@ -73,7 +73,7 @@ object TableCommands {
   val AlterTableAddPartition = {
     val cmd = "org.apache.spark.sql.execution.command.AlterTableAddPartitionCommand"
     val columnDesc =
-      ColumnDesc("partitionSpecsAndLocs", classSimpleName[PartitionLocsSeqColumnExtractor])
+      ColumnDesc("partitionSpecsAndLocs", classOf[PartitionLocsSeqColumnExtractor])
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
@@ -82,7 +82,7 @@ object TableCommands {
 
   val AlterTableChangeColumn = {
     val cmd = "org.apache.spark.sql.execution.command.AlterTableChangeColumnCommand"
-    val columnDesc = ColumnDesc("columnName", classSimpleName[StringColumnExtractor])
+    val columnDesc = ColumnDesc("columnName", classOf[StringColumnExtractor])
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
@@ -91,7 +91,7 @@ object TableCommands {
 
   val AlterTableDropPartition = {
     val cmd = "org.apache.spark.sql.execution.command.AlterTableDropPartitionCommand"
-    val columnDesc = ColumnDesc("specs", classSimpleName[PartitionSeqColumnExtractor])
+    val columnDesc = ColumnDesc("specs", classOf[PartitionSeqColumnExtractor])
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
@@ -105,7 +105,7 @@ object TableCommands {
     val oldTableTableTypeDesc =
       TableTypeDesc(
         "oldName",
-        classSimpleName[TableIdentifierTableTypeExtractor],
+        classOf[TableIdentifierTableTypeExtractor],
         Seq("TEMP_VIEW"))
     val oldTableD = TableDesc(
       "oldName",
@@ -131,7 +131,7 @@ object TableCommands {
 
   val AlterTableRenamePartition = {
     val cmd = "org.apache.spark.sql.execution.command.AlterTableRenamePartitionCommand"
-    val columnDesc = ColumnDesc("oldPartition", classSimpleName[PartitionColumnExtractor])
+    val columnDesc = ColumnDesc("oldPartition", classOf[PartitionColumnExtractor])
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
@@ -140,7 +140,7 @@ object TableCommands {
 
   val AlterTableSerDeProperties = {
     val cmd = "org.apache.spark.sql.execution.command.AlterTableSerDePropertiesCommand"
-    val columnDesc = ColumnDesc("partSpec", classSimpleName[PartitionOptionColumnExtractor])
+    val columnDesc = ColumnDesc("partSpec", classOf[PartitionOptionColumnExtractor])
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
@@ -149,7 +149,7 @@ object TableCommands {
 
   val AlterTableSetLocation = {
     val cmd = "org.apache.spark.sql.execution.command.AlterTableSetLocationCommand"
-    val columnDesc = ColumnDesc("partitionSpec", classSimpleName[PartitionOptionColumnExtractor])
+    val columnDesc = ColumnDesc("partitionSpec", classOf[PartitionOptionColumnExtractor])
     TableCommandSpec(
       cmd,
       Seq(tableNameDesc.copy(columnDesc = Some(columnDesc))),
@@ -166,7 +166,7 @@ object TableCommands {
 
   val AlterViewAs = {
     val tableTypeDesc =
-      TableTypeDesc("name", classSimpleName[TableIdentifierTableTypeExtractor], Seq("TEMP_VIEW"))
+      TableTypeDesc("name", classOf[TableIdentifierTableTypeExtractor], Seq("TEMP_VIEW"))
 
     TableCommandSpec(
       "org.apache.spark.sql.execution.command.AlterViewAsCommand",
@@ -177,8 +177,8 @@ object TableCommands {
 
   val AnalyzeColumn = {
     val cmd = "org.apache.spark.sql.execution.command.AnalyzeColumnCommand"
-    val cd1 = ColumnDesc("columnNames", classSimpleName[StringSeqColumnExtractor])
-    val cd2 = cd1.copy(fieldExtractor = classSimpleName[StringSeqOptionColumnExtractor])
+    val cd1 = ColumnDesc("columnNames", classOf[StringSeqColumnExtractor])
+    val cd2 = cd1.copy(fieldExtractor = classOf[StringSeqOptionColumnExtractor])
     val td1 = tableIdentDesc.copy(columnDesc = Some(cd1), isInput = true)
     val td2 = td1.copy(columnDesc = Some(cd2))
     TableCommandSpec(cmd, Seq(td1, td2), ANALYZE_TABLE)
@@ -186,7 +186,7 @@ object TableCommands {
 
   val AnalyzePartition = {
     val cmd = "org.apache.spark.sql.execution.command.AnalyzePartitionCommand"
-    val columnDesc = ColumnDesc("partitionSpec", classSimpleName[PartitionColumnExtractor])
+    val columnDesc = ColumnDesc("partitionSpec", classOf[PartitionColumnExtractor])
     TableCommandSpec(
       cmd,
       Seq(tableIdentDesc.copy(columnDesc = Some(columnDesc), isInput = true)),
@@ -205,7 +205,7 @@ object TableCommands {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.CreateTable"
     val tableDesc = TableDesc(
       "tableName",
-      classSimpleName[IdentifierTableExtractor],
+      classOf[IdentifierTableExtractor],
       catalogDesc = Some(CatalogDesc()))
     TableCommandSpec(cmd, Seq(tableDesc, resolvedDbObjectNameDesc), CREATETABLE)
   }
@@ -214,7 +214,7 @@ object TableCommands {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.CreateV2Table"
     val tableDesc = TableDesc(
       "tableName",
-      classSimpleName[IdentifierTableExtractor],
+      classOf[IdentifierTableExtractor],
       catalogDesc = Some(CatalogDesc()))
     TableCommandSpec(cmd, Seq(tableDesc), CREATETABLE)
   }
@@ -223,7 +223,7 @@ object TableCommands {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.CreateTableAsSelect"
     val tableDesc = TableDesc(
       "tableName",
-      classSimpleName[IdentifierTableExtractor],
+      classOf[IdentifierTableExtractor],
       catalogDesc = Some(CatalogDesc()))
     TableCommandSpec(
       cmd,
@@ -243,7 +243,7 @@ object TableCommands {
     val tableDesc =
       TableDesc(
         "table",
-        classSimpleName[DataSourceV2RelationTableExtractor],
+        classOf[DataSourceV2RelationTableExtractor],
         actionTypeDesc = Some(actionTypeDesc))
     TableCommandSpec(cmd, Seq(tableDesc), queryDescs = Seq(QueryDesc("query")))
   }
@@ -254,7 +254,7 @@ object TableCommands {
     val tableDesc =
       TableDesc(
         "table",
-        classSimpleName[DataSourceV2RelationTableExtractor],
+        classOf[DataSourceV2RelationTableExtractor],
         actionTypeDesc = Some(actionTypeDesc))
     TableCommandSpec(cmd, Seq(tableDesc), queryDescs = Seq(QueryDesc("query")))
   }
@@ -270,7 +270,7 @@ object TableCommands {
     val tableDesc =
       TableDesc(
         "table",
-        classSimpleName[DataSourceV2RelationTableExtractor],
+        classOf[DataSourceV2RelationTableExtractor],
         actionTypeDesc = Some(actionTypeDesc))
     TableCommandSpec(cmd, Seq(tableDesc), queryDescs = Seq(QueryDesc("query")))
   }
@@ -283,28 +283,28 @@ object TableCommands {
   val AddPartitions = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.AddPartitions"
     // TODO: add column desc
-    val tableDesc = TableDesc("table", classSimpleName[DataSourceV2RelationTableExtractor])
+    val tableDesc = TableDesc("table", classOf[DataSourceV2RelationTableExtractor])
     TableCommandSpec(cmd, Seq(tableDesc), ALTERTABLE_ADDPARTS)
   }
 
   val DropPartitions = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.DropPartitions"
     // TODO: add column desc
-    val tableDesc = TableDesc("table", classSimpleName[DataSourceV2RelationTableExtractor])
+    val tableDesc = TableDesc("table", classOf[DataSourceV2RelationTableExtractor])
     TableCommandSpec(cmd, Seq(tableDesc), ALTERTABLE_DROPPARTS)
   }
 
   val RenamePartitions = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.RenamePartitions"
     // TODO: add column desc
-    val tableDesc = TableDesc("table", classSimpleName[DataSourceV2RelationTableExtractor])
+    val tableDesc = TableDesc("table", classOf[DataSourceV2RelationTableExtractor])
     TableCommandSpec(cmd, Seq(tableDesc), ALTERTABLE_RENAMEPART)
   }
 
   val TruncatePartition = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.TruncatePartition"
     // TODO: add column desc
-    val tableDesc = TableDesc("table", classSimpleName[DataSourceV2RelationTableExtractor])
+    val tableDesc = TableDesc("table", classOf[DataSourceV2RelationTableExtractor])
     TableCommandSpec(cmd, Seq(tableDesc), ALTERTABLE_DROPPARTS)
   }
 
@@ -315,7 +315,7 @@ object TableCommands {
 
   val CacheTable = {
     val cmd = "org.apache.spark.sql.execution.command.CacheTableCommand"
-    val queryDesc = QueryDesc("plan", classSimpleName[LogicalPlanOptionQueryExtractor])
+    val queryDesc = QueryDesc("plan", classOf[LogicalPlanOptionQueryExtractor])
     TableCommandSpec(cmd, Nil, CREATEVIEW, queryDescs = Seq(queryDesc))
   }
 
@@ -328,11 +328,11 @@ object TableCommands {
     val cmd = "org.apache.spark.sql.execution.command.CreateViewCommand"
     val tableTypeDesc = TableTypeDesc(
       "viewType",
-      classSimpleName[ViewTypeTableTypeExtractor],
+      classOf[ViewTypeTableTypeExtractor],
       Seq("TEMP_VIEW", "GLOBAL_TEMP_VIEW"))
     val tableDesc = TableDesc(
       "name",
-      classSimpleName[TableIdentifierTableExtractor],
+      classOf[TableIdentifierTableExtractor],
       tableTypeDesc = Some(tableTypeDesc))
     val queryDesc1 = QueryDesc("plan")
     val queryDesc2 = QueryDesc("child")
@@ -350,7 +350,7 @@ object TableCommands {
 
   val CreateDataSourceTable = {
     val cmd = "org.apache.spark.sql.execution.command.CreateDataSourceTableCommand"
-    val tableDesc = TableDesc("table", classSimpleName[CatalogTableTableExtractor])
+    val tableDesc = TableDesc("table", classOf[CatalogTableTableExtractor])
     TableCommandSpec(cmd, Seq(tableDesc), CREATETABLE)
   }
 
@@ -364,9 +364,9 @@ object TableCommands {
 
   val CreateHiveTableAsSelect = {
     val cmd = "org.apache.spark.sql.hive.execution.CreateHiveTableAsSelectCommand"
-    val columnDesc = ColumnDesc("outputColumnNames", classSimpleName[StringSeqColumnExtractor])
+    val columnDesc = ColumnDesc("outputColumnNames", classOf[StringSeqColumnExtractor])
     val tableDesc =
-      TableDesc("tableDesc", classSimpleName[CatalogTableTableExtractor], Some(columnDesc))
+      TableDesc("tableDesc", classOf[CatalogTableTableExtractor], Some(columnDesc))
     val queryDesc = QueryDesc("query")
     TableCommandSpec(cmd, Seq(tableDesc), "CREATETABLE_AS_SELECT", queryDescs = Seq(queryDesc))
   }
@@ -375,11 +375,11 @@ object TableCommands {
     val cmd = "org.apache.spark.sql.execution.command.CreateTableLikeCommand"
     val tableDesc1 = TableDesc(
       "targetTable",
-      classSimpleName[TableIdentifierTableExtractor],
+      classOf[TableIdentifierTableExtractor],
       setCurrentDatabaseIfMissing = true)
     val tableDesc2 = TableDesc(
       "sourceTable",
-      classSimpleName[TableIdentifierTableExtractor],
+      classOf[TableIdentifierTableExtractor],
       isInput = true,
       setCurrentDatabaseIfMissing = true)
     TableCommandSpec(cmd, Seq(tableDesc1, tableDesc2), CREATETABLE)
@@ -387,10 +387,10 @@ object TableCommands {
 
   val DescribeColumn = {
     val cmd = "org.apache.spark.sql.execution.command.DescribeColumnCommand"
-    val columnDesc = ColumnDesc("colNameParts", classSimpleName[StringSeqLastColumnExtractor])
+    val columnDesc = ColumnDesc("colNameParts", classOf[StringSeqLastColumnExtractor])
     val tableDesc = TableDesc(
       "table",
-      classSimpleName[TableIdentifierTableExtractor],
+      classOf[TableIdentifierTableExtractor],
       Some(columnDesc),
       isInput = true)
     TableCommandSpec(cmd, Seq(tableDesc), DESCTABLE)
@@ -398,10 +398,10 @@ object TableCommands {
 
   val DescribeTable = {
     val cmd = "org.apache.spark.sql.execution.command.DescribeTableCommand"
-    val columnDesc = ColumnDesc("partitionSpec", classSimpleName[PartitionColumnExtractor])
+    val columnDesc = ColumnDesc("partitionSpec", classOf[PartitionColumnExtractor])
     val tableDesc = TableDesc(
       "table",
-      classSimpleName[TableIdentifierTableExtractor],
+      classOf[TableIdentifierTableExtractor],
       Some(columnDesc),
       isInput = true,
       setCurrentDatabaseIfMissing = true)
@@ -413,7 +413,7 @@ object TableCommands {
     val tableTypeDesc =
       TableTypeDesc(
         "tableName",
-        classSimpleName[TableIdentifierTableTypeExtractor],
+        classOf[TableIdentifierTableTypeExtractor],
         Seq("TEMP_VIEW"))
     TableCommandSpec(
       cmd,
@@ -432,7 +432,7 @@ object TableCommands {
     val actionTypeDesc = ActionTypeDesc(null, null, Some("UPDATE"))
     val tableDesc = TableDesc(
       "targetTable",
-      classSimpleName[DataSourceV2RelationTableExtractor],
+      classOf[DataSourceV2RelationTableExtractor],
       actionTypeDesc = Some(actionTypeDesc))
     val queryDesc = QueryDesc("sourceTable")
     TableCommandSpec(cmd, Seq(tableDesc), queryDescs = Seq(queryDesc))
@@ -459,27 +459,27 @@ object TableCommands {
   val ShowCreateTableV2 = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.ShowCreateTable"
     val tableDesc =
-      TableDesc("child", classSimpleName[ResolvedTableTableExtractor], isInput = true)
+      TableDesc("child", classOf[ResolvedTableTableExtractor], isInput = true)
     TableCommandSpec(cmd, Seq(tableDesc), SHOW_CREATETABLE)
   }
 
   val ShowTablePropertiesV2 = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.ShowTableProperties"
     val tableDesc =
-      TableDesc("table", classSimpleName[ResolvedTableTableExtractor], isInput = true)
+      TableDesc("table", classOf[ResolvedTableTableExtractor], isInput = true)
     TableCommandSpec(cmd, Seq(tableDesc), SHOW_TBLPROPERTIES)
   }
 
   val ShowPartitions = {
     val cmd = "org.apache.spark.sql.execution.command.ShowPartitionsCommand"
-    val columnDesc = ColumnDesc("spec", classSimpleName[PartitionOptionColumnExtractor])
+    val columnDesc = ColumnDesc("spec", classOf[PartitionOptionColumnExtractor])
     val tableDesc = tableNameDesc.copy(isInput = true, columnDesc = Some(columnDesc))
     TableCommandSpec(cmd, Seq(tableDesc), SHOWPARTITIONS)
   }
 
   val TruncateTable = {
     val cmd = "org.apache.spark.sql.execution.command.TruncateTableCommand"
-    val columnDesc = ColumnDesc("partitionSpec", classSimpleName[PartitionOptionColumnExtractor])
+    val columnDesc = ColumnDesc("partitionSpec", classOf[PartitionOptionColumnExtractor])
     val tableDesc = tableNameDesc.copy(columnDesc = Some(columnDesc))
     TableCommandSpec(cmd, Seq(tableDesc), TRUNCATETABLE)
   }
@@ -494,7 +494,7 @@ object TableCommands {
     val actionTypeDesc = overwriteActionTypeDesc
     val tableDesc = TableDesc(
       "logicalRelation",
-      classSimpleName[LogicalRelationTableExtractor],
+      classOf[LogicalRelationTableExtractor],
       actionTypeDesc = Some(actionTypeDesc))
     TableCommandSpec(cmd, Seq(tableDesc), queryDescs = Seq(QueryDesc("query")))
   }
@@ -502,10 +502,10 @@ object TableCommands {
   val InsertIntoHiveTable = {
     val cmd = "org.apache.spark.sql.hive.execution.InsertIntoHiveTable"
     val actionTypeDesc = overwriteActionTypeDesc
-    val columnDesc = ColumnDesc("outputColumnNames", classSimpleName[StringSeqColumnExtractor])
+    val columnDesc = ColumnDesc("outputColumnNames", classOf[StringSeqColumnExtractor])
     val tableDesc = TableDesc(
       "table",
-      classSimpleName[CatalogTableTableExtractor],
+      classOf[CatalogTableTableExtractor],
       Some(columnDesc),
       Some(actionTypeDesc))
     val queryDesc = QueryDesc("query")
@@ -521,7 +521,7 @@ object TableCommands {
   val LoadData = {
     val cmd = "org.apache.spark.sql.execution.command.LoadDataCommand"
     val actionTypeDesc = overwriteActionTypeDesc.copy(fieldName = "isOverwrite")
-    val columnDesc = ColumnDesc("partition", classSimpleName[PartitionOptionColumnExtractor])
+    val columnDesc = ColumnDesc("partition", classOf[PartitionOptionColumnExtractor])
     val tableDesc = tableIdentDesc.copy(
       fieldName = "table",
       columnDesc = Some(columnDesc),

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/package.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/package.scala
@@ -18,14 +18,11 @@
 package org.apache.kyuubi.plugin.spark.authz
 
 import scala.language.implicitConversions
-import scala.reflect.ClassTag
 
 import org.apache.kyuubi.plugin.spark.authz.OperationType.OperationType
 
 package object gen {
-  implicit def classSimpleName[T](implicit ct: ClassTag[T]): String = {
-    ct.runtimeClass.getSimpleName
-  }
+  implicit def classSimpleName[T](clz: Class[_]): String = clz.getSimpleName
 
   implicit def operationTypeStr(t: OperationType): String = t.toString
 }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/package.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/package.scala
@@ -22,7 +22,7 @@ import scala.language.implicitConversions
 import org.apache.kyuubi.plugin.spark.authz.OperationType.OperationType
 
 package object gen {
-  implicit def classSimpleName[T](clz: Class[_]): String = clz.getSimpleName
+  implicit def classSimpleName(clz: Class[_]): String = clz.getSimpleName
 
   implicit def operationTypeStr(t: OperationType): String = t.toString
 }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/package.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/package.scala
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.plugin.spark.authz
+
+import scala.reflect.ClassTag
+
+package object gen {
+  implicit def classSimpleName[T](implicit ct: ClassTag[T]): String = {
+    ct.runtimeClass.getSimpleName
+  }
+}

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/package.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/package.scala
@@ -17,10 +17,15 @@
 
 package org.apache.kyuubi.plugin.spark.authz
 
+import scala.language.implicitConversions
 import scala.reflect.ClassTag
+
+import org.apache.kyuubi.plugin.spark.authz.OperationType.OperationType
 
 package object gen {
   implicit def classSimpleName[T](implicit ct: ClassTag[T]): String = {
     ct.runtimeClass.getSimpleName
   }
+
+  implicit def operationTypeStr(t: OperationType): String = t.toString
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

- add implicit methods `classSimpleName` and `operationTypeStr` to package object `org.apache.kyuubi.plugin.spark.authz` in test sources
- increase compilation alignment to extractor itself, and easier use for future third party adaptation avoiding calling wrong `getName` of the calss
- preventing use String or class name as magic value directly which easily causes mistakes
- no changes with spec JSON file regeneration after this PR 


### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
