### PR TITLE
Remove reference to removed DISCLAIMER file in build/dist script and doc

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -46,7 +46,6 @@
   - ".github/**/*"
   - ".gitignore"
   - ".travis.yml"
-  - "DISCLAIMER"
   - "LICENSE"
   - "LICENSE-binary"
   - "NOTICE"

--- a/build/dist
+++ b/build/dist
@@ -322,7 +322,6 @@ if [[ "$HIVE_PROVIDED" != "true" ]]; then
 fi
 
 # Copy license files
-cp "$KYUUBI_HOME/DISCLAIMER" "$DISTDIR/DISCLAIMER"
 if [[ -f $"$KYUUBI_HOME/LICENSE-binary" ]]; then
   cp "$KYUUBI_HOME/LICENSE-binary" "$DISTDIR/LICENSE"
   cp -r "$KYUUBI_HOME/licenses-binary" "$DISTDIR/licenses"

--- a/docs/quick_start/quick_start.rst
+++ b/docs/quick_start/quick_start.rst
@@ -86,7 +86,6 @@ To install Kyuubi, you need to unpack the tarball. For example,
 .. code-block::
    :class: toggle
 
-   ├── DISCLAIMER
    ├── LICENSE
    ├── NOTICE
    ├── RELEASE
@@ -113,7 +112,6 @@ To install Kyuubi, you need to unpack the tarball. For example,
 
 From top to bottom are:
 
-- DISCLAIMER: the disclaimer made by Apache Kyuubi Community as a project still in ASF Incubator.
 - LICENSE: the APACHE `LICENSE`_, VERSION 2.0 we claim to obey.
 - RELEASE: the build information of this package.
 - NOTICE: the notice made by Apache Kyuubi Community about its project and dependencies.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

- DISCLAIMER file on top-level folder of project was already removed after graduation in (https://github.com/apache/kyuubi/issues/4020)
- fix build/dist for `cp` non-existed DISCLAIMER file
- remove DISCLAIMER file reference in dev/dist script, doc


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
