### PR TITLE
Enforce maven using Java 11+ with profile `java-11`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2185,6 +2185,7 @@
                 <maven.compiler.source></maven.compiler.source>
                 <maven.compiler.target></maven.compiler.target>
                 <maven.compiler.release>${java.version}</maven.compiler.release>
+                <minimalJavaBuildVersion>${java.version}</minimalJavaBuildVersion>
             </properties>
         </profile>
 


### PR DESCRIPTION
…ldVersion prop to profile for maven-enforcer-plugin

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

- Enforce using Java 11+ for profile `java-11`
- adding minimalJavaBuildVersion prop to profile `java-11` for maven-enforcer-plugin's [`enforce-java-version` execution] in Apache parent pom (https://github.com/apache/maven-apache-parent/blob/apache-29/pom.xml#L361)


Running with profile java-11 with Java 8 failed on `validate` phase and gets the error message below:
```
[INFO] --- maven-enforcer-plugin:3.1.0:enforce (enforce-java-version) @ kyuubi-parent ---
[ERROR] Rule 0: org.apache.maven.plugins.enforcer.RequireJavaVersion failed with message:
Detected JDK Version: 1.8.0-301 is not in the allowed range 11.
```


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
