### PR TITLE
[BUILD] Provide GitHub token to prevent 403 error

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -351,8 +351,9 @@ jobs:
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.7.2
         with:
-          minikube version: 'v1.25.2'
-          kubernetes version: 'v1.23.3'
+          minikube version: 'v1.28.0'
+          kubernetes version: 'v1.25.4'
+          github token: ${{ secrets.GITHUB_TOKEN }}
       - name: kubectl pre-check
         run: |
           kubectl get serviceaccount


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

1. Provide GitHub token to prevent 403 error.

https://github.com/apache/kyuubi/actions/runs/3852055295/jobs/6563845498

```
    data: {
      message: "API rate limit exceeded for 65.52.35.0. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)",
      documentation_url: 'https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting'
    }
```

from [Github docs](https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limits-for-requests-from-github-actions)

> When using GITHUB_TOKEN, the rate limit is 1,000 requests per hour per repository. For requests to resources that belong to an enterprise account on GitHub.com, GitHub Enterprise Cloud's rate limit applies, and the limit is 15,000 requests per hour per repository.


from [actions-setup-minikube docs](https://github.com/manusa/actions-setup-minikube#optional-input-parameters)

> GITHUB_TOKEN secret value to access GitHub REST API with an unlimited number of requests (optional but recommended)

2. bump up minikube from v1.25.2 to v1.28.0
3. bump up kubernetes from v1.23.3 to v1.25.4


### _How was this patch tested?_

Pass CI.
