### PR TITLE
[Authz] [Bug] Correct `getRangerConf` for Ranger 2.0 and below

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/util/RangerConfigProvider.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/util/RangerConfigProvider.scala
@@ -34,16 +34,14 @@ trait RangerConfigProvider {
    *         for Ranger 2.0 and below
    */
   def getRangerConf: Configuration = {
-    try {
+    if (isRanger21orGreater) {
       // for Ranger 2.1+
       invokeAs[Configuration](this, "getConfig")
-    } catch {
-      case _: NoSuchMethodException =>
-        // for Ranger 2.0 and below
-        invokeStatic(
-          Class.forName("org.apache.ranger.authorization.hadoop.config.RangerConfiguration"),
-          "getInstance")
-          .asInstanceOf[Configuration]
+    } else {
+      // for Ranger 2.0 and below
+      invokeStaticAs[Configuration](
+        Class.forName("org.apache.ranger.authorization.hadoop.config.RangerConfiguration"),
+        "getInstance")
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- To fix `RuntimeException` when executing `getRangerConf` with Ranger 2.0 and below. Previously `getRangerConf` method tries to get config in Ranger 2.1+ way via `invoke`  first and relies on the `NoSuchMethodException` to turn to Ranger 2.0 way , but `invoke` of `AuthzUtils` actually throws `RuntimeException` instead of  `NoSuchMethodException` which makes `getRangerConf` miss the back-up Ranger 2.0 way.
- change getRangerConf to use added `isRanger21orGreater` in AuthZUtils to determine the way of getting config from the ranger plugin

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
