### PR TITLE
[Authz] remove usage of `ClassTagExtensions` and make dependency `jackson-module-scala` in `provided` scope

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/pom.xml
+++ b/extensions/spark/kyuubi-spark-authz/pom.xml
@@ -32,8 +32,6 @@
     <url>https://kyuubi.apache.org/</url>
 
     <properties>
-        <!-- ensure earliest version of fasterxml.jackson provided in Spark 3.x -->
-        <authz.jackson.version>2.10.0</authz.jackson.version>
         <gethostname4j.version>1.0.0</gethostname4j.version>
         <jna.version>5.7.0</jna.version>
     </properties>
@@ -256,7 +254,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-scala_${scala.binary.version}</artifactId>
-            <version>${authz.jackson.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/extensions/spark/kyuubi-spark-authz/pom.xml
+++ b/extensions/spark/kyuubi-spark-authz/pom.xml
@@ -254,6 +254,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-scala_${scala.binary.version}</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/extensions/spark/kyuubi-spark-authz/pom.xml
+++ b/extensions/spark/kyuubi-spark-authz/pom.xml
@@ -32,6 +32,8 @@
     <url>https://kyuubi.apache.org/</url>
 
     <properties>
+        <!-- ensure earliest version of fasterxml.jackson provided in Spark 3.x -->
+        <authz.jackson.version>2.10.0</authz.jackson.version>
         <gethostname4j.version>1.0.0</gethostname4j.version>
         <jna.version>5.7.0</jna.version>
     </properties>
@@ -254,6 +256,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-scala_${scala.binary.version}</artifactId>
+            <version>${authz.jackson.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/serde/package.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/serde/package.scala
@@ -26,9 +26,7 @@ import org.apache.kyuubi.plugin.spark.authz.OperationType.{OperationType, QUERY}
 
 package object serde {
 
-  final val mapper = JsonMapper.builder()
-    .addModule(DefaultScalaModule)
-    .build()
+  final val mapper = JsonMapper.builder().addModule(DefaultScalaModule).build()
 
   final lazy val DB_COMMAND_SPECS: Map[String, DatabaseCommandSpec] = {
     val is = getClass.getClassLoader.getResourceAsStream("database_command_spec.json")

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/serde/package.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/serde/package.scala
@@ -17,8 +17,9 @@
 
 package org.apache.kyuubi.plugin.spark.authz
 
+import com.fasterxml.jackson.core.`type`.TypeReference
 import com.fasterxml.jackson.databind.json.JsonMapper
-import com.fasterxml.jackson.module.scala.{ClassTagExtensions, DefaultScalaModule}
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 
 import org.apache.kyuubi.plugin.spark.authz.OperationType.{OperationType, QUERY}
@@ -27,16 +28,18 @@ package object serde {
 
   final val mapper = JsonMapper.builder()
     .addModule(DefaultScalaModule)
-    .build() :: ClassTagExtensions
+    .build()
 
   final lazy val DB_COMMAND_SPECS: Map[String, DatabaseCommandSpec] = {
     val is = getClass.getClassLoader.getResourceAsStream("database_command_spec.json")
-    mapper.readValue[Array[DatabaseCommandSpec]](is).map(e => (e.classname, e)).toMap
+    mapper.readValue(is, new TypeReference[Array[DatabaseCommandSpec]] {})
+      .map(e => (e.classname, e)).toMap
   }
 
   final lazy val TABLE_COMMAND_SPECS: Map[String, TableCommandSpec] = {
     val is = getClass.getClassLoader.getResourceAsStream("table_command_spec.json")
-    mapper.readValue[Array[TableCommandSpec]](is).map(e => (e.classname, e)).toMap
+    mapper.readValue(is, new TypeReference[Array[TableCommandSpec]] {})
+      .map(e => (e.classname, e)).toMap
   }
 
   def isKnownTableCommand(r: AnyRef): Boolean = {
@@ -49,12 +52,14 @@ package object serde {
 
   final lazy val FUNCTION_COMMAND_SPECS: Map[String, FunctionCommandSpec] = {
     val is = getClass.getClassLoader.getResourceAsStream("function_command_spec.json")
-    mapper.readValue[Array[FunctionCommandSpec]](is).map(e => (e.classname, e)).toMap
+    mapper.readValue(is, new TypeReference[Array[FunctionCommandSpec]] {})
+      .map(e => (e.classname, e)).toMap
   }
 
   final private lazy val SCAN_SPECS: Map[String, ScanSpec] = {
     val is = getClass.getClassLoader.getResourceAsStream("scan_command_spec.json")
-    mapper.readValue[Array[ScanSpec]](is).map(e => (e.classname, e)).toMap
+    mapper.readValue(is, new TypeReference[Array[ScanSpec]] {})
+      .map(e => (e.classname, e)).toMap
   }
 
   def isKnownScan(r: AnyRef): Boolean = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- to fix #4102
- remove usage of ClassTagExtensions for better compatibility to `jackson-module-scala`
- `spark-core` of Spark 3.x's core already has dependency on `com.fasterxml.jackson.module:jackson-module-scala_${scala.binary.version}` 
- change the scope of `com.fasterxml.jackson.module:jackson-module-scala_${scala.binary.version}` to `provided`

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
