### PR TITLE
Bump `commons-lang3` to 3.12.0 and `commons-io` to 2.11.0

### DIFF
--- a/dev/dependencyList
+++ b/dev/dependencyList
@@ -25,7 +25,7 @@ classgraph/4.8.138//classgraph-4.8.138.jar
 commons-codec/1.15//commons-codec-1.15.jar
 commons-collections/3.2.2//commons-collections-3.2.2.jar
 commons-lang/2.6//commons-lang-2.6.jar
-commons-lang3/3.10//commons-lang3-3.10.jar
+commons-lang3/3.12.0//commons-lang3-3.12.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
 curator-client/2.12.0//curator-client-2.12.0.jar
 curator-framework/2.12.0//curator-framework-2.12.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
         <commons-cli.version>1.5.0</commons-cli.version>
         <commons-codec.version>1.15</commons-codec.version>
         <commons-collections.version>3.2.2</commons-collections.version>
-        <commons-io.version>2.8.0</commons-io.version>
+        <commons-io.version>2.11.0</commons-io.version>
         <commons-lang.version>2.6</commons-lang.version>
         <commons-lang3.version>3.10</commons-lang3.version>
         <curator.version>2.12.0</curator.version>

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <commons-collections.version>3.2.2</commons-collections.version>
         <commons-io.version>2.11.0</commons-io.version>
         <commons-lang.version>2.6</commons-lang.version>
-        <commons-lang3.version>3.10</commons-lang3.version>
+        <commons-lang3.version>3.12.0</commons-lang3.version>
         <curator.version>2.12.0</curator.version>
         <etcd.version>0.7.3</etcd.version>
         <delta.version>2.2.0</delta.version>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Upgrade all outdated Apache Commons series dependencies released in 2020 to the latest versions released in 2021.
- bump `commons-io` from 2.8.0 to 2.11.0 (release notes: https://commons.apache.org/proper/commons-io/changes-report.html#a2.11.0)
- bump `commons-lang3` from 3.10 to 3.12.0 (release notes: https://commons.apache.org/proper/commons-lang/changes-report.html#a3.12.0)


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
