### PR TITLE
[Doc] Remove improper docs of saving dataframe for PySpark client

### DIFF
--- a/docs/client/python/pyspark.md
+++ b/docs/client/python/pyspark.md
@@ -92,18 +92,6 @@ jdbcDF = spark.read \
            query="select * from testdb.src_table"
            ) \
   .load()
-
-
-# Saving data to Kyuubi via HiveDriver as JDBC datasource
-jdbcDF.write \
-    .format("jdbc") \
-    .options(driver="org.apache.hive.jdbc.HiveDriver",
-             url="jdbc:hive2://kyuubi_server_ip:port",
-           user="user",
-           password="password",
-           dbtable="testdb.tgt_table"
-           ) \
-    .save()
 ```
 
 ### Using as JDBC Datasource table with SQL


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

Remove improper docs saving dataframe for pyspark, as hive-like JDBC driver not supporting `addBatch` which is required by Spark JDBC datasource in `JDBCUtils`.

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
