### PR TITLE
[TEST] Refine `GoldenFileUtils::baseResourcePath`

### DIFF
--- a/extensions/spark/kyuubi-spark-connector-common/src/test/scala/org/apache/kyuubi/spark/connector/common/GoldenFileUtils.scala
+++ b/extensions/spark/kyuubi-spark-connector-common/src/test/scala/org/apache/kyuubi/spark/connector/common/GoldenFileUtils.scala
@@ -43,7 +43,11 @@ object GoldenFileUtils {
   private val regenerateGoldenFiles: Boolean = sys.env.get("KYUUBI_UPDATE").contains("1")
 
   private val baseResourcePath: Path =
-    Paths.get("src", "main", "resources")
+    Paths.get(
+      Option(Thread.currentThread().getContextClassLoader).getOrElse(getClass.getClassLoader)
+        .getResource(".")
+        .getPath,
+      Seq("..", "..", "..", "src", "main", "resources"): _*)
 
   private def fileToString(file: Path): String = {
     new String(Files.readAllBytes(file), StandardCharsets.UTF_8)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

before this PR, an exception is thrown when we run `TPCHQuerySuite` on the idea

```
Caused by: java.nio.file.NoSuchFileException: /Users/fchen/Project/bigdata/incubator-kyuubi/src/main/resources/kyuubi/tpch/q3.output.schema
	at sun.nio.fs.UnixException.translateToIOException(UnixException.java:86)
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102)
...
```

### _How was this patch tested?_

Pass Github Action.
