### PR TITLE
Update  class name of MySQL 8 JDBC driver used in kyuubi-server tests

### DIFF
--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/mysql/MySQLJDBCTestHelper.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/mysql/MySQLJDBCTestHelper.scala
@@ -22,7 +22,7 @@ import org.apache.kyuubi.operation.JDBCTestHelper
 
 trait MySQLJDBCTestHelper extends JDBCTestHelper {
 
-  override def jdbcDriverClass: String = "com.mysql.jdbc.Driver"
+  override def jdbcDriverClass: String = "com.mysql.cj.jdbc.Driver"
 
   protected lazy val user: String = Utils.currentUser
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Prefer MySQL JDBC driver's new class name `com.mysql.cj.jdbc.Driver` in testing.
To eliminate this warning message in kyuubi-server‘s test runs:
```
[INFO] --- scalatest-maven-plugin:2.0.2:test (test) @ kyuubi-server_2.12 ---
Discovery starting.
Loading class `com.mysql.jdbc.Driver'. This is deprecated. The new driver class is `com.mysql.cj.jdbc.Driver'. The driver is automatically registered via the SPI and manual loading of the driver class is generally unnecessary.
```


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
