### PR TITLE
Support to ignore subdomain when engine pool conditions are met

### DIFF
--- a/docs/deployment/settings.md
+++ b/docs/deployment/settings.md
@@ -246,7 +246,6 @@ kyuubi.engine.jdbc.memory|1g|The heap memory for the jdbc query engine|string|1.
 kyuubi.engine.jdbc.type|&lt;undefined&gt;|The short name of jdbc type|string|1.6.0
 kyuubi.engine.operation.convert.catalog.database.enabled|true|When set to true, The engine converts the JDBC methods of set/get Catalog and set/get Schema to the implementation of different engines|boolean|1.6.0
 kyuubi.engine.operation.log.dir.root|engine_operation_logs|Root directory for query operation log at engine-side.|string|1.4.0
-kyuubi.engine.pool.first|false|Used for arbitration when engine pool conditions are met and subdomain is specified.|boolean|1.7.0
 kyuubi.engine.pool.name|engine-pool|The name of engine pool.|string|1.5.0
 kyuubi.engine.pool.selectPolicy|RANDOM|The select policy of an engine from the corresponding engine pool engine for a session. <ul><li>RANDOM - Randomly use the engine in the pool</li><li>POLLING - Polling use the engine in the pool</li></ul>|string|1.7.0
 kyuubi.engine.pool.size|-1|The size of engine pool. Note that, if the size is less than 1, the engine pool will not be enabled; otherwise, the size of the engine pool will be min(this, kyuubi.engine.pool.size.threshold).|int|1.4.0

--- a/docs/deployment/settings.md
+++ b/docs/deployment/settings.md
@@ -246,6 +246,7 @@ kyuubi.engine.jdbc.memory|1g|The heap memory for the jdbc query engine|string|1.
 kyuubi.engine.jdbc.type|&lt;undefined&gt;|The short name of jdbc type|string|1.6.0
 kyuubi.engine.operation.convert.catalog.database.enabled|true|When set to true, The engine converts the JDBC methods of set/get Catalog and set/get Schema to the implementation of different engines|boolean|1.6.0
 kyuubi.engine.operation.log.dir.root|engine_operation_logs|Root directory for query operation log at engine-side.|string|1.4.0
+kyuubi.engine.pool.first|false|Used for arbitration when engine pool conditions are met and subdomain is specified.|boolean|1.7.0
 kyuubi.engine.pool.name|engine-pool|The name of engine pool.|string|1.5.0
 kyuubi.engine.pool.selectPolicy|RANDOM|The select policy of an engine from the corresponding engine pool engine for a session. <ul><li>RANDOM - Randomly use the engine in the pool</li><li>POLLING - Polling use the engine in the pool</li></ul>|string|1.7.0
 kyuubi.engine.pool.size|-1|The size of engine pool. Note that, if the size is less than 1, the engine pool will not be enabled; otherwise, the size of the engine pool will be min(this, kyuubi.engine.pool.size.threshold).|int|1.4.0

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -1652,11 +1652,13 @@ object KyuubiConf {
     .checkValues(EngineType.values.map(_.toString))
     .createWithDefault(EngineType.SPARK_SQL.toString)
 
-  val ENGINE_POOL_FIRST: ConfigEntry[Boolean] = buildConf("kyuubi.engine.pool.first")
-    .doc("Used for arbitration when engine pool conditions are met and subdomain is specified.")
-    .version("1.7.0")
-    .booleanConf
-    .createWithDefault(false)
+  val ENGINE_POOL_IGNORE_SUBDOMAIN: ConfigEntry[Boolean] =
+    buildConf("kyuubi.engine.pool.ignoreSubdomain")
+      .doc("Whether to ignore subdomain when engine pool conditions are met.")
+      .internal
+      .version("1.7.0")
+      .booleanConf
+      .createWithDefault(false)
 
   val ENGINE_POOL_NAME: ConfigEntry[String] = buildConf("kyuubi.engine.pool.name")
     .doc("The name of engine pool.")

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -1654,7 +1654,8 @@ object KyuubiConf {
 
   val ENGINE_POOL_IGNORE_SUBDOMAIN: ConfigEntry[Boolean] =
     buildConf("kyuubi.engine.pool.ignoreSubdomain")
-      .doc("Whether to ignore subdomain when engine pool conditions are met.")
+      .doc(s"Whether to ignore ${ENGINE_SHARE_LEVEL_SUBDOMAIN.key}" +
+        s" when engine pool conditions met.")
       .internal
       .version("1.7.0")
       .booleanConf

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -1652,7 +1652,7 @@ object KyuubiConf {
     .checkValues(EngineType.values.map(_.toString))
     .createWithDefault(EngineType.SPARK_SQL.toString)
 
-  val ENGINE_POOL_FIRST: ConfigEntry[Boolean] = buildConf("kyuubi.engine.pool.enabled")
+  val ENGINE_POOL_FIRST: ConfigEntry[Boolean] = buildConf("kyuubi.engine.pool.first")
     .doc("Used for arbitration when engine pool conditions are met and subdomain is specified.")
     .version("1.7.0")
     .booleanConf

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -1652,6 +1652,12 @@ object KyuubiConf {
     .checkValues(EngineType.values.map(_.toString))
     .createWithDefault(EngineType.SPARK_SQL.toString)
 
+  val ENGINE_POOL_FIRST: ConfigEntry[Boolean] = buildConf("kyuubi.engine.pool.enabled")
+    .doc("Used for arbitration when engine pool conditions are met and subdomain is specified.")
+    .version("1.7.0")
+    .booleanConf
+    .createWithDefault(false)
+
   val ENGINE_POOL_NAME: ConfigEntry[String] = buildConf("kyuubi.engine.pool.name")
     .doc("The name of engine pool.")
     .version("1.5.0")

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
@@ -72,6 +72,8 @@ private[kyuubi] class EngineRef(
 
   private val clientPoolName: String = conf.get(ENGINE_POOL_NAME)
 
+  private val enginePoolFirst: Boolean = conf.get(ENGINE_POOL_FIRST)
+
   private val enginePoolBalancePolicy: String = conf.get(ENGINE_POOL_BALANCE_POLICY)
 
   // In case the multi kyuubi instances have the small gap of timeout, here we add
@@ -89,7 +91,7 @@ private[kyuubi] class EngineRef(
 
   @VisibleForTesting
   private[kyuubi] val subdomain: String = conf.get(ENGINE_SHARE_LEVEL_SUBDOMAIN) match {
-    case Some(_subdomain) => _subdomain
+    case Some(_subdomain) if !enginePoolFirst || clientPoolSize <= 0 => _subdomain
     case None if clientPoolSize > 0 =>
       val poolSize = math.min(clientPoolSize, poolThreshold)
       if (poolSize < clientPoolSize) {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
@@ -72,7 +72,7 @@ private[kyuubi] class EngineRef(
 
   private val clientPoolName: String = conf.get(ENGINE_POOL_NAME)
 
-  private val enginePoolFirst: Boolean = conf.get(ENGINE_POOL_FIRST)
+  private val enginePoolIgnoreSubdomain: Boolean = conf.get(ENGINE_POOL_IGNORE_SUBDOMAIN)
 
   private val enginePoolBalancePolicy: String = conf.get(ENGINE_POOL_BALANCE_POLICY)
 
@@ -91,8 +91,7 @@ private[kyuubi] class EngineRef(
 
   @VisibleForTesting
   private[kyuubi] val subdomain: String = conf.get(ENGINE_SHARE_LEVEL_SUBDOMAIN) match {
-    case Some(_subdomain) if !enginePoolFirst || clientPoolSize <= 0 => _subdomain
-    case None if clientPoolSize > 0 =>
+    case subdomain if clientPoolSize > 0 && (subdomain.isEmpty || enginePoolIgnoreSubdomain) =>
       val poolSize = math.min(clientPoolSize, poolThreshold)
       if (poolSize < clientPoolSize) {
         warn(s"Request engine pool size($clientPoolSize) exceeds, fallback to " +
@@ -113,6 +112,7 @@ private[kyuubi] class EngineRef(
           Random.nextInt(poolSize)
       }
       s"$clientPoolName-${seqNum % poolSize}"
+    case Some(_subdomain) => _subdomain
     case _ => "default" // [KYUUBI #1293]
   }
 

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/EngineRefTests.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/EngineRefTests.scala
@@ -293,12 +293,12 @@ trait EngineRefTests extends KyuubiFunSuite {
     }
   }
 
-  test("support arbitration when when engine pool conditions are met and subdomain is specified") {
+  test("support to ignore subdomain when engine pool conditions are met") {
     val id = UUID.randomUUID().toString
 
     // set subdomain and disable engine pool
     conf.set(ENGINE_SHARE_LEVEL_SUBDOMAIN.key, "abc")
-    conf.set(ENGINE_POOL_FIRST, false)
+    conf.set(ENGINE_POOL_IGNORE_SUBDOMAIN, false)
     conf.set(ENGINE_POOL_SIZE, -1)
     val engine1 = new EngineRef(conf, user, "grp", id, null)
     assert(engine1.subdomain === "abc")
@@ -312,8 +312,8 @@ trait EngineRefTests extends KyuubiFunSuite {
     assert(engine3.subdomain.startsWith("engine-pool-"))
 
     conf.set(ENGINE_SHARE_LEVEL_SUBDOMAIN.key, "abc")
-    conf.set(ENGINE_POOL_FIRST, true)
+    conf.set(ENGINE_POOL_IGNORE_SUBDOMAIN, true)
     val engine4 = new EngineRef(conf, user, "grp", id, null)
-    assert(engine3.subdomain.startsWith("engine-pool-"))
+    assert(engine4.subdomain.startsWith("engine-pool-"))
   }
 }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/EngineRefTests.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/EngineRefTests.scala
@@ -292,4 +292,28 @@ trait EngineRefTests extends KyuubiFunSuite {
       executor.shutdown()
     }
   }
+
+  test("support arbitration when when engine pool conditions are met and subdomain is specified") {
+    val id = UUID.randomUUID().toString
+
+    // set subdomain and disable engine pool
+    conf.set(ENGINE_SHARE_LEVEL_SUBDOMAIN.key, "abc")
+    conf.set(ENGINE_POOL_FIRST, false)
+    conf.set(ENGINE_POOL_SIZE, -1)
+    val engine1 = new EngineRef(conf, user, "grp", id, null)
+    assert(engine1.subdomain === "abc")
+
+    conf.set(ENGINE_POOL_SIZE, 1)
+    val engine2 = new EngineRef(conf, user, "grp", id, null)
+    assert(engine2.subdomain === "abc")
+
+    conf.unset(ENGINE_SHARE_LEVEL_SUBDOMAIN)
+    val engine3 = new EngineRef(conf, user, "grp", id, null)
+    assert(engine3.subdomain.startsWith("engine-pool-"))
+
+    conf.set(ENGINE_SHARE_LEVEL_SUBDOMAIN.key, "abc")
+    conf.set(ENGINE_POOL_FIRST, true)
+    val engine4 = new EngineRef(conf, user, "grp", id, null)
+    assert(engine3.subdomain.startsWith("engine-pool-"))
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Support to ignore subdomain when engine pool conditions are met.
It is difficult to understand the engine routing rule for customers, especially for the engine pool and subdomain.
Maybe a user use subdomain before, and then they want to use engine pool.
Then specify the engine pool name, engine pool size, but the result is not expected.
They need to remove the subdomain specified before, otherwise, the engine pool will not work.
I need tell customer that, the engine subdomain config has higher priority and tell them the routing rule.
The understanding cost is high.
With this change, it is clear for engine pool conditions.
### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
