### PR TITLE
Eliminate unhelpful warning messages in Javac output of building and testing

### DIFF
--- a/kyuubi-common/src/main/java/org/apache/kyuubi/reflection/DynConstructors.java
+++ b/kyuubi-common/src/main/java/org/apache/kyuubi/reflection/DynConstructors.java
@@ -119,6 +119,7 @@ public class DynConstructors {
     return new Builder(baseClass);
   }
 
+  @SuppressWarnings( "rawtypes")
   public static class Builder {
     private final Class<?> baseClass;
     private ClassLoader loader = Thread.currentThread().getContextClassLoader();
@@ -182,7 +183,7 @@ public class DynConstructors {
       return this;
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public Builder hiddenImpl(String className, Class<?>... types) {
       // don't do any work if an implementation has been found
       if (ctor != null) {

--- a/kyuubi-common/src/main/java/org/apache/kyuubi/reflection/DynConstructors.java
+++ b/kyuubi-common/src/main/java/org/apache/kyuubi/reflection/DynConstructors.java
@@ -119,7 +119,7 @@ public class DynConstructors {
     return new Builder(baseClass);
   }
 
-  @SuppressWarnings( "rawtypes")
+  @SuppressWarnings("rawtypes")
   public static class Builder {
     private final Class<?> baseClass;
     private ClassLoader loader = Thread.currentThread().getContextClassLoader();

--- a/kyuubi-common/src/main/java/org/apache/kyuubi/reflection/DynFields.java
+++ b/kyuubi-common/src/main/java/org/apache/kyuubi/reflection/DynFields.java
@@ -300,6 +300,7 @@ public class DynFields {
      * @see Class#forName(String)
      * @see Class#getField(String)
      */
+    @SuppressWarnings("rawtypes")
     public Builder hiddenImpl(Class<?> targetClass, String fieldName) {
       // don't do any work if an implementation has been found
       if (field != null || targetClass == null) {

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiArrowBasedResultSet.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiArrowBasedResultSet.java
@@ -34,6 +34,7 @@ import org.apache.kyuubi.jdbc.hive.arrow.ArrowColumnarBatchRow;
 import org.apache.kyuubi.jdbc.hive.arrow.ArrowUtils;
 
 /** Data independent base class which implements the common part of all Kyuubi result sets. */
+@SuppressWarnings("deprecation")
 public abstract class KyuubiArrowBasedResultSet implements SQLResultSet {
 
   protected Statement statement = null;

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiBaseResultSet.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiBaseResultSet.java
@@ -32,6 +32,7 @@ import org.apache.kyuubi.jdbc.hive.common.HiveIntervalYearMonth;
 import org.apache.kyuubi.jdbc.hive.common.TimestampTZUtil;
 
 /** Data independent base class which implements the common part of all Kyuubi result sets. */
+@SuppressWarnings("deprecation")
 public abstract class KyuubiBaseResultSet implements SQLResultSet {
 
   protected Statement statement = null;

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
@@ -1248,6 +1248,7 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
     return protocol;
   }
 
+  @SuppressWarnings("rawtypes")
   public static TCLIService.Iface newSynchronizedClient(TCLIService.Iface client) {
     return (TCLIService.Iface)
         Proxy.newProxyInstance(

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
@@ -1287,6 +1287,7 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
     }
   }
 
+  @SuppressWarnings("fallthrough")
   public void waitLaunchEngineToComplete() throws SQLException {
     if (launchEngineOpHandle == null) return;
 

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/adapter/SQLCallableStatement.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/adapter/SQLCallableStatement.java
@@ -25,6 +25,7 @@ import java.sql.*;
 import java.util.Calendar;
 import java.util.Map;
 
+@SuppressWarnings("deprecation")
 public interface SQLCallableStatement extends CallableStatement {
 
   @Override

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/adapter/SQLPreparedStatement.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/adapter/SQLPreparedStatement.java
@@ -23,6 +23,7 @@ import java.net.URL;
 import java.sql.*;
 import java.util.Calendar;
 
+@SuppressWarnings("deprecation")
 public interface SQLPreparedStatement extends PreparedStatement {
 
   @Override

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/adapter/SQLResultSet.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/adapter/SQLResultSet.java
@@ -25,6 +25,7 @@ import java.sql.*;
 import java.util.Calendar;
 import java.util.Map;
 
+@SuppressWarnings("deprecation")
 public interface SQLResultSet extends ResultSet {
 
   @Override

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/cli/ColumnBuffer.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/cli/ColumnBuffer.java
@@ -89,6 +89,7 @@ public class ColumnBuffer extends AbstractList<Object> {
     }
   }
 
+  @SuppressWarnings("unchecked")
   public ColumnBuffer(TTypeId type, BitSet nulls, Object values) {
     this.type = type;
     this.nulls = nulls;

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/common/FastHiveDecimal.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/common/FastHiveDecimal.java
@@ -457,6 +457,7 @@ public class FastHiveDecimal {
         fastSignum, fast0, fast1, fast2, fastIntegerDigitCount, fastScale, n, fastResult);
   }
 
+  @SuppressWarnings("deprecation")
   protected static String fastRoundingModeToString(int roundingMode) {
     String roundingModeString;
     switch (roundingMode) {

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/common/FastHiveDecimalImpl.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/common/FastHiveDecimalImpl.java
@@ -9369,7 +9369,7 @@ public class FastHiveDecimalImpl extends FastHiveDecimal {
   public static String displayBytes(byte[] bytes, int start, int length) {
     StringBuilder sb = new StringBuilder();
     for (int i = start; i < start + length; i++) {
-      sb.append(String.format("\\%03d", (int) (bytes[i] & 0xff)));
+      sb.append(String.format("\\%03d", bytes[i] & 0xff));
     }
     return sb.toString();
   }

--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/RetryableRestClient.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/RetryableRestClient.java
@@ -48,6 +48,7 @@ public class RetryableRestClient implements InvocationHandler {
     newRestClient();
   }
 
+  @SuppressWarnings("rawtypes")
   public static IRestClient getRestClient(List<String> uris, RestClientConf conf) {
     RetryableRestClient client = new RetryableRestClient(uris, conf);
     return (IRestClient)

--- a/pom.xml
+++ b/pom.xml
@@ -1750,7 +1750,7 @@
                         <maxmem>1024m</maxmem>
                         <fork>true</fork>
                         <compilerArgs>
-                            <arg>-Xlint:all,-serial,-path</arg>
+                            <arg>-Xlint:all,-serial,-path,-processing</arg>
                         </compilerArgs>
                     </configuration>
                 </plugin>
@@ -1778,7 +1778,7 @@
                             <jvmArg>-XX:ReservedCodeCacheSize=512M</jvmArg>
                         </jvmArgs>
                         <javacArgs>
-                            <javacArg>-Xlint:all,-serial,-path,-try</javacArg>
+                            <javacArg>-Xlint:all,-serial,-path,-try,-processing</javacArg>
                         </javacArgs>
                         <compilerPlugins>
                             <compilerPlugin>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The output of building and testing is now brought with repeated unuseful warnings from `javac`.
This PR reduces over 500 unhelpful  warning message lines from `-Xlint` rules in `javac` compilation output in a single run, by eliminating :
- 74 of `deprecation`, by adding `@SuppressWarning` to 6 Java classes
- 6 of `rawtypes`, by adding `@SuppressWarning` to methods of Java class
- 4 of `unchecked`, by adding `@SuppressWarning` to methods of Java class
- 1 of `fallthrough`, by adding `@SuppressWarning` to method of Java class
- 1 of `cast`, by removal of  redundant type casting
- repeated `processing` for, by adding `-processing` to disable annotation processor warning for annotations from testing framework :
```
- Warning:  Unexpected javac output: warning: No processor claimed any of these annotations: /org.scalatest.TagAnnotation

Warning:  Unexpected javac output: warning: No processor claimed any of these annotations: /org.junit.Test,/org.junit.Before,/org.junit.After
 ```
As 1 [fallthrough] warning message remain, which will be reported in followup issues or PR to fix missing breaks for branches of `switch-case` in Java.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
