### PR TITLE
[Arrow] Fix `fallthrough` cases in type conversion and  resultset handling in kyuubi-hive-jdbc

### DIFF
--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiStatement.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiStatement.java
@@ -280,6 +280,7 @@ public class KyuubiStatement implements SQLStatement, KyuubiLoggable {
                 .setScrollable(isScrollableResultset)
                 .setSchema(columnNames, columnTypes, columnAttributes)
                 .build();
+        break;
       default:
         resultSet =
             new KyuubiQueryResultSet.Builder(this)

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/arrow/ArrowUtils.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/arrow/ArrowUtils.java
@@ -79,6 +79,8 @@ public class ArrowUtils {
         if (jdbcColumnAttributes != null) {
           return ArrowType.Decimal.createDecimal(
               jdbcColumnAttributes.precision, jdbcColumnAttributes.scale, null);
+        } else {
+          throw new IllegalStateException("Missing precision and scale where it is mandatory.");
         }
       case DATE_TYPE:
         return new ArrowType.Date(DateUnit.DAY);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Fix possible `fallthrough` cases:
- in DECIMAL_TYPE case of `ArrowUtils#toArrowType`
- in "arrow" case of `KyuubiStatement#executeAsync`

The cases above are discovered from warning from javac output which will be eliminated after this PR:
```
/home/runner/work/kyuubi/kyuubi/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiStatement.java:283: warning: [fallthrough] possible fall-through into case
      default:
      ^
/home/runner/work/kyuubi/kyuubi/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/arrow/ArrowUtils.java:83: warning: [fallthrough] possible fall-through into case
      case DATE_TYPE:
      ^
```



### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
