### PR TITLE
Eliminate `scalac` warnings for class link in comments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1769,6 +1769,7 @@
                             <arg>-explaintypes</arg>
                             <arg>-Yno-adapted-args</arg>
                             <arg>-P:silencer:globalFilters=.*deprecated.*</arg>
+                            <arg>-P:silencer:globalFilters=.*Could not find any member to link for.*</arg>
                             <arg>-Xfatal-warnings</arg>
                             <arg>-Ywarn-unused:imports</arg>
                         </args>

--- a/pom.xml
+++ b/pom.xml
@@ -1770,6 +1770,7 @@
                             <arg>-Yno-adapted-args</arg>
                             <arg>-P:silencer:globalFilters=.*deprecated.*</arg>
                             <arg>-P:silencer:globalFilters=.*Could not find any member to link for.*</arg>
+                            <arg>-P:silencer:globalFilters=.*undefined in comment for class.*</arg>
                             <arg>-Xfatal-warnings</arg>
                             <arg>-Ywarn-unused:imports</arg>
                         </args>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Adding following rules to `globalFilters` for `silencer` plugin
- `.*Could not find any member to link for.*`
- `.*undefined in comment for class.*`

To refine CI output in a more helpful, to eliminate over 68 class link warnings in Scala comments in single run , as outputs like:
```
/home/runner/work/kyuubi/kyuubi/kyuubi-common/src/main/scala/org/apache/kyuubi/util/KyuubiHadoopUtils.scala:80: warning: Could not find any member to link for "Credentials#tokenMap".
  /**
  ^

/home/runner/work/kyuubi/kyuubi/kyuubi-events/src/main/scala/org/apache/kyuubi/events/handler/JsonLoggingEventHandler.scala:37: warning: Variable eventType undefined in comment for class JsonLoggingEventHandler in class JsonLoggingEventHandler
 *   ${ENGINE_EVENT_JSON_LOG_PATH}/${eventType}/day=${date}/${logName}.json
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
