### PR TITLE
Bump guava from 30.1 to 31.1

### DIFF
--- a/dev/dependencyList
+++ b/dev/dependencyList
@@ -45,7 +45,7 @@ grpc-protobuf-lite/1.48.0//grpc-protobuf-lite-1.48.0.jar
 grpc-protobuf/1.48.0//grpc-protobuf-1.48.0.jar
 grpc-stub/1.48.0//grpc-stub-1.48.0.jar
 gson/2.8.9//gson-2.8.9.jar
-guava/30.1-jre//guava-30.1-jre.jar
+guava/31.1-jre//guava-31.1-jre.jar
 hadoop-client-api/3.3.4//hadoop-client-api-3.3.4.jar
 hadoop-client-runtime/3.3.4//hadoop-client-runtime-3.3.4.jar
 hive-common/3.1.3//hive-common-3.1.3.jar

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
         <google.jsr305.version>3.0.2</google.jsr305.version>
         <grpc.version>1.48.0</grpc.version>
         <gson.version>2.8.9</gson.version>
-        <guava.version>30.1-jre</guava.version>
+        <guava.version>31.1-jre</guava.version>
         <guava.failureaccess.version>1.0.1</guava.failureaccess.version>
         <hadoop.version>3.3.4</hadoop.version>
         <hikaricp.version>4.0.3</hikaricp.version>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- bump `com.google.guava:guava` from 30.1 to 31.1 (released in Mar 2022, https://github.com/google/guava/releases/tag/v31.1)

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
