### PR TITLE
Eliminate unhelpful warning messages in Javac output of Java 11

### DIFF
--- a/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/KyuubiBeeLine.java
+++ b/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/KyuubiBeeLine.java
@@ -40,6 +40,7 @@ public class KyuubiBeeLine extends BeeLine {
     this(true);
   }
 
+  @SuppressWarnings("deprecation")
   public KyuubiBeeLine(boolean isBeeLine) {
     super(isBeeLine);
     try {

--- a/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/KyuubiCommands.java
+++ b/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/KyuubiCommands.java
@@ -470,9 +470,7 @@ public class KyuubiCommands extends Commands {
       props.setProperty(AUTH_USER, username);
       if (password == null) {
         password =
-            beeLine
-                .getConsoleReader()
-                .readLine("Enter password for " + urlForPrompt + ": ", '*');
+            beeLine.getConsoleReader().readLine("Enter password for " + urlForPrompt + ": ", '*');
       }
       props.setProperty(AUTH_PASSWD, password);
     }

--- a/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/KyuubiCommands.java
+++ b/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/KyuubiCommands.java
@@ -405,7 +405,7 @@ public class KyuubiCommands extends Commands {
       }
     }
 
-    for (Iterator i = props.keySet().iterator(); i.hasNext(); ) {
+    for (Iterator<Object> i = props.keySet().iterator(); i.hasNext(); ) {
       String key = (String) i.next();
       for (int j = 0; j < keys.length; j++) {
         if (key.endsWith(keys[j])) {
@@ -472,7 +472,7 @@ public class KyuubiCommands extends Commands {
         password =
             beeLine
                 .getConsoleReader()
-                .readLine("Enter password for " + urlForPrompt + ": ", new Character('*'));
+                .readLine("Enter password for " + urlForPrompt + ": ", '*');
       }
       props.setProperty(AUTH_PASSWD, password);
     }

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/common/FastHiveDecimalImpl.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/common/FastHiveDecimalImpl.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
  * vectorization to implement decimals by storing the fast0, fast1, and fast2 longs and the
  * fastSignum, fastScale, etc ints in the DecimalColumnVector class.
  */
+@SuppressWarnings("deprecation")
 public class FastHiveDecimalImpl extends FastHiveDecimal {
 
   /**

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/common/HiveDecimal.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/common/HiveDecimal.java
@@ -80,6 +80,7 @@ import java.util.Arrays;
  * <p>The original V1 public methods and fields are annotated with @HiveDecimalVersionV1; new public
  * methods and fields are annotated with @HiveDecimalVersionV2.
  */
+@SuppressWarnings("deprecation")
 public final class HiveDecimal extends FastHiveDecimal implements Comparable<HiveDecimal> {
 
   /*


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
As #4166 cleanup unhelpful warning messages in Java 8, this PR does the same to Java 11 deprecation warnings.

- add @SuppressWarnings("deprecation") to `HiveDecimal` and `FastHiveDecimalImpl`, eliminating warnings of using the deprecated field of `BigDecimal` since Java 9 in Java 11, e.g. (40 warnings in a build)

```
Warning:  /home/runner/work/kyuubi/kyuubi/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/common/HiveDecimal.java:[133,50] [deprecation] ROUND_FLOOR in BigDecimal has been deprecated
Warning:  /home/runner/work/kyuubi/kyuubi/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/common/HiveDecimal.java:[150,52] [deprecation] ROUND_CEILING in BigDecimal has been deprecated
Warning:  /home/runner/work/kyuubi/kyuubi/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/common/HiveDecimal.java:[165,52] [deprecation] ROUND_HALF_UP in BigDecimal has been deprecated
Warning:  /home/runner/work/kyuubi/kyuubi/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/common/HiveDecimal.java:[186,54] [deprecation] ROUND_HALF_EVEN in BigDecimal has been deprecated
Warning:  /home/runner/work/kyuubi/kyuubi/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/common/FastHiveDecimalImpl.java:[2934,20] [deprecation] ROUND_HALF_UP in BigDecimal has been deprecated
Warning:  /home/runner/work/kyuubi/kyuubi/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/common/FastHiveDecimalImpl.java:[4411,23] [deprecation] ROUND_DOWN in BigDecimal has been deprecated
Warning:  /home/runner/work/kyuubi/kyuubi/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/common/FastHiveDecimalImpl.java:[4424,23] [deprecation] ROUND_UP in BigDecimal has been deprecated
```

- fix `rawtypes` usages and redundant boxing in `KyuubiCommands`
```
Warning:  /home/runner/work/kyuubi/kyuubi/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/KyuubiCommands.java:408:9:  [rawtypes] found raw type: Iterator
Warning:  /home/runner/work/kyuubi/kyuubi/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/KyuubiCommands.java:[475,71] [deprecation] Character(char) in Character has been deprecated
```


- add @SuppressWarnings("deprecation") to `KyuubiBeeLine.java` for using deprecated `Class#newInstance` of Java 11

```
Warning:  /home/runner/work/kyuubi/kyuubi/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/KyuubiBeeLine.java:[59,18] [deprecation] newInstance() in Class has been deprecated
  where T is a type-variable:
    T extends Object declared in class Class
Warning:  /home/runner/work/kyuubi/kyuubi/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/KyuubiBeeLine.java:59:18:  [deprecation] newInstance() in Class has been deprecated
Warning:  /home/runner/work/kyuubi/kyuubi/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/KyuubiCommands.java:475:71:  [deprecation] Character(char) in Character has been deprecated
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
