### PR TITLE
[Improvement] Print revision commit time on server startup

### DIFF
--- a/build/kyuubi-build-info
+++ b/build/kyuubi-build-info
@@ -32,6 +32,7 @@ echo_build_properties() {
   echo kyuubi_trino_version="$9"
   echo user="$USER"
   echo revision=$(git rev-parse HEAD)
+  echo revision_time=$(git show -s --format=%ci HEAD)
   echo branch=$(git rev-parse --abbrev-ref HEAD)
   echo date=$(date -u +%Y-%m-%dT%H:%M:%SZ)
   echo url=$(git config --get remote.origin.url)

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/package.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/package.scala
@@ -53,6 +53,7 @@ package object kyuubi {
     val trino_version: String = props.getProperty("kyuubi_trino_version", unknown)
     val branch: String = props.getProperty("branch", unknown)
     val revision: String = props.getProperty("revision", unknown)
+    val revisionTime: String = props.getProperty("revision_time", unknown)
     val user: String = props.getProperty("user", unknown)
     val repoUrl: String = props.getProperty("url", unknown)
     val buildDate: String = props.getProperty("date", unknown)
@@ -68,6 +69,7 @@ package object kyuubi {
   val TRINO_COMPILE_VERSION: String = BuildInfo.trino_version
   val BRANCH: String = BuildInfo.branch
   val REVISION: String = BuildInfo.revision
+  val REVISION_TIME: String = BuildInfo.revisionTime
   val BUILD_USER: String = BuildInfo.user
   val REPO_URL: String = BuildInfo.repoUrl
   val BUILD_DATE: String = BuildInfo.buildDate

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/UtilsSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/UtilsSuite.scala
@@ -49,6 +49,7 @@ class UtilsSuite extends KyuubiFunSuite {
     assert(props.getProperty("kyuubi_trino_version") === TRINO_COMPILE_VERSION)
     assert(props.getProperty("branch") === BRANCH)
     assert(props.getProperty("revision") === REVISION)
+    assert(props.getProperty("revision_time") === REVISION_TIME)
     assert(props.getProperty("user") === BUILD_USER)
     assert(props.getProperty("url") === REPO_URL)
     assert(props.getProperty("date") === BUILD_DATE)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiServer.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiServer.scala
@@ -82,7 +82,7 @@ object KyuubiServer extends Logging {
         |                /\___/
         |                \/__/
        """.stripMargin)
-    info(s"Version: $KYUUBI_VERSION, Revision: $REVISION, Branch: $BRANCH," +
+    info(s"Version: $KYUUBI_VERSION, Revision: $REVISION ($REVISION_TIME), Branch: $BRANCH," +
       s" Java: $JAVA_COMPILE_VERSION, Scala: $SCALA_COMPILE_VERSION," +
       s" Spark: $SPARK_COMPILE_VERSION, Hadoop: $HADOOP_COMPILE_VERSION," +
       s" Hive: $HIVE_COMPILE_VERSION, Flink: $FLINK_COMPILE_VERSION," +


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- commit date is more readable and helpful to determine earlier/later version, especially for snapshot branch
- adding revision commit date from git to `kyuubi-version-info.properties`
- Print revision date on server startup 

![image](https://user-images.githubusercontent.com/1935105/213330684-26ef3b3f-eaf3-4cb1-b0cb-81dba30dbee3.png)


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
