### PR TITLE
Scala repl output log level adjusted to debug

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteScala.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteScala.scala
@@ -112,7 +112,7 @@ class ExecuteScala(
               new ArrayFetchIterator[Row](result.collect())
             } else {
               val output = repl.getOutput
-              info("scala repl output:\n" + output)
+              debug("scala repl output:\n" + output)
               new ArrayFetchIterator[Row](Array(Row(output)))
             }
           }


### PR DESCRIPTION
Motivation: When the running result of scala code is very long, all the information will be printed to info, and it is not very elegant to print the result set to the info level.
