### PR TITLE
[Improvement] Skip fetching Maven dependency snapshot update when building `dependencyList`

### DIFF
--- a/build/dependency.sh
+++ b/build/dependency.sh
@@ -32,7 +32,7 @@ DEP="${PWD}/dev/dependencyList"
 
 
 function build_classpath() {
-  $MVN dependency:build-classpath -pl kyuubi-ctl,kyuubi-server,kyuubi-assembly |\
+  $MVN dependency:build-classpath --no-snapshot-updates -pl kyuubi-ctl,kyuubi-server,kyuubi-assembly |\
     grep -v "INFO\|WARN" | \
     tail -1 | \
     tr ":" "\n" | \


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- Skip Maven dependency snapshot update fetching to building `dependencyList` faster without waiting for fetching daily snapshots checking (only snapshots of submodules used).

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
