### PR TITLE
[INFRA] Make all CI jobs run on `ubuntu-22.04`

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -22,7 +22,7 @@ on: issues
 
 jobs:
   greeting:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   triage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/labeler@v4
       with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       pull-requests: write
     steps:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

In 21 CI workflow jobs, 18 run on `ubuntu-22.04` and 3 run on `ubuntu-latest` (the same as `ubuntu-22.04` currently),

Making all CI jobs run on `ubuntu-22.04` to ensure alignment in the same operation system version, and it benefits from future version updates.

### _How was this patch tested?_
CI actions pass.
