### PR TITLE
[Improvement] Remove Gson as direct dependency by using Jackson instead in Authz tests

### DIFF
--- a/dev/dependencyList
+++ b/dev/dependencyList
@@ -44,7 +44,7 @@ grpc-netty/1.48.0//grpc-netty-1.48.0.jar
 grpc-protobuf-lite/1.48.0//grpc-protobuf-lite-1.48.0.jar
 grpc-protobuf/1.48.0//grpc-protobuf-1.48.0.jar
 grpc-stub/1.48.0//grpc-stub-1.48.0.jar
-gson/2.8.9//gson-2.8.9.jar
+gson/2.9.0//gson-2.9.0.jar
 guava/31.1-jre//guava-31.1-jre.jar
 hadoop-client-api/3.3.4//hadoop-client-api-3.3.4.jar
 hadoop-client-runtime/3.3.4//hadoop-client-runtime-3.3.4.jar

--- a/extensions/spark/kyuubi-spark-authz/pom.xml
+++ b/extensions/spark/kyuubi-spark-authz/pom.xml
@@ -284,12 +284,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <scope>test</scope>

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerLocalClient.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerLocalClient.scala
@@ -17,11 +17,9 @@
 
 package org.apache.kyuubi.plugin.spark.authz.ranger
 
-import java.io.InputStreamReader
 import java.text.SimpleDateFormat
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import com.google.gson.GsonBuilder
 import org.apache.ranger.admin.client.RangerAdminRESTClient
 import org.apache.ranger.plugin.util.ServicePolicies
 

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerLocalClient.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerLocalClient.scala
@@ -18,21 +18,24 @@
 package org.apache.kyuubi.plugin.spark.authz.ranger
 
 import java.io.InputStreamReader
+import java.text.SimpleDateFormat
 
+import com.fasterxml.jackson.databind.json.JsonMapper
 import com.google.gson.GsonBuilder
 import org.apache.ranger.admin.client.RangerAdminRESTClient
 import org.apache.ranger.plugin.util.ServicePolicies
 
 class RangerLocalClient extends RangerAdminRESTClient with RangerClientHelper {
 
-  private val g =
-    new GsonBuilder().setDateFormat("yyyyMMdd-HH:mm:ss.SSS-Z").setPrettyPrinting().create
+  private val mapper = new JsonMapper()
+    .setDateFormat(new SimpleDateFormat("yyyyMMdd-HH:mm:ss.SSS-Z"))
+
   private val policies: ServicePolicies = {
     val loader = Thread.currentThread().getContextClassLoader
     val inputStream = {
       loader.getResourceAsStream("sparkSql_hive_jenkins.json")
     }
-    g.fromJson(new InputStreamReader(inputStream), classOf[ServicePolicies])
+    mapper.readValue(inputStream, classOf[ServicePolicies])
   }
 
   override def getServicePoliciesIfUpdated(

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,6 @@
         <flink.archive.download.skip>false</flink.archive.download.skip>
         <google.jsr305.version>3.0.2</google.jsr305.version>
         <grpc.version>1.48.0</grpc.version>
-        <gson.version>2.8.9</gson.version>
         <guava.version>31.1-jre</guava.version>
         <guava.failureaccess.version>1.0.1</guava.failureaccess.version>
         <hadoop.version>3.3.4</hadoop.version>
@@ -1598,12 +1597,6 @@
                         <artifactId>log4j-slf4j-impl</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-
-            <dependency>
-                <groupId>com.google.code.gson</groupId>
-                <artifactId>gson</artifactId>
-                <version>${gson.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- use `Jackson` instead of `Gson` in Authz tests, where it is the only place `Gson` is used in project
- remove `Gson` as the dependency
- Notice: Gson project is in maintenance mode, (see https://github.com/google/gson/pull/2085)
- Gson is still on `dependencyList`, as depended in kyuubi-ha
<img width="640" alt="image" src="https://user-images.githubusercontent.com/1935105/213956635-ce079638-15c3-4de2-9f46-a93dfe3db199.png">

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
