### PR TITLE
[KYUUBI #4119][FOLLOWUP] Do not fail on unknown properties to keep kyuubi-ctl compatiblity 

### DIFF
--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/util/JsonUtils.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/util/JsonUtils.java
@@ -17,12 +17,14 @@
 
 package org.apache.kyuubi.client.util;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.kyuubi.client.exception.KyuubiRestException;
 
 public final class JsonUtils {
 
-  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final ObjectMapper MAPPER =
+      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
   public static String toJson(Object object) {
     try {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

```
Caused by: com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "appStartTime" (class org.apache.kyuubi.client.api.v1.dto.Batch), not marked as ignorable (13 known properties: "appDiagnostic", "createTime", "kyuubiInstance", "user", "appUrl", "appState", "state", "batchType", "cluster", "id", "appId", "endTime", "name"])
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
