### PR TITLE
[Authz] Set logging level to DEBUG in PrivilegesBuilder for multiple specs

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -144,7 +144,7 @@ object PrivilegesBuilder {
         }
       } catch {
         case e: Exception =>
-          LOG.warn(tableDesc.error(plan, e))
+          LOG.debug(tableDesc.error(plan, e))
           Nil
       }
     }
@@ -162,7 +162,7 @@ object PrivilegesBuilder {
             }
           } catch {
             case e: Exception =>
-              LOG.warn(databaseDesc.error(plan, e))
+              LOG.debug(databaseDesc.error(plan, e))
           }
         }
         desc.operationType
@@ -193,7 +193,7 @@ object PrivilegesBuilder {
             }
           } catch {
             case e: Exception =>
-              LOG.warn(fd.error(plan, e))
+              LOG.debug(fd.error(plan, e))
           }
         }
         spec.operationType

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/serde/CommandSpec.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/serde/CommandSpec.scala
@@ -85,7 +85,7 @@ case class TableCommandSpec(
         qd.extract(plan)
       } catch {
         case e: Exception =>
-          LOG.warn(qd.error(plan, e))
+          LOG.debug(qd.error(plan, e))
           None
       }
     }
@@ -102,7 +102,7 @@ case class ScanSpec(
         td.extract(plan, spark)
       } catch {
         case e: Exception =>
-          LOG.warn(td.error(plan, e))
+          LOG.debug(td.error(plan, e))
           None
       }
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- change logging level from `warn` to `debug` in Authz
- to eliminate duplicated unuseful messages (as screenshot below) with multiple specs in extracting resources with lower Spark versions 
![WechatIMG7517](https://user-images.githubusercontent.com/1935105/215329357-ad242cf4-9c98-44b0-978a-f37304a85ef0.png)


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
