### PR TITLE
Show line number and assertion when verifying generated markdown files in lines

### DIFF
--- a/docs/deployment/settings.md
+++ b/docs/deployment/settings.md
@@ -97,7 +97,7 @@ You can configure the environment variables in `$KYUUBI_HOME/conf/kyuubi-env.sh`
 
 For the environment variables that only needed to be transferred into engine side, you can set it with a Kyuubi configuration item formatted `kyuubi.engineEnv.VAR_NAME`. For example, with `kyuubi.engineEnv.SPARK_DRIVER_MEMORY=4g`, the environment variable `SPARK_DRIVER_MEMORY` with value `4g` would be transferred into engine side. With `kyuubi.engineEnv.SPARK_CONF_DIR=/apache/confs/spark/conf`, the value of `SPARK_CONF_DIR` on the engine side is set to `/apache/confs/spark/conf`.
 
-## Kyuubi Configurations [SOMETHING-IN-FILE]
+## Kyuubi Configurations
 
 You can configure the Kyuubi properties in `$KYUUBI_HOME/conf/kyuubi-defaults.conf`. For example:
 

--- a/docs/deployment/settings.md
+++ b/docs/deployment/settings.md
@@ -97,7 +97,7 @@ You can configure the environment variables in `$KYUUBI_HOME/conf/kyuubi-env.sh`
 
 For the environment variables that only needed to be transferred into engine side, you can set it with a Kyuubi configuration item formatted `kyuubi.engineEnv.VAR_NAME`. For example, with `kyuubi.engineEnv.SPARK_DRIVER_MEMORY=4g`, the environment variable `SPARK_DRIVER_MEMORY` with value `4g` would be transferred into engine side. With `kyuubi.engineEnv.SPARK_CONF_DIR=/apache/confs/spark/conf`, the value of `SPARK_CONF_DIR` on the engine side is set to `/apache/confs/spark/conf`.
 
-## Kyuubi Configurations
+## Kyuubi Configurations [SOMETHING-IN-FILE]
 
 You can configure the Kyuubi properties in `$KYUUBI_HOME/conf/kyuubi-defaults.conf`. For example:
 

--- a/docs/develop_tools/developer.md
+++ b/docs/develop_tools/developer.md
@@ -56,5 +56,5 @@ You can run `dev/reformat` to format all Java and Scala code.
 
 Kyuubi uses settings.md to explain available configurations.
 
-You can run `KYUUBI_UPDATE=1 build/mvn clean install -Pflink-provided,spark-provided,hive-provided -DwildcardSuites=org.apache.kyuubi.config.AllKyuubiConfiguration`
+You can run `KYUUBI_UPDATE=1 build/mvn clean test -Pflink-provided,spark-provided,hive-provided -DwildcardSuites=org.apache.kyuubi.config.AllKyuubiConfiguration`
 to append descriptions of new configurations to settings.md.

--- a/docs/develop_tools/developer.md
+++ b/docs/develop_tools/developer.md
@@ -56,5 +56,5 @@ You can run `dev/reformat` to format all Java and Scala code.
 
 Kyuubi uses settings.md to explain available configurations.
 
-You can run `KYUUBI_UPDATE=1 build/mvn clean test -Pflink-provided,spark-provided,hive-provided -DwildcardSuites=org.apache.kyuubi.config.AllKyuubiConfiguration`
+You can run `KYUUBI_UPDATE=1 build/mvn clean test -pl kyuubi-server -am -Pflink-provided,spark-provided,hive-provided -DwildcardSuites=org.apache.kyuubi.config.AllKyuubiConfiguration`
 to append descriptions of new configurations to settings.md.

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/udf/KyuubiDefinedFunctionSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/udf/KyuubiDefinedFunctionSuite.scala
@@ -30,12 +30,12 @@ import org.apache.kyuubi.{KyuubiFunSuite, TestUtils, Utils}
  *
  * To run the entire test suite:
  * {{{
- *   build/mvn clean install -Pflink-provided,spark-provided,hive-provided -DwildcardSuites=org.apache.kyuubi.engine.spark.udf.KyuubiDefinedFunctionSuite
+ *   build/mvn clean test -Pflink-provided,spark-provided,hive-provided -DwildcardSuites=org.apache.kyuubi.engine.spark.udf.KyuubiDefinedFunctionSuite
  * }}}
  *
  * To re-generate golden files for entire suite, run:
  * {{{
- *   KYUUBI_UPDATE=1 build/mvn clean install -Pflink-provided,spark-provided,hive-provided -DwildcardSuites=org.apache.kyuubi.engine.spark.udf.KyuubiDefinedFunctionSuite
+ *   KYUUBI_UPDATE=1 build/mvn clean test -Pflink-provided,spark-provided,hive-provided -DwildcardSuites=org.apache.kyuubi.engine.spark.udf.KyuubiDefinedFunctionSuite
  * }}}
  */
 // scalastyle:on line.size.limit

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/udf/KyuubiDefinedFunctionSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/udf/KyuubiDefinedFunctionSuite.scala
@@ -30,12 +30,12 @@ import org.apache.kyuubi.{KyuubiFunSuite, TestUtils, Utils}
  *
  * To run the entire test suite:
  * {{{
- *   build/mvn clean test -Pflink-provided,spark-provided,hive-provided -DwildcardSuites=org.apache.kyuubi.engine.spark.udf.KyuubiDefinedFunctionSuite
+ *   build/mvn clean test -pl externals/kyuubi-spark-sql-engine -am -Pflink-provided,spark-provided,hive-provided -DwildcardSuites=org.apache.kyuubi.engine.spark.udf.KyuubiDefinedFunctionSuite
  * }}}
  *
  * To re-generate golden files for entire suite, run:
  * {{{
- *   KYUUBI_UPDATE=1 build/mvn clean test -Pflink-provided,spark-provided,hive-provided -DwildcardSuites=org.apache.kyuubi.engine.spark.udf.KyuubiDefinedFunctionSuite
+ *   KYUUBI_UPDATE=1 build/mvn clean test -pl externals/kyuubi-spark-sql-engine -am -Pflink-provided,spark-provided,hive-provided -DwildcardSuites=org.apache.kyuubi.engine.spark.udf.KyuubiDefinedFunctionSuite
  * }}}
  */
 // scalastyle:on line.size.limit
@@ -83,6 +83,10 @@ class KyuubiDefinedFunctionSuite extends KyuubiFunSuite {
       newOutput += s"${func.name} | ${func.description} | ${func.returnType} | ${func.since}"
     }
     newOutput += ""
-    TestUtils.verifyOutput(markdown, newOutput, getClass.getCanonicalName)
+    TestUtils.verifyOutput(
+      markdown,
+      newOutput,
+      getClass.getCanonicalName,
+      "externals/kyuubi-spark-sql-engine")
   }
 }

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/TestUtils.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/TestUtils.scala
@@ -81,7 +81,11 @@ object TestUtils {
       })
   }
 
-  def verifyOutput(markdown: Path, newOutput: ArrayBuffer[String], agent: String): Unit = {
+  def verifyOutput(
+      markdown: Path,
+      newOutput: ArrayBuffer[String],
+      agent: String,
+      module: String): Unit = {
     if (System.getenv("KYUUBI_UPDATE") == "1") {
       val formatted = formatMarkdown(newOutput)
       Files.write(
@@ -93,9 +97,11 @@ object TestUtils {
       val linesInFile = Files.readAllLines(markdown, StandardCharsets.UTF_8)
       val formatted = formatMarkdown(newOutput)
       linesInFile.asScala.zipWithIndex.zip(formatted).foreach { case ((str1, index), str2) =>
-        withClue(s"$markdown out of date, as line ${index + 1} is not expected." +
-          s" Please update doc with KYUUBI_UPDATE=1 build/mvn clean test" +
-          s" -Pflink-provided,spark-provided,hive-provided -DwildcardSuites=$agent") {
+        withClue(
+          s"$markdown out of date, as line ${index + 1} is not expected." +
+            " Please update doc with KYUUBI_UPDATE=1 build/mvn clean test" +
+            s" -pl $module -am" +
+            s" -Pflink-provided,spark-provided,hive-provided -DwildcardSuites=$agent") {
           assertResult(str2)(str1)
         }
       }

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/TestUtils.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/TestUtils.scala
@@ -30,7 +30,7 @@ import com.vladsch.flexmark.parser.{Parser, ParserEmulationProfile, PegdownExten
 import com.vladsch.flexmark.profile.pegdown.PegdownOptionsAdapter
 import com.vladsch.flexmark.util.data.{MutableDataHolder, MutableDataSet}
 import com.vladsch.flexmark.util.sequence.SequenceUtils
-import org.scalatest.Assertions.convertToEqualizer
+import org.scalatest.Assertions.{assertResult, withClue}
 
 object TestUtils {
 
@@ -92,11 +92,13 @@ object TestUtils {
     } else {
       val linesInFile = Files.readAllLines(markdown, StandardCharsets.UTF_8)
       val formatted = formatMarkdown(newOutput)
-      val hint = s"$markdown out of date, please update doc with " +
-        s"KYUUBI_UPDATE=1 build/mvn clean install -Pflink-provided,spark-provided,hive-provided " +
-        s"-DwildcardSuites=$agent"
-      assert(linesInFile.size() === formatted.size, hint)
-      linesInFile.asScala.zip(formatted).foreach { case (out, in) => assert(out === in, hint) }
+      linesInFile.asScala.zipWithIndex.zip(formatted).foreach { case ((str1, index), str2) =>
+        withClue(s"$markdown out of date, as line ${index + 1} is not expected." +
+          s" Please update doc with KYUUBI_UPDATE=1 build/mvn clean test" +
+          s" -Pflink-provided,spark-provided,hive-provided -DwildcardSuites=$agent") {
+          assertResult(str2)(str1)
+        }
+      }
     }
   }
 

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/TestUtils.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/TestUtils.scala
@@ -97,11 +97,10 @@ object TestUtils {
       val linesInFile = Files.readAllLines(markdown, StandardCharsets.UTF_8)
       val formatted = formatMarkdown(newOutput)
       linesInFile.asScala.zipWithIndex.zip(formatted).foreach { case ((str1, index), str2) =>
-        withClue(
-          s"$markdown out of date, as line ${index + 1} is not expected." +
-            " Please update doc with KYUUBI_UPDATE=1 build/mvn clean test" +
-            s" -pl $module -am" +
-            s" -Pflink-provided,spark-provided,hive-provided -DwildcardSuites=$agent") {
+        withClue(s"$markdown out of date, as line ${index + 1} is not expected." +
+          " Please update doc with KYUUBI_UPDATE=1 build/mvn clean test" +
+          s" -pl $module -am -Pflink-provided,spark-provided,hive-provided" +
+          s" -DwildcardSuites=$agent") {
           assertResult(str2)(str1)
         }
       }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/config/AllKyuubiConfiguration.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/config/AllKyuubiConfiguration.scala
@@ -37,12 +37,12 @@ import org.apache.kyuubi.zookeeper.ZookeeperConf
  *
  * To run the entire test suite:
  * {{{
- *   build/mvn clean package -pl kyuubi-server -am -Pflink-provided,spark-provided,hive-provided -DwildcardSuites=org.apache.kyuubi.config.AllKyuubiConfiguration
+ *   build/mvn clean test -pl kyuubi-server -am -Pflink-provided,spark-provided,hive-provided -DwildcardSuites=org.apache.kyuubi.config.AllKyuubiConfiguration
  * }}}
  *
  * To re-generate golden files for entire suite, run:
  * {{{
- *   KYUUBI_UPDATE=1 build/mvn clean package -pl kyuubi-server -am -Pflink-provided,spark-provided,hive-provided -DwildcardSuites=org.apache.kyuubi.config.AllKyuubiConfiguration
+ *   KYUUBI_UPDATE=1 build/mvn clean test -pl kyuubi-server -am -Pflink-provided,spark-provided,hive-provided -DwildcardSuites=org.apache.kyuubi.config.AllKyuubiConfiguration
  * }}}
  */
 // scalastyle:on line.size.limit

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/config/AllKyuubiConfiguration.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/config/AllKyuubiConfiguration.scala
@@ -300,6 +300,6 @@ class AllKyuubiConfiguration extends KyuubiFunSuite {
       " executor and obey the Spark AQE behavior of Kyuubi system default. On the other hand," +
       " for those users who do not have custom configurations will use system defaults."
 
-    TestUtils.verifyOutput(markdown, newOutput, getClass.getCanonicalName)
+    TestUtils.verifyOutput(markdown, newOutput, getClass.getCanonicalName, "kyuubi-server")
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- Show line number and assertion when verifying generated markdown files, e.g. `settings.md` from `AllKyuubiConfiguration`, for quicker locating the place and differences in files.
- updated hint message to `mvn clean test` instead of `mvn clean install` for faster verification or regeneration

Hints with line num as below if assertion fails in line comparison.
<img width="1121" alt="image" src="https://user-images.githubusercontent.com/1935105/215451115-813b90f0-9d9d-4ebd-974e-8a071424aa42.png">

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
