### PR TITLE
Exclude indirect dependency `error_prone_annotations` from `grpc-grpclb` for less compilation conflict warning

### DIFF
--- a/kyuubi-ha/pom.xml
+++ b/kyuubi-ha/pom.xml
@@ -70,6 +70,23 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-grpclb</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java-util</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java-util</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- exclude indirect dependency `error_prone_annotations` from `grpc-grpclb`, resolving conflicts and reducing javac warning
```
KYUUBI_UPDATE=1 build/mvn clean test -pl kyuubi-server -am -Pflink-provided,spark-provided,hive-provided -DwildcardSuites=org.apache.kyuubi.config.AllKyuubiConfiguration


KYUUBI_UPDATE=1 build/mvn clean test -pl externals/kyuubi-spark-sql-engine -am -Pflink-provided,spark-provided,hive-provided -DwildcardSuites=org.apache.kyuubi.engine.spark.udf.KyuubiDefinedFunctionSuite

[WARNING] 
Dependency convergence error for com.google.errorprone:error_prone_annotations:jar:2.14.0:compile paths to dependency are:
+-org.apache.kyuubi:kyuubi-ha_2.12:jar:1.7.0-SNAPSHOT
  +-io.grpc:grpc-core:jar:1.48.0:compile
    +-io.grpc:grpc-api:jar:1.48.0:compile
      +-com.google.errorprone:error_prone_annotations:jar:2.14.0:compile
and
+-org.apache.kyuubi:kyuubi-ha_2.12:jar:1.7.0-SNAPSHOT
  +-io.grpc:grpc-core:jar:1.48.0:compile
    +-com.google.errorprone:error_prone_annotations:jar:2.14.0:compile
and
+-org.apache.kyuubi:kyuubi-ha_2.12:jar:1.7.0-SNAPSHOT
  +-io.grpc:grpc-grpclb:jar:1.48.0:compile
    +-com.google.errorprone:error_prone_annotations:jar:2.14.0:runtime
and
+-org.apache.kyuubi:kyuubi-ha_2.12:jar:1.7.0-SNAPSHOT
  +-com.google.protobuf:protobuf-java-util:jar:3.21.7:compile
    +-com.google.errorprone:error_prone_annotations:jar:2.5.1:compile
and
+-org.apache.kyuubi:kyuubi-ha_2.12:jar:1.7.0-SNAPSHOT
  +-io.grpc:grpc-netty:jar:1.48.0:compile
    +-com.google.errorprone:error_prone_annotations:jar:2.14.0:runtime
and
+-org.apache.kyuubi:kyuubi-ha_2.12:jar:1.7.0-SNAPSHOT
  +-io.grpc:grpc-stub:jar:1.48.0:compile
    +-com.google.errorprone:error_prone_annotations:jar:2.14.0:runtime
```

```
Warning:  Unexpected javac output: /home/runner/.m2/repository/com/google/guava/guava/31.1-jre/guava-31.1-jre.jar(com/google/common/collect/ImmutableMap.class): warning: Cannot find annotation method 'value()' in type 'DoNotMock': class file for com.google.errorprone.annotations.DoNotMock not found
/home/runner/.m2/repository/com/google/guava/guava/31.1-jre/guava-31.1-jre.jar(com/google/common/collect/ImmutableMap.class): warning: Cannot find annotation method 'value()' in type 'DoNotCall': class file for com.google.errorprone.annotations.DoNotCall not found
/home/runner/.m2/repository/com/google/guava/guava/31.1-jre/guava-31.1-jre.jar(com/google/common/collect/ImmutableMap.class): warning: Cannot find annotation method 'value()' in type 'DoNotCall'
/home/runner/.m2/repository/com/google/guava/guava/31.1-jre/guava-31.1-jre.jar(com/google/common/collect/ImmutableMap.class): warning: Cannot find annotation method 'value()' in type 'DoNotCall'
/home/runner/.m2/repository/com/google/guava/guava/31.1-jre/guava-31.1-jre.jar(com/google/common/collect/ImmutableMap.class): warning: Cannot find annotation method 'value()' in type 'DoNotCall'
/home/runner/.m2/repository/com/google/guava/guava/31.1-jre/guava-31.1-jre.jar(com/google/common/collect/ImmutableMap.class): warning: Cannot find annotation method 'value()' in type 'DoNotCall'
/home/runner/.m2/repository/com/google/guava/guava/31.1-jre/guava-31.1-jre.jar(com/google/common/collect/ImmutableMap.class): warning: Cannot find annotation method 'value()' in type 'DoNotCall'
/home/runner/.m2/repository/com/google/guava/guava/31.1-jre/guava-31.1-jre.jar(com/google/common/collect/ImmutableMap.class): warning: Cannot find annotation method 'value()' in type 'DoNotCall'
/home/runner/.m2/repository/com/google/guava/guava/31.1-jre/guava-31.1-jre.jar(com/google/common/collect/ImmutableMap.class): warning: Cannot find annotation method 'value()' in type 'DoNotCall'
/home/runner/.m2/repository/com/google/guava/guava/31.1-jre/guava-31.1-jre.jar(com/google/common/collect/ImmutableMap.class): warning: Cannot find annotation method 'value()' in type 'DoNotCall'
/home/runner/.m2/repository/com/google/guava/guava/31.1-jre/guava-31.1-jre.jar(com/google/common/collect/ImmutableMap.class): warning: Cannot find annotation method 'value()' in type 'DoNotCall'
/home/runner/.m2/repository/com/google/guava/guava/31.1-jre/guava-31.1-jre.jar(com/google/common/collect/ImmutableMap.class): warning: Cannot find annotation method 'value()' in type 'DoNotCall'
/home/runner/.m2/repository/com/google/guava/guava/31.1-jre/guava-31.1-jre.jar(com/google/common/collect/ImmutableMap.class): warning: Cannot find annotation method 'value()' in type 'DoNotCall'
/home/runner/.m2/repository/com/google/guava/guava/31.1-jre/guava-31.1-jre.jar(com/google/common/collect/ImmutableMap.class): warning: Cannot find annotation method 'value()' in type 'DoNotCall'
/home/runner/.m2/repository/com/google/guava/guava/31.1-jre/guava-31.1-jre.jar(com/google/common/collect/ImmutableCollection.class): warning: Cannot find annotation method 'value()' in type 'DoNotMock'
/home/runner/.m2/repository/com/google/guava/guava/31.1-jre/guava-31.1-jre.jar(com/google/common/collect/ImmutableCollection.class): warning: Cannot find annotation method 'value()' in type 'DoNotCall'
/home/runner/.m2/repository/com/google/guava/guava/31.1-jre/guava-31.1-jre.jar(com/google/common/collect/ImmutableCollection.class): warning: Cannot find annotation method 'value()' in type 'DoNotCall'
/home/runner/.m2/repository/com/google/guava/guava/31.1-jre/guava-31.1-jre.jar(com/google/common/collect/ImmutableCollection.class): warning: Cannot find annotation method 'value()' in type 'DoNotCall'
/home/runner/.m2/repository/com/google/guava/guava/31.1-jre/guava-31.1-jre.jar(com/google/common/collect/ImmutableCollection.class): warning: Cannot find annotation method 'value()' in type 'DoNotCall'
/home/runner/.m2/repository/com/google/guava/guava/31.1-jre/guava-31.1-jre.jar(com/google/common/collect/ImmutableCollection.class): warning: Cannot find annotation method 'value()' in type 'DoNotCall'
/home/runner/.m2/repository/com/google/guava/guava/31.1-jre/guava-31.1-jre.jar(com/google/common/collect/ImmutableCollection.class): warning: Cannot find annotation method 'value()' in type 'DoNotCall'
/home/runner/.m2/repository/com/google/guava/guava/31.1-jre/guava-31.1-jre.jar(com/google/common/collect/ImmutableCollection.class): warning: Cannot find annotation method 'value()' in type 'DoNotCall'
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
