### PR TITLE
Enlarge REST client default timeout

### DIFF
--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/KyuubiRestClient.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/KyuubiRestClient.java
@@ -165,13 +165,16 @@ public class KyuubiRestClient implements AutoCloseable, Cloneable {
 
     private String password;
 
-    private int socketTimeout = 3000;
+    // 5 minutes
+    private int socketTimeout = 5 * 60 * 1000;
 
-    private int connectTimeout = 3000;
+    // 9s
+    private int connectTimeout = 9 * 1000;
 
     private int maxAttempts = 3;
 
-    private int attemptWaitTime = 3000;
+    // 3s
+    private int attemptWaitTime = 3 * 1000;
 
     public Builder(String hostUrl) {
       if (StringUtils.isBlank(hostUrl)) {

--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/KyuubiRestClient.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/KyuubiRestClient.java
@@ -165,11 +165,11 @@ public class KyuubiRestClient implements AutoCloseable, Cloneable {
 
     private String password;
 
-    // 5 minutes
-    private int socketTimeout = 5 * 60 * 1000;
+    // 2 minutes
+    private int socketTimeout = 2 * 60 * 1000;
 
-    // 9s
-    private int connectTimeout = 9 * 1000;
+    // 30s
+    private int connectTimeout = 30 * 1000;
 
     private int maxAttempts = 3;
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

The current default socket timeout is set to 3s, which is too short, when Kyuubi Server is busy, e.g. during GC, the client will fail w/ socket read timeout after 3s if no bytes are returned in the socket.

This PR proposes to enlarge the REST client default timeout

- connect timeout from 3s to 30s
- socket timeout from 3s to 2min
- attempt interval keep 3s

They keep consistent w/ `org.apache.kyuubi.ctl.CtlConf`

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
