### PR TITLE
[KYUUBI #3658][FOLLOWUP] Show ssl enabled protocols

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/TBinaryFrontendService.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/TBinaryFrontendService.scala
@@ -163,7 +163,7 @@ abstract class TBinaryFrontendService(name: String)
           }
         }
         sslServerSocket.setEnabledProtocols(enabledProtocols)
-        info(s"SSL Server Socket enabled protocols: $enabledProtocols")
+        info(s"SSL Server Socket enabled protocols: ${enabledProtocols.mkString(",")}")
 
       case _ =>
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Before:
```
2023-02-02 22:21:35.507 INFO org.apache.kyuubi.server.KyuubiTBinaryFrontendService: SSL Server Socket enabled protocols: [Ljava.lang.String;@2fca3eb5
```

Seems `enabledProtocols` is a java array, the output is not friendly.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
