### PR TITLE
[KYUUBI #4245][SPARK] Support UserDefinedType for Spark 3.2 and above

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/schema/SchemaHelper.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/schema/SchemaHelper.scala
@@ -41,6 +41,24 @@ object SchemaHelper {
    */
   final val YEAR_MONTH_INTERVAL = "YearMonthIntervalType"
 
+  /**
+   * Spark 3.2.0 DataType UserDefinedType's class name.
+   * And UDT API has been public since Spark 3.2.0.
+   * Return true if dt is subClass of UserDefinedType, which has been set to public
+   * since Spark 3.2.0
+   */
+  final private val isUserDefinedType = (dt: DataType) => {
+    val dataType = "DataType"
+    val userDefinedType = "UserDefinedType"
+
+    var curClass: Class[_] = dt.getClass
+    while (!curClass.getSimpleName.equals(userDefinedType)
+      && !curClass.getSimpleName.equals(dataType)) {
+      curClass = curClass.getSuperclass
+    }
+    curClass.getSimpleName.equals(userDefinedType)
+  }
+
   def toTTypeId(typ: DataType): TTypeId = typ match {
     case NullType => TTypeId.NULL_TYPE
     case BooleanType => TTypeId.BOOLEAN_TYPE
@@ -64,7 +82,7 @@ object SchemaHelper {
     case _: ArrayType => TTypeId.ARRAY_TYPE
     case _: MapType => TTypeId.MAP_TYPE
     case _: StructType => TTypeId.STRUCT_TYPE
-    // TODO: it is private now, case udt: UserDefinedType => TTypeId.USER_DEFINED_TYPE
+    case dt: DateType if isUserDefinedType(dt) => TTypeId.USER_DEFINED_TYPE
     case other =>
       throw new IllegalArgumentException(s"Unrecognized type name: ${other.catalogString}")
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
to close issue #4245
As user-defined type (UDT) API is public since Spark 3.2.0, kyuubi should support udt schema converter.

reference:
[SPARK-7768](https://issues.apache.org/jira/browse/SPARK-7768)


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
