### PR TITLE
Bump maven from 3.8.6 to 3.6.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <maven.version>3.8.6</maven.version>
+        <maven.version>3.8.7</maven.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <scala.version>2.12.17</scala.version>


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->


For `maven version` in CI is 3.8.7(get info by adding `/usr/bin/mvn --version` in `.github/workflows/dep.yaml`), 
![popo_2023-02-06  09-34-07](https://user-images.githubusercontent.com/52876270/216862168-beda949f-a77b-44db-ad11-b959e27627ef.jpg)

We should bump maven version property in parent pom.yaml 3.8.6 => 3.8.7.
### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
