### PR TITLE
[KYUUBI #4255][AUTHZ] Add authz for describe relation

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/resources/table_command_spec.json
+++ b/extensions/spark/kyuubi-spark-authz/src/main/resources/table_command_spec.json
@@ -220,6 +220,20 @@
     "fieldExtractor" : "LogicalPlanQueryExtractor"
   } ]
 }, {
+  "classname" : "org.apache.spark.sql.catalyst.plans.logical.DescribeRelation",
+  "tableDescs" : [ {
+    "fieldName" : "relation",
+    "fieldExtractor" : "ResolvedTableTableExtractor",
+    "columnDesc" : null,
+    "actionTypeDesc" : null,
+    "tableTypeDesc" : null,
+    "catalogDesc" : null,
+    "isInput" : true,
+    "setCurrentDatabaseIfMissing" : true
+  } ],
+  "opType" : "DESCTABLE",
+  "queryDescs" : [ ]
+}, {
   "classname" : "org.apache.spark.sql.catalyst.plans.logical.DropColumns",
   "tableDescs" : [ {
     "fieldName" : "child",

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/V2CommandsPrivilegesSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/V2CommandsPrivilegesSuite.scala
@@ -515,6 +515,24 @@ abstract class V2CommandsPrivilegesSuite extends PrivilegesBuilderSuite {
     assert(accessType === AccessType.UPDATE)
   }
 
+  test("DescribeTable") {
+    val plan = executePlan(s"DESCRIBE TABLE $catalogTable").analyzed
+    val (inputs, outputs, operationType) = PrivilegesBuilder.build(plan, spark)
+    assert(operationType === DESCTABLE)
+    assert(inputs.size === 1)
+    val po = inputs.head
+    assert(po.actionType === PrivilegeObjectActionType.OTHER)
+    assert(po.privilegeObjectType === PrivilegeObjectType.TABLE_OR_VIEW)
+    assert(po.catalog === Some(catalogV2))
+    assert(po.dbname === namespace)
+    assert(po.objectName === catalogTableShort)
+    assert(po.columns.isEmpty)
+    checkV2TableOwner(po)
+    val accessType = AccessType(po, operationType, isInput = true)
+    assert(accessType === AccessType.SELECT)
+    assert(outputs.size === 0)
+  }
+
   // with V2AlterTableCommand
 
   test("AddColumns") {

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/TableCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/TableCommands.scala
@@ -410,6 +410,16 @@ object TableCommands {
     TableCommandSpec(cmd, Seq(tableDesc), DESCTABLE)
   }
 
+  val DescribeRelationTable = {
+    val cmd = "org.apache.spark.sql.catalyst.plans.logical.DescribeRelation"
+    val tableDesc = TableDesc(
+      "relation",
+      classOf[ResolvedTableTableExtractor],
+      isInput = true,
+      setCurrentDatabaseIfMissing = true)
+    TableCommandSpec(cmd, Seq(tableDesc), DESCTABLE)
+  }
+
   val DropTable = {
     val cmd = "org.apache.spark.sql.execution.command.DropTableCommand"
     val tableTypeDesc =
@@ -614,6 +624,7 @@ object TableCommands {
     DeleteFromTable,
     DescribeColumn,
     DescribeTable,
+    DescribeRelationTable,
     DropTable,
     DropTableV2,
     InsertIntoDataSource,

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/IcebergCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/IcebergCatalogRangerSparkExtensionSuite.scala
@@ -222,4 +222,13 @@ class IcebergCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite 
         })
     }
   }
+
+  test("[KYUUBI #4255] DESCRIBE TABLE") {
+    assume(isSparkV32OrGreater)
+    val e1 = intercept[AccessControlException](
+      doAs("someone", sql(s"DESCRIBE TABLE $catalogV2.$namespace1.$table1").explain()))
+    assert(e1.getMessage.contains(s"does not have [select] privilege" +
+      s" on [$namespace1/$table1]"))
+  }
+
 }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
@@ -107,6 +107,14 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
       s" on [$namespace1/$table1/id]"))
   }
 
+  test("[KYUUBI #4255] DESCRIBE TABLE") {
+    assume(isSparkV31OrGreater)
+    val e1 = intercept[AccessControlException](
+      doAs("someone", sql(s"DESCRIBE TABLE $catalogV2.$namespace1.$table1").explain()))
+    assert(e1.getMessage.contains(s"does not have [select] privilege" +
+      s" on [$namespace1/$table1]"))
+  }
+
   test("[KYUUBI #3424] CREATE TABLE") {
     assume(isSparkV31OrGreater)
 


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
During a describe table call, if the table it's a v2 table, it's a DescribeRelation a not a DescribeTableCommand.

So DescribeRelation should have same authorization than DescribeTableCommand. 

Fix https://github.com/apache/kyuubi/issues/4255


### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
