### PR TITLE
cache npm global and pnpm in style workflow

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -86,6 +86,12 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
+          cache:
+            - 'npm'
+            - 'pnpm'
+          cache-dependency-path: |
+            kyuubi-server/web-ui/package-lock.json
+            kyuubi-server/web-ui/pnpm-lock.yaml
       - name: Web UI Style with node
         run: |
           cd ./kyuubi-server/web-ui

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -86,9 +86,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
-          cache:
-            - 'npm'
-            - 'pnpm'
+          cache: 'pnpm'
           cache-dependency-path: |
             kyuubi-server/web-ui/package-lock.json
             kyuubi-server/web-ui/pnpm-lock.yaml


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- set 'npm' to cache in style workflow, this wont cachet node_modules but the global installed packages (pnpm in this case) only
- set 'pnpm' to cache packages used

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
