### PR TITLE
[INFRA] Add Dependency Review step to prevent introducing vulnerable dependencies

### DIFF
--- a/.github/workflows/dep.yml
+++ b/.github/workflows/dep.yml
@@ -23,8 +23,9 @@ on:
       - master
       - branch-*
     paths:
-      # dependency check happens only pom changes
+      # when pom or dependency workflow changes
       - '**/pom.xml'
+      - '.github/workflows/dep.yml'
 
 concurrency:
   group: dep-${{ github.ref }}
@@ -57,3 +58,7 @@ jobs:
           -pl kyuubi-ctl,kyuubi-server,kyuubi-assembly -am
       - name: Check dependency list
         run: build/dependency.sh
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v3
+        with:
+          fail-on-severity: moderate


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- Add actions/dependency-review-action (https://github.com/actions/dependency-review-action) as new step in the dependency workflow, which fails when future PR is bringing vulnerable dependencies.
- configuring `fail-on-severity` to `moderate` level

<img width="760" alt="image" src="https://user-images.githubusercontent.com/1935105/217551476-e2858c04-ebcb-4028-a209-e547690b5d79.png">


### _How was this patch tested?_
- [x] Pass the Dependency Check CI job
