### PR TITLE
Clarify incremental collect mode ignore `kyuubi.operation.result.max.rows`

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
@@ -74,8 +74,9 @@ class ExecuteStatement(
         .getOrElse(session.sessionManager.getConf.get(OPERATION_RESULT_MAX_ROWS))
       iter = if (incrementalCollect) {
         if (resultMaxRows > 0) {
-          logger.warn(s"Ignore ${OPERATION_RESULT_MAX_ROWS.key} on incremental collect mode.")
+          warn(s"Ignore ${OPERATION_RESULT_MAX_ROWS.key} on incremental collect mode.")
         }
+        info("Execute in incremental collect mode")
         def internalIterator(): Iterator[Any] = if (arrowEnabled) {
           SparkDatasetHelper.toArrowBatchRdd(convertComplexType(result)).toLocalIterator
         } else {

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
@@ -68,10 +68,10 @@ class ExecuteStatement(
       info(diagnostics)
       Thread.currentThread().setContextClassLoader(spark.sharedState.jarClassLoader)
       addOperationListener()
+      result = spark.sql(statement)
 
       val resultMaxRows = spark.conf.getOption(OPERATION_RESULT_MAX_ROWS.key).map(_.toInt)
         .getOrElse(session.sessionManager.getConf.get(OPERATION_RESULT_MAX_ROWS))
-      result = spark.sql(statement)
       iter = if (incrementalCollect) {
         if (resultMaxRows <= 0) {
           info("Execute in incremental collect mode")

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
@@ -21,7 +21,7 @@ import java.util.concurrent.RejectedExecutionException
 
 import scala.collection.JavaConverters._
 
-import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.kyuubi.SparkDatasetHelper
 import org.apache.spark.sql.types._
 
@@ -68,45 +68,47 @@ class ExecuteStatement(
       info(diagnostics)
       Thread.currentThread().setContextClassLoader(spark.sharedState.jarClassLoader)
       addOperationListener()
-      result = spark.sql(statement)
 
-      iter =
-        if (incrementalCollect) {
+      val resultMaxRows = spark.conf.getOption(OPERATION_RESULT_MAX_ROWS.key).map(_.toInt)
+        .getOrElse(session.sessionManager.getConf.get(OPERATION_RESULT_MAX_ROWS))
+      result = spark.sql(statement)
+      iter = if (incrementalCollect) {
+        if (resultMaxRows <= 0) {
           info("Execute in incremental collect mode")
+        } else {
+          info(s"Execute in incremental collect mode max result rows[$resultMaxRows]")
+        }
+        var internalIterator = if (arrowEnabled) {
+          SparkDatasetHelper.toArrowBatchRdd(convertComplexType(result)).toLocalIterator
+        } else {
+          result.toLocalIterator().asScala
+        }
+        if (resultMaxRows <= 0) {
+          internalIterator = internalIterator.take(resultMaxRows)
+        }
+        new IterableFetchIterator[Any](new Iterable[Any] {
+          override def iterator: Iterator[Any] = internalIterator
+        })
+      } else {
+        val internalArray = if (resultMaxRows <= 0) {
+          info("Execute in full collect mode")
           if (arrowEnabled) {
-            new IterableFetchIterator[Array[Byte]](new Iterable[Array[Byte]] {
-              override def iterator: Iterator[Array[Byte]] = SparkDatasetHelper.toArrowBatchRdd(
-                convertComplexType(result)).toLocalIterator
-            })
+            SparkDatasetHelper.toArrowBatchRdd(convertComplexType(result)).collect()
           } else {
-            new IterableFetchIterator[Row](new Iterable[Row] {
-              override def iterator: Iterator[Row] = result.toLocalIterator().asScala
-            })
+            result.collect()
           }
         } else {
-          val resultMaxRows = spark.conf.getOption(OPERATION_RESULT_MAX_ROWS.key).map(_.toInt)
-            .getOrElse(session.sessionManager.getConf.get(OPERATION_RESULT_MAX_ROWS))
-          if (resultMaxRows <= 0) {
-            info("Execute in full collect mode")
-            if (arrowEnabled) {
-              new ArrayFetchIterator(
-                SparkDatasetHelper.toArrowBatchRdd(
-                  convertComplexType(result)).collect())
-            } else {
-              new ArrayFetchIterator(result.collect())
-            }
+          info(s"Execute with max result rows[$resultMaxRows]")
+          if (arrowEnabled) {
+            // this will introduce shuffle and hurt performance
+            val limitedResult = result.limit(resultMaxRows)
+            SparkDatasetHelper.toArrowBatchRdd(convertComplexType(limitedResult)).collect()
           } else {
-            info(s"Execute with max result rows[$resultMaxRows]")
-            if (arrowEnabled) {
-              // this will introduce shuffle and hurt performance
-              new ArrayFetchIterator(
-                SparkDatasetHelper.toArrowBatchRdd(
-                  convertComplexType(result.limit(resultMaxRows))).collect())
-            } else {
-              new ArrayFetchIterator(result.take(resultMaxRows))
-            }
+            result.take(resultMaxRows)
           }
         }
+        new ArrayFetchIterator(internalArray)
+      }
       setCompiledStateIfNeeded()
       setState(OperationState.FINISHED)
     } catch {

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
@@ -76,13 +76,13 @@ class ExecuteStatement(
         if (resultMaxRows > 0) {
           logger.warn(s"Ignore ${OPERATION_RESULT_MAX_ROWS.key} on incremental collect mode.")
         }
-        val internalIterator = if (arrowEnabled) {
+        def internalIterator(): Iterator[Any] = if (arrowEnabled) {
           SparkDatasetHelper.toArrowBatchRdd(convertComplexType(result)).toLocalIterator
         } else {
           result.toLocalIterator().asScala
         }
         new IterableFetchIterator[Any](new Iterable[Any] {
-          override def iterator: Iterator[Any] = internalIterator
+          override def iterator: Iterator[Any] = internalIterator()
         })
       } else {
         val internalArray = if (resultMaxRows <= 0) {

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkOperation.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkOperation.scala
@@ -259,13 +259,13 @@ abstract class SparkOperation(session: Session)
 
   override def shouldRunAsync: Boolean = false
 
-  protected def arrowEnabled(): Boolean = {
-    resultFormat().equalsIgnoreCase("arrow") &&
+  protected def arrowEnabled: Boolean = {
+    resultFormat.equalsIgnoreCase("arrow") &&
     // TODO: (fchen) make all operation support arrow
     getClass.getCanonicalName == classOf[ExecuteStatement].getCanonicalName
   }
 
-  protected def resultFormat(): String = {
+  protected def resultFormat: String = {
     // TODO: respect the config of the operation ExecuteStatement, if it was set.
     spark.conf.get("kyuubi.operation.result.format", "thrift")
   }

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -1658,7 +1658,7 @@ object KyuubiConf {
       .internal
       .doc("When true, the executor side result will be sequentially calculated and returned to" +
         s" the Spark driver side. Note that, ${OPERATION_RESULT_MAX_ROWS.key} will be ignored" +
-        s" on incremental collect mode.")
+        " on incremental collect mode.")
       .version("1.4.0")
       .booleanConf
       .createWithDefault(false)

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -1645,11 +1645,20 @@ object KyuubiConf {
       .checkValue(_ >= 1000, "must >= 1s if set")
       .createOptional
 
+  val OPERATION_RESULT_MAX_ROWS: ConfigEntry[Int] =
+    buildConf("kyuubi.operation.result.max.rows")
+      .doc("Max rows of Spark query results. Rows exceeding the limit would be ignored. " +
+        "By setting this value to 0 to disable the max rows limit.")
+      .version("1.6.0")
+      .intConf
+      .createWithDefault(0)
+
   val OPERATION_INCREMENTAL_COLLECT: ConfigEntry[Boolean] =
     buildConf("kyuubi.operation.incremental.collect")
       .internal
       .doc("When true, the executor side result will be sequentially calculated and returned to" +
-        " the Spark driver side.")
+        s" the Spark driver side. Note that, ${OPERATION_RESULT_MAX_ROWS.key} will be ignored" +
+        s" on incremental collect mode.")
       .version("1.4.0")
       .booleanConf
       .createWithDefault(false)
@@ -1666,14 +1675,6 @@ object KyuubiConf {
       .checkValues(Set("arrow", "thrift"))
       .transform(_.toLowerCase(Locale.ROOT))
       .createWithDefault("thrift")
-
-  val OPERATION_RESULT_MAX_ROWS: ConfigEntry[Int] =
-    buildConf("kyuubi.operation.result.max.rows")
-      .doc("Max rows of Spark query results. Rows exceeding the limit would be ignored. " +
-        "By setting this value to 0 to disable the max rows limit.")
-      .version("1.6.0")
-      .intConf
-      .createWithDefault(0)
 
   val SERVER_OPERATION_LOG_DIR_ROOT: ConfigEntry[String] =
     buildConf("kyuubi.operation.log.dir.root")

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerUserSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerUserSuite.scala
@@ -169,15 +169,18 @@ class KyuubiOperationPerUserSuite
   test("test engine spark result format") {
     Seq("thrift", "arrow").foreach { resultFormat =>
       Seq("0", "1").foreach { maxResultSize =>
-        withSessionConf()(Map.empty)(Map(
-          KyuubiConf.OPERATION_RESULT_FORMAT.key -> resultFormat,
-          KyuubiConf.OPERATION_RESULT_MAX_ROWS.key -> maxResultSize)) {
-          withJdbcStatement("va") { statement =>
-            statement.executeQuery("create temporary view va as select * from values(1),(2)")
-            val resultLimit1 = statement.executeQuery("select * from va")
-            assert(resultLimit1.next())
-            if (maxResultSize == "0") assert(resultLimit1.next())
-            assert(!resultLimit1.next())
+        Seq("true", "false").foreach { incremental =>
+          withSessionConf()(Map.empty)(Map(
+            KyuubiConf.OPERATION_RESULT_FORMAT.key -> resultFormat,
+            KyuubiConf.OPERATION_RESULT_MAX_ROWS.key -> maxResultSize,
+            KyuubiConf.OPERATION_INCREMENTAL_COLLECT.key -> incremental)) {
+            withJdbcStatement("va") { statement =>
+              statement.executeQuery("create temporary view va as select * from values(1),(2)")
+              val resultLimit1 = statement.executeQuery("select * from va")
+              assert(resultLimit1.next())
+              if (maxResultSize == "0") assert(resultLimit1.next())
+              assert(!resultLimit1.next())
+            }
           }
         }
       }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerUserSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerUserSuite.scala
@@ -166,28 +166,6 @@ class KyuubiOperationPerUserSuite
     assert(r1 !== r2)
   }
 
-  test("max result rows") {
-    Seq("true", "false").foreach { incremental =>
-      Seq("thrift", "arrow").foreach { resultFormat =>
-        Seq("0", "1").foreach { maxResultRows =>
-          withSessionConf()(Map.empty)(Map(
-            KyuubiConf.OPERATION_RESULT_FORMAT.key -> resultFormat,
-            KyuubiConf.OPERATION_RESULT_MAX_ROWS.key -> maxResultRows,
-            KyuubiConf.OPERATION_INCREMENTAL_COLLECT.key -> incremental)) {
-            withJdbcStatement("va") { statement =>
-              statement.executeQuery("create temporary view va as select * from values(1),(2)")
-              val resultLimit = statement.executeQuery("select * from va")
-              assert(resultLimit.next())
-              // always ignore max result rows on incremental collect mode
-              if (incremental == "true" || maxResultRows == "0") assert(resultLimit.next())
-              assert(!resultLimit.next())
-            }
-          }
-        }
-      }
-    }
-  }
-
   test("support to interrupt the thrift request if remote engine is broken") {
     assume(!httpMode)
     withSessionConf(Map(
@@ -228,6 +206,28 @@ class KyuubiOperationPerUserSuite
         val elapsedTime = System.currentTimeMillis() - startTime
         assert(elapsedTime < 20 * 1000)
         assert(session.client.asyncRequestInterrupted)
+      }
+    }
+  }
+
+  test("max result rows") {
+    Seq("true", "false").foreach { incremental =>
+      Seq("thrift", "arrow").foreach { resultFormat =>
+        Seq("0", "1").foreach { maxResultRows =>
+          withSessionConf()(Map.empty)(Map(
+            KyuubiConf.OPERATION_RESULT_FORMAT.key -> resultFormat,
+            KyuubiConf.OPERATION_RESULT_MAX_ROWS.key -> maxResultRows,
+            KyuubiConf.OPERATION_INCREMENTAL_COLLECT.key -> incremental)) {
+            withJdbcStatement("va") { statement =>
+              statement.executeQuery("create temporary view va as select * from values(1),(2)")
+              val resultLimit = statement.executeQuery("select * from va")
+              assert(resultLimit.next())
+              // always ignore max result rows on incremental collect mode
+              if (incremental == "true" || maxResultRows == "0") assert(resultLimit.next())
+              assert(!resultLimit.next())
+            }
+          }
+        }
       }
     }
   }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerUserSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerUserSuite.scala
@@ -166,20 +166,20 @@ class KyuubiOperationPerUserSuite
     assert(r1 !== r2)
   }
 
-  test("max result size") {
+  test("max result rows") {
     Seq("true", "false").foreach { incremental =>
       Seq("thrift", "arrow").foreach { resultFormat =>
-        Seq("0", "1").foreach { maxResultSize =>
+        Seq("0", "1").foreach { maxResultRows =>
           withSessionConf()(Map.empty)(Map(
             KyuubiConf.OPERATION_RESULT_FORMAT.key -> resultFormat,
-            KyuubiConf.OPERATION_RESULT_MAX_ROWS.key -> maxResultSize,
+            KyuubiConf.OPERATION_RESULT_MAX_ROWS.key -> maxResultRows,
             KyuubiConf.OPERATION_INCREMENTAL_COLLECT.key -> incremental)) {
             withJdbcStatement("va") { statement =>
               statement.executeQuery("create temporary view va as select * from values(1),(2)")
               val resultLimit = statement.executeQuery("select * from va")
               assert(resultLimit.next())
-              // always ignore max result size on incremental collect mode
-              if (incremental == "true" || maxResultSize == "0") assert(resultLimit.next())
+              // always ignore max result rows on incremental collect mode
+              if (incremental == "true" || maxResultRows == "0") assert(resultLimit.next())
               assert(!resultLimit.next())
             }
           }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
`kyuubi.operation.result.max.rows` does not take effect on incremental collect mode because of performance concerns, this PR updates the configuration docs to mention that.

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
