### PR TITLE
[KYUUBI #4262] [AUTHZ] Change from DROP to ALTER as required privilege of the source table in AlterTableRenameCommand 

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/resources/table_command_spec.json
+++ b/extensions/spark/kyuubi-spark-authz/src/main/resources/table_command_spec.json
@@ -691,23 +691,6 @@
     "fieldName" : "oldName",
     "fieldExtractor" : "TableIdentifierTableExtractor",
     "columnDesc" : null,
-    "actionTypeDesc" : {
-      "fieldName" : null,
-      "fieldExtractor" : null,
-      "actionType" : "DELETE"
-    },
-    "tableTypeDesc" : {
-      "fieldName" : "oldName",
-      "fieldExtractor" : "TableIdentifierTableTypeExtractor",
-      "skipTypes" : [ "TEMP_VIEW" ]
-    },
-    "catalogDesc" : null,
-    "isInput" : false,
-    "setCurrentDatabaseIfMissing" : false
-  }, {
-    "fieldName" : "newName",
-    "fieldExtractor" : "TableIdentifierTableExtractor",
-    "columnDesc" : null,
     "actionTypeDesc" : null,
     "tableTypeDesc" : {
       "fieldName" : "oldName",

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/AccessType.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/AccessType.scala
@@ -35,14 +35,13 @@ object AccessType extends Enumeration {
           case CREATETABLE | CREATEVIEW | CREATETABLE_AS_SELECT
               if obj.privilegeObjectType == TABLE_OR_VIEW =>
             if (isInput) SELECT else CREATE
-          // new table new `CREATE` privilege here and the old table gets `DELETE` via actionType
-          case ALTERTABLE_RENAME => CREATE
           case ALTERDATABASE |
               ALTERDATABASE_LOCATION |
               ALTERTABLE_ADDCOLS |
               ALTERTABLE_ADDPARTS |
               ALTERTABLE_DROPPARTS |
               ALTERTABLE_LOCATION |
+              ALTERTABLE_RENAME |
               ALTERTABLE_PROPERTIES |
               ALTERTABLE_RENAMECOL |
               ALTERTABLE_RENAMEPART |

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilderSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilderSuite.scala
@@ -143,7 +143,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
         val (in, out, operationType) = PrivilegesBuilder.build(plan, spark)
         assert(operationType === ALTERTABLE_RENAME)
         assert(in.isEmpty)
-        assert(out.size === 2)
+        assert(out.size === 1)
         out.foreach { po =>
           assert(po.privilegeObjectType === PrivilegeObjectType.TABLE_OR_VIEW)
           assert(po.catalog.isEmpty)
@@ -151,10 +151,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
           assert(Set(oldTableShort, "efg").contains(po.objectName))
           assert(po.columns.isEmpty)
           val accessType = ranger.AccessType(po, operationType, isInput = false)
-          assert(Set(AccessType.CREATE, AccessType.DROP).contains(accessType))
-          if (accessType == AccessType.DROP) {
-            checkTableOwner(po)
-          }
+          assert(accessType == AccessType.ALTER)
         }
       }
     }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/TableCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/TableCommands.scala
@@ -102,7 +102,6 @@ object TableCommands {
 
   val AlterTableRename = {
     val cmd = "org.apache.spark.sql.execution.command.AlterTableRenameCommand"
-    val actionTypeDesc = ActionTypeDesc(actionType = Some(DELETE))
 
     val oldTableTableTypeDesc =
       TableTypeDesc(
@@ -112,12 +111,9 @@ object TableCommands {
     val oldTableD = TableDesc(
       "oldName",
       tite,
-      tableTypeDesc = Some(oldTableTableTypeDesc),
-      actionTypeDesc = Some(actionTypeDesc))
+      tableTypeDesc = Some(oldTableTableTypeDesc))
 
-    val newTableD =
-      TableDesc("newName", tite, tableTypeDesc = Some(oldTableTableTypeDesc))
-    TableCommandSpec(cmd, Seq(oldTableD, newTableD), ALTERTABLE_RENAME)
+    TableCommandSpec(cmd, Seq(oldTableD), ALTERTABLE_RENAME)
   }
 
   // this is for spark 3.1 or below


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
to close #4262 .
- change the required privilege of the source table from DROP to ALTER
- skip privilege checks of the new target table, as the same way in Ranger's Hive plugin

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
