### PR TITLE
[TEST] Fix flaky test in SessionsResourceSuite

### DIFF
--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/SessionsResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/SessionsResourceSuite.scala
@@ -296,7 +296,7 @@ class SessionsResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper {
       response = webTarget.path(s"api/v1/sessions/$sessionHandle").request().get()
       // will meet json parse exception with response.readEntity(classOf[KyuubiSessionEvent])
       val sessionEvent = response.readEntity(classOf[String])
-      assert(sessionEvent.contains("SparkException: Master"))
+      assert(sessionEvent.contains("The last 10 line(s) of log are:"))
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

This PR proposes to fix the flaky test
```
- post session exception if failed to open engine session *** FAILED ***
```
which was introduced in #4185 

https://github.com/apache/kyuubi/actions/runs/4131523933/jobs/7139249142

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
