### PR TITLE
Use `eclipse-temurin:8-jdk-focal` as default base image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -29,9 +29,9 @@
 
 # Declare the BASE_IMAGE argument in the first line, for more detail
 # see: https://github.com/moby/moby/issues/38379
-ARG BASE_IMAGE=openjdk:8-jdk
+ARG BASE_IMAGE=eclipse-temurin:8-jdk-focal
 
-FROM maven:3.6-jdk-8 as builder
+FROM eclipse-temurin:8-jdk-focal as builder
 
 ARG MVN_ARG
 
@@ -48,7 +48,8 @@ WORKDIR /workspace/kyuubi
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive \
-    apt-get install -y python3 && \
+    apt-get install -y bash python3 && \
+    ln -snf /bin/bash /bin/sh && \
     ./build/dist ${MVN_ARG} && \
     mv /workspace/kyuubi/dist /opt/kyuubi && \
     # Removing stuff saves time because docker creates a temporary layer
@@ -71,7 +72,8 @@ COPY --from=builder /opt/kyuubi ${KYUUBI_HOME}
 RUN set -ex && \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive \
-    apt install -y bash tini libc6 libpam-modules krb5-user libnss3 procps && \
+    apt-get install -y bash tini libc6 libpam-modules krb5-user libnss3 procps && \
+    ln -snf /bin/bash /bin/sh && \
     useradd -u ${kyuubi_uid} -g root kyuubi && \
     mkdir -p ${KYUUBI_HOME} ${KYUUBI_LOG_DIR} ${KYUUBI_PID_DIR} ${KYUUBI_WORK_DIR_ROOT} && \
     chmod ug+rw -R ${KYUUBI_HOME} && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,7 +24,7 @@
 #     -t the target repo and tag name
 #     more options can be found with -h
 
-ARG BASE_IMAGE=openjdk:8-jre-slim
+ARG BASE_IMAGE=eclipse-temurin:8-jdk-focal
 ARG spark_provided="spark_builtin"
 
 FROM ${BASE_IMAGE} as builder_spark_provided
@@ -34,7 +34,7 @@ ONBUILD ENV SPARK_HOME ${spark_home_in_docker}
 FROM ${BASE_IMAGE} as builder_spark_builtin
 
 ONBUILD ENV SPARK_HOME /opt/spark
-ONBUILD RUN mkdir -p  ${SPARK_HOME}
+ONBUILD RUN mkdir -p ${SPARK_HOME}
 ONBUILD COPY spark-binary ${SPARK_HOME}
 
 FROM builder_${spark_provided}
@@ -50,7 +50,8 @@ ENV KYUUBI_WORK_DIR_ROOT ${KYUUBI_HOME}/work
 RUN set -ex && \
     sed -i 's/http:\/\/deb.\(.*\)/https:\/\/deb.\1/g' /etc/apt/sources.list && \
     apt-get update && \
-    apt install -y bash tini libc6 libpam-modules krb5-user libnss3 procps && \
+    apt-get install -y bash tini libc6 libpam-modules krb5-user libnss3 procps && \
+    ln -snf /bin/bash /bin/sh && \
     useradd -u ${kyuubi_uid} -g root kyuubi -d /home/kyuubi -m && \
     mkdir -p ${KYUUBI_HOME} ${KYUUBI_LOG_DIR} ${KYUUBI_PID_DIR} ${KYUUBI_WORK_DIR_ROOT} && \
     rm -rf /var/cache/apt/*

--- a/tools/spark-block-cleaner/kubernetes/docker/Dockerfile
+++ b/tools/spark-block-cleaner/kubernetes/docker/Dockerfile
@@ -14,10 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM openjdk:8-jre-slim
+FROM eclipse-temurin:8-jdk-focal
 
 RUN apt-get update && \
     apt install -y tini && \
+    rm -rf /var/cache/apt/* && \
     mkdir /data && \
     mkdir -p /opt/block-cleaner && \
     mkdir -p /log/cleanerLog


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
eclipse-temurin is the successor for openjdk, see https://github.com/apache/spark/pull/37705

"The core change is: the OS of base image changes debian-bullseye to ubuntu-focal (based on debian bullseye)."

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
