### PR TITLE
[INFRA] Skip the building step in dependency workflow

### DIFF
--- a/.github/workflows/dep.yml
+++ b/.github/workflows/dep.yml
@@ -37,26 +37,14 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - name: setup java
+      - name: Setup JDK 8
         uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: 8
           cache: 'maven'
           check-latest: false
-      - name: build
-        env:
-          MAVEN_OPTS: -Dorg.slf4j.simpleLogger.defaultLogLevel=error
-        run: >-
-          build/mvn clean install
-          -Pflink-provided,spark-provided,hive-provided
-          -Dmaven.javadoc.skip=true
-          -Drat.skip=true
-          -Dscalastyle.skip=true
-          -Dspotless.check.skip
-          -DskipTests
-          -pl kyuubi-ctl,kyuubi-server,kyuubi-assembly -am
-      - name: Check dependency list
+      - name: Check Dependency List
         run: build/dependency.sh
       - name: Dependency Review
         uses: actions/dependency-review-action@v3


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- Skip the `build` step with `mvn install`  in dependency workflow. `build/dependency.sh` is able to check the dependency list without  `mvn install`.
- Dependency check job of single run with maven dependencies cached takes ~2min , comparing to ~11min before this PR.


### _How was this patch tested?_
- [x] Pass CI jobs
