### PR TITLE
Change log level from debug to info for creating work dir

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ProcBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ProcBuilder.scala
@@ -118,7 +118,7 @@ trait ProcBuilder {
     env.get("KYUUBI_WORK_DIR_ROOT").map { root =>
       val workingRoot = Paths.get(root).toAbsolutePath
       if (!Files.exists(workingRoot)) {
-        debug(s"Creating KYUUBI_WORK_DIR_ROOT at $workingRoot")
+        info(s"Creating KYUUBI_WORK_DIR_ROOT at $workingRoot")
         Files.createDirectories(workingRoot)
       }
       if (Files.isDirectory(workingRoot)) {
@@ -127,7 +127,7 @@ trait ProcBuilder {
     }.map { rootAbs =>
       val working = Paths.get(rootAbs, proxyUser)
       if (!Files.exists(working)) {
-        debug(s"Creating $proxyUser's working directory at $working")
+        info(s"Creating $proxyUser's working directory at $working")
         Files.createDirectories(working)
       }
       if (Files.isDirectory(working)) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The message is not noisy and is helpful when failing to create, e.g. no permission.

```
2023-02-10 14:30:32.731 INFO org.apache.kyuubi.operation.LaunchEngine: Processing simba's query[d51a4def-d3d7-454b-a63d-28e27a1e3c3f]: RUNNING_STATE -> ERROR_STATE, time taken: 0.1 seconds
Error: org.apache.kyuubi.KyuubiSQLException: Error operating LaunchEngine: java.io.IOException: 权限不够
	at java.io.UnixFileSystem.createFileExclusively(Native Method)
	at java.io.File.createNewFile(File.java:1012)
	at org.apache.kyuubi.engine.ProcBuilder.$anonfun$engineLog$6(ProcBuilder.scala:187)
	at scala.Option.getOrElse(Option.scala:189)
	at org.apache.kyuubi.engine.ProcBuilder.engineLog(ProcBuilder.scala:184)
	at org.apache.kyuubi.engine.ProcBuilder.engineLog$(ProcBuilder.scala:159)
	at org.apache.kyuubi.engine.spark.SparkProcessBuilder.engineLog$lzycompute(SparkProcessBuilder.scala:36)
	at org.apache.kyuubi.engine.spark.SparkProcessBuilder.engineLog(SparkProcessBuilder.scala:36)
	at org.apache.kyuubi.engine.ProcBuilder.processBuilder(ProcBuilder.scala:141)
	at org.apache.kyuubi.engine.ProcBuilder.processBuilder$(ProcBuilder.scala:135)
	at org.apache.kyuubi.engine.spark.SparkProcessBuilder.processBuilder$lzycompute(SparkProcessBuilder.scala:36)
	at org.apache.kyuubi.engine.spark.SparkProcessBuilder.processBuilder(SparkProcessBuilder.scala:36)
	at org.apache.kyuubi.engine.ProcBuilder.start(ProcBuilder.scala:198)
	at org.apache.kyuubi.engine.ProcBuilder.start$(ProcBuilder.scala:197)
	at org.apache.kyuubi.engine.spark.SparkProcessBuilder.start(SparkProcessBuilder.scala:36)
	at org.apache.kyuubi.engine.EngineRef.$anonfun$create$1(EngineRef.scala:194)
	at org.apache.kyuubi.ha.client.zookeeper.ZookeeperDiscoveryClient.tryWithLock(ZookeeperDiscoveryClient.scala:174)
	at org.apache.kyuubi.engine.EngineRef.tryWithLock(EngineRef.scala:160)
	at org.apache.kyuubi.engine.EngineRef.create(EngineRef.scala:165)
	at org.apache.kyuubi.engine.EngineRef.$anonfun$getOrCreate$1(EngineRef.scala:260)
	at scala.Option.getOrElse(Option.scala:189)
	at org.apache.kyuubi.engine.EngineRef.getOrCreate(EngineRef.scala:260)
	at org.apache.kyuubi.session.KyuubiSessionImpl.$anonfun$openEngineSession$1(KyuubiSessionImpl.scala:120)
	at org.apache.kyuubi.session.KyuubiSessionImpl.$anonfun$openEngineSession$1$adapted(KyuubiSessionImpl.scala:113)
	at org.apache.kyuubi.ha.client.DiscoveryClientProvider$.withDiscoveryClient(DiscoveryClientProvider.scala:36)
	at org.apache.kyuubi.session.KyuubiSessionImpl.openEngineSession(KyuubiSessionImpl.scala:113)
	at org.apache.kyuubi.operation.LaunchEngine.$anonfun$runInternal$2(LaunchEngine.scala:49)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)

	at org.apache.kyuubi.KyuubiSQLException$.apply(KyuubiSQLException.scala:69)
	at org.apache.kyuubi.operation.KyuubiOperation$$anonfun$onError$1.applyOrElse(KyuubiOperation.scala:75)
	at org.apache.kyuubi.operation.KyuubiOperation$$anonfun$onError$1.applyOrElse(KyuubiOperation.scala:56)
	at scala.runtime.AbstractPartialFunction.apply(AbstractPartialFunction.scala:38)
	at org.apache.kyuubi.operation.LaunchEngine.$anonfun$runInternal$2(LaunchEngine.scala:51)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.io.IOException: 权限不够
	at java.io.UnixFileSystem.createFileExclusively(Native Method)
	at java.io.File.createNewFile(File.java:1012)
	at org.apache.kyuubi.engine.ProcBuilder.$anonfun$engineLog$6(ProcBuilder.scala:187)
	at scala.Option.getOrElse(Option.scala:189)
	at org.apache.kyuubi.engine.ProcBuilder.engineLog(ProcBuilder.scala:184)
	at org.apache.kyuubi.engine.ProcBuilder.engineLog$(ProcBuilder.scala:159)
	at org.apache.kyuubi.engine.spark.SparkProcessBuilder.engineLog$lzycompute(SparkProcessBuilder.scala:36)
	at org.apache.kyuubi.engine.spark.SparkProcessBuilder.engineLog(SparkProcessBuilder.scala:36)
	at org.apache.kyuubi.engine.ProcBuilder.processBuilder(ProcBuilder.scala:141)
	at org.apache.kyuubi.engine.ProcBuilder.processBuilder$(ProcBuilder.scala:135)
	at org.apache.kyuubi.engine.spark.SparkProcessBuilder.processBuilder$lzycompute(SparkProcessBuilder.scala:36)
	at org.apache.kyuubi.engine.spark.SparkProcessBuilder.processBuilder(SparkProcessBuilder.scala:36)
	at org.apache.kyuubi.engine.ProcBuilder.start(ProcBuilder.scala:198)
	at org.apache.kyuubi.engine.ProcBuilder.start$(ProcBuilder.scala:197)
	at org.apache.kyuubi.engine.spark.SparkProcessBuilder.start(SparkProcessBuilder.scala:36)
	at org.apache.kyuubi.engine.EngineRef.$anonfun$create$1(EngineRef.scala:194)
	at org.apache.kyuubi.ha.client.zookeeper.ZookeeperDiscoveryClient.tryWithLock(ZookeeperDiscoveryClient.scala:174)
	at org.apache.kyuubi.engine.EngineRef.tryWithLock(EngineRef.scala:160)
	at org.apache.kyuubi.engine.EngineRef.create(EngineRef.scala:165)
	at org.apache.kyuubi.engine.EngineRef.$anonfun$getOrCreate$1(EngineRef.scala:260)
	at scala.Option.getOrElse(Option.scala:189)
	at org.apache.kyuubi.engine.EngineRef.getOrCreate(EngineRef.scala:260)
	at org.apache.kyuubi.session.KyuubiSessionImpl.$anonfun$openEngineSession$1(KyuubiSessionImpl.scala:120)
	at org.apache.kyuubi.session.KyuubiSessionImpl.$anonfun$openEngineSession$1$adapted(KyuubiSessionImpl.scala:113)
	at org.apache.kyuubi.ha.client.DiscoveryClientProvider$.withDiscoveryClient(DiscoveryClientProvider.scala:36)
	at org.apache.kyuubi.session.KyuubiSessionImpl.openEngineSession(KyuubiSessionImpl.scala:113)
	at org.apache.kyuubi.operation.LaunchEngine.$anonfun$runInternal$2(LaunchEngine.scala:49)
	... 5 more (state=,code=0)
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
