### PR TITLE
[INFRA] Check modules available before build step in dependency workflow

### DIFF
--- a/.github/workflows/dep.yml
+++ b/.github/workflows/dep.yml
@@ -52,7 +52,7 @@ jobs:
         run: >-
           build/mvnd dependency:resolve validate
           -DincludeGroupIds="org.apache.kyuubi" -DincludeScope="compile"
-          -Pfast -Penforcer.skip=false
+          -Pfast -Denforcer.skip=false
           -pl kyuubi-ctl,kyuubi-server,kyuubi-assembly -am
         continue-on-error: true
       - name: build

--- a/.github/workflows/dep.yml
+++ b/.github/workflows/dep.yml
@@ -51,12 +51,7 @@ jobs:
         id: modules-check
         run: >-
           build/mvnd dependency:resolve -DincludeGroupIds="org.apache.kyuubi" -DincludeScope="compile"
-          -Pflink-provided,spark-provided,hive-provided
-          -Dmaven.javadoc.skip=true
-          -Drat.skip=true
-          -Dscalastyle.skip=true
-          -Dspotless.check.skip
-          -DskipTests
+          -Pfast -Denforcer.skip=true
           -pl kyuubi-ctl,kyuubi-server,kyuubi-assembly -am
         continue-on-error: true
       - name: build

--- a/.github/workflows/dep.yml
+++ b/.github/workflows/dep.yml
@@ -47,9 +47,22 @@ jobs:
           check-latest: false
       - name: Setup Mvnd
         uses: ./.github/actions/setup-mvnd
+      - name: Check kyuubi modules available
+        id: modules-check
+        run: |
+          build/mvnd dependency:resolve -DincludeGroupIds="org.apache.kyuubi" -DincludeScope="compile"
+          -Pflink-provided,spark-provided,hive-provided
+          -Dmaven.javadoc.skip=true
+          -Drat.skip=true
+          -Dscalastyle.skip=true
+          -Dspotless.check.skip
+          -DskipTests
+          -pl kyuubi-ctl,kyuubi-server,kyuubi-assembly -am
+        continue-on-error: true
       - name: build
         env:
           MAVEN_OPTS: -Dorg.slf4j.simpleLogger.defaultLogLevel=error
+        if: steps.modules-check.conclusion == 'success' && steps.modules-check.outcome == 'failure'
         run: >-
           build/mvnd clean install
           -Pflink-provided,spark-provided,hive-provided

--- a/.github/workflows/dep.yml
+++ b/.github/workflows/dep.yml
@@ -50,8 +50,14 @@ jobs:
       - name: Check kyuubi modules available
         id: modules-check
         run: >-
-          build/mvnd dependency:resolve -DincludeGroupIds="org.apache.kyuubi" -DincludeScope="compile"
-          -Pfast
+          build/mvnd dependency:resolve validate
+          -DincludeGroupIds="org.apache.kyuubi" -DincludeScope="compile"
+          -Pflink-provided,spark-provided,hive-provided
+          -Dmaven.javadoc.skip=true
+          -Drat.skip=true
+          -Dscalastyle.skip=true
+          -Dspotless.check.skip
+          -DskipTests
           -pl kyuubi-ctl,kyuubi-server,kyuubi-assembly -am
         continue-on-error: true
       - name: build

--- a/.github/workflows/dep.yml
+++ b/.github/workflows/dep.yml
@@ -51,7 +51,7 @@ jobs:
         id: modules-check
         run: >-
           build/mvnd dependency:resolve -DincludeGroupIds="org.apache.kyuubi" -DincludeScope="compile"
-          -Pfast -Denforcer.skip=true
+          -Pfast
           -pl kyuubi-ctl,kyuubi-server,kyuubi-assembly -am
         continue-on-error: true
       - name: build

--- a/.github/workflows/dep.yml
+++ b/.github/workflows/dep.yml
@@ -49,7 +49,7 @@ jobs:
         uses: ./.github/actions/setup-mvnd
       - name: Check kyuubi modules available
         id: modules-check
-        run: |
+        run: >-
           build/mvnd dependency:resolve -DincludeGroupIds="org.apache.kyuubi" -DincludeScope="compile"
           -Pflink-provided,spark-provided,hive-provided
           -Dmaven.javadoc.skip=true

--- a/.github/workflows/dep.yml
+++ b/.github/workflows/dep.yml
@@ -52,12 +52,7 @@ jobs:
         run: >-
           build/mvnd dependency:resolve validate
           -DincludeGroupIds="org.apache.kyuubi" -DincludeScope="compile"
-          -Pflink-provided,spark-provided,hive-provided
-          -Dmaven.javadoc.skip=true
-          -Drat.skip=true
-          -Dscalastyle.skip=true
-          -Dspotless.check.skip
-          -DskipTests
+          -Pfast -Penforcer.skip=false
           -pl kyuubi-ctl,kyuubi-server,kyuubi-assembly -am
         continue-on-error: true
       - name: build


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- Check whether modules are available by running `mvnd dependency:resolve`. if true, skip the `build` step of `mvnd install`.
- Reducing the time cost of dependency workflow from  ~ 10 min to ~4 min ([see log](https://github.com/apache/kyuubi/actions/runs/4162071562/jobs/7200786535)).

### _How was this patch tested?_
- [x] Pass CI workflows