### PR TITLE
MySQL url configuration joiner should use `&` instead of `;`

### DIFF
--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/mysql/MySQLJDBCTestHelper.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/mysql/MySQLJDBCTestHelper.scala
@@ -42,7 +42,7 @@ trait MySQLJDBCTestHelper extends JDBCTestHelper {
       if (jdbcConfigs.isEmpty) {
         ""
       } else {
-        "?" + jdbcConfigs.map(kv => kv._1 + "=" + kv._2).mkString(";")
+        "?" + jdbcConfigs.map(kv => kv._1 + "=" + kv._2).mkString("&")
       }
     jdbcUrl + jdbcConfStr
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The mysql url configuration joiner should use `&` instead of `;`

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
