### PR TITLE
Improve trino session context

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/trino/api/v1/StatementResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/trino/api/v1/StatementResource.scala
@@ -215,9 +215,10 @@ private[v1] class StatementResource extends ApiRequestContext with Logging {
       slug: String,
       token: Long,
       slugContext: Slug.Context.Context): Try[Query] = {
-
-    Try(be.sessionManager.operationManager.getOperation(queryId.operationHandle)).map { _ =>
-      Query(queryId, context, be)
+    Try(be.sessionManager.operationManager.getOperation(queryId.operationHandle)).map { op =>
+      val sessionWithId = context.session ++
+        Map(Query.KYUUBI_SESSION_ID -> op.getSession.handle.identifier.toString)
+      Query(queryId, context.copy(session = sessionWithId), be)
     }.filter(_.getSlug.isValid(slugContext, slug, token))
   }
 

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/trino/api/TrinoClientApiSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/trino/api/TrinoClientApiSuite.scala
@@ -45,16 +45,24 @@ class TrinoClientApiSuite extends KyuubiFunSuite with TrinoRestFrontendTestHelpe
   test("submit query with trino client api") {
     val trino = getTrinoStatementClient("select 1")
     val result = execute(trino)
-    val sessionId = trino.getSetSessionProperties.asScala.get("sessionId")
+    val sessionId = trino.getSetSessionProperties.asScala.get(Query.KYUUBI_SESSION_ID)
     assert(result == List(List(1)))
 
     updateClientSession(trino)
 
-    val trino1 = getTrinoStatementClient("select 2")
+    val trino1 = getTrinoStatementClient("set k=v")
     val result1 = execute(trino1)
-    val sessionId1 = trino1.getSetSessionProperties.asScala.get("sessionId")
-    assert(result1 == List(List(2)))
-    assert(sessionId != sessionId1)
+    val sessionId1 = trino1.getSetSessionProperties.asScala.get(Query.KYUUBI_SESSION_ID)
+    assert(result1 == List(List("k", "v")))
+    assert(sessionId == sessionId1)
+
+    updateClientSession(trino)
+
+    val trino2 = getTrinoStatementClient("set k")
+    val result2 = execute(trino2)
+    val sessionId2 = trino2.getSetSessionProperties.asScala.get(Query.KYUUBI_SESSION_ID)
+    assert(result2 == List(List("k", "v")))
+    assert(sessionId == sessionId2)
 
     trino.close()
   }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/trino/api/v1/StatementResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/trino/api/v1/StatementResourceSuite.scala
@@ -19,9 +19,12 @@ package org.apache.kyuubi.server.trino.api.v1
 
 import javax.ws.rs.client.Entity
 import javax.ws.rs.core.{MediaType, Response}
+
 import scala.collection.JavaConverters._
+
 import io.trino.client.{QueryError, QueryResults}
 import io.trino.client.ProtocolHeaders.TRINO_HEADERS
+
 import org.apache.kyuubi.{KyuubiFunSuite, KyuubiSQLException, TrinoRestFrontendTestHelper}
 import org.apache.kyuubi.operation.{OperationHandle, OperationState}
 import org.apache.kyuubi.server.trino.api.{Query, TrinoContext}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This pr improves the trino session context:
1. always reuse the kyuubi session if session id exists, so we can restore the session context for next query
2. transform trino client information to kyuubi session, e.g. trino request source (trino-cli)

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
