### PR TITLE
Bump up markdown version from 3.3.7 to 3.4.1

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -17,8 +17,7 @@
 # under the License.
 #
 
-# we shall bypass markdown-3.4.1, see details in KYUUBI-3126
-markdown==3.3.7
+markdown==3.4.1
 recommonmark==0.7.1
 sphinx==4.5.0
 sphinx-book-theme==0.3.3


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Bump up markdown version from 3.3.7 to 3.4.1, the sphinx-markdown-tables has been upgraded to 0.0.17 in which the regression is resolved. It now conflicts with markdown 3.3.7 

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
