### PR TITLE
Support to return null value for OperationsResource rowset

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/OperationsResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/OperationsResource.scala
@@ -222,7 +222,7 @@ private[v1] class OperationsResource extends ApiRequestContext with Logging {
                 if (i.getI64Val.isSetValue) {
                   i.getI64Val.getFieldValue(TI64Value._Fields.VALUE)
                 } else {
-                  null;
+                  null
                 }
             })
         }).asJava)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/OperationsResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/OperationsResource.scala
@@ -183,43 +183,43 @@ private[v1] class OperationsResource extends ApiRequestContext with Logging {
             i.getSetField.name(),
             i.getSetField match {
               case TColumnValue._Fields.STRING_VAL =>
-                if (i.isSetStringVal) {
+                if (i.getStringVal.isSetValue) {
                   i.getStringVal.getFieldValue(TStringValue._Fields.VALUE)
                 } else {
                   null
                 }
               case TColumnValue._Fields.BOOL_VAL =>
-                if (i.isSetBoolVal) {
+                if (i.getBoolVal.isSetValue) {
                   i.getBoolVal.getFieldValue(TBoolValue._Fields.VALUE)
                 } else {
                   null
                 }
               case TColumnValue._Fields.BYTE_VAL =>
-                if (i.isSetByteVal) {
+                if (i.getByteVal.isSetValue) {
                   i.getByteVal.getFieldValue(TByteValue._Fields.VALUE)
                 } else {
                   null
                 }
               case TColumnValue._Fields.DOUBLE_VAL =>
-                if (i.isSetDoubleVal) {
+                if (i.getDoubleVal.isSetValue) {
                   i.getDoubleVal.getFieldValue(TDoubleValue._Fields.VALUE)
                 } else {
                   null
                 }
               case TColumnValue._Fields.I16_VAL =>
-                if (i.isSetI16Val) {
+                if (i.getI16Val.isSetValue) {
                   i.getI16Val.getFieldValue(TI16Value._Fields.VALUE)
                 } else {
                   null
                 }
               case TColumnValue._Fields.I32_VAL =>
-                if (i.isSetI32Val) {
+                if (i.getI32Val.isSetValue) {
                   i.getI32Val.getFieldValue(TI32Value._Fields.VALUE)
                 } else {
                   null
                 }
               case TColumnValue._Fields.I64_VAL =>
-                if (i.isSetI64Val) {
+                if (i.getI64Val.isSetValue) {
                   i.getI64Val.getFieldValue(TI64Value._Fields.VALUE)
                 } else {
                   null;

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/OperationsResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/OperationsResource.scala
@@ -183,19 +183,47 @@ private[v1] class OperationsResource extends ApiRequestContext with Logging {
             i.getSetField.name(),
             i.getSetField match {
               case TColumnValue._Fields.STRING_VAL =>
-                i.getStringVal.getFieldValue(TStringValue._Fields.VALUE)
+                if (i.isSetStringVal) {
+                  i.getStringVal.getFieldValue(TStringValue._Fields.VALUE)
+                } else {
+                  null
+                }
               case TColumnValue._Fields.BOOL_VAL =>
-                i.getBoolVal.getFieldValue(TBoolValue._Fields.VALUE)
+                if (i.isSetBoolVal) {
+                  i.getBoolVal.getFieldValue(TBoolValue._Fields.VALUE)
+                } else {
+                  null
+                }
               case TColumnValue._Fields.BYTE_VAL =>
-                i.getByteVal.getFieldValue(TByteValue._Fields.VALUE)
+                if (i.isSetByteVal) {
+                  i.getByteVal.getFieldValue(TByteValue._Fields.VALUE)
+                } else {
+                  null
+                }
               case TColumnValue._Fields.DOUBLE_VAL =>
-                i.getDoubleVal.getFieldValue(TDoubleValue._Fields.VALUE)
+                if (i.isSetDoubleVal) {
+                  i.getDoubleVal.getFieldValue(TDoubleValue._Fields.VALUE)
+                } else {
+                  null
+                }
               case TColumnValue._Fields.I16_VAL =>
-                i.getI16Val.getFieldValue(TI16Value._Fields.VALUE)
+                if (i.isSetI16Val) {
+                  i.getI16Val.getFieldValue(TI16Value._Fields.VALUE)
+                } else {
+                  null
+                }
               case TColumnValue._Fields.I32_VAL =>
-                i.getI32Val.getFieldValue(TI32Value._Fields.VALUE)
+                if (i.isSetI32Val) {
+                  i.getI32Val.getFieldValue(TI32Value._Fields.VALUE)
+                } else {
+                  null
+                }
               case TColumnValue._Fields.I64_VAL =>
-                i.getI64Val.getFieldValue(TI64Value._Fields.VALUE)
+                if (i.isSetI64Val) {
+                  i.getI64Val.getFieldValue(TI64Value._Fields.VALUE)
+                } else {
+                  null;
+                }
             })
         }).asJava)
       })

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/OperationsResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/OperationsResourceSuite.scala
@@ -146,8 +146,7 @@ class OperationsResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper
       .request(MediaType.APPLICATION_JSON).get()
     assert(200 == response.getStatus)
     val logRowSet = response.readEntity(classOf[ResultRowSet])
-    assert(logRowSet.getRows.asScala.head.getFields.asScala.map(_.getValue).toList ===
-      List(null, null, null, null, null, null, null))
+    assert(logRowSet.getRows.asScala.head.getFields.asScala.forall(_.getValue == null))
     assert(logRowSet.getRowCount == 1)
   }
 

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/OperationsResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/OperationsResourceSuite.scala
@@ -126,6 +126,31 @@ class OperationsResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper
     assert(logRowSet.getRowCount == 1)
   }
 
+  test("test get result row set with null value") {
+    val opHandleStr = getOpHandleStr(
+      s"""
+         |select
+         |cast(null as string) as c1,
+         |cast(null as boolean) as c2,
+         |cast(null as byte) as c3,
+         |cast(null as double) as c4,
+         |cast(null as short) as c5,
+         |cast(null as int) as c6,
+         |cast(null as bigint) as c7
+         |""".stripMargin)
+    checkOpState(opHandleStr, FINISHED)
+    val response = webTarget.path(
+      s"api/v1/operations/$opHandleStr/rowset")
+      .queryParam("maxrows", "2")
+      .queryParam("fetchorientation", "FETCH_NEXT")
+      .request(MediaType.APPLICATION_JSON).get()
+    assert(200 == response.getStatus)
+    val logRowSet = response.readEntity(classOf[ResultRowSet])
+    assert(logRowSet.getRows.asScala.head.getFields.asScala.map(_.getValue).toList ===
+      List(null, null, null, null, null, null, null))
+    assert(logRowSet.getRowCount == 1)
+  }
+
   def getOpHandleStr(statement: String = "show tables"): String = {
     val sessionHandle = fe.be.openSession(
       HIVE_CLI_SERVICE_PROTOCOL_V2,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

With restful api, for query `select cast(null as int) c1`

#### Before
the result is `0`

#### After
the result is `null`.
### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
