### PR TITLE
Refine unit tests to adapt Spark-3.4

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -64,11 +64,6 @@ jobs:
             spark-archive: '-Dspark.archive.mirror=https://archive.apache.org/dist/spark/spark-3.2.3 -Dspark.archive.name=spark-3.2.3-bin-hadoop3.2.tgz'
             exclude-tags: '-Dmaven.plugin.scalatest.exclude.tags=org.scalatest.tags.Slow,org.apache.kyuubi.tags.DeltaTest,org.apache.kyuubi.tags.HudiTest,org.apache.kyuubi.tags.IcebergTest'
             comment: 'verify-on-spark-3.2-binary'
-          - java: 8
-            spark: '3.4'
-            spark-archive: '-Dspark.archive.mirror=https://dist.apache.org/repos/dist/dev/spark/v3.4.0-rc1-bin -Dspark.archive.name=spark-3.4.0-bin-hadoop3.tgz'
-            exclude-tags: '-Dmaven.plugin.scalatest.exclude.tags=org.scalatest.tags.Slow,org.apache.kyuubi.tags.DeltaTest,org.apache.kyuubi.tags.HudiTest,org.apache.kyuubi.tags.IcebergTest'
-            comment: 'verify-on-spark-3.4-binary'
     env:
       SPARK_LOCAL_IP: localhost
     steps:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -67,7 +67,7 @@ jobs:
           - java: 8
             spark: '3.4'
             spark-archive: '-Dspark.archive.mirror=https://dist.apache.org/repos/dist/dev/spark/v3.4.0-rc1-bin -Dspark.archive.name=spark-3.4.0-bin-hadoop3.tgz'
-            exclude-tags: '-Dmaven.plugin.scalatest.exclude.tags=org.scalatest.tags.Slow,org.apache.kyuubi.tags.DeltaTest,org.apache.kyuubi.tags.HudiTest,org.apache.kyuubi.tags.IcebergTest,org.apache.kyuubi.tags.PySparkTest'
+            exclude-tags: '-Dmaven.plugin.scalatest.exclude.tags=org.scalatest.tags.Slow,org.apache.kyuubi.tags.DeltaTest,org.apache.kyuubi.tags.HudiTest,org.apache.kyuubi.tags.IcebergTest'
             comment: 'verify-on-spark-3.4-binary'
     env:
       SPARK_LOCAL_IP: localhost

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -67,7 +67,7 @@ jobs:
           - java: 8
             spark: '3.4'
             spark-archive: '-Dspark.archive.mirror=https://dist.apache.org/repos/dist/dev/spark/v3.4.0-rc1-bin -Dspark.archive.name=spark-3.4.0-bin-hadoop3.tgz'
-            exclude-tags: '-Dmaven.plugin.scalatest.exclude.tags=org.scalatest.tags.Slow,org.apache.kyuubi.tags.DeltaTest,org.apache.kyuubi.tags.HudiTest,org.apache.kyuubi.tags.IcebergTest'
+            exclude-tags: '-Dmaven.plugin.scalatest.exclude.tags=org.scalatest.tags.Slow,org.apache.kyuubi.tags.DeltaTest,org.apache.kyuubi.tags.HudiTest,org.apache.kyuubi.tags.IcebergTest,org.apache.kyuubi.tags.PySparkTest'
             comment: 'verify-on-spark-3.4-binary'
     env:
       SPARK_LOCAL_IP: localhost

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -64,6 +64,11 @@ jobs:
             spark-archive: '-Dspark.archive.mirror=https://archive.apache.org/dist/spark/spark-3.2.3 -Dspark.archive.name=spark-3.2.3-bin-hadoop3.2.tgz'
             exclude-tags: '-Dmaven.plugin.scalatest.exclude.tags=org.scalatest.tags.Slow,org.apache.kyuubi.tags.DeltaTest,org.apache.kyuubi.tags.HudiTest,org.apache.kyuubi.tags.IcebergTest'
             comment: 'verify-on-spark-3.2-binary'
+          - java: 8
+            spark: '3.4'
+            spark-archive: '-Dspark.archive.mirror=https://dist.apache.org/repos/dist/dev/spark/v3.4.0-rc1-bin -Dspark.archive.name=spark-3.4.0-bin-hadoop3.tgz'
+            exclude-tags: '-Dmaven.plugin.scalatest.exclude.tags=org.scalatest.tags.Slow,org.apache.kyuubi.tags.DeltaTest,org.apache.kyuubi.tags.HudiTest,org.apache.kyuubi.tags.IcebergTest'
+            comment: 'verify-on-spark-3.4-binary'
     env:
       SPARK_LOCAL_IP: localhost
     steps:

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/SparkOperationSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/SparkOperationSuite.scala
@@ -39,7 +39,6 @@ import org.apache.kyuubi.engine.spark.shim.SparkCatalogShim
 import org.apache.kyuubi.operation.{HiveMetadataTests, SparkQueryTests}
 import org.apache.kyuubi.operation.meta.ResultSetSchemaConstant._
 import org.apache.kyuubi.util.KyuubiHadoopUtils
-import org.apache.kyuubi.util.SparkVersionUtil.isSparkVersionAtLeast
 
 class SparkOperationSuite extends WithSparkSQLEngine with HiveMetadataTests with SparkQueryTests {
 
@@ -93,12 +92,12 @@ class SparkOperationSuite extends WithSparkSQLEngine with HiveMetadataTests with
       .add("c17", "struct<X: string>", nullable = true, "17")
 
     // since spark3.3.0
-    if (SPARK_ENGINE_VERSION >= "3.3") {
+    if (SPARK_ENGINE_RUNTIME_VERSION >= "3.3") {
       schema = schema.add("c18", "interval day", nullable = true, "18")
         .add("c19", "interval year", nullable = true, "19")
     }
     // since spark3.4.0
-    if (SPARK_ENGINE_VERSION >= "3.4") {
+    if (SPARK_ENGINE_RUNTIME_VERSION >= "3.4") {
       schema = schema.add("c20", "timestamp_ntz", nullable = true, "20")
     }
 
@@ -511,7 +510,7 @@ class SparkOperationSuite extends WithSparkSQLEngine with HiveMetadataTests with
       val status = tOpenSessionResp.getStatus
       val errorMessage = status.getErrorMessage
       assert(status.getStatusCode === TStatusCode.ERROR_STATUS)
-      if (isSparkVersionAtLeast("3.4")) {
+      if (SPARK_ENGINE_RUNTIME_VERSION >= "3.4") {
         assert(errorMessage.contains("[SCHEMA_NOT_FOUND]"))
         assert(errorMessage.contains(s"The schema `$dbName` cannot be found."))
       } else {

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/Logging.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/Logging.scala
@@ -117,16 +117,16 @@ object Logging {
     // This distinguishes the log4j 1.2 binding, currently
     // org.slf4j.impl.Log4jLoggerFactory, from the log4j 2.0 binding, currently
     // org.apache.logging.slf4j.Log4jLoggerFactory
-    val binderClass = StaticLoggerBinder.getSingleton.getLoggerFactoryClassStr
-    "org.slf4j.impl.Log4jLoggerFactory".equals(binderClass)
+    "org.slf4j.impl.Log4jLoggerFactory"
+      .equals(LoggerFactory.getILoggerFactory.getClass.getName)
   }
 
   private[kyuubi] def isLog4j2: Boolean = {
     // This distinguishes the log4j 1.2 binding, currently
     // org.slf4j.impl.Log4jLoggerFactory, from the log4j 2.0 binding, currently
     // org.apache.logging.slf4j.Log4jLoggerFactory
-    val binderClass = StaticLoggerBinder.getSingleton.getLoggerFactoryClassStr
-    "org.apache.logging.slf4j.Log4jLoggerFactory".equals(binderClass)
+    "org.apache.logging.slf4j.Log4jLoggerFactory"
+      .equals(LoggerFactory.getILoggerFactory.getClass.getName)
   }
 
   /**

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/Logging.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/Logging.scala
@@ -22,7 +22,6 @@ import org.apache.logging.log4j.core.{Logger => Log4jLogger, LoggerContext}
 import org.apache.logging.log4j.core.config.DefaultConfiguration
 import org.slf4j.{Logger, LoggerFactory}
 import org.slf4j.bridge.SLF4JBridgeHandler
-import org.slf4j.impl.StaticLoggerBinder
 
 import org.apache.kyuubi.util.ClassUtils
 

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/IcebergMetadataTests.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/IcebergMetadataTests.scala
@@ -17,11 +17,11 @@
 
 package org.apache.kyuubi.operation
 
-import org.apache.kyuubi.IcebergSuiteMixin
+import org.apache.kyuubi.{IcebergSuiteMixin, SPARK_COMPILE_VERSION}
 import org.apache.kyuubi.operation.meta.ResultSetSchemaConstant._
-import org.apache.kyuubi.util.SparkVersionUtil.isSparkVersionAtLeast
+import org.apache.kyuubi.util.SparkVersionUtil
 
-trait IcebergMetadataTests extends HiveJDBCTestHelper with IcebergSuiteMixin {
+trait IcebergMetadataTests extends HiveJDBCTestHelper with IcebergSuiteMixin with SparkVersionUtil {
 
   test("get catalogs") {
     withJdbcStatement() { statement =>
@@ -153,11 +153,11 @@ trait IcebergMetadataTests extends HiveJDBCTestHelper with IcebergSuiteMixin {
       "date",
       "timestamp",
       // SPARK-37931
-      if (isSparkVersionAtLeast("3.3")) "struct<X: bigint, Y: double>"
+      if (SPARK_ENGINE_RUNTIME_VERSION >= "3.3") "struct<X: bigint, Y: double>"
       else "struct<`X`: bigint, `Y`: double>",
       "binary",
       // SPARK-37931
-      if (isSparkVersionAtLeast("3.3")) "struct<X: string>" else "struct<`X`: string>")
+      if (SPARK_COMPILE_VERSION >= "3.3") "struct<X: string>" else "struct<`X`: string>")
     val cols = dataTypes.zipWithIndex.map { case (dt, idx) => s"c$idx" -> dt }
     val (colNames, _) = cols.unzip
 

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/SparkDataTypeTests.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/SparkDataTypeTests.scala
@@ -27,7 +27,8 @@ trait SparkDataTypeTests extends HiveJDBCTestHelper with SparkVersionUtil {
 
   test("execute statement - select null") {
     assume(
-      resultFormat == "thrift" || (resultFormat == "arrow" && SPARK_ENGINE_RUNTIME_VERSION >= "3.2"))
+      resultFormat == "thrift" ||
+        (resultFormat == "arrow" && SPARK_ENGINE_RUNTIME_VERSION >= "3.2"))
     withJdbcStatement() { statement =>
       val resultSet = statement.executeQuery("SELECT NULL AS col")
       assert(resultSet.next())
@@ -214,7 +215,8 @@ trait SparkDataTypeTests extends HiveJDBCTestHelper with SparkVersionUtil {
 
   test("execute statement - select daytime interval") {
     assume(
-      resultFormat == "thrift" || (resultFormat == "arrow" && SPARK_ENGINE_RUNTIME_VERSION >= "3.3"))
+      resultFormat == "thrift" ||
+        (resultFormat == "arrow" && SPARK_ENGINE_RUNTIME_VERSION >= "3.3"))
     withJdbcStatement() { statement =>
       Map(
         "interval 1 day 1 hour -60 minutes 30 seconds" ->
@@ -260,7 +262,8 @@ trait SparkDataTypeTests extends HiveJDBCTestHelper with SparkVersionUtil {
 
   test("execute statement - select year/month interval") {
     assume(
-      resultFormat == "thrift" || (resultFormat == "arrow" && SPARK_ENGINE_RUNTIME_VERSION >= "3.3"))
+      resultFormat == "thrift" ||
+        (resultFormat == "arrow" && SPARK_ENGINE_RUNTIME_VERSION >= "3.3"))
     withJdbcStatement() { statement =>
       Map(
         "INTERVAL 2022 YEAR" -> Tuple2("2022-0", "2022 years"),
@@ -290,7 +293,8 @@ trait SparkDataTypeTests extends HiveJDBCTestHelper with SparkVersionUtil {
 
   test("execute statement - select array") {
     assume(
-      resultFormat == "thrift" || (resultFormat == "arrow" && SPARK_ENGINE_RUNTIME_VERSION >= "3.2"))
+      resultFormat == "thrift" ||
+        (resultFormat == "arrow" && SPARK_ENGINE_RUNTIME_VERSION >= "3.2"))
     withJdbcStatement() { statement =>
       val resultSet = statement.executeQuery(
         "SELECT array() AS col1, array(1) AS col2, array(null) AS col3")
@@ -309,7 +313,8 @@ trait SparkDataTypeTests extends HiveJDBCTestHelper with SparkVersionUtil {
 
   test("execute statement - select map") {
     assume(
-      resultFormat == "thrift" || (resultFormat == "arrow" && SPARK_ENGINE_RUNTIME_VERSION >= "3.2"))
+      resultFormat == "thrift" ||
+        (resultFormat == "arrow" && SPARK_ENGINE_RUNTIME_VERSION >= "3.2"))
     withJdbcStatement() { statement =>
       val resultSet = statement.executeQuery(
         "SELECT map() AS col1, map(1, 2, 3, 4) AS col2, map(1, null) AS col3")
@@ -328,7 +333,8 @@ trait SparkDataTypeTests extends HiveJDBCTestHelper with SparkVersionUtil {
 
   test("execute statement - select struct") {
     assume(
-      resultFormat == "thrift" || (resultFormat == "arrow" && SPARK_ENGINE_RUNTIME_VERSION >= "3.2"))
+      resultFormat == "thrift" ||
+        (resultFormat == "arrow" && SPARK_ENGINE_RUNTIME_VERSION >= "3.2"))
     withJdbcStatement() { statement =>
       val resultSet = statement.executeQuery(
         "SELECT struct('1', '2') AS col1," +

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/SparkDataTypeTests.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/SparkDataTypeTests.scala
@@ -20,14 +20,15 @@ package org.apache.kyuubi.operation
 import java.sql.{Date, Timestamp}
 
 import org.apache.kyuubi.engine.SemanticVersion
+import org.apache.kyuubi.util.SparkVersionUtil
 
-trait SparkDataTypeTests extends HiveJDBCTestHelper {
-  protected lazy val SPARK_ENGINE_VERSION = sparkEngineMajorMinorVersion
+trait SparkDataTypeTests extends HiveJDBCTestHelper with SparkVersionUtil {
 
   def resultFormat: String = "thrift"
 
   test("execute statement - select null") {
-    assume(resultFormat == "thrift" || (resultFormat == "arrow" && SPARK_ENGINE_VERSION >= "3.2"))
+    assume(
+      resultFormat == "thrift" || (resultFormat == "arrow" && SPARK_ENGINE_RUNTIME_VERSION >= "3.2"))
     withJdbcStatement() { statement =>
       val resultSet = statement.executeQuery("SELECT NULL AS col")
       assert(resultSet.next())
@@ -199,7 +200,7 @@ trait SparkDataTypeTests extends HiveJDBCTestHelper {
   }
 
   test("execute statement - select timestamp_ntz") {
-    assume(SPARK_ENGINE_VERSION >= "3.4")
+    assume(SPARK_ENGINE_RUNTIME_VERSION >= "3.4")
     withJdbcStatement() { statement =>
       val resultSet = statement.executeQuery(
         "SELECT make_timestamp_ntz(2022, 03, 24, 18, 08, 31.8888) AS col")
@@ -213,7 +214,8 @@ trait SparkDataTypeTests extends HiveJDBCTestHelper {
   }
 
   test("execute statement - select daytime interval") {
-    assume(resultFormat == "thrift" || (resultFormat == "arrow" && SPARK_ENGINE_VERSION >= "3.3"))
+    assume(
+      resultFormat == "thrift" || (resultFormat == "arrow" && SPARK_ENGINE_RUNTIME_VERSION >= "3.3"))
     withJdbcStatement() { statement =>
       Map(
         "interval 1 day 1 hour -60 minutes 30 seconds" ->
@@ -242,7 +244,7 @@ trait SparkDataTypeTests extends HiveJDBCTestHelper {
           assert(resultSet.next())
           val result = resultSet.getString("col")
           val metaData = resultSet.getMetaData
-          if (SPARK_ENGINE_VERSION < "3.2") {
+          if (SPARK_ENGINE_RUNTIME_VERSION < "3.2") {
             // for spark 3.1 and backwards
             assert(result === kv._2._2)
             assert(metaData.getPrecision(1) === Int.MaxValue)
@@ -258,7 +260,8 @@ trait SparkDataTypeTests extends HiveJDBCTestHelper {
   }
 
   test("execute statement - select year/month interval") {
-    assume(resultFormat == "thrift" || (resultFormat == "arrow" && SPARK_ENGINE_VERSION >= "3.3"))
+    assume(
+      resultFormat == "thrift" || (resultFormat == "arrow" && SPARK_ENGINE_RUNTIME_VERSION >= "3.3"))
     withJdbcStatement() { statement =>
       Map(
         "INTERVAL 2022 YEAR" -> Tuple2("2022-0", "2022 years"),
@@ -271,7 +274,7 @@ trait SparkDataTypeTests extends HiveJDBCTestHelper {
         assert(resultSet.next())
         val result = resultSet.getString("col")
         val metaData = resultSet.getMetaData
-        if (SPARK_ENGINE_VERSION < "3.2") {
+        if (SPARK_ENGINE_RUNTIME_VERSION < "3.2") {
           // for spark 3.1 and backwards
           assert(result === kv._2._2)
           assert(metaData.getPrecision(1) === Int.MaxValue)
@@ -287,7 +290,8 @@ trait SparkDataTypeTests extends HiveJDBCTestHelper {
   }
 
   test("execute statement - select array") {
-    assume(resultFormat == "thrift" || (resultFormat == "arrow" && SPARK_ENGINE_VERSION >= "3.2"))
+    assume(
+      resultFormat == "thrift" || (resultFormat == "arrow" && SPARK_ENGINE_RUNTIME_VERSION >= "3.2"))
     withJdbcStatement() { statement =>
       val resultSet = statement.executeQuery(
         "SELECT array() AS col1, array(1) AS col2, array(null) AS col3")
@@ -305,7 +309,8 @@ trait SparkDataTypeTests extends HiveJDBCTestHelper {
   }
 
   test("execute statement - select map") {
-    assume(resultFormat == "thrift" || (resultFormat == "arrow" && SPARK_ENGINE_VERSION >= "3.2"))
+    assume(
+      resultFormat == "thrift" || (resultFormat == "arrow" && SPARK_ENGINE_RUNTIME_VERSION >= "3.2"))
     withJdbcStatement() { statement =>
       val resultSet = statement.executeQuery(
         "SELECT map() AS col1, map(1, 2, 3, 4) AS col2, map(1, null) AS col3")
@@ -323,7 +328,8 @@ trait SparkDataTypeTests extends HiveJDBCTestHelper {
   }
 
   test("execute statement - select struct") {
-    assume(resultFormat == "thrift" || (resultFormat == "arrow" && SPARK_ENGINE_VERSION >= "3.2"))
+    assume(
+      resultFormat == "thrift" || (resultFormat == "arrow" && SPARK_ENGINE_RUNTIME_VERSION >= "3.2"))
     withJdbcStatement() { statement =>
       val resultSet = statement.executeQuery(
         "SELECT struct('1', '2') AS col1," +
@@ -341,16 +347,5 @@ trait SparkDataTypeTests extends HiveJDBCTestHelper {
       assert(metaData.getScale(1) == 0)
       assert(metaData.getScale(2) == 0)
     }
-  }
-
-  def sparkEngineMajorMinorVersion: SemanticVersion = {
-    var sparkRuntimeVer = ""
-    withJdbcStatement() { stmt =>
-      val result = stmt.executeQuery("SELECT version()")
-      assert(result.next())
-      sparkRuntimeVer = result.getString(1)
-      assert(!result.next())
-    }
-    SemanticVersion(sparkRuntimeVer)
   }
 }

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/SparkDataTypeTests.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/SparkDataTypeTests.scala
@@ -19,7 +19,6 @@ package org.apache.kyuubi.operation
 
 import java.sql.{Date, Timestamp}
 
-import org.apache.kyuubi.engine.SemanticVersion
 import org.apache.kyuubi.util.SparkVersionUtil
 
 trait SparkDataTypeTests extends HiveJDBCTestHelper with SparkVersionUtil {

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/SparkQueryTests.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/SparkQueryTests.scala
@@ -28,7 +28,6 @@ import org.apache.hive.service.rpc.thrift.{TExecuteStatementReq, TFetchResultsRe
 
 import org.apache.kyuubi.{KYUUBI_VERSION, Utils}
 import org.apache.kyuubi.config.KyuubiConf
-import org.apache.kyuubi.util.SparkVersionUtil.isSparkVersionAtLeast
 
 trait SparkQueryTests extends SparkDataTypeTests with HiveJDBCTestHelper {
 
@@ -187,7 +186,7 @@ trait SparkQueryTests extends SparkDataTypeTests with HiveJDBCTestHelper {
     withJdbcStatement("t") { statement =>
       try {
         val assertTableOrViewNotfound: (Exception, String) => Unit = (e, tableName) => {
-          if (isSparkVersionAtLeast("3.4")) {
+          if (SPARK_ENGINE_RUNTIME_VERSION >= "3.4") {
             assert(e.getMessage.contains("[TABLE_OR_VIEW_NOT_FOUND]"))
             assert(e.getMessage.contains(s"The table or view `$tableName` cannot be found."))
           } else {

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/util/SparkVersionUtil.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/util/SparkVersionUtil.scala
@@ -17,13 +17,22 @@
 
 package org.apache.kyuubi.util
 
-import org.apache.kyuubi.SPARK_COMPILE_VERSION
 import org.apache.kyuubi.engine.SemanticVersion
+import org.apache.kyuubi.operation.HiveJDBCTestHelper
 
-object SparkVersionUtil {
-  lazy val sparkSemanticVersion: SemanticVersion = SemanticVersion(SPARK_COMPILE_VERSION)
+trait SparkVersionUtil {
+  this: HiveJDBCTestHelper =>
 
-  def isSparkVersionAtLeast(ver: String): Boolean = {
-    sparkSemanticVersion.isVersionAtLeast(ver)
+  protected lazy val SPARK_ENGINE_RUNTIME_VERSION = sparkEngineMajorMinorVersion
+
+  def sparkEngineMajorMinorVersion: SemanticVersion = {
+    var sparkRuntimeVer = ""
+    withJdbcStatement() { stmt =>
+      val result = stmt.executeQuery("SELECT version()")
+      assert(result.next())
+      sparkRuntimeVer = result.getString(1)
+      assert(!result.next())
+    }
+    SemanticVersion(sparkRuntimeVer)
   }
 }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/spark/PySparkTests.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/spark/PySparkTests.scala
@@ -24,17 +24,19 @@ import java.util.Properties
 
 import scala.sys.process._
 
-import org.apache.kyuubi.engine.spark.WithSparkSQLEngine
+import org.apache.kyuubi.WithKyuubiServer
+import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.jdbc.KyuubiHiveDriver
 import org.apache.kyuubi.jdbc.hive.{KyuubiSQLException, KyuubiStatement}
 import org.apache.kyuubi.operation.HiveJDBCTestHelper
 import org.apache.kyuubi.tags.PySparkTest
 
 @PySparkTest
-class PySparkTests extends WithSparkSQLEngine with HiveJDBCTestHelper {
+class PySparkTests extends WithKyuubiServer with HiveJDBCTestHelper {
 
   override protected def jdbcUrl: String = getJdbcUrl
-  override def withKyuubiConf: Map[String, String] = Map.empty
+
+  override protected val conf: KyuubiConf = new KyuubiConf
 
   test("pyspark support") {
     val code = "print(1)"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

1. get spark engine runtime version instead of compile version
2. moved `PySparkTests` from the module `kyuubi-spark-sql-engine` to `kyuubi-server` to ensure that the python progress loading library PYSPARK has the same version as the launched Spark engine. see https://github.com/apache/kyuubi/pull/4381#issuecomment-1442871106

### _How was this patch tested?_

Pass Github Action.
