### PR TITLE
[KYUUBI #4267] Show warning if SessionHandle is invalid

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/session/SparkSQLSessionManager.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/session/SparkSQLSessionManager.scala
@@ -164,7 +164,12 @@ class SparkSQLSessionManager private (name: String, spark: SparkSession)
         }
       }
     }
-    super.closeSession(sessionHandle)
+    try {
+      super.closeSession(sessionHandle)
+    } catch {
+      case e: KyuubiSQLException =>
+        warn(s"Error closing session ${sessionHandle}", e)
+    }
     if (shareLevel == ShareLevel.CONNECTION) {
       info("Session stopped due to shared level is Connection.")
       stopSession()


### PR DESCRIPTION
### _Why are the changes needed?_
If SessionManager tries to close a session, that was previously closed - it throws an error `org.apache.kyuubi.KyuubiSQLException: Invalid SessionHandle` which causes spark session exit with non-zero code. 


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [X] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
