### PR TITLE
Remove redundant config in Trino frontend

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiTrinoFrontendService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiTrinoFrontendService.scala
@@ -64,15 +64,6 @@ class KyuubiTrinoFrontendService(override val serverable: Serverable)
   private def startInternal(): Unit = {
     val contextHandler = ApiRootResource.getServletHandler(this)
     server.addHandler(contextHandler)
-
-    server.addStaticHandler("org/apache/kyuubi/ui/static", "/static/")
-    server.addRedirectHandler("/", "/static/")
-    server.addRedirectHandler("/static", "/static/")
-    server.addStaticHandler("META-INF/resources/webjars/swagger-ui/4.9.1/", "/swagger-static/")
-    server.addStaticHandler("org/apache/kyuubi/ui/swagger", "/swagger/")
-    server.addRedirectHandler("/docs", "/swagger/")
-    server.addRedirectHandler("/docs/", "/swagger/")
-    server.addRedirectHandler("/swagger", "/swagger/")
   }
 
   override def start(): Unit = synchronized {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
It seems to be redundant to keep these configurations in the Trino frontend module. Thus, to my mind, removing them make things better.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
