### PR TITLE
Implement simple EngineSecuritySecretProvider

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -2068,8 +2068,23 @@ object KyuubiConf {
         "subclass of `EngineSecuritySecretProvider`.")
       .version("1.5.0")
       .stringConf
-      .createWithDefault(
-        "org.apache.kyuubi.service.authentication.ZooKeeperEngineSecuritySecretProviderImpl")
+      .transform {
+        case "simple" =>
+          "org.apache.kyuubi.service.authentication.SimpleEngineSecuritySecretProviderImpl"
+        case "zookeeper" =>
+          "org.apache.kyuubi.service.authentication.ZooKeeperEngineSecuritySecretProviderImpl"
+        case other => other
+      }
+      .createWithDefault("simple")
+
+  val SIMPLE_SECURITY_SECRET_PROVIDER_PROVIDER_SECRET: OptionalConfigEntry[String] =
+    buildConf("kyuubi.engine.security.secret.provider.simple.secret")
+      .internal
+      .doc("The secret key used for internal security access. Only take affects when " +
+        s"${ENGINE_SECURITY_SECRET_PROVIDER.key} is 'simple'")
+      .version("1.7.0")
+      .stringConf
+      .createOptional
 
   val ENGINE_SECURITY_CRYPTO_KEY_LENGTH: ConfigEntry[Int] =
     buildConf("kyuubi.engine.security.crypto.keyLength")

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -2075,7 +2075,7 @@ object KyuubiConf {
           "org.apache.kyuubi.service.authentication.ZooKeeperEngineSecuritySecretProviderImpl"
         case other => other
       }
-      .createWithDefault("simple")
+      .createWithDefault("zookeeper")
 
   val SIMPLE_SECURITY_SECRET_PROVIDER_PROVIDER_SECRET: OptionalConfigEntry[String] =
     buildConf("kyuubi.engine.security.secret.provider.simple.secret")

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/EngineSecuritySecretProvider.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/EngineSecuritySecretProvider.scala
@@ -18,7 +18,7 @@
 package org.apache.kyuubi.service.authentication
 
 import org.apache.kyuubi.config.KyuubiConf
-import org.apache.kyuubi.config.KyuubiConf.ENGINE_SECURITY_SECRET_PROVIDER
+import org.apache.kyuubi.config.KyuubiConf._
 
 trait EngineSecuritySecretProvider {
 
@@ -31,6 +31,27 @@ trait EngineSecuritySecretProvider {
    * Get the secret to encrypt and decrypt the secure access token.
    */
   def getSecret(): String
+}
+
+class SimpleEngineSecuritySecretProviderImpl extends EngineSecuritySecretProvider {
+
+  private var _conf: KyuubiConf = _
+
+  /**
+   * Initialize with kyuubi conf.
+   */
+  override def initialize(conf: KyuubiConf): Unit = _conf = conf
+
+  /**
+   * Get the secret to encrypt and decrypt the secure access token.
+   */
+  override def getSecret(): String = {
+    _conf.get(SIMPLE_SECURITY_SECRET_PROVIDER_PROVIDER_SECRET).getOrElse {
+      throw new IllegalArgumentException(
+        s"${SIMPLE_SECURITY_SECRET_PROVIDER_PROVIDER_SECRET.key} must be configured " +
+          s"when ${ENGINE_SECURITY_SECRET_PROVIDER.key} is `simple`.")
+    }
+  }
 }
 
 object EngineSecuritySecretProvider {

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/EngineSecuritySecretProvider.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/EngineSecuritySecretProvider.scala
@@ -37,14 +37,8 @@ class SimpleEngineSecuritySecretProviderImpl extends EngineSecuritySecretProvide
 
   private var _conf: KyuubiConf = _
 
-  /**
-   * Initialize with kyuubi conf.
-   */
   override def initialize(conf: KyuubiConf): Unit = _conf = conf
 
-  /**
-   * Get the secret to encrypt and decrypt the secure access token.
-   */
   override def getSecret(): String = {
     _conf.get(SIMPLE_SECURITY_SECRET_PROVIDER_PROVIDER_SECRET).getOrElse {
       throw new IllegalArgumentException(

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/service/authentication/InternalSecurityAccessorSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/service/authentication/InternalSecurityAccessorSuite.scala
@@ -22,9 +22,8 @@ import org.apache.kyuubi.config.KyuubiConf
 
 class InternalSecurityAccessorSuite extends KyuubiFunSuite {
   private val conf = KyuubiConf()
-  conf.set(
-    KyuubiConf.ENGINE_SECURITY_SECRET_PROVIDER,
-    classOf[UserDefinedEngineSecuritySecretProvider].getCanonicalName)
+    .set(KyuubiConf.ENGINE_SECURITY_SECRET_PROVIDER, "simple")
+    .set(KyuubiConf.SIMPLE_SECURITY_SECRET_PROVIDER_PROVIDER_SECRET, "ENGINE____SECRET")
 
   test("test encrypt/decrypt, issue token/auth token") {
     Seq("AES/CBC/PKCS5PADDING", "AES/CTR/NoPadding").foreach { cipher =>

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
@@ -43,7 +43,7 @@ import org.apache.kyuubi.operation.OperationState.OperationState
 import org.apache.kyuubi.server.KyuubiRestFrontendService
 import org.apache.kyuubi.server.http.authentication.AuthenticationHandler.AUTHORIZATION_HEADER
 import org.apache.kyuubi.server.metadata.api.Metadata
-import org.apache.kyuubi.service.authentication.{KyuubiAuthenticationFactory, UserDefinedEngineSecuritySecretProvider}
+import org.apache.kyuubi.service.authentication.KyuubiAuthenticationFactory
 import org.apache.kyuubi.session.{KyuubiBatchSessionImpl, KyuubiSessionManager, SessionHandle, SessionType}
 
 class BatchesResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper with BatchTestHelper {

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
@@ -49,9 +49,8 @@ import org.apache.kyuubi.session.{KyuubiBatchSessionImpl, KyuubiSessionManager, 
 class BatchesResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper with BatchTestHelper {
   override protected lazy val conf: KyuubiConf = KyuubiConf()
     .set(KyuubiConf.ENGINE_SECURITY_ENABLED, true)
-    .set(
-      KyuubiConf.ENGINE_SECURITY_SECRET_PROVIDER,
-      classOf[UserDefinedEngineSecuritySecretProvider].getName)
+    .set(KyuubiConf.ENGINE_SECURITY_SECRET_PROVIDER, "simple")
+    .set(KyuubiConf.SIMPLE_SECURITY_SECRET_PROVIDER_PROVIDER_SECRET, "ENGINE____SECRET")
     .set(
       KyuubiConf.SESSION_LOCAL_DIR_ALLOW_LIST,
       Seq(Paths.get(sparkBatchTestResource.get).getParent.toString))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This PR implements a simple `EngineSecuritySecretProvider` beside the existing zookeeper implementation, which simplifies the user threshold to use RESTful API w/ HA mode, and this PR also allows the user set `kyuubi.engine.security.secret.provider` using short name 'simple' or 'zookeeper' as well as the full class name.

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
