### PR TITLE
Simplify assertions in Authz tests in declarative style

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/SparkSessionProvider.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/SparkSessionProvider.scala
@@ -22,6 +22,7 @@ import java.security.PrivilegedExceptionAction
 
 import scala.util.Try
 
+import org.apache.commons.lang3.StringUtils
 import org.apache.hadoop.security.UserGroupInformation
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{DataFrame, SparkSession, SparkSessionExtensions}
@@ -102,15 +103,15 @@ trait SparkSessionProvider {
   }
 
   protected def runSqlAsWithAccessException(user: String = "someone")(
-      sqlStr: String,
+      sqlText: String,
       isCollect: Boolean = false,
       isExplain: Boolean = false,
-      contains: String = null): Unit = {
-    withClue(sqlStr) {
+      contains: String = ""): Unit = {
+    withClue(sqlText) {
       val e = intercept[AccessControlException](
         doAs(
           user, {
-            val df = sql(sqlStr)
+            val df = sql(sqlText)
             if (isExplain) {
               df.explain()
             }
@@ -118,7 +119,7 @@ trait SparkSessionProvider {
               df.collect()
             }
           }))
-      if (contains != null) {
+      if (StringUtils.isNotBlank(contains)) {
         assert(e.getMessage.contains(contains))
       }
     }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/SparkSessionProvider.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/SparkSessionProvider.scala
@@ -83,7 +83,7 @@ trait SparkSessionProvider {
   }
 
   protected def doAs[T](user: String)(f: => T): T = {
-      doAs[T](user, f)
+    doAs[T](user, f)
   }
 
   protected def runSqlAsInSuccess(user: String)(

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/SparkSessionProvider.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/SparkSessionProvider.scala
@@ -105,11 +105,20 @@ trait SparkSessionProvider {
     }
   }
 
+  /**
+   * intercept [AccessControlException] when running sql
+   * and assert error message contains certain char sequence
+   * @param user user name to execute sql , default to "someone"
+   * @param sqlText parse ans run sql to dataframe
+   * @param contains assert error message containing certain char sequence
+   * @param isExplain whether execute explain for dataframe
+   * @param isCollect whether execute collect for dataframe
+   */
   protected def runSqlAsWithAccessException(user: String = "someone")(
       sqlText: String,
-      isCollect: Boolean = false,
+      contains: String,
       isExplain: Boolean = false,
-      contains: String = ""): Unit = {
+      isCollect: Boolean = false): Unit = {
     withClue(sqlText) {
       val e = intercept[AccessControlException](
         doAs(user) {

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/SparkSessionProvider.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/SparkSessionProvider.scala
@@ -23,6 +23,7 @@ import java.security.PrivilegedExceptionAction
 import org.apache.hadoop.security.UserGroupInformation
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{DataFrame, SparkSession, SparkSessionExtensions}
+import org.scalatest.Assertions.withClue
 
 import org.apache.kyuubi.Utils
 import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
@@ -77,6 +78,13 @@ trait SparkSessionProvider {
         override def run(): T = f
       })
   }
+
+  protected def doAs[T](user: String, clue: String = "")(f: => T): T = {
+    withClue(clue) {
+      doAs(user, f)
+    }
+  }
+
   protected def withCleanTmpResources[T](res: Seq[(String, String)])(f: => T): T = {
     try {
       f

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/SparkSessionProvider.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/SparkSessionProvider.scala
@@ -84,9 +84,9 @@ trait SparkSessionProvider {
 
   protected def runSqlAs(user: String)(
       sqlStr: String,
-      isCollect: Boolean = false,
       collectSize: Int = Int.MinValue,
-      countSize: Int = Int.MinValue): Unit = {
+      countSize: Int = Int.MinValue,
+      isCollect: Boolean = false): Unit = {
     doAs(user) {
       assert(Try {
         val df = sql(sqlStr)

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/SparkSessionProvider.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/SparkSessionProvider.scala
@@ -87,8 +87,7 @@ trait SparkSessionProvider {
     }
   }
 
-  protected def runSqlAsInSuccess(
-      user: String,
+  protected def runSqlAsInSuccess(user: String)(
       sqlStr: String,
       isCollect: Boolean = false): Unit = {
     doAs(

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/SparkSessionProvider.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/SparkSessionProvider.scala
@@ -106,7 +106,7 @@ trait SparkSessionProvider {
   }
 
   /**
-   * intercept [AccessControlException] when running sql
+   * intercept [[AccessControlException]] when running sql
    * and assert error message contains certain char sequence
    * @param user user name to execute sql , default to "someone"
    * @param sqlText parse ans run sql to dataframe

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/SparkSessionProvider.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/SparkSessionProvider.scala
@@ -20,6 +20,8 @@ package org.apache.kyuubi.plugin.spark.authz
 import java.nio.file.Files
 import java.security.PrivilegedExceptionAction
 
+import scala.util.Try
+
 import org.apache.hadoop.security.UserGroupInformation
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{DataFrame, SparkSession, SparkSessionExtensions}
@@ -87,6 +89,21 @@ trait SparkSessionProvider {
 
   protected def runSqlAs(user: String, sqlStr: String): DataFrame = {
     doAs[DataFrame](user, sql(sqlStr))
+  }
+
+  protected def runSqlAsInSuccess(
+      user: String,
+      sqlStr: String,
+      isCollect: Boolean = false): Unit = {
+    doAs(
+      user,
+      assert(
+        Try {
+          val df = sql(sqlStr)
+          if (isCollect) {
+            df.collect()
+          }
+        }.isSuccess))
   }
 
   protected def withCleanTmpResources[T](res: Seq[(String, String)])(f: => T): T = {

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/SparkSessionProvider.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/SparkSessionProvider.scala
@@ -87,10 +87,6 @@ trait SparkSessionProvider {
     }
   }
 
-  protected def runSqlAs(user: String, sqlStr: String): DataFrame = {
-    doAs[DataFrame](user, sql(sqlStr))
-  }
-
   protected def runSqlAsInSuccess(
       user: String,
       sqlStr: String,

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/SparkSessionProvider.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/SparkSessionProvider.scala
@@ -82,10 +82,8 @@ trait SparkSessionProvider {
       })
   }
 
-  protected def doAs[T](user: String, clue: String = "")(f: => T): T = {
-    withClue[T](clue) {
+  protected def doAs[T](user: String)(f: => T): T = {
       doAs[T](user, f)
-    }
   }
 
   protected def runSqlAsInSuccess(user: String)(

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/SparkSessionProvider.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/SparkSessionProvider.scala
@@ -80,9 +80,13 @@ trait SparkSessionProvider {
   }
 
   protected def doAs[T](user: String, clue: String = "")(f: => T): T = {
-    withClue(clue) {
-      doAs(user, f)
+    withClue[T](clue) {
+      doAs[T](user, f)
     }
+  }
+
+  protected def runSqlAs(user: String, sqlStr: String): DataFrame = {
+    doAs[DataFrame](user, sql(sqlStr))
   }
 
   protected def withCleanTmpResources[T](res: Seq[(String, String)])(f: => T): T = {

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/IcebergCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/IcebergCatalogRangerSparkExtensionSuite.scala
@@ -78,15 +78,19 @@ class IcebergCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite 
       """.stripMargin
 
     // MergeIntoTable:  Using a MERGE INTO Statement
-    runSqlAsWithAccessException()(mergeIntoSql, s"does not have [select] privilege on [$namespace1/$table1/id]")
+    runSqlAsWithAccessException()(
+      mergeIntoSql,
+      s"does not have [select] privilege on [$namespace1/$table1/id]")
 
     try {
       SparkRangerAdminPlugin.getRangerConf.setBoolean(
         s"ranger.plugin.${SparkRangerAdminPlugin.getServiceType}.authorize.in.single.call",
         true)
-      runSqlAsWithAccessException()(mergeIntoSql, s"does not have [select] privilege" +
-        s" on [$namespace1/$table1/id,$namespace1/table1/name,$namespace1/$table1/city]," +
-        s" [update] privilege on [$namespace1/$outputTable1]")
+      runSqlAsWithAccessException()(
+        mergeIntoSql,
+        s"does not have [select] privilege" +
+          s" on [$namespace1/$table1/id,$namespace1/table1/name,$namespace1/$table1/city]," +
+          s" [update] privilege on [$namespace1/$outputTable1]")
     } finally {
       SparkRangerAdminPlugin.getRangerConf.setBoolean(
         s"ranger.plugin.${SparkRangerAdminPlugin.getServiceType}.authorize.in.single.call",
@@ -101,7 +105,9 @@ class IcebergCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite 
 
     // UpdateTable
     val update = s"UPDATE $catalogV2.$namespace1.$table1 SET city='Guangzhou' WHERE id=1"
-    runSqlAsWithAccessException()(update, s"does not have [update] privilege on [$namespace1/$table1]")
+    runSqlAsWithAccessException()(
+      update,
+      s"does not have [update] privilege on [$namespace1/$table1]")
 
     runSqlAs("admin")(update)
   }
@@ -110,7 +116,9 @@ class IcebergCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite 
     assume(isSparkV32OrGreater)
 
     // DeleteFromTable
-    runSqlAsWithAccessException()(s"DELETE FROM $catalogV2.$namespace1.$table1 WHERE id=2", s"does not have [update] privilege on [$namespace1/$table1]")
+    runSqlAsWithAccessException()(
+      s"DELETE FROM $catalogV2.$namespace1.$table1 WHERE id=2",
+      s"does not have [update] privilege on [$namespace1/$table1]")
 
     runSqlAs("admin")(s"DELETE FROM $catalogV2.$namespace1.$table1 WHERE id=2")
   }
@@ -127,7 +135,10 @@ class IcebergCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite 
 
       runSqlAs(defaultTableOwner)(select, isCollect = true)
 
-      runSqlAsWithAccessException("create_only_user")(select, errorMessage("select", s"$namespace1/$table/key"), isCollect = true)
+      runSqlAsWithAccessException("create_only_user")(
+        select,
+        errorMessage("select", s"$namespace1/$table/key"),
+        isCollect = true)
     }
   }
 
@@ -177,7 +188,10 @@ class IcebergCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite 
 
   test("[KYUUBI #4255] DESCRIBE TABLE") {
     assume(isSparkV32OrGreater)
-    runSqlAsWithAccessException()(s"DESCRIBE TABLE $catalogV2.$namespace1.$table1", s"does not have [select] privilege on [$namespace1/$table1]", isExplain = true)
+    runSqlAsWithAccessException()(
+      s"DESCRIBE TABLE $catalogV2.$namespace1.$table1",
+      s"does not have [select] privilege on [$namespace1/$table1]",
+      isExplain = true)
   }
 
 }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/IcebergCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/IcebergCatalogRangerSparkExtensionSuite.scala
@@ -151,17 +151,11 @@ class IcebergCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite 
     val select = s"SELECT key FROM $catalogV2.$namespace1.$table"
 
     withCleanTmpResources(Seq((s"$catalogV2.$namespace1.$table", "table"))) {
-      doAs(
+      runSqlAsInSuccess(
         defaultTableOwner,
-        assert(Try {
-          sql(s"CREATE TABLE $catalogV2.$namespace1.$table (key int, value int) USING iceberg")
-        }.isSuccess))
+        s"CREATE TABLE $catalogV2.$namespace1.$table (key int, value int) USING iceberg")
 
-      doAs(
-        defaultTableOwner,
-        assert(Try {
-          sql(select).collect()
-        }.isSuccess))
+      runSqlAsInSuccess(defaultTableOwner, select, true)
 
       doAs(
         "create_only_user", {

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/IcebergCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/IcebergCatalogRangerSparkExtensionSuite.scala
@@ -110,15 +110,12 @@ class IcebergCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite 
     assume(isSparkV32OrGreater)
 
     // UpdateTable
+    val update = s"UPDATE $catalogV2.$namespace1.$table1 SET city='Guangzhou' WHERE id=1"
     runSqlAsWithAccessException()(
-      s"UPDATE $catalogV2.$namespace1.$table1 SET city='Guangzhou' " +
-        " WHERE id=1",
+      update,
       contains = s"does not have [update] privilege on [$namespace1/$table1]")
 
-    doAs(
-      "admin",
-      sql(s"UPDATE $catalogV2.$namespace1.$table1 SET city='Guangzhou' " +
-        " WHERE id=1"))
+    doAs("admin", sql(update))
   }
 
   test("[KYUUBI #3515] DELETE FROM TABLE") {

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/IcebergCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/IcebergCatalogRangerSparkExtensionSuite.scala
@@ -136,11 +136,10 @@ class IcebergCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite 
     val select = s"SELECT key FROM $catalogV2.$namespace1.$table"
 
     withCleanTmpResources(Seq((s"$catalogV2.$namespace1.$table", "table"))) {
-      runSqlAsInSuccess(
-        defaultTableOwner,
+      runSqlAsInSuccess(defaultTableOwner)(
         s"CREATE TABLE $catalogV2.$namespace1.$table (key int, value int) USING iceberg")
 
-      runSqlAsInSuccess(defaultTableOwner, select, true)
+      runSqlAsInSuccess(defaultTableOwner)(select, isCollect = true)
 
       runSqlAsWithAccessException("create_only_user")(
         select,

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/IcebergCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/IcebergCatalogRangerSparkExtensionSuite.scala
@@ -78,19 +78,15 @@ class IcebergCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite 
       """.stripMargin
 
     // MergeIntoTable:  Using a MERGE INTO Statement
-    runSqlAsWithAccessException()(
-      mergeIntoSql,
-      contains = s"does not have [select] privilege on [$namespace1/$table1/id]")
+    runSqlAsWithAccessException()(mergeIntoSql, s"does not have [select] privilege on [$namespace1/$table1/id]")
 
     try {
       SparkRangerAdminPlugin.getRangerConf.setBoolean(
         s"ranger.plugin.${SparkRangerAdminPlugin.getServiceType}.authorize.in.single.call",
         true)
-      runSqlAsWithAccessException()(
-        mergeIntoSql,
-        contains = s"does not have [select] privilege" +
-          s" on [$namespace1/$table1/id,$namespace1/table1/name,$namespace1/$table1/city]," +
-          s" [update] privilege on [$namespace1/$outputTable1]")
+      runSqlAsWithAccessException()(mergeIntoSql, s"does not have [select] privilege" +
+        s" on [$namespace1/$table1/id,$namespace1/table1/name,$namespace1/$table1/city]," +
+        s" [update] privilege on [$namespace1/$outputTable1]")
     } finally {
       SparkRangerAdminPlugin.getRangerConf.setBoolean(
         s"ranger.plugin.${SparkRangerAdminPlugin.getServiceType}.authorize.in.single.call",
@@ -105,9 +101,7 @@ class IcebergCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite 
 
     // UpdateTable
     val update = s"UPDATE $catalogV2.$namespace1.$table1 SET city='Guangzhou' WHERE id=1"
-    runSqlAsWithAccessException()(
-      update,
-      contains = s"does not have [update] privilege on [$namespace1/$table1]")
+    runSqlAsWithAccessException()(update, s"does not have [update] privilege on [$namespace1/$table1]")
 
     runSqlAs("admin")(update)
   }
@@ -116,9 +110,7 @@ class IcebergCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite 
     assume(isSparkV32OrGreater)
 
     // DeleteFromTable
-    runSqlAsWithAccessException()(
-      s"DELETE FROM $catalogV2.$namespace1.$table1 WHERE id=2",
-      contains = s"does not have [update] privilege on [$namespace1/$table1]")
+    runSqlAsWithAccessException()(s"DELETE FROM $catalogV2.$namespace1.$table1 WHERE id=2", s"does not have [update] privilege on [$namespace1/$table1]")
 
     runSqlAs("admin")(s"DELETE FROM $catalogV2.$namespace1.$table1 WHERE id=2")
   }
@@ -135,10 +127,7 @@ class IcebergCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite 
 
       runSqlAs(defaultTableOwner)(select, isCollect = true)
 
-      runSqlAsWithAccessException("create_only_user")(
-        select,
-        isCollect = true,
-        contains = errorMessage("select", s"$namespace1/$table/key"))
+      runSqlAsWithAccessException("create_only_user")(select, errorMessage("select", s"$namespace1/$table/key"), isCollect = true)
     }
   }
 
@@ -188,10 +177,7 @@ class IcebergCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite 
 
   test("[KYUUBI #4255] DESCRIBE TABLE") {
     assume(isSparkV32OrGreater)
-    runSqlAsWithAccessException()(
-      s"DESCRIBE TABLE $catalogV2.$namespace1.$table1",
-      isExplain = true,
-      contains = s"does not have [select] privilege on [$namespace1/$table1]")
+    runSqlAsWithAccessException()(s"DESCRIBE TABLE $catalogV2.$namespace1.$table1", s"does not have [select] privilege on [$namespace1/$table1]", isExplain = true)
   }
 
 }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
@@ -185,7 +185,10 @@ abstract class RangerSparkExtensionSuite extends AnyFunSuite
         s"SELECT coalesce(max(value), 1) FROM $db.$table",
         s"SELECT key FROM $db.$table WHERE value in (SELECT value as key FROM $db.$table)")
         .foreach { q =>
-          runSqlAsWithAccessException("kent")(q, errorMessage("select", "default/src/value"), isCollect = true)
+          runSqlAsWithAccessException("kent")(
+            q,
+            errorMessage("select", "default/src/value"),
+            isCollect = true)
         }
     }
   }
@@ -283,9 +286,9 @@ abstract class RangerSparkExtensionSuite extends AnyFunSuite
       runSqlAs("admin")(s"CREATE TABLE IF NOT EXISTS $db.$table (key int) USING $format")
       runSqlAs("admin")(s"CREATE TABLE IF NOT EXISTS $db.${table}for_show (key int) USING $format")
 
-      runSqlAs("admin")(s"show tables from $db", collectSize = 2)
-      runSqlAs("bob")(s"show tables from $db", collectSize = 0)
-      runSqlAs("i_am_invisible")(s"show tables from $db", collectSize = 0)
+      runSqlAs("admin")(s"show tables from $db", 2)
+      runSqlAs("bob")(s"show tables from $db", 0)
+      runSqlAs("i_am_invisible")(s"show tables from $db", 0)
     }
   }
 
@@ -294,11 +297,11 @@ abstract class RangerSparkExtensionSuite extends AnyFunSuite
 
     withCleanTmpResources(Seq((db, "database"))) {
       runSqlAs("admin")(s"CREATE DATABASE IF NOT EXISTS $db")
-      runSqlAs("admin")(s"SHOW DATABASES", collectSize = 2)
+      runSqlAs("admin")(s"SHOW DATABASES", 2)
       doAs("admin")(assert(sql(s"SHOW DATABASES").collectAsList().get(0).getString(0) == "default"))
       doAs("admin")(assert(sql(s"SHOW DATABASES").collectAsList().get(1).getString(0) == s"$db"))
 
-      runSqlAs("bob")("SHOW DATABASES", collectSize = 1)
+      runSqlAs("bob")("SHOW DATABASES", 1)
       doAs("bob")(assert(sql(s"SHOW DATABASES").collectAsList().get(0).getString(0) == "default"))
     }
   }
@@ -313,14 +316,14 @@ abstract class RangerSparkExtensionSuite extends AnyFunSuite
       (s"$db3.$function1", "function"),
       (db3, "database"))) {
       runSqlAs("admin")(s"CREATE FUNCTION $function1 AS 'Function1'")
-      runSqlAs("admin")(s"show user functions $default.$function1", collectSize = 1)
-      runSqlAs("bob")(s"show user functions $default.$function1", collectSize = 0)
+      runSqlAs("admin")(s"show user functions $default.$function1", 1)
+      runSqlAs("bob")(s"show user functions $default.$function1", 0)
 
       runSqlAs("admin")(s"CREATE DATABASE IF NOT EXISTS $db3")
       runSqlAs("admin")(s"CREATE FUNCTION $db3.$function1 AS 'Function1'")
 
-      runSqlAs("admin")(s"show user functions $db3.$function1", collectSize = 1)
-      runSqlAs("bob")(s"show user functions $db3.$function1", collectSize = 0)
+      runSqlAs("admin")(s"show user functions $db3.$function1", 1)
+      runSqlAs("bob")(s"show user functions $db3.$function1", 0)
 
       val showSysFunctions = s"show system functions"
       doAs("admin")(assert(sql(showSysFunctions).collect().length > 0))
@@ -341,13 +344,13 @@ abstract class RangerSparkExtensionSuite extends AnyFunSuite
     withCleanTmpResources(Seq((s"$db.$table", "table"))) {
       runSqlAs("admin")(create)
 
-      runSqlAs("admin")(s"SHOW COLUMNS IN $table", countSize = 2)
-      runSqlAs("admin")(s"SHOW COLUMNS IN $db.$table", countSize = 2)
-      runSqlAs("admin")(s"SHOW COLUMNS IN $table IN $db", countSize = 2)
+      runSqlAs("admin")(s"SHOW COLUMNS IN $table", 2)
+      runSqlAs("admin")(s"SHOW COLUMNS IN $db.$table", 2)
+      runSqlAs("admin")(s"SHOW COLUMNS IN $table IN $db", 2)
 
-      runSqlAs("kent")(s"SHOW COLUMNS IN $table", countSize = 1)
-      runSqlAs("kent")(s"SHOW COLUMNS IN $db.$table", countSize = 1)
-      runSqlAs("kent")(s"SHOW COLUMNS IN $table IN $db", countSize = 1)
+      runSqlAs("kent")(s"SHOW COLUMNS IN $table", 1)
+      runSqlAs("kent")(s"SHOW COLUMNS IN $db.$table", 1)
+      runSqlAs("kent")(s"SHOW COLUMNS IN $table IN $db", 1)
     }
   }
 
@@ -369,10 +372,10 @@ abstract class RangerSparkExtensionSuite extends AnyFunSuite
       runSqlAs("admin")(s"CREATE TABLE IF NOT EXISTS $db.${table}_select2 (key int) USING $format")
       runSqlAs("admin")(s"CREATE TABLE IF NOT EXISTS $db.${table}_select3 (key int) USING $format")
 
-      runSqlAs("admin")(s"show table extended from $db like '$table*'", collectSize = 5)
-      runSqlAs("bob")(s"show tables from $db", collectSize = 5)
-      runSqlAs("bob")(s"show table extended from $db like '$table*'", collectSize = 3)
-      runSqlAs("i_am_invisible")(s"show table extended from $db like '$table*'", collectSize = 0)
+      runSqlAs("admin")(s"show table extended from $db like '$table*'", 5)
+      runSqlAs("bob")(s"show tables from $db", 5)
+      runSqlAs("bob")(s"show table extended from $db like '$table*'", 3)
+      runSqlAs("i_am_invisible")(s"show table extended from $db like '$table*'", 0)
     }
   }
 
@@ -393,7 +396,7 @@ abstract class RangerSparkExtensionSuite extends AnyFunSuite
 
     runSqlAs("admin")(s"DROP VIEW IF EXISTS $tempView2")
     runSqlAs("admin")(s"DROP VIEW IF EXISTS global_temp.$globalTempView2")
-    runSqlAs("admin")("show tables from global_temp", collectSize = 0)
+    runSqlAs("admin")("show tables from global_temp", 0)
   }
 
   test("[KYUUBI #3426] Drop temp view should be skipped permission check") {
@@ -407,12 +410,12 @@ abstract class RangerSparkExtensionSuite extends AnyFunSuite
       s" AS select * from values(1)")
 
     // global_temp will contain the temporary view, even if it is not global
-    runSqlAs("admin")("show tables from global_temp", collectSize = 2)
+    runSqlAs("admin")("show tables from global_temp", 2)
 
     runSqlAs("denyuser2")(s"DROP VIEW IF EXISTS $tempView")
     runSqlAs("denyuser2")(s"DROP VIEW IF EXISTS global_temp.$globalTempView")
 
-    runSqlAs("admin")("show tables from global_temp", collectSize = 0)
+    runSqlAs("admin")("show tables from global_temp", 0)
   }
 
   test("[KYUUBI #3428] AlterViewAsCommand should be skipped permission check") {
@@ -433,7 +436,7 @@ abstract class RangerSparkExtensionSuite extends AnyFunSuite
 
     runSqlAs("admin")(s"DROP VIEW IF EXISTS $tempView")
     runSqlAs("admin")(s"DROP VIEW IF EXISTS global_temp.$globalTempView")
-    runSqlAs("admin")("show tables from global_temp", collectSize = 0)
+    runSqlAs("admin")("show tables from global_temp", 0)
   }
 
   test("[KYUUBI #3343] pass temporary view creation") {
@@ -442,8 +445,7 @@ abstract class RangerSparkExtensionSuite extends AnyFunSuite
 
     withTempView(tempView) {
       runSqlAs("denyuser")(s"CREATE TEMPORARY VIEW $tempView AS select * from values(1)")
-      runSqlAs("denyuser")(
-        s"CREATE OR REPLACE TEMPORARY VIEW $tempView AS select * from values(1)")
+      runSqlAs("denyuser")(s"CREATE OR REPLACE TEMPORARY VIEW $tempView AS select * from values(1)")
     }
 
     withGlobalTempView(globalTempView) {
@@ -453,7 +455,7 @@ abstract class RangerSparkExtensionSuite extends AnyFunSuite
         s"CREATE OR REPLACE GLOBAL TEMPORARY VIEW $globalTempView AS select * from values(1)")
     }
 
-    runSqlAs("admin")("show tables from global_temp", collectSize = 0)
+    runSqlAs("admin")("show tables from global_temp", 0)
   }
 }
 
@@ -521,7 +523,9 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
 
       runSqlAs("admin")(s"CREATE VIEW ${adminPermView} AS SELECT * FROM $table")
 
-      runSqlAsWithAccessException()(s"CREATE VIEW $permView AS SELECT 1 as a", s"does not have [create] privilege on [default/$permView]")
+      runSqlAsWithAccessException()(
+        s"CREATE VIEW $permView AS SELECT 1 as a",
+        s"does not have [create] privilege on [default/$permView]")
 
       val errorMsg = if (isSparkV32OrGreater) {
         s"does not have [select] privilege on [default/$table/id]"
@@ -580,18 +584,22 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
         s" FROM $db1.$srcTable1 as tb1" +
         s" JOIN $db1.$srcTable2 as tb2" +
         s" on tb1.id = tb2.id"
-      runSqlAsWithAccessException()(insertSql1, s"does not have [select] privilege on [$db1/$srcTable1/id]")
+      runSqlAsWithAccessException()(
+        insertSql1,
+        s"does not have [select] privilege on [$db1/$srcTable1/id]")
 
       try {
         SparkRangerAdminPlugin.getRangerConf.setBoolean(
           s"ranger.plugin.${SparkRangerAdminPlugin.getServiceType}.authorize.in.single.call",
           true)
-        runSqlAsWithAccessException()(insertSql1, s"does not have" +
-          s" [select] privilege on" +
-          s" [$db1/$srcTable1/id,$db1/$srcTable1/name,$db1/$srcTable1/city," +
-          s"$db1/$srcTable2/age,$db1/$srcTable2/id]," +
-          s" [update] privilege on [$db1/$sinkTable1/id,$db1/$sinkTable1/age," +
-          s"$db1/$sinkTable1/name,$db1/$sinkTable1/city]")
+        runSqlAsWithAccessException()(
+          insertSql1,
+          s"does not have" +
+            s" [select] privilege on" +
+            s" [$db1/$srcTable1/id,$db1/$srcTable1/name,$db1/$srcTable1/city," +
+            s"$db1/$srcTable2/age,$db1/$srcTable2/id]," +
+            s" [update] privilege on [$db1/$sinkTable1/id,$db1/$sinkTable1/age," +
+            s"$db1/$sinkTable1/name,$db1/$sinkTable1/city]")
       } finally {
         // revert to default value
         SparkRangerAdminPlugin.getRangerConf.setBoolean(
@@ -621,7 +629,9 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
         runSqlAs("admin")(s"CREATE TABLE IF NOT EXISTS $db1.$srcTable1" +
           s" (id int, name string, city string)")
 
-        runSqlAsWithAccessException()(s"CACHE TABLE $cacheTable2 select * from $db1.$srcTable1", s"does not have [select] privilege on [$db1/$srcTable1/id]")
+        runSqlAsWithAccessException()(
+          s"CACHE TABLE $cacheTable2 select * from $db1.$srcTable1",
+          s"does not have [select] privilege on [$db1/$srcTable1/id]")
 
         runSqlAs("admin")(s"CACHE TABLE $cacheTable3 SELECT 1 AS a, 2 AS b ")
         runSqlAs("someone")(s"CACHE TABLE $cacheTable4 select 1 as a, 2 as b ")
@@ -640,7 +650,10 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
 
       runSqlAs(defaultTableOwner)(select, isCollect = true)
 
-      runSqlAsWithAccessException("create_only_user")(select, errorMessage("select", s"$db/$table/key"), isCollect = true)
+      runSqlAsWithAccessException("create_only_user")(
+        select,
+        errorMessage("select", s"$db/$table/key"),
+        isCollect = true)
     }
   }
 

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
@@ -152,8 +152,8 @@ abstract class RangerSparkExtensionSuite extends AnyFunSuite
 
     runSqlAsWithAccessException()(create, contains = errorMessage("create", "mydb"))
     withCleanTmpResources(Seq((testDb, "database"))) {
-      runSqlAsInSuccess("admin", create)
-      runSqlAsInSuccess("admin", alter)
+      runSqlAsInSuccess("admin")(create)
+      runSqlAsInSuccess("admin")(alter)
       runSqlAsWithAccessException()(alter, contains = errorMessage("alter", "mydb"))
       runSqlAsWithAccessException()(drop, contains = errorMessage("drop", "mydb"))
       doAs("kent", Try(sql("SHOW DATABASES")).isSuccess)
@@ -172,13 +172,13 @@ abstract class RangerSparkExtensionSuite extends AnyFunSuite
     runSqlAsWithAccessException()(create0, contains = errorMessage("create"))
 
     withCleanTmpResources(Seq((s"$db.$table", "table"))) {
-      runSqlAsInSuccess("bob", create0)
-      runSqlAsInSuccess("bob", alter0)
+      runSqlAsInSuccess("bob")(create0)
+      runSqlAsInSuccess("bob")(alter0)
 
       runSqlAsWithAccessException()(drop0, contains = errorMessage("drop"))
-      runSqlAsInSuccess("bob", alter0)
-      runSqlAsInSuccess("bob", select, true)
-      runSqlAsInSuccess("kent", s"SELECT key FROM $db.$table", true)
+      runSqlAsInSuccess("bob")(alter0)
+      runSqlAsInSuccess("bob")(select, isCollect = true)
+      runSqlAsInSuccess("kent")(s"SELECT key FROM $db.$table", isCollect = true)
 
       Seq(
         select,
@@ -211,7 +211,7 @@ abstract class RangerSparkExtensionSuite extends AnyFunSuite
     val create = s"CREATE TABLE IF NOT EXISTS $db.$table ($col int, value int) USING $format"
 
     withCleanTmpResources(Seq((s"$db.${table}2", "table"), (s"$db.$table", "table"))) {
-      runSqlAsInSuccess("admin", create)
+      runSqlAsInSuccess("admin")(create)
       doAs("admin", sql(s"INSERT INTO $db.$table SELECT 1, 1"))
       doAs("admin", sql(s"INSERT INTO $db.$table SELECT 20, 2"))
       doAs("admin", sql(s"INSERT INTO $db.$table SELECT 30, 3"))
@@ -257,8 +257,8 @@ abstract class RangerSparkExtensionSuite extends AnyFunSuite
     withCleanTmpResources(Seq(
       (s"$db.$table", "table"),
       (s"$db.$permView", "view"))) {
-      runSqlAsInSuccess("admin", create)
-      runSqlAsInSuccess("admin", createView)
+      runSqlAsInSuccess("admin")(create)
+      runSqlAsInSuccess("admin")(createView)
       doAs("admin", sql(s"INSERT INTO $db.$table SELECT 1, 1"))
       doAs("admin", sql(s"INSERT INTO $db.$table SELECT 20, 2"))
       doAs("admin", sql(s"INSERT INTO $db.$table SELECT 30, 3"))
@@ -700,11 +700,10 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
     val select = s"SELECT key FROM $db.$table"
 
     withCleanTmpResources(Seq((s"$db.$table", "table"))) {
-      runSqlAsInSuccess(
-        defaultTableOwner,
+      runSqlAsInSuccess(defaultTableOwner)(
         s"CREATE TABLE $db.$table (key int, value int) USING $format")
 
-      runSqlAsInSuccess(defaultTableOwner, select, true)
+      runSqlAsInSuccess(defaultTableOwner)(select, isCollect = true)
 
       runSqlAsWithAccessException("create_only_user")(
         select,

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
@@ -197,10 +197,7 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
       """.stripMargin
 
     // MergeIntoTable:  Using a MERGE INTO Statement
-    val e1 = intercept[AccessControlException](
-      doAs(
-        "someone",
-        sql(mergeIntoSql)))
+    val e1 = intercept[AccessControlException](doAs("someone", sql(mergeIntoSql)))
     assert(e1.getMessage.contains(s"does not have [select] privilege" +
       s" on [$namespace1/$table1/id]"))
 
@@ -208,10 +205,7 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
       SparkRangerAdminPlugin.getRangerConf.setBoolean(
         s"ranger.plugin.${SparkRangerAdminPlugin.getServiceType}.authorize.in.single.call",
         true)
-      val e2 = intercept[AccessControlException](
-        doAs(
-          "someone",
-          sql(mergeIntoSql)))
+      val e2 = intercept[AccessControlException](doAs("someone", sql(mergeIntoSql)))
       assert(e2.getMessage.contains(s"does not have" +
         s" [select] privilege" +
         s" on [$namespace1/$table1/id,$namespace1/table1/name,$namespace1/$table1/city]," +

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
@@ -76,64 +76,90 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
     assume(isSparkV31OrGreater)
 
     // create database
-    runSqlAsWithAccessException()(s"CREATE DATABASE IF NOT EXISTS $catalogV2.$namespace2", s"does not have [create] privilege on [$namespace2]", isExplain = true)
+    runSqlAsWithAccessException()(
+      s"CREATE DATABASE IF NOT EXISTS $catalogV2.$namespace2",
+      s"does not have [create] privilege on [$namespace2]",
+      isExplain = true)
   }
 
   test("[KYUUBI #3424] DROP DATABASE") {
     assume(isSparkV31OrGreater)
 
     // create database
-    runSqlAsWithAccessException()(s"DROP DATABASE IF EXISTS $catalogV2.$namespace2", s"does not have [drop] privilege on [$namespace2]", isExplain = true)
+    runSqlAsWithAccessException()(
+      s"DROP DATABASE IF EXISTS $catalogV2.$namespace2",
+      s"does not have [drop] privilege on [$namespace2]",
+      isExplain = true)
   }
 
   test("[KYUUBI #3424] SELECT TABLE") {
     assume(isSparkV31OrGreater)
 
     // select
-    runSqlAsWithAccessException()(s"select city, id from $catalogV2.$namespace1.$table1", s"does not have [select] privilege on [$namespace1/$table1/city]", isExplain = true)
+    runSqlAsWithAccessException()(
+      s"select city, id from $catalogV2.$namespace1.$table1",
+      s"does not have [select] privilege on [$namespace1/$table1/city]",
+      isExplain = true)
   }
 
   test("[KYUUBI #4255] DESCRIBE TABLE") {
     assume(isSparkV31OrGreater)
-    runSqlAsWithAccessException()(s"DESCRIBE TABLE $catalogV2.$namespace1.$table1", s"does not have [select] privilege on [$namespace1/$table1]", isExplain = true)
+    runSqlAsWithAccessException()(
+      s"DESCRIBE TABLE $catalogV2.$namespace1.$table1",
+      s"does not have [select] privilege on [$namespace1/$table1]",
+      isExplain = true)
   }
 
   test("[KYUUBI #3424] CREATE TABLE") {
     assume(isSparkV31OrGreater)
 
     // CreateTable
-    runSqlAsWithAccessException()(s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table2", s"does not have [create] privilege on [$namespace1/$table2]")
+    runSqlAsWithAccessException()(
+      s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table2",
+      s"does not have [create] privilege on [$namespace1/$table2]")
 
     // CreateTableAsSelect
-    runSqlAsWithAccessException()(s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table2" +
-      s" AS select * from $catalogV2.$namespace1.$table1", s"does not have [select] privilege on [$namespace1/$table1/id]")
+    runSqlAsWithAccessException()(
+      s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table2" +
+        s" AS select * from $catalogV2.$namespace1.$table1",
+      s"does not have [select] privilege on [$namespace1/$table1/id]")
   }
 
   test("[KYUUBI #3424] DROP TABLE") {
     assume(isSparkV31OrGreater)
 
     // DropTable
-    runSqlAsWithAccessException()(s"DROP TABLE $catalogV2.$namespace1.$table1", s"does not have [drop] privilege on [$namespace1/$table1]")
+    runSqlAsWithAccessException()(
+      s"DROP TABLE $catalogV2.$namespace1.$table1",
+      s"does not have [drop] privilege on [$namespace1/$table1]")
   }
 
   test("[KYUUBI #3424] INSERT TABLE") {
     assume(isSparkV31OrGreater)
 
     // AppendData: Insert Using a VALUES Clause
-    runSqlAsWithAccessException()(s"INSERT INTO $catalogV2.$namespace1.$outputTable1 (id, name, city)" +
-      s" VALUES (1, 'bowenliang123', 'Guangzhou')", s"does not have [update] privilege on [$namespace1/$outputTable1]")
+    runSqlAsWithAccessException()(
+      s"INSERT INTO $catalogV2.$namespace1.$outputTable1 (id, name, city)" +
+        s" VALUES (1, 'bowenliang123', 'Guangzhou')",
+      s"does not have [update] privilege on [$namespace1/$outputTable1]")
 
     // AppendData: Insert Using a TABLE Statement
-    runSqlAsWithAccessException()(s"INSERT INTO $catalogV2.$namespace1.$outputTable1 (id, name, city)" +
-      s" TABLE $catalogV2.$namespace1.$table1", s"does not have [select] privilege on [$namespace1/$table1/id]")
+    runSqlAsWithAccessException()(
+      s"INSERT INTO $catalogV2.$namespace1.$outputTable1 (id, name, city)" +
+        s" TABLE $catalogV2.$namespace1.$table1",
+      s"does not have [select] privilege on [$namespace1/$table1/id]")
 
     // AppendData: Insert Using a SELECT Statement
-    runSqlAsWithAccessException()(s"INSERT INTO $catalogV2.$namespace1.$outputTable1 (id, name, city)" +
-      s" SELECT * from $catalogV2.$namespace1.$table1", s"does not have [select] privilege on [$namespace1/$table1/id]")
+    runSqlAsWithAccessException()(
+      s"INSERT INTO $catalogV2.$namespace1.$outputTable1 (id, name, city)" +
+        s" SELECT * from $catalogV2.$namespace1.$table1",
+      s"does not have [select] privilege on [$namespace1/$table1/id]")
 
     // OverwriteByExpression: Insert Overwrite
-    runSqlAsWithAccessException()(s"INSERT OVERWRITE $catalogV2.$namespace1.$outputTable1 (id, name, city)" +
-      s" VALUES (1, 'bowenliang123', 'Guangzhou')", s"does not have [update] privilege on [$namespace1/$outputTable1]")
+    runSqlAsWithAccessException()(
+      s"INSERT OVERWRITE $catalogV2.$namespace1.$outputTable1 (id, name, city)" +
+        s" VALUES (1, 'bowenliang123', 'Guangzhou')",
+      s"does not have [update] privilege on [$namespace1/$outputTable1]")
   }
 
   test("[KYUUBI #3424] MERGE INTO") {
@@ -149,16 +175,20 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
       """.stripMargin
 
     // MergeIntoTable:  Using a MERGE INTO Statement
-    runSqlAsWithAccessException()(mergeIntoSql, s"does not have [select] privilege on [$namespace1/$table1/id]")
+    runSqlAsWithAccessException()(
+      mergeIntoSql,
+      s"does not have [select] privilege on [$namespace1/$table1/id]")
 
     try {
       SparkRangerAdminPlugin.getRangerConf.setBoolean(
         s"ranger.plugin.${SparkRangerAdminPlugin.getServiceType}.authorize.in.single.call",
         true)
-      runSqlAsWithAccessException()(mergeIntoSql, s"does not have" +
-        s" [select] privilege" +
-        s" on [$namespace1/$table1/id,$namespace1/table1/name,$namespace1/$table1/city]," +
-        s" [update] privilege on [$namespace1/$outputTable1]")
+      runSqlAsWithAccessException()(
+        mergeIntoSql,
+        s"does not have" +
+          s" [select] privilege" +
+          s" on [$namespace1/$table1/id,$namespace1/table1/name,$namespace1/$table1/city]," +
+          s" [update] privilege on [$namespace1/$outputTable1]")
     } finally {
       SparkRangerAdminPlugin.getRangerConf.setBoolean(
         s"ranger.plugin.${SparkRangerAdminPlugin.getServiceType}.authorize.in.single.call",
@@ -170,14 +200,18 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
     assume(isSparkV31OrGreater)
 
     // UpdateTable
-    runSqlAsWithAccessException()(s"UPDATE $catalogV2.$namespace1.$table1 SET city='Hangzhou' WHERE id=1", s"does not have [update] privilege on [$namespace1/$table1]")
+    runSqlAsWithAccessException()(
+      s"UPDATE $catalogV2.$namespace1.$table1 SET city='Hangzhou' WHERE id=1",
+      s"does not have [update] privilege on [$namespace1/$table1]")
   }
 
   test("[KYUUBI #3424] DELETE FROM TABLE") {
     assume(isSparkV31OrGreater)
 
     // DeleteFromTable
-    runSqlAsWithAccessException()(s"DELETE FROM $catalogV2.$namespace1.$table1 WHERE id=1", s"does not have [update] privilege on [$namespace1/$table1]")
+    runSqlAsWithAccessException()(
+      s"DELETE FROM $catalogV2.$namespace1.$table1 WHERE id=1",
+      s"does not have [update] privilege on [$namespace1/$table1]")
   }
 
   test("[KYUUBI #3424] CACHE TABLE") {
@@ -189,48 +223,74 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
     } else {
       s"does not have [select] privilege on [$catalogV2.$namespace1/$table1]"
     }
-    runSqlAsWithAccessException()(s"CACHE TABLE $cacheTable1 AS select * from $catalogV2.$namespace1.$table1", errorMsg)
+    runSqlAsWithAccessException()(
+      s"CACHE TABLE $cacheTable1 AS select * from $catalogV2.$namespace1.$table1",
+      errorMsg)
   }
 
   test("[KYUUBI #3424] TRUNCATE TABLE") {
     assume(isSparkV32OrGreater)
 
-    runSqlAsWithAccessException()(s"TRUNCATE TABLE $catalogV2.$namespace1.$table1", s"does not have [update] privilege on [$namespace1/$table1]")
+    runSqlAsWithAccessException()(
+      s"TRUNCATE TABLE $catalogV2.$namespace1.$table1",
+      s"does not have [update] privilege on [$namespace1/$table1]")
   }
 
   test("[KYUUBI #3424] MSCK REPAIR TABLE") {
     assume(isSparkV32OrGreater)
 
-    runSqlAsWithAccessException()(s"MSCK REPAIR TABLE $catalogV2.$namespace1.$table1", s"does not have [alter] privilege on [$namespace1/$table1]")
+    runSqlAsWithAccessException()(
+      s"MSCK REPAIR TABLE $catalogV2.$namespace1.$table1",
+      s"does not have [alter] privilege on [$namespace1/$table1]")
   }
 
   test("[KYUUBI #3424] ALTER TABLE") {
     assume(isSparkV31OrGreater)
 
     // AddColumns
-    runSqlAsWithAccessException()(s"ALTER TABLE $catalogV2.$namespace1.$table1 ADD COLUMNS (age int)", s"does not have [alter] privilege on [$namespace1/$table1]", isExplain = true)
+    runSqlAsWithAccessException()(
+      s"ALTER TABLE $catalogV2.$namespace1.$table1 ADD COLUMNS (age int)",
+      s"does not have [alter] privilege on [$namespace1/$table1]",
+      isExplain = true)
 
     // DropColumns
-    runSqlAsWithAccessException()(s"ALTER TABLE $catalogV2.$namespace1.$table1 DROP COLUMNS city", s"does not have [alter] privilege on [$namespace1/$table1]", isExplain = true)
+    runSqlAsWithAccessException()(
+      s"ALTER TABLE $catalogV2.$namespace1.$table1 DROP COLUMNS city",
+      s"does not have [alter] privilege on [$namespace1/$table1]",
+      isExplain = true)
 
     // RenameColumn
-    runSqlAsWithAccessException()(s"ALTER TABLE $catalogV2.$namespace1.$table1 RENAME COLUMN city TO city2 ", s"does not have [alter] privilege on [$namespace1/$table1]", isExplain = true)
+    runSqlAsWithAccessException()(
+      s"ALTER TABLE $catalogV2.$namespace1.$table1 RENAME COLUMN city TO city2 ",
+      s"does not have [alter] privilege on [$namespace1/$table1]",
+      isExplain = true)
 
     // AlterColumn
-    runSqlAsWithAccessException()(s"ALTER TABLE $catalogV2.$namespace1.$table1 ALTER COLUMN city COMMENT 'city'", s"does not have [alter] privilege on [$namespace1/$table1]")
+    runSqlAsWithAccessException()(
+      s"ALTER TABLE $catalogV2.$namespace1.$table1 ALTER COLUMN city COMMENT 'city'",
+      s"does not have [alter] privilege on [$namespace1/$table1]")
   }
 
   test("[KYUUBI #3424] COMMENT ON") {
     assume(isSparkV31OrGreater)
 
     // CommentOnNamespace
-    runSqlAsWithAccessException()(s"COMMENT ON DATABASE $catalogV2.$namespace1 IS 'xYz'", s"does not have [alter] privilege on [$namespace1]", isExplain = true)
+    runSqlAsWithAccessException()(
+      s"COMMENT ON DATABASE $catalogV2.$namespace1 IS 'xYz'",
+      s"does not have [alter] privilege on [$namespace1]",
+      isExplain = true)
 
     // CommentOnNamespace
-    runSqlAsWithAccessException()(s"COMMENT ON NAMESPACE $catalogV2.$namespace1 IS 'xYz' ", s"does not have [alter] privilege on [$namespace1]", isExplain = true)
+    runSqlAsWithAccessException()(
+      s"COMMENT ON NAMESPACE $catalogV2.$namespace1 IS 'xYz' ",
+      s"does not have [alter] privilege on [$namespace1]",
+      isExplain = true)
 
     // CommentOnTable
-    runSqlAsWithAccessException()(s"COMMENT ON TABLE $catalogV2.$namespace1.$table1 IS 'xYz' ", s"does not have [alter] privilege on [$namespace1/$table1]", isExplain = true)
+    runSqlAsWithAccessException()(
+      s"COMMENT ON TABLE $catalogV2.$namespace1.$table1 IS 'xYz' ",
+      s"does not have [alter] privilege on [$namespace1/$table1]",
+      isExplain = true)
 
   }
 }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
@@ -53,15 +53,11 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
 
       super.beforeAll()
 
-      doAs("admin", sql(s"CREATE DATABASE IF NOT EXISTS $catalogV2.$namespace1"))
-      doAs(
-        "admin",
-        sql(s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table1" +
-          " (id int, name string, city string)"))
-      doAs(
-        "admin",
-        sql(s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$outputTable1" +
-          " (id int, name string, city string)"))
+      runSqlAs("admin")(s"CREATE DATABASE IF NOT EXISTS $catalogV2.$namespace1")
+      runSqlAs("admin")(s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table1" +
+        " (id int, name string, city string)")
+      runSqlAs("admin")(s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$outputTable1" +
+        " (id int, name string, city string)")
     }
   }
 

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
@@ -76,90 +76,64 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
     assume(isSparkV31OrGreater)
 
     // create database
-    runSqlAsWithAccessException()(
-      s"CREATE DATABASE IF NOT EXISTS $catalogV2.$namespace2",
-      isExplain = true,
-      contains = s"does not have [create] privilege on [$namespace2]")
+    runSqlAsWithAccessException()(s"CREATE DATABASE IF NOT EXISTS $catalogV2.$namespace2", s"does not have [create] privilege on [$namespace2]", isExplain = true)
   }
 
   test("[KYUUBI #3424] DROP DATABASE") {
     assume(isSparkV31OrGreater)
 
     // create database
-    runSqlAsWithAccessException()(
-      s"DROP DATABASE IF EXISTS $catalogV2.$namespace2",
-      isExplain = true,
-      contains = s"does not have [drop] privilege on [$namespace2]")
+    runSqlAsWithAccessException()(s"DROP DATABASE IF EXISTS $catalogV2.$namespace2", s"does not have [drop] privilege on [$namespace2]", isExplain = true)
   }
 
   test("[KYUUBI #3424] SELECT TABLE") {
     assume(isSparkV31OrGreater)
 
     // select
-    runSqlAsWithAccessException()(
-      s"select city, id from $catalogV2.$namespace1.$table1",
-      isExplain = true,
-      contains = s"does not have [select] privilege on [$namespace1/$table1/city]")
+    runSqlAsWithAccessException()(s"select city, id from $catalogV2.$namespace1.$table1", s"does not have [select] privilege on [$namespace1/$table1/city]", isExplain = true)
   }
 
   test("[KYUUBI #4255] DESCRIBE TABLE") {
     assume(isSparkV31OrGreater)
-    runSqlAsWithAccessException()(
-      s"DESCRIBE TABLE $catalogV2.$namespace1.$table1",
-      isExplain = true,
-      contains = s"does not have [select] privilege on [$namespace1/$table1]")
+    runSqlAsWithAccessException()(s"DESCRIBE TABLE $catalogV2.$namespace1.$table1", s"does not have [select] privilege on [$namespace1/$table1]", isExplain = true)
   }
 
   test("[KYUUBI #3424] CREATE TABLE") {
     assume(isSparkV31OrGreater)
 
     // CreateTable
-    runSqlAsWithAccessException()(
-      s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table2",
-      contains = s"does not have [create] privilege on [$namespace1/$table2]")
+    runSqlAsWithAccessException()(s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table2", s"does not have [create] privilege on [$namespace1/$table2]")
 
     // CreateTableAsSelect
-    runSqlAsWithAccessException()(
-      s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table2" +
-        s" AS select * from $catalogV2.$namespace1.$table1",
-      contains = s"does not have [select] privilege on [$namespace1/$table1/id]")
+    runSqlAsWithAccessException()(s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table2" +
+      s" AS select * from $catalogV2.$namespace1.$table1", s"does not have [select] privilege on [$namespace1/$table1/id]")
   }
 
   test("[KYUUBI #3424] DROP TABLE") {
     assume(isSparkV31OrGreater)
 
     // DropTable
-    runSqlAsWithAccessException()(
-      s"DROP TABLE $catalogV2.$namespace1.$table1",
-      contains = s"does not have [drop] privilege on [$namespace1/$table1]")
+    runSqlAsWithAccessException()(s"DROP TABLE $catalogV2.$namespace1.$table1", s"does not have [drop] privilege on [$namespace1/$table1]")
   }
 
   test("[KYUUBI #3424] INSERT TABLE") {
     assume(isSparkV31OrGreater)
 
     // AppendData: Insert Using a VALUES Clause
-    runSqlAsWithAccessException()(
-      s"INSERT INTO $catalogV2.$namespace1.$outputTable1 (id, name, city)" +
-        s" VALUES (1, 'bowenliang123', 'Guangzhou')",
-      contains = s"does not have [update] privilege on [$namespace1/$outputTable1]")
+    runSqlAsWithAccessException()(s"INSERT INTO $catalogV2.$namespace1.$outputTable1 (id, name, city)" +
+      s" VALUES (1, 'bowenliang123', 'Guangzhou')", s"does not have [update] privilege on [$namespace1/$outputTable1]")
 
     // AppendData: Insert Using a TABLE Statement
-    runSqlAsWithAccessException()(
-      s"INSERT INTO $catalogV2.$namespace1.$outputTable1 (id, name, city)" +
-        s" TABLE $catalogV2.$namespace1.$table1",
-      contains = s"does not have [select] privilege on [$namespace1/$table1/id]")
+    runSqlAsWithAccessException()(s"INSERT INTO $catalogV2.$namespace1.$outputTable1 (id, name, city)" +
+      s" TABLE $catalogV2.$namespace1.$table1", s"does not have [select] privilege on [$namespace1/$table1/id]")
 
     // AppendData: Insert Using a SELECT Statement
-    runSqlAsWithAccessException()(
-      s"INSERT INTO $catalogV2.$namespace1.$outputTable1 (id, name, city)" +
-        s" SELECT * from $catalogV2.$namespace1.$table1",
-      contains = s"does not have [select] privilege on [$namespace1/$table1/id]")
+    runSqlAsWithAccessException()(s"INSERT INTO $catalogV2.$namespace1.$outputTable1 (id, name, city)" +
+      s" SELECT * from $catalogV2.$namespace1.$table1", s"does not have [select] privilege on [$namespace1/$table1/id]")
 
     // OverwriteByExpression: Insert Overwrite
-    runSqlAsWithAccessException()(
-      s"INSERT OVERWRITE $catalogV2.$namespace1.$outputTable1 (id, name, city)" +
-        s" VALUES (1, 'bowenliang123', 'Guangzhou')",
-      contains = s"does not have [update] privilege on [$namespace1/$outputTable1]")
+    runSqlAsWithAccessException()(s"INSERT OVERWRITE $catalogV2.$namespace1.$outputTable1 (id, name, city)" +
+      s" VALUES (1, 'bowenliang123', 'Guangzhou')", s"does not have [update] privilege on [$namespace1/$outputTable1]")
   }
 
   test("[KYUUBI #3424] MERGE INTO") {
@@ -175,20 +149,16 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
       """.stripMargin
 
     // MergeIntoTable:  Using a MERGE INTO Statement
-    runSqlAsWithAccessException()(
-      mergeIntoSql,
-      contains = s"does not have [select] privilege on [$namespace1/$table1/id]")
+    runSqlAsWithAccessException()(mergeIntoSql, s"does not have [select] privilege on [$namespace1/$table1/id]")
 
     try {
       SparkRangerAdminPlugin.getRangerConf.setBoolean(
         s"ranger.plugin.${SparkRangerAdminPlugin.getServiceType}.authorize.in.single.call",
         true)
-      runSqlAsWithAccessException()(
-        mergeIntoSql,
-        contains = s"does not have" +
-          s" [select] privilege" +
-          s" on [$namespace1/$table1/id,$namespace1/table1/name,$namespace1/$table1/city]," +
-          s" [update] privilege on [$namespace1/$outputTable1]")
+      runSqlAsWithAccessException()(mergeIntoSql, s"does not have" +
+        s" [select] privilege" +
+        s" on [$namespace1/$table1/id,$namespace1/table1/name,$namespace1/$table1/city]," +
+        s" [update] privilege on [$namespace1/$outputTable1]")
     } finally {
       SparkRangerAdminPlugin.getRangerConf.setBoolean(
         s"ranger.plugin.${SparkRangerAdminPlugin.getServiceType}.authorize.in.single.call",
@@ -200,18 +170,14 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
     assume(isSparkV31OrGreater)
 
     // UpdateTable
-    runSqlAsWithAccessException()(
-      s"UPDATE $catalogV2.$namespace1.$table1 SET city='Hangzhou' WHERE id=1",
-      contains = s"does not have [update] privilege on [$namespace1/$table1]")
+    runSqlAsWithAccessException()(s"UPDATE $catalogV2.$namespace1.$table1 SET city='Hangzhou' WHERE id=1", s"does not have [update] privilege on [$namespace1/$table1]")
   }
 
   test("[KYUUBI #3424] DELETE FROM TABLE") {
     assume(isSparkV31OrGreater)
 
     // DeleteFromTable
-    runSqlAsWithAccessException()(
-      s"DELETE FROM $catalogV2.$namespace1.$table1 WHERE id=1",
-      contains = s"does not have [update] privilege on [$namespace1/$table1]")
+    runSqlAsWithAccessException()(s"DELETE FROM $catalogV2.$namespace1.$table1 WHERE id=1", s"does not have [update] privilege on [$namespace1/$table1]")
   }
 
   test("[KYUUBI #3424] CACHE TABLE") {
@@ -223,74 +189,48 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
     } else {
       s"does not have [select] privilege on [$catalogV2.$namespace1/$table1]"
     }
-    runSqlAsWithAccessException()(
-      s"CACHE TABLE $cacheTable1 AS select * from $catalogV2.$namespace1.$table1",
-      contains = errorMsg)
+    runSqlAsWithAccessException()(s"CACHE TABLE $cacheTable1 AS select * from $catalogV2.$namespace1.$table1", errorMsg)
   }
 
   test("[KYUUBI #3424] TRUNCATE TABLE") {
     assume(isSparkV32OrGreater)
 
-    runSqlAsWithAccessException()(
-      s"TRUNCATE TABLE $catalogV2.$namespace1.$table1",
-      contains = s"does not have [update] privilege on [$namespace1/$table1]")
+    runSqlAsWithAccessException()(s"TRUNCATE TABLE $catalogV2.$namespace1.$table1", s"does not have [update] privilege on [$namespace1/$table1]")
   }
 
   test("[KYUUBI #3424] MSCK REPAIR TABLE") {
     assume(isSparkV32OrGreater)
 
-    runSqlAsWithAccessException()(
-      s"MSCK REPAIR TABLE $catalogV2.$namespace1.$table1",
-      contains = s"does not have [alter] privilege on [$namespace1/$table1]")
+    runSqlAsWithAccessException()(s"MSCK REPAIR TABLE $catalogV2.$namespace1.$table1", s"does not have [alter] privilege on [$namespace1/$table1]")
   }
 
   test("[KYUUBI #3424] ALTER TABLE") {
     assume(isSparkV31OrGreater)
 
     // AddColumns
-    runSqlAsWithAccessException()(
-      s"ALTER TABLE $catalogV2.$namespace1.$table1 ADD COLUMNS (age int)",
-      isExplain = true,
-      contains = s"does not have [alter] privilege on [$namespace1/$table1]")
+    runSqlAsWithAccessException()(s"ALTER TABLE $catalogV2.$namespace1.$table1 ADD COLUMNS (age int)", s"does not have [alter] privilege on [$namespace1/$table1]", isExplain = true)
 
     // DropColumns
-    runSqlAsWithAccessException()(
-      s"ALTER TABLE $catalogV2.$namespace1.$table1 DROP COLUMNS city",
-      isExplain = true,
-      contains = s"does not have [alter] privilege on [$namespace1/$table1]")
+    runSqlAsWithAccessException()(s"ALTER TABLE $catalogV2.$namespace1.$table1 DROP COLUMNS city", s"does not have [alter] privilege on [$namespace1/$table1]", isExplain = true)
 
     // RenameColumn
-    runSqlAsWithAccessException()(
-      s"ALTER TABLE $catalogV2.$namespace1.$table1 RENAME COLUMN city TO city2 ",
-      isExplain = true,
-      contains = s"does not have [alter] privilege on [$namespace1/$table1]")
+    runSqlAsWithAccessException()(s"ALTER TABLE $catalogV2.$namespace1.$table1 RENAME COLUMN city TO city2 ", s"does not have [alter] privilege on [$namespace1/$table1]", isExplain = true)
 
     // AlterColumn
-    runSqlAsWithAccessException()(
-      s"ALTER TABLE $catalogV2.$namespace1.$table1 ALTER COLUMN city COMMENT 'city'",
-      contains = s"does not have [alter] privilege on [$namespace1/$table1]")
+    runSqlAsWithAccessException()(s"ALTER TABLE $catalogV2.$namespace1.$table1 ALTER COLUMN city COMMENT 'city'", s"does not have [alter] privilege on [$namespace1/$table1]")
   }
 
   test("[KYUUBI #3424] COMMENT ON") {
     assume(isSparkV31OrGreater)
 
     // CommentOnNamespace
-    runSqlAsWithAccessException()(
-      s"COMMENT ON DATABASE $catalogV2.$namespace1 IS 'xYz'",
-      isExplain = true,
-      contains = s"does not have [alter] privilege on [$namespace1]")
+    runSqlAsWithAccessException()(s"COMMENT ON DATABASE $catalogV2.$namespace1 IS 'xYz'", s"does not have [alter] privilege on [$namespace1]", isExplain = true)
 
     // CommentOnNamespace
-    runSqlAsWithAccessException()(
-      s"COMMENT ON NAMESPACE $catalogV2.$namespace1 IS 'xYz' ",
-      isExplain = true,
-      contains = s"does not have [alter] privilege on [$namespace1]")
+    runSqlAsWithAccessException()(s"COMMENT ON NAMESPACE $catalogV2.$namespace1 IS 'xYz' ", s"does not have [alter] privilege on [$namespace1]", isExplain = true)
 
     // CommentOnTable
-    runSqlAsWithAccessException()(
-      s"COMMENT ON TABLE $catalogV2.$namespace1.$table1 IS 'xYz' ",
-      isExplain = true,
-      contains = s"does not have [alter] privilege on [$namespace1/$table1]")
+    runSqlAsWithAccessException()(s"COMMENT ON TABLE $catalogV2.$namespace1.$table1 IS 'xYz' ", s"does not have [alter] privilege on [$namespace1/$table1]", isExplain = true)
 
   }
 }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
@@ -21,7 +21,6 @@ import java.sql.DriverManager
 import scala.util.Try
 
 // scalastyle:off
-import org.apache.kyuubi.plugin.spark.authz.AccessControlException
 
 /**
  * Tests for RangerSparkExtensionSuite
@@ -81,107 +80,90 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
     assume(isSparkV31OrGreater)
 
     // create database
-    val e1 = intercept[AccessControlException](
-      doAs("someone", sql(s"CREATE DATABASE IF NOT EXISTS $catalogV2.$namespace2").explain()))
-    assert(e1.getMessage.contains(s"does not have [create] privilege" +
-      s" on [$namespace2]"))
+    runSqlAsWithAccessException()(
+      s"CREATE DATABASE IF NOT EXISTS $catalogV2.$namespace2",
+      isExplain = true,
+      contains = s"does not have [create] privilege on [$namespace2]")
   }
 
   test("[KYUUBI #3424] DROP DATABASE") {
     assume(isSparkV31OrGreater)
 
     // create database
-    val e1 = intercept[AccessControlException](
-      doAs("someone", sql(s"DROP DATABASE IF EXISTS $catalogV2.$namespace2").explain()))
-    assert(e1.getMessage.contains(s"does not have [drop] privilege" +
-      s" on [$namespace2]"))
+    runSqlAsWithAccessException()(
+      s"DROP DATABASE IF EXISTS $catalogV2.$namespace2",
+      isExplain = true,
+      contains = s"does not have [drop] privilege on [$namespace2]")
   }
 
   test("[KYUUBI #3424] SELECT TABLE") {
     assume(isSparkV31OrGreater)
 
     // select
-    val e1 = intercept[AccessControlException](
-      doAs("someone", sql(s"select city, id from $catalogV2.$namespace1.$table1").explain()))
-    assert(e1.getMessage.contains(s"does not have [select] privilege" +
-      s" on [$namespace1/$table1/city]"))
+    runSqlAsWithAccessException()(
+      s"select city, id from $catalogV2.$namespace1.$table1",
+      isExplain = true,
+      contains = s"does not have [select] privilege on [$namespace1/$table1/city]")
   }
 
   test("[KYUUBI #4255] DESCRIBE TABLE") {
     assume(isSparkV31OrGreater)
-    val e1 = intercept[AccessControlException](
-      doAs("someone", sql(s"DESCRIBE TABLE $catalogV2.$namespace1.$table1").explain()))
-    assert(e1.getMessage.contains(s"does not have [select] privilege" +
-      s" on [$namespace1/$table1]"))
+    runSqlAsWithAccessException()(
+      s"DESCRIBE TABLE $catalogV2.$namespace1.$table1",
+      isExplain = true,
+      contains = s"does not have [select] privilege on [$namespace1/$table1]")
   }
 
   test("[KYUUBI #3424] CREATE TABLE") {
     assume(isSparkV31OrGreater)
 
     // CreateTable
-    val e2 = intercept[AccessControlException](
-      doAs("someone", sql(s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table2")))
-    assert(e2.getMessage.contains(s"does not have [create] privilege" +
-      s" on [$namespace1/$table2]"))
+    runSqlAsWithAccessException()(
+      s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table2",
+      contains = s"does not have [create] privilege on [$namespace1/$table2]")
 
     // CreateTableAsSelect
-    val e21 = intercept[AccessControlException](
-      doAs(
-        "someone",
-        sql(s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table2" +
-          s" AS select * from $catalogV2.$namespace1.$table1")))
-    assert(e21.getMessage.contains(s"does not have [select] privilege" +
-      s" on [$namespace1/$table1/id]"))
+    runSqlAsWithAccessException()(
+      s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table2" +
+        s" AS select * from $catalogV2.$namespace1.$table1",
+      contains = s"does not have [select] privilege on [$namespace1/$table1/id]")
   }
 
   test("[KYUUBI #3424] DROP TABLE") {
     assume(isSparkV31OrGreater)
 
     // DropTable
-    val e3 = intercept[AccessControlException](
-      doAs("someone", sql(s"DROP TABLE $catalogV2.$namespace1.$table1")))
-    assert(e3.getMessage.contains(s"does not have [drop] privilege" +
-      s" on [$namespace1/$table1]"))
+    runSqlAsWithAccessException()(
+      s"DROP TABLE $catalogV2.$namespace1.$table1",
+      contains = s"does not have [drop] privilege on [$namespace1/$table1]")
   }
 
   test("[KYUUBI #3424] INSERT TABLE") {
     assume(isSparkV31OrGreater)
 
     // AppendData: Insert Using a VALUES Clause
-    val e4 = intercept[AccessControlException](
-      doAs(
-        "someone",
-        sql(s"INSERT INTO $catalogV2.$namespace1.$outputTable1 (id, name, city)" +
-          s" VALUES (1, 'bowenliang123', 'Guangzhou')")))
-    assert(e4.getMessage.contains(s"does not have [update] privilege" +
-      s" on [$namespace1/$outputTable1]"))
+    runSqlAsWithAccessException()(
+      s"INSERT INTO $catalogV2.$namespace1.$outputTable1 (id, name, city)" +
+        s" VALUES (1, 'bowenliang123', 'Guangzhou')",
+      contains = s"does not have [update] privilege on [$namespace1/$outputTable1]")
 
     // AppendData: Insert Using a TABLE Statement
-    val e42 = intercept[AccessControlException](
-      doAs(
-        "someone",
-        sql(s"INSERT INTO $catalogV2.$namespace1.$outputTable1 (id, name, city)" +
-          s" TABLE $catalogV2.$namespace1.$table1")))
-    assert(e42.getMessage.contains(s"does not have [select] privilege" +
-      s" on [$namespace1/$table1/id]"))
+    runSqlAsWithAccessException()(
+      s"INSERT INTO $catalogV2.$namespace1.$outputTable1 (id, name, city)" +
+        s" TABLE $catalogV2.$namespace1.$table1",
+      contains = s"does not have [select] privilege on [$namespace1/$table1/id]")
 
     // AppendData: Insert Using a SELECT Statement
-    val e43 = intercept[AccessControlException](
-      doAs(
-        "someone",
-        sql(s"INSERT INTO $catalogV2.$namespace1.$outputTable1 (id, name, city)" +
-          s" SELECT * from $catalogV2.$namespace1.$table1")))
-    assert(e43.getMessage.contains(s"does not have [select] privilege" +
-      s" on [$namespace1/$table1/id]"))
+    runSqlAsWithAccessException()(
+      s"INSERT INTO $catalogV2.$namespace1.$outputTable1 (id, name, city)" +
+        s" SELECT * from $catalogV2.$namespace1.$table1",
+      contains = s"does not have [select] privilege on [$namespace1/$table1/id]")
 
     // OverwriteByExpression: Insert Overwrite
-    val e44 = intercept[AccessControlException](
-      doAs(
-        "someone",
-        sql(s"INSERT OVERWRITE $catalogV2.$namespace1.$outputTable1 (id, name, city)" +
-          s" VALUES (1, 'bowenliang123', 'Guangzhou')")))
-    assert(e44.getMessage.contains(s"does not have [update] privilege" +
-      s" on [$namespace1/$outputTable1]"))
+    runSqlAsWithAccessException()(
+      s"INSERT OVERWRITE $catalogV2.$namespace1.$outputTable1 (id, name, city)" +
+        s" VALUES (1, 'bowenliang123', 'Guangzhou')",
+      contains = s"does not have [update] privilege on [$namespace1/$outputTable1]")
   }
 
   test("[KYUUBI #3424] MERGE INTO") {
@@ -197,19 +179,20 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
       """.stripMargin
 
     // MergeIntoTable:  Using a MERGE INTO Statement
-    val e1 = intercept[AccessControlException](doAs("someone", sql(mergeIntoSql)))
-    assert(e1.getMessage.contains(s"does not have [select] privilege" +
-      s" on [$namespace1/$table1/id]"))
+    runSqlAsWithAccessException()(
+      mergeIntoSql,
+      contains = s"does not have [select] privilege on [$namespace1/$table1/id]")
 
     try {
       SparkRangerAdminPlugin.getRangerConf.setBoolean(
         s"ranger.plugin.${SparkRangerAdminPlugin.getServiceType}.authorize.in.single.call",
         true)
-      val e2 = intercept[AccessControlException](doAs("someone", sql(mergeIntoSql)))
-      assert(e2.getMessage.contains(s"does not have" +
-        s" [select] privilege" +
-        s" on [$namespace1/$table1/id,$namespace1/table1/name,$namespace1/$table1/city]," +
-        s" [update] privilege on [$namespace1/$outputTable1]"))
+      runSqlAsWithAccessException()(
+        mergeIntoSql,
+        contains = s"does not have" +
+          s" [select] privilege" +
+          s" on [$namespace1/$table1/id,$namespace1/table1/name,$namespace1/$table1/city]," +
+          s" [update] privilege on [$namespace1/$outputTable1]")
     } finally {
       SparkRangerAdminPlugin.getRangerConf.setBoolean(
         s"ranger.plugin.${SparkRangerAdminPlugin.getServiceType}.authorize.in.single.call",
@@ -221,128 +204,97 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
     assume(isSparkV31OrGreater)
 
     // UpdateTable
-    val e5 = intercept[AccessControlException](
-      doAs(
-        "someone",
-        sql(s"UPDATE $catalogV2.$namespace1.$table1 SET city='Hangzhou' " +
-          " WHERE id=1")))
-    assert(e5.getMessage.contains(s"does not have [update] privilege" +
-      s" on [$namespace1/$table1]"))
+    runSqlAsWithAccessException()(
+      s"UPDATE $catalogV2.$namespace1.$table1 SET city='Hangzhou' WHERE id=1",
+      contains = s"does not have [update] privilege on [$namespace1/$table1]")
   }
 
   test("[KYUUBI #3424] DELETE FROM TABLE") {
     assume(isSparkV31OrGreater)
 
     // DeleteFromTable
-    val e6 = intercept[AccessControlException](
-      doAs("someone", sql(s"DELETE FROM $catalogV2.$namespace1.$table1 WHERE id=1")))
-    assert(e6.getMessage.contains(s"does not have [update] privilege" +
-      s" on [$namespace1/$table1]"))
+    runSqlAsWithAccessException()(
+      s"DELETE FROM $catalogV2.$namespace1.$table1 WHERE id=1",
+      contains = s"does not have [update] privilege on [$namespace1/$table1]")
   }
 
   test("[KYUUBI #3424] CACHE TABLE") {
     assume(isSparkV31OrGreater)
 
     // CacheTable
-    val e7 = intercept[AccessControlException](
-      doAs(
-        "someone",
-        sql(s"CACHE TABLE $cacheTable1" +
-          s" AS select * from $catalogV2.$namespace1.$table1")))
-    if (isSparkV32OrGreater) {
-      assert(e7.getMessage.contains(s"does not have [select] privilege" +
-        s" on [$namespace1/$table1/id]"))
+    val errorMsg = if (isSparkV32OrGreater) {
+      s"does not have [select] privilege on [$namespace1/$table1/id]"
     } else {
-      assert(e7.getMessage.contains(s"does not have [select] privilege" +
-        s" on [$catalogV2.$namespace1/$table1]"))
+      s"does not have [select] privilege on [$catalogV2.$namespace1/$table1]"
     }
+    runSqlAsWithAccessException()(
+      s"CACHE TABLE $cacheTable1 AS select * from $catalogV2.$namespace1.$table1",
+      contains = errorMsg)
   }
 
   test("[KYUUBI #3424] TRUNCATE TABLE") {
     assume(isSparkV32OrGreater)
 
-    val e1 = intercept[AccessControlException](
-      doAs(
-        "someone",
-        sql(s"TRUNCATE TABLE $catalogV2.$namespace1.$table1")))
-    assert(e1.getMessage.contains(s"does not have [update] privilege" +
-      s" on [$namespace1/$table1]"))
+    runSqlAsWithAccessException()(
+      s"TRUNCATE TABLE $catalogV2.$namespace1.$table1",
+      contains = s"does not have [update] privilege on [$namespace1/$table1]")
   }
 
   test("[KYUUBI #3424] MSCK REPAIR TABLE") {
     assume(isSparkV32OrGreater)
 
-    val e1 = intercept[AccessControlException](
-      doAs(
-        "someone",
-        sql(s"MSCK REPAIR TABLE $catalogV2.$namespace1.$table1")))
-    assert(e1.getMessage.contains(s"does not have [alter] privilege" +
-      s" on [$namespace1/$table1]"))
+    runSqlAsWithAccessException()(
+      s"MSCK REPAIR TABLE $catalogV2.$namespace1.$table1",
+      contains = s"does not have [alter] privilege on [$namespace1/$table1]")
   }
 
   test("[KYUUBI #3424] ALTER TABLE") {
     assume(isSparkV31OrGreater)
 
     // AddColumns
-    val e61 = intercept[AccessControlException](
-      doAs(
-        "someone",
-        sql(s"ALTER TABLE $catalogV2.$namespace1.$table1 ADD COLUMNS (age int) ").explain()))
-    assert(e61.getMessage.contains(s"does not have [alter] privilege" +
-      s" on [$namespace1/$table1]"))
+    runSqlAsWithAccessException()(
+      s"ALTER TABLE $catalogV2.$namespace1.$table1 ADD COLUMNS (age int)",
+      isExplain = true,
+      contains = s"does not have [alter] privilege on [$namespace1/$table1]")
 
     // DropColumns
-    val e62 = intercept[AccessControlException](
-      doAs(
-        "someone",
-        sql(s"ALTER TABLE $catalogV2.$namespace1.$table1 DROP COLUMNS city ").explain()))
-    assert(e62.getMessage.contains(s"does not have [alter] privilege" +
-      s" on [$namespace1/$table1]"))
+    runSqlAsWithAccessException()(
+      s"ALTER TABLE $catalogV2.$namespace1.$table1 DROP COLUMNS city",
+      isExplain = true,
+      contains = s"does not have [alter] privilege on [$namespace1/$table1]")
 
     // RenameColumn
-    val e63 = intercept[AccessControlException](
-      doAs(
-        "someone",
-        sql(s"ALTER TABLE $catalogV2.$namespace1.$table1 RENAME COLUMN city TO city2 ").explain()))
-    assert(e63.getMessage.contains(s"does not have [alter] privilege" +
-      s" on [$namespace1/$table1]"))
+    runSqlAsWithAccessException()(
+      s"ALTER TABLE $catalogV2.$namespace1.$table1 RENAME COLUMN city TO city2 ",
+      isExplain = true,
+      contains = s"does not have [alter] privilege on [$namespace1/$table1]")
 
     // AlterColumn
-    val e64 = intercept[AccessControlException](
-      doAs(
-        "someone",
-        sql(s"ALTER TABLE $catalogV2.$namespace1.$table1 " +
-          s"ALTER COLUMN city COMMENT 'city' ")))
-    assert(e64.getMessage.contains(s"does not have [alter] privilege" +
-      s" on [$namespace1/$table1]"))
+    runSqlAsWithAccessException()(
+      s"ALTER TABLE $catalogV2.$namespace1.$table1 ALTER COLUMN city COMMENT 'city'",
+      contains = s"does not have [alter] privilege on [$namespace1/$table1]")
   }
 
   test("[KYUUBI #3424] COMMENT ON") {
     assume(isSparkV31OrGreater)
 
     // CommentOnNamespace
-    val e1 = intercept[AccessControlException](
-      doAs(
-        "someone",
-        sql(s"COMMENT ON DATABASE $catalogV2.$namespace1 IS 'xYz' ").explain()))
-    assert(e1.getMessage.contains(s"does not have [alter] privilege" +
-      s" on [$namespace1]"))
+    runSqlAsWithAccessException()(
+      s"COMMENT ON DATABASE $catalogV2.$namespace1 IS 'xYz'",
+      isExplain = true,
+      contains = s"does not have [alter] privilege on [$namespace1]")
 
     // CommentOnNamespace
-    val e2 = intercept[AccessControlException](
-      doAs(
-        "someone",
-        sql(s"COMMENT ON NAMESPACE $catalogV2.$namespace1 IS 'xYz' ").explain()))
-    assert(e2.getMessage.contains(s"does not have [alter] privilege" +
-      s" on [$namespace1]"))
+    runSqlAsWithAccessException()(
+      s"COMMENT ON NAMESPACE $catalogV2.$namespace1 IS 'xYz' ",
+      isExplain = true,
+      contains = s"does not have [alter] privilege on [$namespace1]")
 
     // CommentOnTable
-    val e3 = intercept[AccessControlException](
-      doAs(
-        "someone",
-        sql(s"COMMENT ON TABLE $catalogV2.$namespace1.$table1 IS 'xYz' ").explain()))
-    assert(e3.getMessage.contains(s"does not have [alter] privilege" +
-      s" on [$namespace1/$table1]"))
+    runSqlAsWithAccessException()(
+      s"COMMENT ON TABLE $catalogV2.$namespace1.$table1 IS 'xYz' ",
+      isExplain = true,
+      contains = s"does not have [alter] privilege on [$namespace1/$table1]")
 
   }
 }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingTestBase.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingTestBase.scala
@@ -64,11 +64,11 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
   }
 
   override def beforeAll(): Unit = {
-    doAs("admin", setup())
+    doAs("admin")(setup())
     super.beforeAll()
   }
   override def afterAll(): Unit = {
-    doAs("admin", cleanup())
+    doAs("admin")(cleanup())
     spark.stop
     super.afterAll()
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Simplify assertions in Authz tests, by 
- add `doAs(user) { ... }`
- add `runSqlAs` for wrapping SQL running and asserting a successful `Try`
- add `runSqlAsWithAccessException` to intercept `AccessControlException` and assert error message

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
