### PR TITLE
Change kyuubi.operation.result.format log level to debug

### DIFF
--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiStatement.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiStatement.java
@@ -212,7 +212,7 @@ public class KyuubiStatement implements SQLStatement, KyuubiLoggable {
 
     String resultFormat =
         properties.getOrDefault("__kyuubi_operation_result_format__", DEFAULT_RESULT_FORMAT);
-    LOG.debug("kyuubi.operation.result.format: " + resultFormat);
+    LOG.debug("kyuubi.operation.result.format: {}", resultFormat);
     switch (resultFormat) {
       case "arrow":
         boolean timestampAsString =

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiStatement.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiStatement.java
@@ -212,7 +212,7 @@ public class KyuubiStatement implements SQLStatement, KyuubiLoggable {
 
     String resultFormat =
         properties.getOrDefault("__kyuubi_operation_result_format__", DEFAULT_RESULT_FORMAT);
-    LOG.info("kyuubi.operation.result.format: " + resultFormat);
+    LOG.debug("kyuubi.operation.result.format: " + resultFormat);
     switch (resultFormat) {
       case "arrow":
         boolean timestampAsString =
@@ -275,7 +275,7 @@ public class KyuubiStatement implements SQLStatement, KyuubiLoggable {
 
     String resultFormat =
         properties.getOrDefault("__kyuubi_operation_result_format__", DEFAULT_RESULT_FORMAT);
-    LOG.info("kyuubi.operation.result.format: " + resultFormat);
+    LOG.debug("kyuubi.operation.result.format: " + resultFormat);
     switch (resultFormat) {
       case "arrow":
         boolean timestampAsString =

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiStatement.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiStatement.java
@@ -275,7 +275,7 @@ public class KyuubiStatement implements SQLStatement, KyuubiLoggable {
 
     String resultFormat =
         properties.getOrDefault("__kyuubi_operation_result_format__", DEFAULT_RESULT_FORMAT);
-    LOG.debug("kyuubi.operation.result.format: " + resultFormat);
+    LOG.debug("kyuubi.operation.result.format: {}", resultFormat);
     switch (resultFormat) {
       case "arrow":
         boolean timestampAsString =


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
There is no need to log kyuubi.operation.result.format information every time a statement is executed.


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
