### PR TITLE
[Authz] Fix dependencies conflict by replacing `jersey-bundle` with `jersey-client`

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/pom.xml
+++ b/extensions/spark/kyuubi-spark-authz/pom.xml
@@ -32,7 +32,9 @@
     <url>https://kyuubi.apache.org/</url>
 
     <properties>
+        <!-- the following components' version may need to tune to align w/ the ranger.version-->
         <gethostname4j.version>1.0.0</gethostname4j.version>
+        <jersey.client.version>1.19.4</jersey.client.version>
         <jna.version>5.7.0</jna.version>
     </properties>
 
@@ -42,6 +44,10 @@
             <artifactId>ranger-plugins-common</artifactId>
             <version>${ranger.version}</version>
             <exclusions>
+                <exclusion>
+                    <groupId>com.sun.jersey</groupId>
+                    <artifactId>jersey-bundle</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>org.apache.ranger</groupId>
                     <artifactId>ranger-plugin-classloader</artifactId>
@@ -97,6 +103,18 @@
                 <exclusion>
                     <groupId>net.java.dev.jna</groupId>
                     <artifactId>jna-platform</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.sun.jersey</groupId>
+            <artifactId>jersey-client</artifactId>
+            <version>${jersey.client.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>jsr311-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

- `jerysey-bundle` 1.x , which is depended by `ranger-plugins-common`, contains `javax.ws.rs.*` (like `javax.ws.rs.core.*`) packages that conflicted to `jarkarta.ws.rs-api-2.1.6.jar` in Spark 3.0+ jars
- exclude `jerysey-bundle` 1.x and include `jersey-client` 1.19.4 to align with `ranger-plugins-common`

Diff in Authz dependency jar list:
```diff
gethostname4j-1.0.0.jar
jackson-jaxrs-1.9.13.jar
- jersey-bundle-1.19.3.jar
+ jersey-client-1.19.4.jar
+ jersey-core-1.19.4.jar 
jetty-client-9.4.50.v20221201.jar
jetty-http-9.4.50.v20221201.jar
jetty-io-9.4.50.v20221201.jar
jetty-util-9.4.50.v20221201.jar
jna-5.7.0.jar
jna-platform-5.7.0.jar
ranger-plugins-audit-2.3.0.jar
ranger-plugins-common-2.3.0.jar
ranger-plugins-cred-2.3.0.jar
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
