### PR TITLE
Skip etcd test if no docker env

### DIFF
--- a/kyuubi-ha/src/test/scala/org/apache/kyuubi/ha/client/etcd/EtcdDiscoveryClientSuite.scala
+++ b/kyuubi-ha/src/test/scala/org/apache/kyuubi/ha/client/etcd/EtcdDiscoveryClientSuite.scala
@@ -20,8 +20,11 @@ package org.apache.kyuubi.ha.client.etcd
 import java.nio.charset.StandardCharsets
 
 import scala.collection.JavaConverters._
+import scala.util.control.NonFatal
 
 import io.etcd.jetcd.launcher.{Etcd, EtcdCluster}
+import org.scalactic.source.Position
+import org.scalatest.Tag
 
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.ha.HighAvailabilityConf.{HA_ADDRESSES, HA_CLIENT_CLASS}
@@ -41,23 +44,40 @@ class EtcdDiscoveryClientSuite extends DiscoveryClientTests {
   var conf: KyuubiConf = KyuubiConf()
     .set(HA_CLIENT_CLASS, classOf[EtcdDiscoveryClient].getName)
 
+  private var hasDockerEnv = false
+
   override def beforeAll(): Unit = {
-    etcdCluster = new Etcd.Builder()
-      .withNodes(2)
-      .build()
-    etcdCluster.start()
-    conf = new KyuubiConf()
-      .set(HA_CLIENT_CLASS, classOf[EtcdDiscoveryClient].getName)
-      .set(HA_ADDRESSES, getConnectString)
+    try {
+      etcdCluster = new Etcd.Builder()
+        .withNodes(2)
+        .build()
+      etcdCluster.start()
+      conf = new KyuubiConf()
+        .set(HA_CLIENT_CLASS, classOf[EtcdDiscoveryClient].getName)
+        .set(HA_ADDRESSES, getConnectString)
+      hasDockerEnv = true
+    } catch {
+      case NonFatal(_) =>
+      // ignore if no docker environment
+    }
     super.beforeAll()
   }
 
   override def afterAll(): Unit = {
     super.afterAll()
-    if (etcdCluster != null) {
+    if (etcdCluster != null && hasDockerEnv) {
       etcdCluster.close()
       etcdCluster = null
     }
+  }
+
+  override protected def test(
+      testName: String,
+      testTags: Tag*)(testFun: => Any)(implicit pos: Position): Unit = {
+    if (hasDockerEnv) {
+      super.test(testName, testTags: _*)(testFun)
+    }
+    // skip test
   }
 
   test("etcd test: set, get and delete") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Skip etcd test if no docker env.

It would fail if no docker env
```
org.apache.kyuubi.ha.client.etcd.EtcdDiscoveryClientSuite *** ABORTED ***
  java.lang.IllegalStateException: Could not find a valid Docker environment. Please see logs and check configuration
  at org.testcontainers.dockerclient.DockerClientProviderStrategy.lambda$getFirstValidStrategy$6(DockerClientProviderStrategy.java:257)
  at java.util.Optional.orElseThrow(Optional.java:290)
  at org.testcontainers.dockerclient.DockerClientProviderStrategy.getFirstValidStrategy(DockerClientProviderStrategy.java:247)
  at org.testcontainers.DockerClientFactory.getOrInitializeStrategy(DockerClientFactory.java:135)
  at org.testcontainers.DockerClientFactory.client(DockerClientFactory.java:171)
  at org.testcontainers.containers.Network$NetworkImpl.create(Network.java:69)
  at org.testcontainers.containers.Network$NetworkImpl.getId(Network.java:62)
  at io.etcd.jetcd.launcher.EtcdClusterImpl.start(EtcdClusterImpl.java:72)
  at org.apache.kyuubi.ha.client.etcd.EtcdDiscoveryClientSuite.beforeAll(EtcdDiscoveryClientSuite.scala:48)
```
### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
