### PR TITLE
[KYUUBI #4452] Strip the redundant leading and tailing slash of getZooKeeperNamespace.

### DIFF
--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/ZooKeeperHiveClientHelper.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/ZooKeeperHiveClientHelper.java
@@ -17,6 +17,7 @@
 
 package org.apache.kyuubi.jdbc.hive;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -32,7 +33,8 @@ class ZooKeeperHiveClientHelper {
   // Pattern for key1=value1;key2=value2
   private static final Pattern kvPattern = Pattern.compile("([^=;]*)=([^;]*);?");
 
-  public static String getZooKeeperNamespace(JdbcConnectionParams connParams) {
+  @VisibleForTesting
+  protected static String getZooKeeperNamespace(JdbcConnectionParams connParams) {
     String zooKeeperNamespace =
         connParams.getSessionVars().get(JdbcConnectionParams.ZOOKEEPER_NAMESPACE);
     if ((zooKeeperNamespace == null) || (zooKeeperNamespace.isEmpty())) {

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/ZooKeeperHiveClientHelper.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/ZooKeeperHiveClientHelper.java
@@ -32,12 +32,13 @@ class ZooKeeperHiveClientHelper {
   // Pattern for key1=value1;key2=value2
   private static final Pattern kvPattern = Pattern.compile("([^=;]*)=([^;]*);?");
 
-  private static String getZooKeeperNamespace(JdbcConnectionParams connParams) {
+  public static String getZooKeeperNamespace(JdbcConnectionParams connParams) {
     String zooKeeperNamespace =
         connParams.getSessionVars().get(JdbcConnectionParams.ZOOKEEPER_NAMESPACE);
     if ((zooKeeperNamespace == null) || (zooKeeperNamespace.isEmpty())) {
       zooKeeperNamespace = JdbcConnectionParams.ZOOKEEPER_DEFAULT_NAMESPACE;
     }
+    zooKeeperNamespace = zooKeeperNamespace.replaceAll("^/+", "").replaceAll("/+$", "");
     return zooKeeperNamespace;
   }
 

--- a/kyuubi-hive-jdbc/src/test/java/org/apache/kyuubi/jdbc/hive/ZooKeeperHiveClientHelperTest.java
+++ b/kyuubi-hive-jdbc/src/test/java/org/apache/kyuubi/jdbc/hive/ZooKeeperHiveClientHelperTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.jdbc.hive;
+
+import static org.apache.kyuubi.jdbc.hive.Utils.extractURLComponents;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Properties;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class ZooKeeperHiveClientHelperTest {
+
+  private String uri;
+
+  @Parameterized.Parameters
+  public static Collection<String[]> data() {
+    return Arrays.asList(
+        new String[][] {
+          {"jdbc:hive2://hostname:10018/db;zooKeeperNamespace=zookeeper/namespace"},
+          {"jdbc:hive2://hostname:10018/db;zooKeeperNamespace=/zookeeper/namespace"},
+          {"jdbc:hive2://hostname:10018/db;zooKeeperNamespace=zookeeper/namespace/"},
+          {"jdbc:hive2://hostname:10018/db;zooKeeperNamespace=/zookeeper/namespace/"},
+          {"jdbc:hive2://hostname:10018/db;zooKeeperNamespace=///zookeeper/namespace///"}
+        });
+  }
+
+  public ZooKeeperHiveClientHelperTest(String uri) {
+    this.uri = uri;
+  }
+
+  @Test
+  public void testGetZooKeeperNamespace() throws JdbcUriParseException {
+    JdbcConnectionParams jdbcConnectionParams = extractURLComponents(uri, new Properties());
+    assertEquals(
+        "zookeeper/namespace",
+        ZooKeeperHiveClientHelper.getZooKeeperNamespace(jdbcConnectionParams));
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
As described in the discussion:  <https://github.com/apache/kyuubi/discussions/4436>

When the zk namespace contains leading and trailing slashes, the exception will cause the client connection to fail, and the exception prompt information is not clear.

So we strip the redundant leading and tailing slashes of getZooKeeperNamespace and add exception stack information at the same time.

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
