### PR TITLE
[KYUUBI #3420] Spark sql engine register self to `Discover Server` with Spark Web UI uri

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkTBinaryFrontendService.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkTBinaryFrontendService.scala
@@ -94,7 +94,13 @@ class SparkTBinaryFrontendService(
   }
 
   override def attributes: Map[String, String] = {
-    Map(KYUUBI_ENGINE_ID -> KyuubiSparkUtil.engineId)
+    Map(
+      KYUUBI_ENGINE_ID -> KyuubiSparkUtil.engineId,
+      // TODO Support Spark Web UI Enabled SSL
+      KYUUBI_ENGINE_URL -> (sc.uiWebUrl match {
+        case Some(url) => url.split("//").last
+        case None => ""
+      }))
   }
 }
 

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/EtcdSparkEngineRegisterSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/EtcdSparkEngineRegisterSuite.scala
@@ -20,19 +20,18 @@ package org.apache.kyuubi.engine.spark
 import java.util.UUID
 
 import org.apache.kyuubi.config.KyuubiReservedKeys.{KYUUBI_ENGINE_ID, KYUUBI_ENGINE_URL}
-import org.apache.kyuubi.ha.client.zookeeper.ZookeeperClientProvider
 
-class ZookeeperSparkEngineRegisterSuite extends WithDiscoverySparkSQLEngine
-  with WithEmbeddedZookeeper {
+class EtcdSparkEngineRegisterSuite extends WithDiscoverySparkSQLEngine
+  with WithEtcdCluster {
 
   override def withKyuubiConf: Map[String, String] =
-    super.withKyuubiConf ++ zookeeperConf ++ Map(
+    super.withKyuubiConf ++ etcdConf ++ Map(
       "spark.ui.enabled" -> "true")
 
   override val namespace: String = s"/kyuubi/deregister_test/${UUID.randomUUID.toString}"
 
-  test("Spark Engine Register Zookeeper with spark ui info") {
-    zookeeperConf.foreach(entry => kyuubiConf.set(entry._1, entry._2))
+  test("Spark Engine Register Etcd with spark ui info") {
+    etcdConf.foreach(entry => kyuubiConf.set(entry._1, entry._2))
     withDiscoveryClient(client => {
       val info = client.getChildren(namespace).head.split(",")
       assert(info.exists(_.startsWith(KYUUBI_ENGINE_ID)))

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/ZookeeperSparkEngineRegisterSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/ZookeeperSparkEngineRegisterSuite.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.engine.spark
+
+import java.util.UUID
+
+import org.apache.kyuubi.config.KyuubiReservedKeys.{KYUUBI_ENGINE_ID, KYUUBI_ENGINE_URL}
+import org.apache.kyuubi.ha.client.zookeeper.ZookeeperClientProvider
+
+class ZookeeperSparkEngineRegisterSuite extends WithDiscoverySparkSQLEngine
+  with WithEmbeddedZookeeper {
+
+  override def withKyuubiConf: Map[String, String] =
+    super.withKyuubiConf ++ zookeeperConf ++ Map(
+      "spark.ui.enabled" -> "true")
+
+  override val namespace: String = s"/kyuubi/deregister_test/${UUID.randomUUID.toString}"
+
+  test("Spark Engine Register Zookeeper with spark ui info") {
+    zookeeperConf.foreach(entry => kyuubiConf.set(entry._1, entry._2))
+    val client = ZookeeperClientProvider.buildZookeeperClient(kyuubiConf)
+    client.start()
+    val info = client.getChildren.forPath(namespace).get(0).split(";")
+    assert(info.exists(_.startsWith(KYUUBI_ENGINE_ID)))
+    assert(info.exists(_.startsWith(KYUUBI_ENGINE_URL)))
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
see detail in KYUUBI #3420

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
