### PR TITLE
[KYUUBI #4219]invert the pattern match branch order

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/shim/CatalogShim_v3_0.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/shim/CatalogShim_v3_0.scala
@@ -155,14 +155,6 @@ class CatalogShim_v3_0 extends CatalogShim_v2_4 {
     val catalog = getCatalog(spark, catalogName)
     val namespaces = listNamespacesWithPattern(catalog, schemaPattern)
     catalog match {
-      case builtin if builtin.name() == SESSION_CATALOG =>
-        super.getCatalogTablesOrViews(
-          spark,
-          SESSION_CATALOG,
-          schemaPattern,
-          tablePattern,
-          tableTypes,
-          ignoreTableProperties)
       case tc: TableCatalog =>
         val tp = tablePattern.r.pattern
         val identifiers = namespaces.flatMap { ns =>
@@ -176,6 +168,14 @@ class CatalogShim_v3_0 extends CatalogShim_v2_4 {
           val tableName = quoteIfNeeded(ident.name())
           Row(catalog.name(), schema, tableName, "TABLE", comment, null, null, null, null, null)
         }
+      case builtin if builtin.name() == SESSION_CATALOG =>
+        super.getCatalogTablesOrViews(
+          spark,
+          SESSION_CATALOG,
+          schemaPattern,
+          tablePattern,
+          tableTypes,
+          ignoreTableProperties)
       case _ => Seq.empty[Row]
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
It does work after  several tests, that inverting the pattern match branch order in `CatalogShim_v3_0#getColumnsByCatalog`, which ensures BI tools can list columns on Delta Lake tables in all schemas.


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
