### PR TITLE
[KYUUBI #4446] Fix connections blocked by Flink insert statements

### DIFF
--- a/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/ExecuteStatement.scala
@@ -161,6 +161,9 @@ class ExecuteStatement(
       .build(executor)
     val result = executeOperation.invoke[TableResult](sessionId, operation)
     jobId = result.getJobClient.asScala.map(_.getJobID)
+    // this method runs insert operations and non-job operations,
+    // of which the results are immediately available,
+    // thus there's no need to call TableResult#await()
     resultSet = ResultSet.fromTableResult(result)
   }
 

--- a/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/ExecuteStatement.scala
@@ -161,9 +161,8 @@ class ExecuteStatement(
       .build(executor)
     val result = executeOperation.invoke[TableResult](sessionId, operation)
     jobId = result.getJobClient.asScala.map(_.getJobID)
-    // this method runs insert operations and non-job operations,
-    // of which the results are immediately available,
-    // thus there's no need to call TableResult#await()
+    // after FLINK-24461, TableResult#await() would block insert statements
+    // until the job finishes, instead of returning row affected immediately
     resultSet = ResultSet.fromTableResult(result)
   }
 

--- a/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/ExecuteStatement.scala
@@ -161,7 +161,6 @@ class ExecuteStatement(
       .build(executor)
     val result = executeOperation.invoke[TableResult](sessionId, operation)
     jobId = result.getJobClient.asScala.map(_.getJobID)
-    result.await()
     resultSet = ResultSet.fromTableResult(result)
   }
 


### PR DESCRIPTION
### _Why are the changes needed?_
Flink 1.15 refactors the result fetching of insert statements and now `TableResult.await()` would block till the insert finishes. We could remove this line because the insert results are immediately available as other non-job statements. 

Flink JIRA: https://issues.apache.org/jira/browse/FLINK-24461
Critical changes: https://github.com/apache/flink/pull/17441/files#diff-ec88f0e06d880b53e2f152113ab1a4240a820cbb7248815c5f9ecf9ab4fce4caR108

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
