### PR TITLE
Filx list engine no node exception

### DIFF
--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/list/ListEngineCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/list/ListEngineCommand.scala
@@ -17,6 +17,8 @@
 package org.apache.kyuubi.ctl.cmd.list
 
 import org.apache.kyuubi.ctl.opt.CliConfig
+import org.apache.kyuubi.ctl.util.CtlUtils
+import org.apache.kyuubi.ha.client.ServiceNodeInfo
 
 class ListEngineCommand(cliConfig: CliConfig) extends ListCommand(cliConfig) {
 
@@ -28,4 +30,9 @@ class ListEngineCommand(cliConfig: CliConfig) extends ListCommand(cliConfig) {
       fail("Must specify user name for engine, please use -u or --user.")
     }
   }
+
+  override def doRun(): Seq[ServiceNodeInfo] = {
+    CtlUtils.listZkEngineNodes(conf, normalizedCliConfig, filterHostPort = false)
+  }
+
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiServer.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiServer.scala
@@ -157,7 +157,7 @@ class KyuubiServer(name: String) extends Serverable(name) {
         warn("MYSQL frontend protocol is experimental.")
         new KyuubiMySQLFrontendService(this)
       case TRINO =>
-        warn("Trio frontend protocol is experimental.")
+        warn("Trino frontend protocol is experimental.")
         new KyuubiTrinoFrontendService(this)
       case other =>
         throw new UnsupportedOperationException(s"Frontend protocol $other is not supported yet.")


### PR DESCRIPTION
### _Why are the changes needed?_
use kyuubi-ctl list engine produce no node exception, this change fix this bug.
fix warn message trino typos.


### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

build module `kyuubi-ctl` and deploy to my environment and run : `kyuubi-ctl list engine -zk xxx:2181 -n kyuubi_test -u xxx`

get this result:

| Namespace                                                    | Host  | Port  | Version |
| ------------------------------------------------------------ | ----- | ----- | ------- |
| /kyuubi_test_1.7.0_CONNECTION_SPARK_SQL/xxx/5019a9b5-e07f-4983-8c8a-239b5bde842a | Host1 | 13919 | 1.7.0   |
| /kyuubi_test_1.7.0_CONNECTION_SPARK_SQL/xxx/b6e1051c-c423-4d88-92f9-975e805495f6 | Host2 | 9700  | 1.7.0   |

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
