### PR TITLE
`bin/kyuubi` should use `exec` to run Kyuubi server

### DIFF
--- a/bin/kyuubi
+++ b/bin/kyuubi
@@ -155,7 +155,7 @@ function start_kyuubi() {
 
 function run_kyuubi() {
   echo "Starting $CLASS"
-  nice -n "${KYUUBI_NICENESS:-0}" ${cmd}
+  exec nice -n "${KYUUBI_NICENESS:-0}" ${cmd}
 }
 
 function stop_kyuubi() {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

The difference between w/ and w/o `exec` in shell script

https://www.baeldung.com/linux/exec-command-in-shell-script

> When using exec, however, the command following exec replaces the current shell. This means no subshell is created and the current process is replaced with this new command.

We must do this change to make `bin/kyuubi` suitable for Cloudera Manager.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
