### PR TITLE
Return engine id in SessionData and post kyuubi instance in KyuubiOperationEvent

### DIFF
--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/api/v1/dto/SessionData.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/api/v1/dto/SessionData.java
@@ -34,6 +34,7 @@ public class SessionData {
   private String exception;
   private String sessionType;
   private String kyuubiInstance;
+  private String engineId;
 
   public SessionData() {}
 
@@ -47,7 +48,8 @@ public class SessionData {
       Long idleTime,
       String exception,
       String sessionType,
-      String kyuubiInstance) {
+      String kyuubiInstance,
+      String engineId) {
     this.identifier = identifier;
     this.user = user;
     this.ipAddr = ipAddr;
@@ -58,6 +60,7 @@ public class SessionData {
     this.exception = exception;
     this.sessionType = sessionType;
     this.kyuubiInstance = kyuubiInstance;
+    this.engineId = engineId;
   }
 
   public String getIdentifier() {
@@ -141,6 +144,14 @@ public class SessionData {
 
   public void setKyuubiInstance(String kyuubiInstance) {
     this.kyuubiInstance = kyuubiInstance;
+  }
+
+  public String getEngineId() {
+    return engineId;
+  }
+
+  public void setEngineId(String engineId) {
+    this.engineId = engineId;
   }
 
   @Override

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/events/KyuubiOperationEvent.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/events/KyuubiOperationEvent.scala
@@ -42,6 +42,7 @@ import org.apache.kyuubi.session.KyuubiSession
  * @param sessionId the identifier of the parent session
  * @param sessionUser the authenticated client user
  * @param sessionType the type of the parent session
+ * @param kyuubiInstance the parent session connection url
  */
 case class KyuubiOperationEvent private (
     statementId: String,
@@ -56,7 +57,8 @@ case class KyuubiOperationEvent private (
     exception: Option[Throwable],
     sessionId: String,
     sessionUser: String,
-    sessionType: String) extends KyuubiEvent {
+    sessionType: String,
+    kyuubiInstance: String) extends KyuubiEvent {
 
   // operation events are partitioned by the date when the corresponding operations are
   // created.
@@ -85,6 +87,7 @@ object KyuubiOperationEvent {
       status.exception,
       session.handle.identifier.toString,
       session.user,
-      session.sessionType.toString)
+      session.sessionType.toString,
+      session.connectionUrl)
   }
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/ApiUtils.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/ApiUtils.scala
@@ -28,6 +28,7 @@ import org.apache.kyuubi.session.KyuubiSession
 object ApiUtils {
 
   def sessionData(session: KyuubiSession): SessionData = {
+    val sessionEvent = session.getSessionEvent
     new SessionData(
       session.handle.identifier.toString,
       session.user,
@@ -36,9 +37,10 @@ object ApiUtils {
       session.createTime,
       session.lastAccessTime - session.createTime,
       session.getNoOperationTime,
-      session.getSessionEvent.flatMap(_.exception).map(Utils.prettyPrint).getOrElse(""),
+      sessionEvent.flatMap(_.exception).map(Utils.prettyPrint).getOrElse(""),
       session.sessionType.toString,
-      session.connectionUrl)
+      session.connectionUrl,
+      sessionEvent.map(_.engineId).getOrElse(""))
   }
 
   def operationData(operation: KyuubiOperation): OperationData = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
As title.

BTW, for KyuubiSessionEvents, you can get kyuubiInstance from serverIP.
```
 * @param serverIP A unique Kyuubi server id, e.g. kyuubi server ip address and port,
 *                 it is useful if has multi-instance Kyuubi Server
 ```
### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
