### PR TITLE
Update metadata when batch application state changed

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
@@ -300,6 +300,7 @@ class BatchJobSubmission(
         val newApplicationStatus = currentApplicationInfo
         if (newApplicationStatus.map(_.state) != _applicationInfo.map(_.state)) {
           _applicationInfo = newApplicationStatus
+          updateBatchMetadata()
           info(s"Batch report for $batchId, ${_applicationInfo}")
         }
       }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Kyuubi Server should update the metadata store when the batch application state changes, otherwise the peers see the outdated application state.

The following inconsistent happened on a dual Kyuubi Server deployment
```
23/03/15 11:15:36 batchId: e0b06788-46c0-484e-8648-deb08fc5dbd2, appId: null
23/03/15 11:15:41 batchId: e0b06788-46c0-484e-8648-deb08fc5dbd2, appId: null, appStatus: null
23/03/15 11:15:46 batchId: e0b06788-46c0-484e-8648-deb08fc5dbd2, appId: spark-934bd65c1de14fceb22411986dc5fe99, appStatus: PENDING
23/03/15 11:15:51 batchId: e0b06788-46c0-484e-8648-deb08fc5dbd2, appId: spark-934bd65c1de14fceb22411986dc5fe99, appStatus: PENDING
23/03/15 11:15:56 batchId: e0b06788-46c0-484e-8648-deb08fc5dbd2, appId: spark-934bd65c1de14fceb22411986dc5fe99, appStatus: PENDING
23/03/15 11:16:01 batchId: e0b06788-46c0-484e-8648-deb08fc5dbd2, appId: spark-934bd65c1de14fceb22411986dc5fe99, appStatus: PENDING
23/03/15 11:16:06 batchId: e0b06788-46c0-484e-8648-deb08fc5dbd2, appId: spark-934bd65c1de14fceb22411986dc5fe99, appStatus: PENDING
23/03/15 11:16:11 batchId: e0b06788-46c0-484e-8648-deb08fc5dbd2, appId: spark-934bd65c1de14fceb22411986dc5fe99, appStatus: PENDING
23/03/15 11:16:16 batchId: e0b06788-46c0-484e-8648-deb08fc5dbd2, appId: spark-934bd65c1de14fceb22411986dc5fe99, appStatus: PENDING
23/03/15 11:16:21 batchId: e0b06788-46c0-484e-8648-deb08fc5dbd2, appId: spark-934bd65c1de14fceb22411986dc5fe99, appStatus: RUNNING
23/03/15 11:16:26 batchId: e0b06788-46c0-484e-8648-deb08fc5dbd2, appId: spark-934bd65c1de14fceb22411986dc5fe99, appStatus: PENDING
23/03/15 11:16:31 batchId: e0b06788-46c0-484e-8648-deb08fc5dbd2, appId: spark-934bd65c1de14fceb22411986dc5fe99, appStatus: RUNNING
23/03/15 11:16:37 batchId: e0b06788-46c0-484e-8648-deb08fc5dbd2, appId: spark-934bd65c1de14fceb22411986dc5fe99, appStatus: PENDING
23/03/15 11:16:42 batchId: e0b06788-46c0-484e-8648-deb08fc5dbd2, appId: spark-934bd65c1de14fceb22411986dc5fe99, appStatus: RUNNING
23/03/15 11:16:47 batchId: e0b06788-46c0-484e-8648-deb08fc5dbd2, appId: spark-934bd65c1de14fceb22411986dc5fe99, appStatus: PENDING
23/03/15 11:16:52 batchId: e0b06788-46c0-484e-8648-deb08fc5dbd2, appId: spark-934bd65c1de14fceb22411986dc5fe99, appStatus: RUNNING
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
