### PR TITLE
Generate authorization specifications for admin resources

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/AdminResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/AdminResource.scala
@@ -24,8 +24,10 @@ import javax.ws.rs.core.{MediaType, Response}
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
 
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType
 import io.swagger.v3.oas.annotations.media.{ArraySchema, Content, Schema}
 import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.security.{SecurityRequirement, SecurityScheme}
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.apache.zookeeper.KeeperException.NoNodeException
 
@@ -43,6 +45,8 @@ import org.apache.kyuubi.session.{KyuubiSession, SessionHandle}
 
 @Tag(name = "Admin")
 @Produces(Array(MediaType.APPLICATION_JSON))
+@SecurityScheme(name = "basicAuth", `type` = SecuritySchemeType.HTTP, scheme = "basic")
+@SecurityRequirement(name = "basicAuth")
 private[v1] class AdminResource extends ApiRequestContext with Logging {
   private lazy val administrators = fe.getConf.get(KyuubiConf.SERVER_ADMINISTRATORS).toSet +
     Utils.currentUser


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

1. the swagger generated `curl` command

before

```shell
curl -X 'GET' \
  'http://192.168.206.64:10099/api/v1/admin/sessions' \
  -H 'accept: application/json'
```

after

```shell
curl -X 'GET' \
  'http://192.168.206.64:10099/api/v1/admin/sessions' \
  -H 'accept: application/json' \
  -H 'Authorization: Basic ZmNoZW46'
```

2. the swagger 2.x Annotations documentation

https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Annotations#securityrequirement

![截屏2023-03-15 下午2 15 12](https://user-images.githubusercontent.com/8537877/225226142-0d555de4-3c3c-49f6-b341-2044d087d76b.png)

![截屏2023-03-15 下午2 15 31](https://user-images.githubusercontent.com/8537877/225226172-b0087815-75d5-4b96-bf43-0822b2411908.png)

![截屏2023-03-15 下午2 16 01](https://user-images.githubusercontent.com/8537877/225226198-85bf87e8-b83c-43ff-a3f8-33d3b571532f.png)

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
