### PR TITLE
[KYUUBI#4530] fix data masking  does not support CJK for strategies such as MASK_SHOW_FIRST_4 or MASK_SHOW_FIRST_4

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPlugin.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPlugin.scala
@@ -135,7 +135,8 @@ object SparkRangerAdminPlugin extends RangerBasePlugin("spark", "sparkSql")
     val pos = if (hasLen) ", 5" else ""
     val upper = s"regexp_replace($expr, '[A-Z]', 'X'$pos)"
     val lower = s"regexp_replace($upper, '[a-z]', 'x'$pos)"
-    val digits = s"regexp_replace($lower, '[0-9]', 'n'$pos)"
+    val chinese = s"regexp_replace($lower, '[\u4e00-\u9fa5]', 'x'$pos)"
+    val digits = s"regexp_replace($chinese, '[0-9]', 'n'$pos)"
     digits
   }
 

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPlugin.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPlugin.scala
@@ -135,8 +135,8 @@ object SparkRangerAdminPlugin extends RangerBasePlugin("spark", "sparkSql")
     val pos = if (hasLen) ", 5" else ""
     val upper = s"regexp_replace($expr, '[A-Z]', 'X'$pos)"
     val lower = s"regexp_replace($upper, '[a-z]', 'x'$pos)"
-    val chinese = s"regexp_replace($lower, '[\u4e00-\u9fa5]', 'x'$pos)"
-    val digits = s"regexp_replace($chinese, '[0-9]', 'n'$pos)"
+    val cjk = s"regexp_replace($lower, '[\u4e00-\u9fa5]|[\u0800-\u4e00]|[\uac00-\ud7ff]', 'x'$pos)"
+    val digits = s"regexp_replace($cjk, '[0-9]', 'n'$pos)"
     digits
   }
 

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPluginSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPluginSuite.scala
@@ -50,8 +50,8 @@ class SparkRangerAdminPluginSuite extends AnyFunSuite {
     }
     assert(getMaskingExpr(buildAccessRequest(bob, "value1")).get === "md5(cast(value1 as string))")
     assert(getMaskingExpr(buildAccessRequest(bob, "value2")).get ===
-      "regexp_replace(regexp_replace(regexp_replace(value2, '[A-Z]', 'X'), '[a-z]', 'x')," +
-      " '[0-9]', 'n')")
+      "regexp_replace(regexp_replace(regexp_replace(regexp_replace(value2, '[A-Z]', 'X', 5), '[a-z]', 'x', 5), " +
+        "'[\\u4e00-\\u9fa5]', 'x', 5), '[0-9]', 'n', 5)")
     assert(getMaskingExpr(buildAccessRequest(bob, "value3")).get contains "regexp_replace")
     assert(getMaskingExpr(buildAccessRequest(bob, "value4")).get === "date_trunc('YEAR', value4)")
     assert(getMaskingExpr(buildAccessRequest(bob, "value5")).get contains "regexp_replace")

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPluginSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPluginSuite.scala
@@ -51,7 +51,7 @@ class SparkRangerAdminPluginSuite extends AnyFunSuite {
     assert(getMaskingExpr(buildAccessRequest(bob, "value1")).get === "md5(cast(value1 as string))")
     assert(getMaskingExpr(buildAccessRequest(bob, "value2")).get ===
       "regexp_replace(regexp_replace(regexp_replace(regexp_replace(value2, '[A-Z]', 'X', 5), '[a-z]', 'x', 5), " +
-        "'[\\u4e00-\\u9fa5]', 'x', 5), '[0-9]', 'n', 5)")
+        "'[\\u4e00-\\u9fa5]|[\\u0800-\\u4e00]|[\\uac00-\\ud7ff]', 'x', 5), '[0-9]', 'n', 5)")
     assert(getMaskingExpr(buildAccessRequest(bob, "value3")).get contains "regexp_replace")
     assert(getMaskingExpr(buildAccessRequest(bob, "value4")).get === "date_trunc('YEAR', value4)")
     assert(getMaskingExpr(buildAccessRequest(bob, "value5")).get contains "regexp_replace")

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingTestBase.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingTestBase.scala
@@ -82,12 +82,11 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
 
   test("simple query with a user has mask rules") {
     val result =
-      Seq(Row(md5Hex("1"), "xxxxx", "worlx", Timestamp.valueOf("2018-01-01 00:00:00"), "Xorld"),
-        Row(md5Hex("10"), "xxxxx", "分布式计x", Timestamp.valueOf("2018-01-01 00:00:00"), "Xorld"))
-    checkAnswer("bob", "SELECT value1, value2, value3, value4, value5 FROM default.src order by key", result)
+      Seq(Row(md5Hex("1"), "xxxxx", "worlx", Timestamp.valueOf("2018-01-01 00:00:00"), "Xorld"))
+    checkAnswer("bob", "SELECT value1, value2, value3, value4, value5 FROM default.src where key=1", result)
     checkAnswer(
       "bob",
-      "SELECT value1 as key, value2, value3, value4, value5 FROM default.src order by value1",
+      "SELECT value1 as key, value2, value3, value4, value5 FROM default.src where key=1",
       result)
   }
 


### PR DESCRIPTION
…es such as MASK_SHOW_FIRST_4 or MASK_SHOW_FIRST_4

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The data masking  does not support Chinese for strategies such as MASK_SHOW_FIRST_4 or MASK_SHOW_FIRST_4
![image](https://user-images.githubusercontent.com/33471639/225362155-ba64c97b-0890-4e7e-8cc7-918b7ca6ac5b.png)

### _How was this patch tested?_
create table iceberg_spark.test_copy(id string,name string);
insert into  iceberg_spark.test_copy values(“111111”，“中国人人人儿呢热");
insert into  iceberg_spark.test_copy values(“222223”，“rrrrxxxxxx");

Configure the ranger strategy
<img width="1558" alt="image" src="https://user-images.githubusercontent.com/33471639/225361502-a9665aa5-6b37-4d29-b4d4-d7f8255f1fc2.png">
<img width="493" alt="image" src="https://user-images.githubusercontent.com/33471639/225362014-debb9e92-895d-47db-84a1-78d637a6d016.png">



