### PR TITLE
[KYUUBI #4546] Fully exclude `metrics` dir from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,8 +58,7 @@ metastore_db
 derby.log
 rest-audit.log
 **/dependency-reduced-pom.xml
-metrics/report.json
-metrics/.report.json.crc
+metrics/
 /kyuubi-ha/embedded_zookeeper/
 embedded_zookeeper/
 /externals/kyuubi-spark-sql-engine/operation_logs/


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Follow our attitude towards other excluded folders, exclude the entire `metrics` folder.
Like in `.gitignore`
```
embedded_zookeeper/
```

`metrics` dir will be created in source code when run `KyuubiServer` in local IDE.

Close #4546

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
