### PR TITLE
[KYUUBI #4557][HELM] Kyuubi server should bind Pod IP by default

### DIFF
--- a/charts/kyuubi/templates/kyuubi-configmap.yaml
+++ b/charts/kyuubi/templates/kyuubi-configmap.yaml
@@ -34,7 +34,7 @@ data:
   kyuubi-defaults.conf: |
     ## Helm chart provided Kyuubi configurations
     kyuubi.kubernetes.namespace={{ .Release.Namespace }}
-    kyuubi.frontend.bind.host=localhost
+    kyuubi.frontend.connection.url.use.hostname=false
     kyuubi.frontend.thrift.binary.bind.port={{ .Values.server.thriftBinary.port }}
     kyuubi.frontend.thrift.http.bind.port={{ .Values.server.thriftHttp.port }}
     kyuubi.frontend.rest.bind.port={{ .Values.server.rest.port }}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fix #4557.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

After changing, the Kyuubi Server correctly binds the Pod IP.
```
KyuubiTBinaryFrontendService#64 - Starting and exposing JDBC connection at: jdbc:hive2://10.88.224.214:10009/
```

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
