### PR TITLE
[Improvement] Format error log output in case of metrics json file not found

### DIFF
--- a/kyuubi-metrics/src/main/scala/org/apache/kyuubi/metrics/JsonReporterService.scala
+++ b/kyuubi-metrics/src/main/scala/org/apache/kyuubi/metrics/JsonReporterService.scala
@@ -65,7 +65,7 @@ class JsonReporterService(registry: MetricRegistry)
             Files.setPosixFilePermissions(tmpPath, PosixFilePermissions.fromString("rwxr--r--"))
             Files.move(tmpPath, reportPath, StandardCopyOption.REPLACE_EXISTING)
           } catch {
-            case NonFatal(e) => error("Error writing metrics to json file" + reportPath, e)
+            case NonFatal(e) => error("Error writing metrics to json file: " + reportPath, e)
           } finally {
             if (writer != null) writer.close()
           }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Before
```log
2023-03-20 10:02:04.718 ERROR org.apache.kyuubi.metrics.JsonReporterService: Error writing metrics to json file/pathi/metrics/report.json
```

After
```log
2023-03-20 10:02:04.718 ERROR org.apache.kyuubi.metrics.JsonReporterService: Error writing metrics to json file: /path/metrics/report.json
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
