### PR TITLE
[KYUUBI #3646][Improvement][UI] Front-end style should bracket same line

### DIFF
--- a/kyuubi-server/web-ui/.prettierrc
+++ b/kyuubi-server/web-ui/.prettierrc
@@ -4,7 +4,7 @@
   "vueIndentScriptAndStyle": true,
   "singleQuote": true,
   "quoteProps": "as-needed",
-  "jsxBracketSameLine": false,
+  "bracketSameLine": true,
   "jsxSingleQuote": true,
   "arrowParens": "always",
   "htmlWhitespaceSensitivity": "strict",

--- a/kyuubi-server/web-ui/src/components/menu/index.vue
+++ b/kyuubi-server/web-ui/src/components/menu/index.vue
@@ -21,14 +21,12 @@
     class="el-menu-container"
     :collapse="isCollapse"
     :default-active="activePath"
-    :router="true"
-  >
+    :router="true">
     <template v-for="(menu, index) in menus">
       <el-menu-item
         v-if="!menu.children || menu.children.length === 0"
         :key="index + '-1'"
-        :index="menu.router"
-      >
+        :index="menu.router">
         <el-icon>
           <component :is="menu.icon" />
         </el-icon>
@@ -44,8 +42,7 @@
         <el-menu-item
           v-for="(child, index2) in menu.children"
           :key="index2"
-          :index="child.router"
-        >
+          :index="child.router">
           <el-icon :size="16">
             <component :is="child.icon" />
           </el-icon>

--- a/kyuubi-server/web-ui/src/views/layout/components/header/index.vue
+++ b/kyuubi-server/web-ui/src/views/layout/components/header/index.vue
@@ -33,8 +33,7 @@
           <el-dropdown-item
             v-for="(locale, key) in locales"
             :key="key"
-            :command="locale.key"
-          >
+            :command="locale.key">
             {{ locale.label }}
           </el-dropdown-item>
         </el-dropdown-menu>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Should bracket same line.

According to https://www.npmjs.com/package/prettier-config-standard?activeTab=code, should set true to bracketSameLine and also drop jsxBracketSameLine, which been deprecated.

Close #3646

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request

- [x] CI
