### PR TITLE
Fix the empty last line may causes the session to exit directly

### DIFF
--- a/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/KyuubiCommands.java
+++ b/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/KyuubiCommands.java
@@ -93,8 +93,9 @@ public class KyuubiCommands extends Commands {
           lines += "\n" + extra;
         }
       }
-      String[] cmds = lines.split(";");
+      String[] cmds = lines.split(beeLine.getOpts().getDelimiter());
       for (String c : cmds) {
+        c = c.trim();
         if (!executeInternal(c, false)) {
           return false;
         }


### PR DESCRIPTION
### _Why are the changes needed?_
If the last line of the file is a blank line, there may be a cmd whose content is empty but the length is not 0 after split by ";". When running to this cmd, it will return false, causing the session to exit directly.


### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible
vim test.sql and write :
<img width="527" alt="image" src="https://user-images.githubusercontent.com/43542750/226647817-855d866e-836c-4c60-bc81-0bb192d3d6ff.png">
then start beeline and source this file successfully and session won't exit：
<img width="745" alt="image" src="https://user-images.githubusercontent.com/43542750/226652451-823891f3-2768-4165-8816-c052461d1f9c.png">
<img width="598" alt="image" src="https://user-images.githubusercontent.com/43542750/226650769-25a8becf-4655-41ec-bf91-7ae7e28b7d34.png">

- [x] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
