### PR TITLE
Authz policy file generation

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/pom.xml
+++ b/extensions/spark/kyuubi-spark-authz/pom.xml
@@ -321,7 +321,6 @@
     </dependencies>
 
     <build>
-
         <testResources>
             <testResource>
                 <directory>${project.basedir}/src/test/resources</directory>
@@ -331,4 +330,38 @@
         <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
     </build>
 
+    <profiles>
+        <profile>
+            <id>genpolicy</id>
+            <activation>
+                <!-- activated when Ranger version is identical to required-->
+                <property>
+                    <name>ranger.version</name>
+                    <value>2.3.0</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>add-test-source</id>
+                                <goals>
+                                    <goal>add-test-source</goal>
+                                </goals>
+                                <phase>generate-sources</phase>
+                                <configuration>
+                                    <sources>
+                                        <source>src/test/gen/scala</source>
+                                    </sources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/extensions/spark/kyuubi-spark-authz/src/test/gen/scala/org/apache/kyuubi/plugin/spark/authz/gen/PolicyJsonFileGenerator.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/gen/scala/org/apache/kyuubi/plugin/spark/authz/gen/PolicyJsonFileGenerator.scala
@@ -1,0 +1,357 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.plugin.spark.authz.gen
+
+import java.nio.file.Paths
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicLong
+
+import scala.language.implicitConversions
+
+import com.fasterxml.jackson.annotation.JsonInclude.Include
+import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import org.apache.ranger.plugin.model.RangerPolicy
+
+import org.apache.kyuubi.plugin.spark.authz.gen.KRangerPolicyItemAccess.allowTypes
+import org.apache.kyuubi.plugin.spark.authz.gen.PolicyJsonFileGenerator.RangerAccessType.{all, alter, create, drop, index, lock, read, select, update, use, write, RangerAccessType}
+import org.apache.kyuubi.plugin.spark.authz.gen.RangerClassConversions.getRangerObject
+
+/**
+ * Generates the policy file to test/main/resources dir.
+ *
+ * Usage:
+ * build/mvn scala:run -pl :kyuubi-spark-authz_2.12
+ * -DmainClass=org.apache.kyuubi.plugin.spark.authz.gen.PolicyJsonFileGenerator
+ */
+private object PolicyJsonFileGenerator {
+  def main(args: Array[String]): Unit = {
+    writeRangerServicePolicesJson()
+  }
+
+  final private val mapper: ObjectMapper = JsonMapper.builder()
+    .addModule(DefaultScalaModule)
+    .serializationInclusion(Include.NON_NULL)
+    .build()
+
+  def writeRangerServicePolicesJson(): Unit = {
+    val pluginHome = getClass.getProtectionDomain.getCodeSource.getLocation.getPath
+      .split("target").head
+    val policyFileName = "sparkSql_hive_jenkins.json"
+    val policyFile = Paths.get(pluginHome, "src", "test", "resources", policyFileName).toFile
+    // scalastyle:off println
+    println(s"Writing ranger policies to $policyFileName.")
+    // scalastyle:on println
+    mapper.writerWithDefaultPrettyPrinter().writeValue(policyFile, servicePolicies)
+  }
+
+  private def servicePolicies: JsonNode = {
+    val inputStream = Thread.currentThread().getContextClassLoader
+      .getResourceAsStream("policies_base.json")
+    val rootObjNode = mapper.readTree(inputStream).asInstanceOf[ObjectNode]
+    val policies = genPolicies
+    // scalastyle:off println
+    println(s"Generated ${policies.size} policies.")
+    // scalastyle:on println
+    rootObjNode.set("policies", mapper.readTree(mapper.writeValueAsString(policies)))
+  }
+
+  private def genPolicies: Iterable[RangerPolicy] = {
+    List[RangerPolicy](
+      // access for all
+      policyAccessForAllUrl,
+      policyAccessForAllDbTableColumns,
+      policyAccessForAllDbUdf,
+      // access
+      policyAccessForDbAllColumns,
+      policyAccessForDefaultDbSrcTable,
+      policyAccessForDefaultBobUse,
+      policyAccessForDefaultBobSelect,
+      policyAccessForPermViewAccessOnly,
+      // row filter
+      policyFilterForSrcTableKeyLessThan20,
+      policyFilterForPermViewKeyLessThan20,
+      // data masking
+      policyMaskForPermView,
+      policyMaskForPermViewUser,
+      policyMaskNullifyForValue2,
+      policyMaskShowFirst4ForValue3,
+      policyMaskDateShowYearForValue4,
+      policyMaskShowFirst4ForValue5)
+      // fill the id and guid with auto-increased index
+      .map(p => {
+        val id = policyIdCounter.incrementAndGet()
+        p.setId(id)
+        p.setGuid(UUID.nameUUIDFromBytes(id.toString.getBytes()).toString)
+        p
+      })
+  }
+
+  final private lazy val policyIdCounter = new AtomicLong(0)
+
+  // resource template
+  private def databaseRes(values: List[String]) =
+    "database" -> KRangerPolicyResource(values = values).get
+  private def tableRes(values: List[String]) =
+    "table" -> KRangerPolicyResource(values = values).get
+  private def columnRes(values: List[String]) =
+    "column" -> KRangerPolicyResource(values = values).get
+
+  // users
+  private val admin = "admin"
+  private val bob = "bob"
+  private val kent = "kent"
+  private val permViewUser = "perm_view_user"
+  private val ownerPlaceHolder = "{OWNER}"
+  private val createOnlyUser = "create_only_user"
+  private val defaultTableOwner = "default_table_owner"
+  private val permViewOnlyUser = "user_perm_view_only"
+
+  // db
+  private val defaultDb = "default"
+  private val sparkCatalog = "spark_catalog"
+  private val icebergNamespace = "iceberg_ns"
+  private val namespace1 = "ns1"
+
+  // access type
+  object RangerAccessType extends Enumeration {
+    type RangerAccessType = Value
+    val select, update, create, drop, alter, index, lock, all, read, write, use = Value
+  }
+  implicit def actionTypeStr(t: RangerAccessType): String = t.toString
+
+  // resources
+  private val allDatabaseRes = databaseRes(List("*"))
+  private val allTableRes = tableRes(List("*"))
+  private val allColumnRes = columnRes(List("*"))
+  private val srcTableRes = tableRes(List("src"))
+
+  // policy type
+  private val POLICY_TYPE_ACCESS: Int = 0
+  private val POLICY_TYPE_DATAMASK: Int = 1
+  private val POLICY_TYPE_ROWFILTER: Int = 2
+
+  // policies
+  private val policyAccessForAllUrl = KRangerPolicy(
+    name = "all - url",
+    description = "Policy for all - url",
+    resources = Map("url" -> KRangerPolicyResource(
+      values = List("*"),
+      isRecursive = true)),
+    policyItems = List(KRangerPolicyItem(
+      users = List(admin),
+      accesses = allowTypes(select, update, create, drop, alter, index, lock, all, read, write),
+      delegateAdmin = true)))
+
+  private val policyAccessForAllDbTableColumns = KRangerPolicy(
+    name = "all - database, table, column",
+    description = "Policy for all - database, table, column",
+    resources = Map(allDatabaseRes, allTableRes, allColumnRes),
+    policyItems = List(KRangerPolicyItem(
+      users = List(admin),
+      accesses = allowTypes(select, update, create, drop, alter, index, lock, all, read, write),
+      delegateAdmin = true)))
+
+  private val policyAccessForAllDbUdf = KRangerPolicy(
+    name = "all - database, udf",
+    description = "Policy for all - database, udf",
+    resources = Map(allDatabaseRes, "udf" -> KRangerPolicyResource(values = List("*"))),
+    policyItems = List(KRangerPolicyItem(
+      users = List(admin),
+      accesses = allowTypes(select, update, create, drop, alter, index, lock, all, read, write),
+      delegateAdmin = true)))
+
+  private val policyAccessForDbAllColumns = KRangerPolicy(
+    name = "all - database, udf",
+    description = "Policy for all - database, udf",
+    resources = Map(
+      databaseRes(List(defaultDb, sparkCatalog, icebergNamespace, namespace1)),
+      allTableRes,
+      allColumnRes),
+    policyItems = List(
+      KRangerPolicyItem(
+        users = List(bob, permViewUser, ownerPlaceHolder),
+        accesses = allowTypes(select, update, create, drop, alter, index, lock, all, read, write),
+        delegateAdmin = true),
+      KRangerPolicyItem(
+        users = List(defaultTableOwner, createOnlyUser),
+        accesses = allowTypes(create),
+        delegateAdmin = true)))
+
+  private val policyAccessForDefaultDbSrcTable = KRangerPolicy(
+    name = "default_kent",
+    resources = Map(
+      databaseRes(List(defaultDb, sparkCatalog)),
+      srcTableRes,
+      columnRes(List("key"))),
+    policyItems = List(
+      KRangerPolicyItem(
+        users = List(kent),
+        accesses = allowTypes(select, update, create, drop, alter, index, lock, all, read, write),
+        delegateAdmin = true),
+      KRangerPolicyItem(
+        users = List(defaultTableOwner, createOnlyUser),
+        accesses = allowTypes(create),
+        delegateAdmin = true)))
+
+  private val policyFilterForSrcTableKeyLessThan20 = KRangerPolicy(
+    name = "src_key_less_than_20",
+    policyType = POLICY_TYPE_ROWFILTER,
+    resources = Map(
+      databaseRes(List(defaultDb)),
+      srcTableRes),
+    rowFilterPolicyItems = List(
+      KRangerRowFilterPolicyItem(
+        rowFilterInfo = KRangerPolicyItemRowFilterInfo(filterExpr = "key<20"),
+        accesses = allowTypes(select),
+        users = List(bob, permViewUser))))
+
+  private val policyFilterForPermViewKeyLessThan20 = KRangerPolicy(
+    name = "perm_view_key_less_than_20",
+    policyType = POLICY_TYPE_ROWFILTER,
+    resources = Map(
+      databaseRes(List(defaultDb)),
+      tableRes(List("perm_view"))),
+    rowFilterPolicyItems = List(
+      KRangerRowFilterPolicyItem(
+        rowFilterInfo = KRangerPolicyItemRowFilterInfo(filterExpr = "key<20"),
+        accesses = allowTypes(select),
+        users = List(permViewUser))))
+
+  private val policyAccessForDefaultBobUse = KRangerPolicy(
+    name = "default_bob_use",
+    resources = Map(
+      databaseRes(List("default_bob", sparkCatalog)),
+      tableRes(List("table_use*")),
+      allColumnRes),
+    policyItems = List(
+      KRangerPolicyItem(
+        users = List(bob),
+        accesses = allowTypes(update),
+        delegateAdmin = true)))
+
+  private val policyAccessForDefaultBobSelect = KRangerPolicy(
+    name = "default_bob_select",
+    resources = Map(
+      databaseRes(List("default_bob", sparkCatalog)),
+      tableRes(List("table_select*")),
+      allColumnRes),
+    policyItems = List(
+      KRangerPolicyItem(
+        users = List(bob),
+        accesses = allowTypes(select, use),
+        delegateAdmin = true)))
+
+  private val policyMaskForPermView = KRangerPolicy(
+    name = "src_value_hash_perm_view",
+    policyType = POLICY_TYPE_DATAMASK,
+    resources = Map(
+      databaseRes(List(defaultDb, sparkCatalog)),
+      srcTableRes,
+      columnRes(List("value1"))),
+    dataMaskPolicyItems = List(
+      KRangerDataMaskPolicyItem(
+        dataMaskInfo = KRangerPolicyItemDataMaskInfo(dataMaskType = "MASK_HASH"),
+        users = List(bob),
+        accesses = allowTypes(select),
+        delegateAdmin = true)))
+
+  private val policyMaskForPermViewUser = KRangerPolicy(
+    name = "src_value_hash",
+    policyType = POLICY_TYPE_DATAMASK,
+    resources = Map(
+      databaseRes(List(defaultDb, sparkCatalog)),
+      tableRes(List("perm_view")),
+      columnRes(List("value1"))),
+    dataMaskPolicyItems = List(
+      KRangerDataMaskPolicyItem(
+        dataMaskInfo = KRangerPolicyItemDataMaskInfo(dataMaskType = "MASK_HASH"),
+        users = List(permViewUser),
+        accesses = allowTypes(select),
+        delegateAdmin = true)))
+
+  private val policyMaskNullifyForValue2 = KRangerPolicy(
+    name = "src_value2_nullify",
+    policyType = POLICY_TYPE_DATAMASK,
+    resources = Map(
+      databaseRes(List(defaultDb, sparkCatalog, icebergNamespace, namespace1)),
+      srcTableRes,
+      columnRes(List("value2"))),
+    dataMaskPolicyItems = List(
+      KRangerDataMaskPolicyItem(
+        dataMaskInfo = KRangerPolicyItemDataMaskInfo(dataMaskType = "MASK"),
+        users = List(bob),
+        accesses = allowTypes(select),
+        delegateAdmin = true)))
+
+  private val policyMaskShowFirst4ForValue3 = KRangerPolicy(
+    name = "src_value3_sf4",
+    policyType = POLICY_TYPE_DATAMASK,
+    resources = Map(
+      databaseRes(List(defaultDb, sparkCatalog)),
+      srcTableRes,
+      columnRes(List("value3"))),
+    dataMaskPolicyItems = List(
+      KRangerDataMaskPolicyItem(
+        dataMaskInfo = KRangerPolicyItemDataMaskInfo(dataMaskType = "MASK_SHOW_FIRST_4"),
+        users = List(bob),
+        accesses = allowTypes(select),
+        delegateAdmin = true)))
+
+  private val policyMaskDateShowYearForValue4 = KRangerPolicy(
+    name = "src_value4_sf4",
+    policyType = POLICY_TYPE_DATAMASK,
+    resources = Map(
+      databaseRes(List(defaultDb, sparkCatalog)),
+      srcTableRes,
+      columnRes(List("value4"))),
+    dataMaskPolicyItems = List(
+      KRangerDataMaskPolicyItem(
+        dataMaskInfo = KRangerPolicyItemDataMaskInfo(dataMaskType = "MASK_DATE_SHOW_YEAR"),
+        users = List(bob),
+        accesses = allowTypes(select),
+        delegateAdmin = true)))
+
+  private val policyMaskShowFirst4ForValue5 = KRangerPolicy(
+    name = "src_value5_sf4",
+    policyType = POLICY_TYPE_DATAMASK,
+    resources = Map(
+      databaseRes(List(defaultDb, sparkCatalog)),
+      srcTableRes,
+      columnRes(List("value5"))),
+    dataMaskPolicyItems = List(
+      KRangerDataMaskPolicyItem(
+        dataMaskInfo = KRangerPolicyItemDataMaskInfo(dataMaskType = "MASK_SHOW_LAST_4"),
+        users = List(bob),
+        accesses = allowTypes(select),
+        delegateAdmin = true)))
+
+  private val policyAccessForPermViewAccessOnly = KRangerPolicy(
+    name = "someone_access_perm_view",
+    resources = Map(
+      databaseRes(List(defaultDb)),
+      tableRes(List("perm_view")),
+      allColumnRes),
+    policyItems = List(
+      KRangerPolicyItem(
+        users = List(permViewOnlyUser),
+        accesses = allowTypes(select),
+        delegateAdmin = true)))
+}

--- a/extensions/spark/kyuubi-spark-authz/src/test/gen/scala/org/apache/kyuubi/plugin/spark/authz/gen/RangerGenWrapper.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/gen/scala/org/apache/kyuubi/plugin/spark/authz/gen/RangerGenWrapper.scala
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kyuubi.plugin.spark.authz.gen
+
+import scala.collection.convert.ImplicitConversions._
+import scala.language.implicitConversions
+
+import org.apache.ranger.plugin.model.RangerPolicy
+import org.apache.ranger.plugin.model.RangerPolicy._
+
+trait RangerObjectGenerator[T] {
+  def get: T
+}
+
+object RangerClassConversions {
+  implicit def getRangerObject[T](g: RangerObjectGenerator[T]): T = g.get
+}
+
+case class KRangerPolicy(
+    service: String = "hive_jenkins",
+    name: String,
+    policyType: Int = 0,
+    description: String = "",
+    isAuditEnabled: Boolean = true,
+    resources: Map[String, RangerPolicyResource] = Map.empty,
+    conditions: List[RangerPolicyItemCondition] = List.empty,
+    policyItems: List[RangerPolicyItem] = List.empty,
+    denyPolicyItems: List[RangerPolicyItem] = List.empty,
+    allowExceptions: List[RangerPolicyItem] = List.empty,
+    denyExceptions: List[RangerPolicyItem] = List.empty,
+    dataMaskPolicyItems: List[RangerDataMaskPolicyItem] = List.empty,
+    rowFilterPolicyItems: List[RangerRowFilterPolicyItem] = List.empty,
+    id: Int = 0,
+    guid: String = "",
+    isEnabled: Boolean = true,
+    version: Int = 1) extends RangerObjectGenerator[RangerPolicy] {
+  override def get: RangerPolicy = {
+    val p = new RangerPolicy()
+    p.setService(service)
+    p.setName(name)
+    p.setPolicyType(policyType)
+    p.setDescription(description)
+    p.setIsAuditEnabled(isAuditEnabled)
+    p.setResources(resources)
+    p.setConditions(conditions)
+    p.setPolicyItems(policyItems)
+    p.setAllowExceptions(allowExceptions)
+    p.setDenyExceptions(denyExceptions)
+    p.setDataMaskPolicyItems(dataMaskPolicyItems)
+    p.setRowFilterPolicyItems(rowFilterPolicyItems)
+    p.setId(id)
+    p.setGuid(guid)
+    p.setIsAuditEnabled(isEnabled)
+    p.setVersion(version)
+    p
+  }
+}
+
+case class KRangerPolicyResource(
+    values: List[String] = List.empty,
+    isExcludes: Boolean = false,
+    isRecursive: Boolean = false) extends RangerObjectGenerator[RangerPolicyResource] {
+  override def get: RangerPolicyResource = {
+    val r = new RangerPolicyResource()
+    r.setValues(values)
+    r.setIsExcludes(isExcludes)
+    r.setIsRecursive(isRecursive)
+    r
+  }
+}
+
+case class KRangerPolicyItemCondition(
+    `type`: String,
+    values: List[String]) extends RangerObjectGenerator[RangerPolicyItemCondition] {
+  override def get: RangerPolicyItemCondition = {
+    val c = new RangerPolicyItemCondition()
+    c.setType(`type`)
+    c.setValues(values)
+    c
+  }
+}
+
+case class KRangerPolicyItem(
+    accesses: List[RangerPolicyItemAccess] = List.empty,
+    users: List[String] = List.empty,
+    groups: List[String] = List.empty,
+    conditions: List[RangerPolicyItemCondition] = List.empty,
+    delegateAdmin: Boolean = false) extends RangerObjectGenerator[RangerPolicyItem] {
+  override def get: RangerPolicyItem = {
+    val i = new RangerPolicyItem()
+    i.setAccesses(accesses)
+    i.setUsers(users)
+    i.setGroups(groups)
+    i.setConditions(conditions)
+    i.setDelegateAdmin(delegateAdmin)
+    i
+  }
+}
+
+case class KRangerPolicyItemAccess(
+    `type`: String,
+    isAllowed: Boolean) extends RangerObjectGenerator[RangerPolicyItemAccess] {
+  override def get: RangerPolicyItemAccess = {
+    val a = new RangerPolicyItemAccess
+    a.setType(`type`)
+    a.setIsAllowed(isAllowed)
+    a
+  }
+}
+
+object KRangerPolicyItemAccess {
+  def allowTypes(types: String*): List[RangerPolicyItemAccess] =
+    types.map(t => KRangerPolicyItemAccess(t, isAllowed = true).get).toList
+}
+
+case class KRangerDataMaskPolicyItem(
+    dataMaskInfo: RangerPolicyItemDataMaskInfo,
+    accesses: List[RangerPolicyItemAccess] = List.empty,
+    users: List[String] = List.empty,
+    groups: List[String] = List.empty,
+    conditions: List[RangerPolicyItemCondition] = List.empty,
+    delegateAdmin: Boolean = false) extends RangerObjectGenerator[RangerDataMaskPolicyItem] {
+  override def get: RangerDataMaskPolicyItem = {
+    val i = new RangerDataMaskPolicyItem
+    i.setDataMaskInfo(dataMaskInfo)
+    i.setAccesses(accesses)
+    i.setUsers(users)
+    i.setGroups(groups)
+    i.setConditions(conditions)
+    i.setDelegateAdmin(delegateAdmin)
+    i
+  }
+}
+
+case class KRangerPolicyItemDataMaskInfo(
+    dataMaskType: String) extends RangerObjectGenerator[RangerPolicyItemDataMaskInfo] {
+  override def get: RangerPolicyItemDataMaskInfo = {
+    val i = new RangerPolicyItemDataMaskInfo
+    i.setDataMaskType(dataMaskType)
+    i
+  }
+}
+
+case class KRangerRowFilterPolicyItem(
+    rowFilterInfo: RangerPolicyItemRowFilterInfo,
+    accesses: List[RangerPolicyItemAccess] = List.empty,
+    users: List[String] = List.empty,
+    groups: List[String] = List.empty,
+    conditions: List[RangerPolicyItemCondition] = List.empty,
+    delegateAdmin: Boolean = false) extends RangerObjectGenerator[RangerRowFilterPolicyItem] {
+  override def get: RangerRowFilterPolicyItem = {
+    val i = new RangerRowFilterPolicyItem
+    i.setRowFilterInfo(rowFilterInfo)
+    i.setAccesses(accesses)
+    i.setUsers(users)
+    i.setGroups(groups)
+    i.setConditions(conditions)
+    i.setDelegateAdmin(delegateAdmin)
+    i
+  }
+}
+
+case class KRangerPolicyItemRowFilterInfo(
+    filterExpr: String) extends RangerObjectGenerator[RangerPolicyItemRowFilterInfo] {
+  override def get: RangerPolicyItemRowFilterInfo = {
+    val i = new RangerPolicyItemRowFilterInfo
+    i.setFilterExpr(filterExpr)
+    i
+  }
+}

--- a/extensions/spark/kyuubi-spark-authz/src/test/resources/policies_base.json
+++ b/extensions/spark/kyuubi-spark-authz/src/test/resources/policies_base.json
@@ -1,0 +1,1678 @@
+{
+  "serviceName": "hive_jenkins",
+  "serviceId": 1,
+  "policyVersion": 85,
+  "policyUpdateTime": "20190429-21:36:09.000-+0800",
+  "policies": [
+    {
+      "service": "hive_jenkins",
+      "name": "all - url",
+      "policyType": 0,
+      "policyPriority": 0,
+      "description": "Policy for all - url",
+      "isAuditEnabled": true,
+      "resources": {
+        "url": {
+          "values": [
+            "*"
+          ],
+          "isExcludes": false,
+          "isRecursive": true
+        }
+      },
+      "policyItems": [
+        {
+          "accesses": [
+            {
+              "type": "select",
+              "isAllowed": true
+            },
+            {
+              "type": "update",
+              "isAllowed": true
+            },
+            {
+              "type": "create",
+              "isAllowed": true
+            },
+            {
+              "type": "drop",
+              "isAllowed": true
+            },
+            {
+              "type": "alter",
+              "isAllowed": true
+            },
+            {
+              "type": "index",
+              "isAllowed": true
+            },
+            {
+              "type": "lock",
+              "isAllowed": true
+            },
+            {
+              "type": "all",
+              "isAllowed": true
+            },
+            {
+              "type": "read",
+              "isAllowed": true
+            },
+            {
+              "type": "write",
+              "isAllowed": true
+            }
+          ],
+          "users": [
+            "admin"
+          ],
+          "groups": [],
+          "conditions": [],
+          "delegateAdmin": true
+        }
+      ],
+      "denyPolicyItems": [],
+      "allowExceptions": [],
+      "denyExceptions": [],
+      "dataMaskPolicyItems": [],
+      "rowFilterPolicyItems": [],
+      "options": {},
+      "validitySchedules": [],
+      "policyLabels": [],
+      "id": 1,
+      "guid": "cf7e6725-492f-434f-bffe-6bb4e3147246",
+      "isEnabled": true,
+      "version": 1
+    },
+    {
+      "service": "hive_jenkins",
+      "name": "all - database, table, column",
+      "policyType": 0,
+      "policyPriority": 0,
+      "description": "Policy for all - database, table, column",
+      "isAuditEnabled": true,
+      "resources": {
+        "database": {
+          "values": [
+            "*"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "column": {
+          "values": [
+            "*"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "table": {
+          "values": [
+            "*"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        }
+      },
+      "policyItems": [
+        {
+          "accesses": [
+            {
+              "type": "select",
+              "isAllowed": true
+            },
+            {
+              "type": "update",
+              "isAllowed": true
+            },
+            {
+              "type": "create",
+              "isAllowed": true
+            },
+            {
+              "type": "drop",
+              "isAllowed": true
+            },
+            {
+              "type": "alter",
+              "isAllowed": true
+            },
+            {
+              "type": "index",
+              "isAllowed": true
+            },
+            {
+              "type": "lock",
+              "isAllowed": true
+            },
+            {
+              "type": "all",
+              "isAllowed": true
+            },
+            {
+              "type": "read",
+              "isAllowed": true
+            },
+            {
+              "type": "write",
+              "isAllowed": true
+            }
+          ],
+          "users": [
+            "admin"
+          ],
+          "groups": [],
+          "conditions": [],
+          "delegateAdmin": true
+        }
+      ],
+      "denyPolicyItems": [],
+      "allowExceptions": [],
+      "denyExceptions": [],
+      "dataMaskPolicyItems": [],
+      "rowFilterPolicyItems": [],
+      "options": {},
+      "validitySchedules": [],
+      "policyLabels": [],
+      "id": 2,
+      "guid": "3b96138a-af4d-48bc-9544-58c5bfa1979b",
+      "isEnabled": true,
+      "version": 1
+    },
+    {
+      "service": "hive_jenkins",
+      "name": "all - database, udf",
+      "policyType": 0,
+      "policyPriority": 0,
+      "description": "Policy for all - database, udf",
+      "isAuditEnabled": true,
+      "resources": {
+        "database": {
+          "values": [
+            "*"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "udf": {
+          "values": [
+            "*"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        }
+      },
+      "policyItems": [
+        {
+          "accesses": [
+            {
+              "type": "select",
+              "isAllowed": true
+            },
+            {
+              "type": "update",
+              "isAllowed": true
+            },
+            {
+              "type": "create",
+              "isAllowed": true
+            },
+            {
+              "type": "drop",
+              "isAllowed": true
+            },
+            {
+              "type": "alter",
+              "isAllowed": true
+            },
+            {
+              "type": "index",
+              "isAllowed": true
+            },
+            {
+              "type": "lock",
+              "isAllowed": true
+            },
+            {
+              "type": "all",
+              "isAllowed": true
+            },
+            {
+              "type": "read",
+              "isAllowed": true
+            },
+            {
+              "type": "write",
+              "isAllowed": true
+            }
+          ],
+          "users": [
+            "admin"
+          ],
+          "groups": [],
+          "conditions": [],
+          "delegateAdmin": true
+        }
+      ],
+      "denyPolicyItems": [],
+      "allowExceptions": [],
+      "denyExceptions": [],
+      "dataMaskPolicyItems": [],
+      "rowFilterPolicyItems": [],
+      "options": {},
+      "validitySchedules": [],
+      "policyLabels": [],
+      "id": 3,
+      "guid": "db08fbb0-61da-4f33-8144-ccd89816151d",
+      "isEnabled": true,
+      "version": 1
+    },
+    {
+      "service": "hive_jenkins",
+      "name": "default",
+      "policyType": 0,
+      "policyPriority": 0,
+      "description": "",
+      "isAuditEnabled": true,
+      "resources": {
+        "database": {
+          "values": [
+            "default",
+            "spark_catalog",
+            "iceberg_ns",
+            "ns1"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "column": {
+          "values": [
+            "*"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "table": {
+          "values": [
+            "*"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        }
+      },
+      "policyItems": [
+        {
+          "accesses": [
+            {
+              "type": "select",
+              "isAllowed": true
+            },
+            {
+              "type": "update",
+              "isAllowed": true
+            },
+            {
+              "type": "create",
+              "isAllowed": true
+            },
+            {
+              "type": "drop",
+              "isAllowed": true
+            },
+            {
+              "type": "alter",
+              "isAllowed": true
+            },
+            {
+              "type": "index",
+              "isAllowed": true
+            },
+            {
+              "type": "lock",
+              "isAllowed": true
+            },
+            {
+              "type": "all",
+              "isAllowed": true
+            },
+            {
+              "type": "read",
+              "isAllowed": true
+            },
+            {
+              "type": "write",
+              "isAllowed": true
+            }
+          ],
+          "users": [
+            "bob",
+            "perm_view_user",
+            "{OWNER}"
+          ],
+          "groups": [],
+          "conditions": [],
+          "delegateAdmin": false
+        },
+        {
+          "accesses": [
+            {
+              "type": "select",
+              "isAllowed": false
+            },
+            {
+              "type": "update",
+              "isAllowed": false
+            },
+            {
+              "type": "create",
+              "isAllowed": true
+            },
+            {
+              "type": "drop",
+              "isAllowed": false
+            },
+            {
+              "type": "alter",
+              "isAllowed": false
+            },
+            {
+              "type": "index",
+              "isAllowed": false
+            },
+            {
+              "type": "lock",
+              "isAllowed": false
+            },
+            {
+              "type": "all",
+              "isAllowed": false
+            },
+            {
+              "type": "read",
+              "isAllowed": false
+            },
+            {
+              "type": "write",
+              "isAllowed": false
+            }
+          ],
+          "users": [
+            "default_table_owner",
+            "create_only_user"
+          ],
+          "groups": [],
+          "conditions": [],
+          "delegateAdmin": false
+        }
+      ],
+      "denyPolicyItems": [],
+      "allowExceptions": [],
+      "denyExceptions": [],
+      "dataMaskPolicyItems": [],
+      "rowFilterPolicyItems": [],
+      "options": {},
+      "validitySchedules": [],
+      "policyLabels": [
+        ""
+      ],
+      "id": 5,
+      "guid": "2db6099d-e4f1-41df-9d24-f2f47bed618e",
+      "isEnabled": true,
+      "version": 5
+    },
+    {
+      "service": "hive_jenkins",
+      "name": "default_kent",
+      "policyType": 0,
+      "policyPriority": 0,
+      "description": "",
+      "isAuditEnabled": true,
+      "resources": {
+        "database": {
+          "values": [
+            "default",
+            "spark_catalog"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "column": {
+          "values": [
+            "key"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "table": {
+          "values": [
+            "src"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        }
+      },
+      "policyItems": [
+        {
+          "accesses": [
+            {
+              "type": "select",
+              "isAllowed": true
+            },
+            {
+              "type": "update",
+              "isAllowed": true
+            },
+            {
+              "type": "create",
+              "isAllowed": true
+            },
+            {
+              "type": "drop",
+              "isAllowed": true
+            },
+            {
+              "type": "alter",
+              "isAllowed": true
+            },
+            {
+              "type": "index",
+              "isAllowed": true
+            },
+            {
+              "type": "lock",
+              "isAllowed": true
+            },
+            {
+              "type": "all",
+              "isAllowed": true
+            },
+            {
+              "type": "read",
+              "isAllowed": true
+            },
+            {
+              "type": "write",
+              "isAllowed": true
+            }
+          ],
+          "users": [
+            "kent"
+          ],
+          "groups": [],
+          "conditions": [],
+          "delegateAdmin": false
+        }
+      ],
+      "denyPolicyItems": [],
+      "allowExceptions": [],
+      "denyExceptions": [],
+      "dataMaskPolicyItems": [],
+      "rowFilterPolicyItems": [],
+      "options": {},
+      "validitySchedules": [],
+      "policyLabels": [
+        ""
+      ],
+      "id": 5,
+      "guid": "fd24db19-f7cc-4e13-a8ba-bbd5a07a2d8d",
+      "isEnabled": true,
+      "version": 5
+    },
+    {
+      "service": "hive_jenkins",
+      "name": "src_key _less_than_20",
+      "policyType": 2,
+      "policyPriority": 0,
+      "description": "",
+      "isAuditEnabled": true,
+      "resources": {
+        "database": {
+          "values": [
+            "default"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "table": {
+          "values": [
+            "src"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        }
+      },
+      "policyItems": [],
+      "denyPolicyItems": [],
+      "allowExceptions": [],
+      "denyExceptions": [],
+      "dataMaskPolicyItems": [],
+      "rowFilterPolicyItems": [
+        {
+          "rowFilterInfo": {
+            "filterExpr": "key\u003c20"
+          },
+          "accesses": [
+            {
+              "type": "select",
+              "isAllowed": true
+            }
+          ],
+          "users": [
+            "bob"
+          ],
+          "groups": [],
+          "conditions": [],
+          "delegateAdmin": false
+        }
+      ],
+      "serviceType": "hive",
+      "options": {},
+      "validitySchedules": [],
+      "policyLabels": [
+        ""
+      ],
+      "id": 4,
+      "guid": "f588a9ed-f7b1-48f7-9d0d-c12cf2b9b7ed",
+      "isEnabled": true,
+      "version": 26
+    },
+    {
+      "service": "hive_jenkins",
+      "name": "src_key_less_than_20_perm_view",
+      "policyType": 2,
+      "policyPriority": 0,
+      "description": "",
+      "isAuditEnabled": true,
+      "resources": {
+        "database": {
+          "values": [
+            "default"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "table": {
+          "values": [
+            "perm_view"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        }
+      },
+      "policyItems": [],
+      "denyPolicyItems": [],
+      "allowExceptions": [],
+      "denyExceptions": [],
+      "dataMaskPolicyItems": [],
+      "rowFilterPolicyItems": [
+        {
+          "rowFilterInfo": {
+            "filterExpr": "key\u003c20"
+          },
+          "accesses": [
+            {
+              "type": "select",
+              "isAllowed": true
+            }
+          ],
+          "users": [
+            "perm_view_user"
+          ],
+          "groups": [],
+          "conditions": [],
+          "delegateAdmin": false
+        }
+      ],
+      "serviceType": "hive",
+      "options": {},
+      "validitySchedules": [],
+      "policyLabels": [
+        ""
+      ],
+      "id": 22,
+      "guid": "c240a7ea-9d26-4db2-b925-d5dbe49bd447 \n",
+      "isEnabled": true,
+      "version": 26
+    },
+    {
+      "service": "hive_jenkins",
+      "name": "default_bob_use",
+      "policyType": 0,
+      "policyPriority": 0,
+      "description": "",
+      "isAuditEnabled": true,
+      "resources": {
+        "database": {
+          "values": [
+            "default_bob",
+            "spark_catalog"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "column": {
+          "values": [
+            "*"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "table": {
+          "values": [
+            "table_use*"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        }
+      },
+      "policyItems": [
+        {
+          "accesses": [
+            {
+              "type": "update",
+              "isAllowed": true
+            }
+          ],
+          "users": [
+            "bob"
+          ],
+          "groups": [],
+          "conditions": [],
+          "delegateAdmin": false
+        }
+      ],
+      "denyPolicyItems": [],
+      "allowExceptions": [],
+      "denyExceptions": [],
+      "dataMaskPolicyItems": [],
+      "rowFilterPolicyItems": [],
+      "options": {},
+      "validitySchedules": [],
+      "policyLabels": [
+        ""
+      ],
+      "id": 5,
+      "guid": "2eb6099d-e4f1-41df-9d24-f2f47bed618e",
+      "isEnabled": true,
+      "version": 5
+    },
+    {
+      "service": "hive_jenkins",
+      "name": "default_bob_select",
+      "policyType": 0,
+      "policyPriority": 0,
+      "description": "",
+      "isAuditEnabled": true,
+      "resources": {
+        "database": {
+          "values": [
+            "default_bob",
+            "spark_catalog"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "column": {
+          "values": [
+            "*"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "table": {
+          "values": [
+            "table_select*"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        }
+      },
+      "policyItems": [
+        {
+          "accesses": [
+            {
+              "type": "select",
+              "isAllowed": true
+            },
+            {
+              "type": "use",
+              "isAllowed": true
+            }
+          ],
+          "users": [
+            "bob"
+          ],
+          "groups": [],
+          "conditions": [],
+          "delegateAdmin": false
+        }
+      ],
+      "denyPolicyItems": [],
+      "allowExceptions": [],
+      "denyExceptions": [],
+      "dataMaskPolicyItems": [],
+      "rowFilterPolicyItems": [],
+      "options": {},
+      "validitySchedules": [],
+      "policyLabels": [
+        ""
+      ],
+      "id": 5,
+      "guid": "2fb6099d-e4f1-41df-9d24-f2f47bed618e",
+      "isEnabled": true,
+      "version": 5
+    },
+    {
+      "service": "hive_jenkins",
+      "name": "src_value_hash_perm_view",
+      "policyType": 1,
+      "policyPriority": 0,
+      "description": "",
+      "isAuditEnabled": true,
+      "resources": {
+        "database": {
+          "values": [
+            "default",
+            "spark_catalog"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "column": {
+          "values": [
+            "value1"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "table": {
+          "values": [
+            "src"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        }
+      },
+      "policyItems": [],
+      "denyPolicyItems": [],
+      "allowExceptions": [],
+      "denyExceptions": [],
+      "dataMaskPolicyItems": [
+        {
+          "dataMaskInfo": {
+            "dataMaskType": "MASK_HASH"
+          },
+          "accesses": [
+            {
+              "type": "select",
+              "isAllowed": true
+            }
+          ],
+          "users": [
+            "bob"
+          ],
+          "groups": [],
+          "conditions": [],
+          "delegateAdmin": false
+        }
+      ],
+      "rowFilterPolicyItems": [],
+      "options": {},
+      "validitySchedules": [],
+      "policyLabels": [
+        ""
+      ],
+      "id": 5,
+      "guid": "ed1868a1-bf79-4721-a3d5-6815cc7d4986",
+      "isEnabled": true,
+      "version": 1
+    },
+    {
+      "service": "hive_jenkins",
+      "name": "src_value_hash",
+      "policyType": 1,
+      "policyPriority": 0,
+      "description": "",
+      "isAuditEnabled": true,
+      "resources": {
+        "database": {
+          "values": [
+            "default",
+            "spark_catalog"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "column": {
+          "values": [
+            "value1"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "table": {
+          "values": [
+            "perm_view"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        }
+      },
+      "policyItems": [],
+      "denyPolicyItems": [],
+      "allowExceptions": [],
+      "denyExceptions": [],
+      "dataMaskPolicyItems": [
+        {
+          "dataMaskInfo": {
+            "dataMaskType": "MASK_HASH"
+          },
+          "accesses": [
+            {
+              "type": "select",
+              "isAllowed": true
+            }
+          ],
+          "users": [
+            "perm_view_user"
+          ],
+          "groups": [],
+          "conditions": [],
+          "delegateAdmin": false
+        }
+      ],
+      "rowFilterPolicyItems": [],
+      "options": {},
+      "validitySchedules": [],
+      "policyLabels": [
+        ""
+      ],
+      "id": 20,
+      "guid": "bfeddeab-50d0-4902-985f-42559efa39c3",
+      "isEnabled": true,
+      "version": 1
+    },
+    {
+      "service": "hive_jenkins",
+      "name": "src_value2_nullify",
+      "policyType": 1,
+      "policyPriority": 0,
+      "description": "",
+      "isAuditEnabled": true,
+      "resources": {
+        "database": {
+          "values": [
+            "default",
+            "spark_catalog",
+            "iceberg_ns",
+            "ns1"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "column": {
+          "values": [
+            "value2"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "table": {
+          "values": [
+            "src"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        }
+      },
+      "policyItems": [],
+      "denyPolicyItems": [],
+      "allowExceptions": [],
+      "denyExceptions": [],
+      "dataMaskPolicyItems": [
+        {
+          "dataMaskInfo": {
+            "dataMaskType": "MASK"
+          },
+          "accesses": [
+            {
+              "type": "select",
+              "isAllowed": true
+            }
+          ],
+          "users": [
+            "bob"
+          ],
+          "groups": [],
+          "conditions": [],
+          "delegateAdmin": false
+        }
+      ],
+      "rowFilterPolicyItems": [],
+      "options": {},
+      "validitySchedules": [],
+      "policyLabels": [
+        ""
+      ],
+      "id": 6,
+      "guid": "98a04cd7-8d14-4466-adc9-126d87a3af69",
+      "isEnabled": true,
+      "version": 1
+    },
+    {
+      "service": "hive_jenkins",
+      "name": "src_value3_sf4",
+      "policyType": 1,
+      "policyPriority": 0,
+      "description": "",
+      "isAuditEnabled": true,
+      "resources": {
+        "database": {
+          "values": [
+            "default",
+            "spark_catalog"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "column": {
+          "values": [
+            "value3"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "table": {
+          "values": [
+            "src"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        }
+      },
+      "policyItems": [],
+      "denyPolicyItems": [],
+      "allowExceptions": [],
+      "denyExceptions": [],
+      "dataMaskPolicyItems": [
+        {
+          "dataMaskInfo": {
+            "dataMaskType": "MASK_SHOW_FIRST_4"
+          },
+          "accesses": [
+            {
+              "type": "select",
+              "isAllowed": true
+            }
+          ],
+          "users": [
+            "bob"
+          ],
+          "groups": [],
+          "conditions": [],
+          "delegateAdmin": false
+        }
+      ],
+      "rowFilterPolicyItems": [],
+      "options": {},
+      "validitySchedules": [],
+      "policyLabels": [
+        ""
+      ],
+      "id": 7,
+      "guid": "9d50a525-b24c-4cf5-a885-d10d426368d1",
+      "isEnabled": true,
+      "version": 1
+    },
+    {
+      "service": "hive_jenkins",
+      "name": "src_value4_sf4",
+      "policyType": 1,
+      "policyPriority": 0,
+      "description": "",
+      "isAuditEnabled": true,
+      "resources": {
+        "database": {
+          "values": [
+            "default",
+            "spark_catalog"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "column": {
+          "values": [
+            "value4"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "table": {
+          "values": [
+            "src"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        }
+      },
+      "policyItems": [],
+      "denyPolicyItems": [],
+      "allowExceptions": [],
+      "denyExceptions": [],
+      "dataMaskPolicyItems": [
+        {
+          "dataMaskInfo": {
+            "dataMaskType": "MASK_DATE_SHOW_YEAR"
+          },
+          "accesses": [
+            {
+              "type": "select",
+              "isAllowed": true
+            }
+          ],
+          "users": [
+            "bob"
+          ],
+          "groups": [],
+          "conditions": [],
+          "delegateAdmin": false
+        }
+      ],
+      "rowFilterPolicyItems": [],
+      "options": {},
+      "validitySchedules": [],
+      "policyLabels": [
+        ""
+      ],
+      "id": 8,
+      "guid": "9d50a526-b24c-4cf5-a885-d10d426368d1",
+      "isEnabled": true,
+      "version": 1
+    },
+    {
+      "service": "hive_jenkins",
+      "name": "src_value5_show_last_4",
+      "policyType": 1,
+      "policyPriority": 0,
+      "description": "",
+      "isAuditEnabled": true,
+      "resources": {
+        "database": {
+          "values": [
+            "default",
+            "spark_catalog"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "column": {
+          "values": [
+            "value5"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "table": {
+          "values": [
+            "src"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        }
+      },
+      "policyItems": [],
+      "denyPolicyItems": [],
+      "allowExceptions": [],
+      "denyExceptions": [],
+      "dataMaskPolicyItems": [
+        {
+          "dataMaskInfo": {
+            "dataMaskType": "MASK_SHOW_LAST_4"
+          },
+          "accesses": [
+            {
+              "type": "select",
+              "isAllowed": true
+            }
+          ],
+          "users": [
+            "bob"
+          ],
+          "groups": [],
+          "conditions": [],
+          "delegateAdmin": false
+        }
+      ],
+      "rowFilterPolicyItems": [],
+      "options": {},
+      "validitySchedules": [],
+      "policyLabels": [
+        ""
+      ],
+      "id": 32,
+      "guid": "b3f1f1e0-2bd6-4b20-8a32-a531006ae151",
+      "isEnabled": true,
+      "version": 1
+    },
+    {
+      "service": "hive_jenkins",
+      "name": "someone_access_perm_view",
+      "policyType": 0,
+      "policyPriority": 0,
+      "description": "",
+      "isAuditEnabled": true,
+      "resources": {
+        "database": {
+          "values": [
+            "default"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "column": {
+          "values": [
+            "*"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "table": {
+          "values": [
+            "perm_view"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        }
+      },
+      "policyItems": [
+        {
+          "accesses": [
+            {
+              "type": "select",
+              "isAllowed": true
+            }
+          ],
+          "users": [
+            "user_perm_view_only"
+          ],
+          "groups": [],
+          "conditions": [],
+          "delegateAdmin": false
+        }
+      ],
+      "denyPolicyItems": [],
+      "allowExceptions": [],
+      "denyExceptions": [],
+      "dataMaskPolicyItems": [],
+      "rowFilterPolicyItems": [],
+      "options": {},
+      "validitySchedules": [],
+      "policyLabels": [
+        ""
+      ],
+      "id": 123,
+      "guid": "2fb6099d-e421-41df-9d24-f2f47bed618e",
+      "isEnabled": true,
+      "version": 5
+    }
+  ],
+  "serviceDef": {
+    "name": "hive",
+    "implClass": "org.apache.ranger.services.hive.RangerServiceHive",
+    "label": "Hive Server2",
+    "description": "Hive Server2",
+    "options": {
+      "enableDenyAndExceptionsInPolicies": "true"
+    },
+    "configs": [
+      {
+        "itemId": 1,
+        "name": "username",
+        "type": "string",
+        "mandatory": true,
+        "validationRegEx": "",
+        "validationMessage": "",
+        "uiHint": "",
+        "label": "Username"
+      },
+      {
+        "itemId": 2,
+        "name": "password",
+        "type": "password",
+        "mandatory": true,
+        "validationRegEx": "",
+        "validationMessage": "",
+        "uiHint": "",
+        "label": "Password"
+      },
+      {
+        "itemId": 3,
+        "name": "jdbc.driverClassName",
+        "type": "string",
+        "mandatory": true,
+        "defaultValue": "org.apache.hive.jdbc.HiveDriver",
+        "validationRegEx": "",
+        "validationMessage": "",
+        "uiHint": ""
+      },
+      {
+        "itemId": 4,
+        "name": "jdbc.url",
+        "type": "string",
+        "mandatory": true,
+        "defaultValue": "",
+        "validationRegEx": "",
+        "validationMessage": "",
+        "uiHint": "{\"TextFieldWithIcon\":true, \"info\": \"1.For Remote Mode, eg.\u003cbr\u003ejdbc:hive2://\u0026lt;host\u0026gt;:\u0026lt;port\u0026gt;\u003cbr\u003e2.For Embedded Mode (no host or port), eg.\u003cbr\u003ejdbc:hive2:///;initFile\u003d\u0026lt;file\u0026gt;\u003cbr\u003e3.For HTTP Mode, eg.\u003cbr\u003ejdbc:hive2://\u0026lt;host\u0026gt;:\u0026lt;port\u0026gt;/;\u003cbr\u003etransportMode\u003dhttp;httpPath\u003d\u0026lt;httpPath\u0026gt;\u003cbr\u003e4.For SSL Mode, eg.\u003cbr\u003ejdbc:hive2://\u0026lt;host\u0026gt;:\u0026lt;port\u0026gt;/;ssl\u003dtrue;\u003cbr\u003esslTrustStore\u003dtStore;trustStorePassword\u003dpw\u003cbr\u003e5.For ZooKeeper Mode, eg.\u003cbr\u003ejdbc:hive2://\u0026lt;host\u0026gt;/;serviceDiscoveryMode\u003d\u003cbr\u003ezooKeeper;zooKeeperNamespace\u003dhiveserver2\u003cbr\u003e6.For Kerberos Mode, eg.\u003cbr\u003ejdbc:hive2://\u0026lt;host\u0026gt;:\u0026lt;port\u0026gt;/;\u003cbr\u003eprincipal\u003dhive/domain@EXAMPLE.COM\u003cbr\u003e\"}"
+      },
+      {
+        "itemId": 5,
+        "name": "commonNameForCertificate",
+        "type": "string",
+        "mandatory": false,
+        "validationRegEx": "",
+        "validationMessage": "",
+        "uiHint": "",
+        "label": "Common Name for Certificate"
+      }
+    ],
+    "resources": [
+      {
+        "itemId": 1,
+        "name": "database",
+        "type": "string",
+        "level": 10,
+        "mandatory": true,
+        "lookupSupported": true,
+        "recursiveSupported": false,
+        "excludesSupported": true,
+        "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+        "matcherOptions": {
+          "wildCard": "true",
+          "ignoreCase": "true"
+        },
+        "validationRegEx": "",
+        "validationMessage": "",
+        "uiHint": "",
+        "label": "Hive Database",
+        "description": "Hive Database",
+        "accessTypeRestrictions": [],
+        "isValidLeaf": false
+      },
+      {
+        "itemId": 5,
+        "name": "url",
+        "type": "string",
+        "level": 10,
+        "mandatory": true,
+        "lookupSupported": false,
+        "recursiveSupported": true,
+        "excludesSupported": false,
+        "matcher": "org.apache.ranger.plugin.resourcematcher.RangerPathResourceMatcher",
+        "matcherOptions": {
+          "wildCard": "true",
+          "ignoreCase": "false"
+        },
+        "validationRegEx": "",
+        "validationMessage": "",
+        "uiHint": "",
+        "label": "URL",
+        "description": "URL",
+        "accessTypeRestrictions": [],
+        "isValidLeaf": true
+      },
+      {
+        "itemId": 2,
+        "name": "table",
+        "type": "string",
+        "level": 20,
+        "parent": "database",
+        "mandatory": true,
+        "lookupSupported": true,
+        "recursiveSupported": false,
+        "excludesSupported": true,
+        "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+        "matcherOptions": {
+          "wildCard": "true",
+          "ignoreCase": "true"
+        },
+        "validationRegEx": "",
+        "validationMessage": "",
+        "uiHint": "",
+        "label": "Hive Table",
+        "description": "Hive Table",
+        "accessTypeRestrictions": [],
+        "isValidLeaf": false
+      },
+      {
+        "itemId": 3,
+        "name": "udf",
+        "type": "string",
+        "level": 20,
+        "parent": "database",
+        "mandatory": true,
+        "lookupSupported": true,
+        "recursiveSupported": false,
+        "excludesSupported": true,
+        "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+        "matcherOptions": {
+          "wildCard": "true",
+          "ignoreCase": "true"
+        },
+        "validationRegEx": "",
+        "validationMessage": "",
+        "uiHint": "",
+        "label": "Hive UDF",
+        "description": "Hive UDF",
+        "accessTypeRestrictions": [],
+        "isValidLeaf": true
+      },
+      {
+        "itemId": 4,
+        "name": "column",
+        "type": "string",
+        "level": 30,
+        "parent": "table",
+        "mandatory": true,
+        "lookupSupported": true,
+        "recursiveSupported": false,
+        "excludesSupported": true,
+        "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+        "matcherOptions": {
+          "wildCard": "true",
+          "ignoreCase": "true"
+        },
+        "validationRegEx": "",
+        "validationMessage": "",
+        "uiHint": "",
+        "label": "Hive Column",
+        "description": "Hive Column",
+        "accessTypeRestrictions": [],
+        "isValidLeaf": true
+      }
+    ],
+    "accessTypes": [
+      {
+        "itemId": 1,
+        "name": "select",
+        "label": "select",
+        "impliedGrants": []
+      },
+      {
+        "itemId": 2,
+        "name": "update",
+        "label": "update",
+        "impliedGrants": []
+      },
+      {
+        "itemId": 3,
+        "name": "create",
+        "label": "Create",
+        "impliedGrants": []
+      },
+      {
+        "itemId": 4,
+        "name": "drop",
+        "label": "Drop",
+        "impliedGrants": []
+      },
+      {
+        "itemId": 5,
+        "name": "alter",
+        "label": "Alter",
+        "impliedGrants": []
+      },
+      {
+        "itemId": 6,
+        "name": "index",
+        "label": "Index",
+        "impliedGrants": []
+      },
+      {
+        "itemId": 7,
+        "name": "lock",
+        "label": "Lock",
+        "impliedGrants": []
+      },
+      {
+        "itemId": 8,
+        "name": "all",
+        "label": "All",
+        "impliedGrants": [
+          "select",
+          "update",
+          "create",
+          "drop",
+          "alter",
+          "index",
+          "lock",
+          "read",
+          "write"
+        ]
+      },
+      {
+        "itemId": 9,
+        "name": "read",
+        "label": "Read",
+        "impliedGrants": []
+      },
+      {
+        "itemId": 10,
+        "name": "write",
+        "label": "Write",
+        "impliedGrants": []
+      }
+    ],
+    "policyConditions": [],
+    "contextEnrichers": [],
+    "enums": [],
+    "dataMaskDef": {
+      "maskTypes": [
+        {
+          "itemId": 1,
+          "name": "MASK",
+          "label": "Redact",
+          "description": "Replace lowercase with \u0027x\u0027, uppercase with \u0027X\u0027, digits with \u00270\u0027",
+          "transformer": "mask({col})",
+          "dataMaskOptions": {}
+        },
+        {
+          "itemId": 2,
+          "name": "MASK_SHOW_LAST_4",
+          "label": "Partial mask: show last 4",
+          "description": "Show last 4 characters; replace rest with \u0027x\u0027",
+          "transformer": "mask_show_last_n({col}, 4, \u0027x\u0027, \u0027x\u0027, \u0027x\u0027, -1, \u00271\u0027)",
+          "dataMaskOptions": {}
+        },
+        {
+          "itemId": 3,
+          "name": "MASK_SHOW_FIRST_4",
+          "label": "Partial mask: show first 4",
+          "description": "Show first 4 characters; replace rest with \u0027x\u0027",
+          "transformer": "mask_show_first_n({col}, 4, \u0027x\u0027, \u0027x\u0027, \u0027x\u0027, -1, \u00271\u0027)",
+          "dataMaskOptions": {}
+        },
+        {
+          "itemId": 4,
+          "name": "MASK_HASH",
+          "label": "Hash",
+          "description": "Hash the value",
+          "transformer": "mask_hash({col})",
+          "dataMaskOptions": {}
+        },
+        {
+          "itemId": 5,
+          "name": "MASK_NULL",
+          "label": "Nullify",
+          "description": "Replace with NULL",
+          "dataMaskOptions": {}
+        },
+        {
+          "itemId": 6,
+          "name": "MASK_NONE",
+          "label": "Unmasked (retain original value)",
+          "description": "No masking",
+          "dataMaskOptions": {}
+        },
+        {
+          "itemId": 12,
+          "name": "MASK_DATE_SHOW_YEAR",
+          "label": "Date: show only year",
+          "description": "Date: show only year",
+          "transformer": "mask({col}, \u0027x\u0027, \u0027x\u0027, \u0027x\u0027, -1, \u00271\u0027, 1, 0, -1)",
+          "dataMaskOptions": {}
+        },
+        {
+          "itemId": 13,
+          "name": "CUSTOM",
+          "label": "Custom",
+          "description": "Custom",
+          "dataMaskOptions": {}
+        }
+      ],
+      "accessTypes": [
+        {
+          "itemId": 1,
+          "name": "select",
+          "label": "select",
+          "impliedGrants": []
+        }
+      ],
+      "resources": [
+        {
+          "itemId": 1,
+          "name": "database",
+          "type": "string",
+          "level": 10,
+          "mandatory": true,
+          "lookupSupported": true,
+          "recursiveSupported": false,
+          "excludesSupported": false,
+          "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+          "matcherOptions": {
+            "wildCard": "false",
+            "ignoreCase": "true"
+          },
+          "validationRegEx": "",
+          "validationMessage": "",
+          "uiHint": "{ \"singleValue\":true }",
+          "label": "Hive Database",
+          "description": "Hive Database",
+          "accessTypeRestrictions": [],
+          "isValidLeaf": false
+        },
+        {
+          "itemId": 2,
+          "name": "table",
+          "type": "string",
+          "level": 20,
+          "parent": "database",
+          "mandatory": true,
+          "lookupSupported": true,
+          "recursiveSupported": false,
+          "excludesSupported": false,
+          "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+          "matcherOptions": {
+            "wildCard": "false",
+            "ignoreCase": "true"
+          },
+          "validationRegEx": "",
+          "validationMessage": "",
+          "uiHint": "{ \"singleValue\":true }",
+          "label": "Hive Table",
+          "description": "Hive Table",
+          "accessTypeRestrictions": [],
+          "isValidLeaf": false
+        },
+        {
+          "itemId": 4,
+          "name": "column",
+          "type": "string",
+          "level": 30,
+          "parent": "table",
+          "mandatory": true,
+          "lookupSupported": true,
+          "recursiveSupported": false,
+          "excludesSupported": false,
+          "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+          "matcherOptions": {
+            "wildCard": "false",
+            "ignoreCase": "true"
+          },
+          "validationRegEx": "",
+          "validationMessage": "",
+          "uiHint": "{ \"singleValue\":true }",
+          "label": "Hive Column",
+          "description": "Hive Column",
+          "accessTypeRestrictions": [],
+          "isValidLeaf": true
+        }
+      ]
+    },
+    "rowFilterDef": {
+      "accessTypes": [
+        {
+          "itemId": 1,
+          "name": "select",
+          "label": "select",
+          "impliedGrants": []
+        }
+      ],
+      "resources": [
+        {
+          "itemId": 1,
+          "name": "database",
+          "type": "string",
+          "level": 10,
+          "mandatory": true,
+          "lookupSupported": true,
+          "recursiveSupported": false,
+          "excludesSupported": false,
+          "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+          "matcherOptions": {
+            "wildCard": "false",
+            "ignoreCase": "true"
+          },
+          "validationRegEx": "",
+          "validationMessage": "",
+          "uiHint": "{ \"singleValue\":true }",
+          "label": "Hive Database",
+          "description": "Hive Database",
+          "accessTypeRestrictions": [],
+          "isValidLeaf": false
+        },
+        {
+          "itemId": 2,
+          "name": "table",
+          "type": "string",
+          "level": 20,
+          "parent": "database",
+          "mandatory": true,
+          "lookupSupported": true,
+          "recursiveSupported": false,
+          "excludesSupported": false,
+          "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+          "matcherOptions": {
+            "wildCard": "false",
+            "ignoreCase": "true"
+          },
+          "validationRegEx": "",
+          "validationMessage": "",
+          "uiHint": "{ \"singleValue\":true }",
+          "label": "Hive Table",
+          "description": "Hive Table",
+          "accessTypeRestrictions": [],
+          "isValidLeaf": true
+        }
+      ]
+    },
+    "id": 3,
+    "guid": "3e1afb5a-184a-4e82-9d9c-87a5cacc243c",
+    "isEnabled": true,
+    "createTime": "20190401-20:14:36.000-+0800",
+    "updateTime": "20190401-20:14:36.000-+0800",
+    "version": 1
+  },
+  "auditMode": "audit-default"
+}

--- a/extensions/spark/kyuubi-spark-authz/src/test/resources/sparkSql_hive_jenkins.json
+++ b/extensions/spark/kyuubi-spark-authz/src/test/resources/sparkSql_hive_jenkins.json
@@ -1,1675 +1,1353 @@
 {
-  "serviceName": "hive_jenkins",
-  "serviceId": 1,
-  "policyVersion": 85,
-  "policyUpdateTime": "20190429-21:36:09.000-+0800",
-  "policies": [
-    {
-      "service": "hive_jenkins",
-      "name": "all - url",
-      "policyType": 0,
-      "policyPriority": 0,
-      "description": "Policy for all - url",
-      "isAuditEnabled": true,
-      "resources": {
-        "url": {
-          "values": [
-            "*"
-          ],
-          "isExcludes": false,
-          "isRecursive": true
-        }
-      },
-      "policyItems": [
-        {
-          "accesses": [
-            {
-              "type": "select",
-              "isAllowed": true
-            },
-            {
-              "type": "update",
-              "isAllowed": true
-            },
-            {
-              "type": "create",
-              "isAllowed": true
-            },
-            {
-              "type": "drop",
-              "isAllowed": true
-            },
-            {
-              "type": "alter",
-              "isAllowed": true
-            },
-            {
-              "type": "index",
-              "isAllowed": true
-            },
-            {
-              "type": "lock",
-              "isAllowed": true
-            },
-            {
-              "type": "all",
-              "isAllowed": true
-            },
-            {
-              "type": "read",
-              "isAllowed": true
-            },
-            {
-              "type": "write",
-              "isAllowed": true
-            }
-          ],
-          "users": [
-            "admin"
-          ],
-          "groups": [],
-          "conditions": [],
-          "delegateAdmin": true
-        }
-      ],
-      "denyPolicyItems": [],
-      "allowExceptions": [],
-      "denyExceptions": [],
-      "dataMaskPolicyItems": [],
-      "rowFilterPolicyItems": [],
-      "options": {},
-      "validitySchedules": [],
-      "policyLabels": [],
-      "id": 1,
-      "guid": "cf7e6725-492f-434f-bffe-6bb4e3147246",
-      "isEnabled": true,
-      "version": 1
-    },
-    {
-      "service": "hive_jenkins",
-      "name": "all - database, table, column",
-      "policyType": 0,
-      "policyPriority": 0,
-      "description": "Policy for all - database, table, column",
-      "isAuditEnabled": true,
-      "resources": {
-        "database": {
-          "values": [
-            "*"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        },
-        "column": {
-          "values": [
-            "*"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        },
-        "table": {
-          "values": [
-            "*"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        }
-      },
-      "policyItems": [
-        {
-          "accesses": [
-            {
-              "type": "select",
-              "isAllowed": true
-            },
-            {
-              "type": "update",
-              "isAllowed": true
-            },
-            {
-              "type": "create",
-              "isAllowed": true
-            },
-            {
-              "type": "drop",
-              "isAllowed": true
-            },
-            {
-              "type": "alter",
-              "isAllowed": true
-            },
-            {
-              "type": "index",
-              "isAllowed": true
-            },
-            {
-              "type": "lock",
-              "isAllowed": true
-            },
-            {
-              "type": "all",
-              "isAllowed": true
-            },
-            {
-              "type": "read",
-              "isAllowed": true
-            },
-            {
-              "type": "write",
-              "isAllowed": true
-            }
-          ],
-          "users": [
-            "admin"
-          ],
-          "groups": [],
-          "conditions": [],
-          "delegateAdmin": true
-        }
-      ],
-      "denyPolicyItems": [],
-      "allowExceptions": [],
-      "denyExceptions": [],
-      "dataMaskPolicyItems": [],
-      "rowFilterPolicyItems": [],
-      "options": {},
-      "validitySchedules": [],
-      "policyLabels": [],
-      "id": 2,
-      "guid": "3b96138a-af4d-48bc-9544-58c5bfa1979b",
-      "isEnabled": true,
-      "version": 1
-    },
-    {
-      "service": "hive_jenkins",
-      "name": "all - database, udf",
-      "policyType": 0,
-      "policyPriority": 0,
-      "description": "Policy for all - database, udf",
-      "isAuditEnabled": true,
-      "resources": {
-        "database": {
-          "values": [
-            "*"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        },
-        "udf": {
-          "values": [
-            "*"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        }
-      },
-      "policyItems": [
-        {
-          "accesses": [
-            {
-              "type": "select",
-              "isAllowed": true
-            },
-            {
-              "type": "update",
-              "isAllowed": true
-            },
-            {
-              "type": "create",
-              "isAllowed": true
-            },
-            {
-              "type": "drop",
-              "isAllowed": true
-            },
-            {
-              "type": "alter",
-              "isAllowed": true
-            },
-            {
-              "type": "index",
-              "isAllowed": true
-            },
-            {
-              "type": "lock",
-              "isAllowed": true
-            },
-            {
-              "type": "all",
-              "isAllowed": true
-            },
-            {
-              "type": "read",
-              "isAllowed": true
-            },
-            {
-              "type": "write",
-              "isAllowed": true
-            }
-          ],
-          "users": [
-            "admin"
-          ],
-          "groups": [],
-          "conditions": [],
-          "delegateAdmin": true
-        }
-      ],
-      "denyPolicyItems": [],
-      "allowExceptions": [],
-      "denyExceptions": [],
-      "dataMaskPolicyItems": [],
-      "rowFilterPolicyItems": [],
-      "options": {},
-      "validitySchedules": [],
-      "policyLabels": [],
-      "id": 3,
-      "guid": "db08fbb0-61da-4f33-8144-ccd89816151d",
-      "isEnabled": true,
-      "version": 1
-    },
-    {
-      "service": "hive_jenkins",
-      "name": "default",
-      "policyType": 0,
-      "policyPriority": 0,
-      "description": "",
-      "isAuditEnabled": true,
-      "resources": {
-        "database": {
-          "values": [
-            "default",
-            "spark_catalog",
-            "iceberg_ns",
-            "ns1"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        },
-        "column": {
-          "values": [
-            "*"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        },
-        "table": {
-          "values": [
-            "*"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        }
-      },
-      "policyItems": [
-        {
-          "accesses": [
-            {
-              "type": "select",
-              "isAllowed": true
-            },
-            {
-              "type": "update",
-              "isAllowed": true
-            },
-            {
-              "type": "create",
-              "isAllowed": true
-            },
-            {
-              "type": "drop",
-              "isAllowed": true
-            },
-            {
-              "type": "alter",
-              "isAllowed": true
-            },
-            {
-              "type": "index",
-              "isAllowed": true
-            },
-            {
-              "type": "lock",
-              "isAllowed": true
-            },
-            {
-              "type": "all",
-              "isAllowed": true
-            },
-            {
-              "type": "read",
-              "isAllowed": true
-            },
-            {
-              "type": "write",
-              "isAllowed": true
-            }
-          ],
-          "users": [
-            "bob",
-            "perm_view_user",
-            "{OWNER}"
-          ],
-          "groups": [],
-          "conditions": [],
-          "delegateAdmin": false
-        }, {
-          "accesses": [
-            {
-              "type": "select",
-              "isAllowed": false
-            },
-            {
-              "type": "update",
-              "isAllowed": false
-            },
-            {
-              "type": "create",
-              "isAllowed": true
-            },
-            {
-              "type": "drop",
-              "isAllowed": false
-            },
-            {
-              "type": "alter",
-              "isAllowed": false
-            },
-            {
-              "type": "index",
-              "isAllowed": false
-            },
-            {
-              "type": "lock",
-              "isAllowed": false
-            },
-            {
-              "type": "all",
-              "isAllowed": false
-            },
-            {
-              "type": "read",
-              "isAllowed": false
-            },
-            {
-              "type": "write",
-              "isAllowed": false
-            }
-          ],
-          "users": [
-            "default_table_owner",
-            "create_only_user"
-          ],
-          "groups": [],
-          "conditions": [],
-          "delegateAdmin": false
-        }
-      ],
-      "denyPolicyItems": [],
-      "allowExceptions": [],
-      "denyExceptions": [],
-      "dataMaskPolicyItems": [],
-      "rowFilterPolicyItems": [],
-      "options": {},
-      "validitySchedules": [],
-      "policyLabels": [
-        ""
-      ],
-      "id": 5,
-      "guid": "2db6099d-e4f1-41df-9d24-f2f47bed618e",
-      "isEnabled": true,
-      "version": 5
-    },
-    {
-      "service": "hive_jenkins",
-      "name": "default_kent",
-      "policyType": 0,
-      "policyPriority": 0,
-      "description": "",
-      "isAuditEnabled": true,
-      "resources": {
-        "database": {
-          "values": [
-            "default",
-            "spark_catalog"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        },
-        "column": {
-          "values": [
-            "key"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        },
-        "table": {
-          "values": [
-            "src"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        }
-      },
-      "policyItems": [
-        {
-          "accesses": [
-            {
-              "type": "select",
-              "isAllowed": true
-            },
-            {
-              "type": "update",
-              "isAllowed": true
-            },
-            {
-              "type": "create",
-              "isAllowed": true
-            },
-            {
-              "type": "drop",
-              "isAllowed": true
-            },
-            {
-              "type": "alter",
-              "isAllowed": true
-            },
-            {
-              "type": "index",
-              "isAllowed": true
-            },
-            {
-              "type": "lock",
-              "isAllowed": true
-            },
-            {
-              "type": "all",
-              "isAllowed": true
-            },
-            {
-              "type": "read",
-              "isAllowed": true
-            },
-            {
-              "type": "write",
-              "isAllowed": true
-            }
-          ],
-          "users": [
-            "kent"
-          ],
-          "groups": [],
-          "conditions": [],
-          "delegateAdmin": false
-        }
-      ],
-      "denyPolicyItems": [],
-      "allowExceptions": [],
-      "denyExceptions": [],
-      "dataMaskPolicyItems": [],
-      "rowFilterPolicyItems": [],
-      "options": {},
-      "validitySchedules": [],
-      "policyLabels": [
-        ""
-      ],
-      "id": 5,
-      "guid": "fd24db19-f7cc-4e13-a8ba-bbd5a07a2d8d",
-      "isEnabled": true,
-      "version": 5
-    },
-    {
-      "service": "hive_jenkins",
-      "name": "src_key _less_than_20",
-      "policyType": 2,
-      "policyPriority": 0,
-      "description": "",
-      "isAuditEnabled": true,
-      "resources": {
-        "database": {
-          "values": [
-            "default"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        },
-        "table": {
-          "values": [
-            "src"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        }
-      },
-      "policyItems": [],
-      "denyPolicyItems": [],
-      "allowExceptions": [],
-      "denyExceptions": [],
-      "dataMaskPolicyItems": [],
-      "rowFilterPolicyItems": [
-        {
-          "rowFilterInfo": {
-            "filterExpr": "key\u003c20"
-          },
-          "accesses": [
-            {
-              "type": "select",
-              "isAllowed": true
-            }
-          ],
-          "users": [
-            "bob"
-          ],
-          "groups": [],
-          "conditions": [],
-          "delegateAdmin": false
-        }
-      ],
-      "serviceType": "hive",
-      "options": {},
-      "validitySchedules": [],
-      "policyLabels": [
-        ""
-      ],
-      "id": 4,
-      "guid": "f588a9ed-f7b1-48f7-9d0d-c12cf2b9b7ed",
-      "isEnabled": true,
-      "version": 26
-    },{
-      "service": "hive_jenkins",
-      "name": "src_key_less_than_20_perm_view",
-      "policyType": 2,
-      "policyPriority": 0,
-      "description": "",
-      "isAuditEnabled": true,
-      "resources": {
-        "database": {
-          "values": [
-            "default"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        },
-        "table": {
-          "values": [
-            "perm_view"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        }
-      },
-      "policyItems": [],
-      "denyPolicyItems": [],
-      "allowExceptions": [],
-      "denyExceptions": [],
-      "dataMaskPolicyItems": [],
-      "rowFilterPolicyItems": [
-        {
-          "rowFilterInfo": {
-            "filterExpr": "key\u003c20"
-          },
-          "accesses": [
-            {
-              "type": "select",
-              "isAllowed": true
-            }
-          ],
-          "users": [
-            "perm_view_user"
-          ],
-          "groups": [],
-          "conditions": [],
-          "delegateAdmin": false
-        }
-      ],
-      "serviceType": "hive",
-      "options": {},
-      "validitySchedules": [],
-      "policyLabels": [
-        ""
-      ],
-      "id": 22,
-      "guid": "c240a7ea-9d26-4db2-b925-d5dbe49bd447 \n",
-      "isEnabled": true,
-      "version": 26
-    },
-    {
-      "service": "hive_jenkins",
-      "name": "default_bob_use",
-      "policyType": 0,
-      "policyPriority": 0,
-      "description": "",
-      "isAuditEnabled": true,
-      "resources": {
-        "database": {
-          "values": [
-            "default_bob",
-            "spark_catalog"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        },
-        "column": {
-          "values": [
-            "*"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        },
-        "table": {
-          "values": [
-            "table_use*"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        }
-      },
-      "policyItems": [
-        {
-          "accesses": [
-            {
-              "type": "update",
-              "isAllowed": true
-            }
-          ],
-          "users": [
-            "bob"
-          ],
-          "groups": [],
-          "conditions": [],
-          "delegateAdmin": false
-        }
-      ],
-      "denyPolicyItems": [],
-      "allowExceptions": [],
-      "denyExceptions": [],
-      "dataMaskPolicyItems": [],
-      "rowFilterPolicyItems": [],
-      "options": {},
-      "validitySchedules": [],
-      "policyLabels": [
-        ""
-      ],
-      "id": 5,
-      "guid": "2eb6099d-e4f1-41df-9d24-f2f47bed618e",
-      "isEnabled": true,
-      "version": 5
-    },
-    {
-      "service": "hive_jenkins",
-      "name": "default_bob_select",
-      "policyType": 0,
-      "policyPriority": 0,
-      "description": "",
-      "isAuditEnabled": true,
-      "resources": {
-        "database": {
-          "values": [
-            "default_bob",
-            "spark_catalog"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        },
-        "column": {
-          "values": [
-            "*"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        },
-        "table": {
-          "values": [
-            "table_select*"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        }
-      },
-      "policyItems": [
-        {
-          "accesses": [
-            {
-              "type": "select",
-              "isAllowed": true
-            },
-            {
-              "type": "use",
-              "isAllowed": true
-            }
-          ],
-          "users": [
-            "bob"
-          ],
-          "groups": [],
-          "conditions": [],
-          "delegateAdmin": false
-        }
-      ],
-      "denyPolicyItems": [],
-      "allowExceptions": [],
-      "denyExceptions": [],
-      "dataMaskPolicyItems": [],
-      "rowFilterPolicyItems": [],
-      "options": {},
-      "validitySchedules": [],
-      "policyLabels": [
-        ""
-      ],
-      "id": 5,
-      "guid": "2fb6099d-e4f1-41df-9d24-f2f47bed618e",
-      "isEnabled": true,
-      "version": 5
-    },
-    {
-      "service": "hive_jenkins",
-      "name": "src_value_hash_perm_view",
-      "policyType": 1,
-      "policyPriority": 0,
-      "description": "",
-      "isAuditEnabled": true,
-      "resources": {
-        "database": {
-          "values": [
-            "default",
-            "spark_catalog"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        },
-        "column": {
-          "values": [
-            "value1"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        },
-        "table": {
-          "values": [
-            "src"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        }
-      },
-      "policyItems": [],
-      "denyPolicyItems": [],
-      "allowExceptions": [],
-      "denyExceptions": [],
-      "dataMaskPolicyItems": [
-        {
-          "dataMaskInfo": {
-            "dataMaskType": "MASK_HASH"
-          },
-          "accesses": [
-            {
-              "type": "select",
-              "isAllowed": true
-            }
-          ],
-          "users": [
-            "bob"
-          ],
-          "groups": [],
-          "conditions": [],
-          "delegateAdmin": false
-        }
-      ],
-      "rowFilterPolicyItems": [],
-      "options": {},
-      "validitySchedules": [],
-      "policyLabels": [
-        ""
-      ],
-      "id": 5,
-      "guid": "ed1868a1-bf79-4721-a3d5-6815cc7d4986",
-      "isEnabled": true,
-      "version": 1
-    },{
-      "service": "hive_jenkins",
-      "name": "src_value_hash",
-      "policyType": 1,
-      "policyPriority": 0,
-      "description": "",
-      "isAuditEnabled": true,
-      "resources": {
-        "database": {
-          "values": [
-            "default",
-            "spark_catalog"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        },
-        "column": {
-          "values": [
-            "value1"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        },
-        "table": {
-          "values": [
-            "perm_view"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        }
-      },
-      "policyItems": [],
-      "denyPolicyItems": [],
-      "allowExceptions": [],
-      "denyExceptions": [],
-      "dataMaskPolicyItems": [
-        {
-          "dataMaskInfo": {
-            "dataMaskType": "MASK_HASH"
-          },
-          "accesses": [
-            {
-              "type": "select",
-              "isAllowed": true
-            }
-          ],
-          "users": [
-            "perm_view_user"
-          ],
-          "groups": [],
-          "conditions": [],
-          "delegateAdmin": false
-        }
-      ],
-      "rowFilterPolicyItems": [],
-      "options": {},
-      "validitySchedules": [],
-      "policyLabels": [
-        ""
-      ],
-      "id": 20,
-      "guid": "bfeddeab-50d0-4902-985f-42559efa39c3",
-      "isEnabled": true,
-      "version": 1
-    },
-    {
-      "service": "hive_jenkins",
-      "name": "src_value2_nullify",
-      "policyType": 1,
-      "policyPriority": 0,
-      "description": "",
-      "isAuditEnabled": true,
-      "resources": {
-        "database": {
-          "values": [
-            "default",
-            "spark_catalog",
-            "iceberg_ns",
-            "ns1"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        },
-        "column": {
-          "values": [
-            "value2"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        },
-        "table": {
-          "values": [
-            "src"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        }
-      },
-      "policyItems": [],
-      "denyPolicyItems": [],
-      "allowExceptions": [],
-      "denyExceptions": [],
-      "dataMaskPolicyItems": [
-        {
-          "dataMaskInfo": {
-            "dataMaskType": "MASK"
-          },
-          "accesses": [
-            {
-              "type": "select",
-              "isAllowed": true
-            }
-          ],
-          "users": [
-            "bob"
-          ],
-          "groups": [],
-          "conditions": [],
-          "delegateAdmin": false
-        }
-      ],
-      "rowFilterPolicyItems": [],
-      "options": {},
-      "validitySchedules": [],
-      "policyLabels": [
-        ""
-      ],
-      "id": 6,
-      "guid": "98a04cd7-8d14-4466-adc9-126d87a3af69",
-      "isEnabled": true,
-      "version": 1
-    },
-    {
-      "service": "hive_jenkins",
-      "name": "src_value3_sf4",
-      "policyType": 1,
-      "policyPriority": 0,
-      "description": "",
-      "isAuditEnabled": true,
-      "resources": {
-        "database": {
-          "values": [
-            "default",
-            "spark_catalog"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        },
-        "column": {
-          "values": [
-            "value3"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        },
-        "table": {
-          "values": [
-            "src"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        }
-      },
-      "policyItems": [],
-      "denyPolicyItems": [],
-      "allowExceptions": [],
-      "denyExceptions": [],
-      "dataMaskPolicyItems": [
-        {
-          "dataMaskInfo": {
-            "dataMaskType": "MASK_SHOW_FIRST_4"
-          },
-          "accesses": [
-            {
-              "type": "select",
-              "isAllowed": true
-            }
-          ],
-          "users": [
-            "bob"
-          ],
-          "groups": [],
-          "conditions": [],
-          "delegateAdmin": false
-        }
-      ],
-      "rowFilterPolicyItems": [],
-      "options": {},
-      "validitySchedules": [],
-      "policyLabels": [
-        ""
-      ],
-      "id": 7,
-      "guid": "9d50a525-b24c-4cf5-a885-d10d426368d1",
-      "isEnabled": true,
-      "version": 1
-    },
-    {
-      "service": "hive_jenkins",
-      "name": "src_value4_sf4",
-      "policyType": 1,
-      "policyPriority": 0,
-      "description": "",
-      "isAuditEnabled": true,
-      "resources": {
-        "database": {
-          "values": [
-            "default",
-            "spark_catalog"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        },
-        "column": {
-          "values": [
-            "value4"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        },
-        "table": {
-          "values": [
-            "src"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        }
-      },
-      "policyItems": [],
-      "denyPolicyItems": [],
-      "allowExceptions": [],
-      "denyExceptions": [],
-      "dataMaskPolicyItems": [
-        {
-          "dataMaskInfo": {
-            "dataMaskType": "MASK_DATE_SHOW_YEAR"
-          },
-          "accesses": [
-            {
-              "type": "select",
-              "isAllowed": true
-            }
-          ],
-          "users": [
-            "bob"
-          ],
-          "groups": [],
-          "conditions": [],
-          "delegateAdmin": false
-        }
-      ],
-      "rowFilterPolicyItems": [],
-      "options": {},
-      "validitySchedules": [],
-      "policyLabels": [
-        ""
-      ],
-      "id": 8,
-      "guid": "9d50a526-b24c-4cf5-a885-d10d426368d1",
-      "isEnabled": true,
-      "version": 1
-    },
-    {
-      "service": "hive_jenkins",
-      "name": "src_value5_show_last_4",
-      "policyType": 1,
-      "policyPriority": 0,
-      "description": "",
-      "isAuditEnabled": true,
-      "resources": {
-        "database": {
-          "values": [
-            "default",
-            "spark_catalog"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        },
-        "column": {
-          "values": [
-            "value5"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        },
-        "table": {
-          "values": [
-            "src"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        }
-      },
-      "policyItems": [],
-      "denyPolicyItems": [],
-      "allowExceptions": [],
-      "denyExceptions": [],
-      "dataMaskPolicyItems": [
-        {
-          "dataMaskInfo": {
-            "dataMaskType": "MASK_SHOW_LAST_4"
-          },
-          "accesses": [
-            {
-              "type": "select",
-              "isAllowed": true
-            }
-          ],
-          "users": [
-            "bob"
-          ],
-          "groups": [],
-          "conditions": [],
-          "delegateAdmin": false
-        }
-      ],
-      "rowFilterPolicyItems": [],
-      "options": {},
-      "validitySchedules": [],
-      "policyLabels": [
-        ""
-      ],
-      "id": 32,
-      "guid": "b3f1f1e0-2bd6-4b20-8a32-a531006ae151",
-      "isEnabled": true,
-      "version": 1
-    },
-    {
-      "service": "hive_jenkins",
-      "name": "someone_access_perm_view",
-      "policyType": 0,
-      "policyPriority": 0,
-      "description": "",
-      "isAuditEnabled": true,
-      "resources": {
-        "database": {
-          "values": [
-            "default"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        },
-        "column": {
-          "values": [
-            "*"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        },
-        "table": {
-          "values": [
-            "perm_view"
-          ],
-          "isExcludes": false,
-          "isRecursive": false
-        }
-      },
-      "policyItems": [
-        {
-          "accesses": [
-            {
-              "type": "select",
-              "isAllowed": true
-            }
-          ],
-          "users": [
-            "user_perm_view_only"
-          ],
-          "groups": [],
-          "conditions": [],
-          "delegateAdmin": false
-        }
-      ],
-      "denyPolicyItems": [],
-      "allowExceptions": [],
-      "denyExceptions": [],
-      "dataMaskPolicyItems": [],
-      "rowFilterPolicyItems": [],
-      "options": {},
-      "validitySchedules": [],
-      "policyLabels": [
-        ""
-      ],
-      "id": 123,
-      "guid": "2fb6099d-e421-41df-9d24-f2f47bed618e",
-      "isEnabled": true,
-      "version": 5
-    }
-  ],
-  "serviceDef": {
-    "name": "hive",
-    "implClass": "org.apache.ranger.services.hive.RangerServiceHive",
-    "label": "Hive Server2",
-    "description": "Hive Server2",
-    "options": {
-      "enableDenyAndExceptionsInPolicies": "true"
-    },
-    "configs": [
-      {
-        "itemId": 1,
-        "name": "username",
-        "type": "string",
-        "mandatory": true,
-        "validationRegEx": "",
-        "validationMessage": "",
-        "uiHint": "",
-        "label": "Username"
-      },
-      {
-        "itemId": 2,
-        "name": "password",
-        "type": "password",
-        "mandatory": true,
-        "validationRegEx": "",
-        "validationMessage": "",
-        "uiHint": "",
-        "label": "Password"
-      },
-      {
-        "itemId": 3,
-        "name": "jdbc.driverClassName",
-        "type": "string",
-        "mandatory": true,
-        "defaultValue": "org.apache.hive.jdbc.HiveDriver",
-        "validationRegEx": "",
-        "validationMessage": "",
-        "uiHint": ""
-      },
-      {
-        "itemId": 4,
-        "name": "jdbc.url",
-        "type": "string",
-        "mandatory": true,
-        "defaultValue": "",
-        "validationRegEx": "",
-        "validationMessage": "",
-        "uiHint": "{\"TextFieldWithIcon\":true, \"info\": \"1.For Remote Mode, eg.\u003cbr\u003ejdbc:hive2://\u0026lt;host\u0026gt;:\u0026lt;port\u0026gt;\u003cbr\u003e2.For Embedded Mode (no host or port), eg.\u003cbr\u003ejdbc:hive2:///;initFile\u003d\u0026lt;file\u0026gt;\u003cbr\u003e3.For HTTP Mode, eg.\u003cbr\u003ejdbc:hive2://\u0026lt;host\u0026gt;:\u0026lt;port\u0026gt;/;\u003cbr\u003etransportMode\u003dhttp;httpPath\u003d\u0026lt;httpPath\u0026gt;\u003cbr\u003e4.For SSL Mode, eg.\u003cbr\u003ejdbc:hive2://\u0026lt;host\u0026gt;:\u0026lt;port\u0026gt;/;ssl\u003dtrue;\u003cbr\u003esslTrustStore\u003dtStore;trustStorePassword\u003dpw\u003cbr\u003e5.For ZooKeeper Mode, eg.\u003cbr\u003ejdbc:hive2://\u0026lt;host\u0026gt;/;serviceDiscoveryMode\u003d\u003cbr\u003ezooKeeper;zooKeeperNamespace\u003dhiveserver2\u003cbr\u003e6.For Kerberos Mode, eg.\u003cbr\u003ejdbc:hive2://\u0026lt;host\u0026gt;:\u0026lt;port\u0026gt;/;\u003cbr\u003eprincipal\u003dhive/domain@EXAMPLE.COM\u003cbr\u003e\"}"
-      },
-      {
-        "itemId": 5,
-        "name": "commonNameForCertificate",
-        "type": "string",
-        "mandatory": false,
-        "validationRegEx": "",
-        "validationMessage": "",
-        "uiHint": "",
-        "label": "Common Name for Certificate"
+  "serviceName" : "hive_jenkins",
+  "serviceId" : 1,
+  "policyVersion" : 85,
+  "policyUpdateTime" : "20190429-21:36:09.000-+0800",
+  "policies" : [ {
+    "id" : 1,
+    "guid" : "c4ca4238-a0b9-3382-8dcc-509a6f75849b",
+    "isEnabled" : true,
+    "version" : 1,
+    "service" : "hive_jenkins",
+    "name" : "all - url",
+    "policyType" : 0,
+    "policyPriority" : 0,
+    "description" : "Policy for all - url",
+    "isAuditEnabled" : true,
+    "resources" : {
+      "url" : {
+        "values" : [ "*" ],
+        "isExcludes" : false,
+        "isRecursive" : true
       }
-    ],
-    "resources": [
-      {
-        "itemId": 1,
-        "name": "database",
-        "type": "string",
-        "level": 10,
-        "mandatory": true,
-        "lookupSupported": true,
-        "recursiveSupported": false,
-        "excludesSupported": true,
-        "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
-        "matcherOptions": {
-          "wildCard": "true",
-          "ignoreCase": "true"
-        },
-        "validationRegEx": "",
-        "validationMessage": "",
-        "uiHint": "",
-        "label": "Hive Database",
-        "description": "Hive Database",
-        "accessTypeRestrictions": [],
-        "isValidLeaf": false
-      },
-      {
-        "itemId": 5,
-        "name": "url",
-        "type": "string",
-        "level": 10,
-        "mandatory": true,
-        "lookupSupported": false,
-        "recursiveSupported": true,
-        "excludesSupported": false,
-        "matcher": "org.apache.ranger.plugin.resourcematcher.RangerPathResourceMatcher",
-        "matcherOptions": {
-          "wildCard": "true",
-          "ignoreCase": "false"
-        },
-        "validationRegEx": "",
-        "validationMessage": "",
-        "uiHint": "",
-        "label": "URL",
-        "description": "URL",
-        "accessTypeRestrictions": [],
-        "isValidLeaf": true
-      },
-      {
-        "itemId": 2,
-        "name": "table",
-        "type": "string",
-        "level": 20,
-        "parent": "database",
-        "mandatory": true,
-        "lookupSupported": true,
-        "recursiveSupported": false,
-        "excludesSupported": true,
-        "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
-        "matcherOptions": {
-          "wildCard": "true",
-          "ignoreCase": "true"
-        },
-        "validationRegEx": "",
-        "validationMessage": "",
-        "uiHint": "",
-        "label": "Hive Table",
-        "description": "Hive Table",
-        "accessTypeRestrictions": [],
-        "isValidLeaf": false
-      },
-      {
-        "itemId": 3,
-        "name": "udf",
-        "type": "string",
-        "level": 20,
-        "parent": "database",
-        "mandatory": true,
-        "lookupSupported": true,
-        "recursiveSupported": false,
-        "excludesSupported": true,
-        "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
-        "matcherOptions": {
-          "wildCard": "true",
-          "ignoreCase": "true"
-        },
-        "validationRegEx": "",
-        "validationMessage": "",
-        "uiHint": "",
-        "label": "Hive UDF",
-        "description": "Hive UDF",
-        "accessTypeRestrictions": [],
-        "isValidLeaf": true
-      },
-      {
-        "itemId": 4,
-        "name": "column",
-        "type": "string",
-        "level": 30,
-        "parent": "table",
-        "mandatory": true,
-        "lookupSupported": true,
-        "recursiveSupported": false,
-        "excludesSupported": true,
-        "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
-        "matcherOptions": {
-          "wildCard": "true",
-          "ignoreCase": "true"
-        },
-        "validationRegEx": "",
-        "validationMessage": "",
-        "uiHint": "",
-        "label": "Hive Column",
-        "description": "Hive Column",
-        "accessTypeRestrictions": [],
-        "isValidLeaf": true
-      }
-    ],
-    "accessTypes": [
-      {
-        "itemId": 1,
-        "name": "select",
-        "label": "select",
-        "impliedGrants": []
-      },
-      {
-        "itemId": 2,
-        "name": "update",
-        "label": "update",
-        "impliedGrants": []
-      },
-      {
-        "itemId": 3,
-        "name": "create",
-        "label": "Create",
-        "impliedGrants": []
-      },
-      {
-        "itemId": 4,
-        "name": "drop",
-        "label": "Drop",
-        "impliedGrants": []
-      },
-      {
-        "itemId": 5,
-        "name": "alter",
-        "label": "Alter",
-        "impliedGrants": []
-      },
-      {
-        "itemId": 6,
-        "name": "index",
-        "label": "Index",
-        "impliedGrants": []
-      },
-      {
-        "itemId": 7,
-        "name": "lock",
-        "label": "Lock",
-        "impliedGrants": []
-      },
-      {
-        "itemId": 8,
-        "name": "all",
-        "label": "All",
-        "impliedGrants": [
-          "select",
-          "update",
-          "create",
-          "drop",
-          "alter",
-          "index",
-          "lock",
-          "read",
-          "write"
-        ]
-      },
-      {
-        "itemId": 9,
-        "name": "read",
-        "label": "Read",
-        "impliedGrants": []
-      },
-      {
-        "itemId": 10,
-        "name": "write",
-        "label": "Write",
-        "impliedGrants": []
-      }
-    ],
-    "policyConditions": [],
-    "contextEnrichers": [],
-    "enums": [],
-    "dataMaskDef": {
-      "maskTypes": [
-        {
-          "itemId": 1,
-          "name": "MASK",
-          "label": "Redact",
-          "description": "Replace lowercase with \u0027x\u0027, uppercase with \u0027X\u0027, digits with \u00270\u0027",
-          "transformer": "mask({col})",
-          "dataMaskOptions": {}
-        },
-        {
-          "itemId": 2,
-          "name": "MASK_SHOW_LAST_4",
-          "label": "Partial mask: show last 4",
-          "description": "Show last 4 characters; replace rest with \u0027x\u0027",
-          "transformer": "mask_show_last_n({col}, 4, \u0027x\u0027, \u0027x\u0027, \u0027x\u0027, -1, \u00271\u0027)",
-          "dataMaskOptions": {}
-        },
-        {
-          "itemId": 3,
-          "name": "MASK_SHOW_FIRST_4",
-          "label": "Partial mask: show first 4",
-          "description": "Show first 4 characters; replace rest with \u0027x\u0027",
-          "transformer": "mask_show_first_n({col}, 4, \u0027x\u0027, \u0027x\u0027, \u0027x\u0027, -1, \u00271\u0027)",
-          "dataMaskOptions": {}
-        },
-        {
-          "itemId": 4,
-          "name": "MASK_HASH",
-          "label": "Hash",
-          "description": "Hash the value",
-          "transformer": "mask_hash({col})",
-          "dataMaskOptions": {}
-        },
-        {
-          "itemId": 5,
-          "name": "MASK_NULL",
-          "label": "Nullify",
-          "description": "Replace with NULL",
-          "dataMaskOptions": {}
-        },
-        {
-          "itemId": 6,
-          "name": "MASK_NONE",
-          "label": "Unmasked (retain original value)",
-          "description": "No masking",
-          "dataMaskOptions": {}
-        },
-        {
-          "itemId": 12,
-          "name": "MASK_DATE_SHOW_YEAR",
-          "label": "Date: show only year",
-          "description": "Date: show only year",
-          "transformer": "mask({col}, \u0027x\u0027, \u0027x\u0027, \u0027x\u0027, -1, \u00271\u0027, 1, 0, -1)",
-          "dataMaskOptions": {}
-        },
-        {
-          "itemId": 13,
-          "name": "CUSTOM",
-          "label": "Custom",
-          "description": "Custom",
-          "dataMaskOptions": {}
-        }
-      ],
-      "accessTypes": [
-        {
-          "itemId": 1,
-          "name": "select",
-          "label": "select",
-          "impliedGrants": []
-        }
-      ],
-      "resources": [
-        {
-          "itemId": 1,
-          "name": "database",
-          "type": "string",
-          "level": 10,
-          "mandatory": true,
-          "lookupSupported": true,
-          "recursiveSupported": false,
-          "excludesSupported": false,
-          "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
-          "matcherOptions": {
-            "wildCard": "false",
-            "ignoreCase": "true"
-          },
-          "validationRegEx": "",
-          "validationMessage": "",
-          "uiHint": "{ \"singleValue\":true }",
-          "label": "Hive Database",
-          "description": "Hive Database",
-          "accessTypeRestrictions": [],
-          "isValidLeaf": false
-        },
-        {
-          "itemId": 2,
-          "name": "table",
-          "type": "string",
-          "level": 20,
-          "parent": "database",
-          "mandatory": true,
-          "lookupSupported": true,
-          "recursiveSupported": false,
-          "excludesSupported": false,
-          "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
-          "matcherOptions": {
-            "wildCard": "false",
-            "ignoreCase": "true"
-          },
-          "validationRegEx": "",
-          "validationMessage": "",
-          "uiHint": "{ \"singleValue\":true }",
-          "label": "Hive Table",
-          "description": "Hive Table",
-          "accessTypeRestrictions": [],
-          "isValidLeaf": false
-        },
-        {
-          "itemId": 4,
-          "name": "column",
-          "type": "string",
-          "level": 30,
-          "parent": "table",
-          "mandatory": true,
-          "lookupSupported": true,
-          "recursiveSupported": false,
-          "excludesSupported": false,
-          "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
-          "matcherOptions": {
-            "wildCard": "false",
-            "ignoreCase": "true"
-          },
-          "validationRegEx": "",
-          "validationMessage": "",
-          "uiHint": "{ \"singleValue\":true }",
-          "label": "Hive Column",
-          "description": "Hive Column",
-          "accessTypeRestrictions": [],
-          "isValidLeaf": true
-        }
-      ]
     },
-    "rowFilterDef": {
-      "accessTypes": [
-        {
-          "itemId": 1,
-          "name": "select",
-          "label": "select",
-          "impliedGrants": []
-        }
-      ],
-      "resources": [
-        {
-          "itemId": 1,
-          "name": "database",
-          "type": "string",
-          "level": 10,
-          "mandatory": true,
-          "lookupSupported": true,
-          "recursiveSupported": false,
-          "excludesSupported": false,
-          "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
-          "matcherOptions": {
-            "wildCard": "false",
-            "ignoreCase": "true"
-          },
-          "validationRegEx": "",
-          "validationMessage": "",
-          "uiHint": "{ \"singleValue\":true }",
-          "label": "Hive Database",
-          "description": "Hive Database",
-          "accessTypeRestrictions": [],
-          "isValidLeaf": false
-        },
-        {
-          "itemId": 2,
-          "name": "table",
-          "type": "string",
-          "level": 20,
-          "parent": "database",
-          "mandatory": true,
-          "lookupSupported": true,
-          "recursiveSupported": false,
-          "excludesSupported": false,
-          "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
-          "matcherOptions": {
-            "wildCard": "false",
-            "ignoreCase": "true"
-          },
-          "validationRegEx": "",
-          "validationMessage": "",
-          "uiHint": "{ \"singleValue\":true }",
-          "label": "Hive Table",
-          "description": "Hive Table",
-          "accessTypeRestrictions": [],
-          "isValidLeaf": true
-        }
-      ]
+    "conditions" : [ ],
+    "policyItems" : [ {
+      "accesses" : [ {
+        "type" : "select",
+        "isAllowed" : true
+      }, {
+        "type" : "update",
+        "isAllowed" : true
+      }, {
+        "type" : "create",
+        "isAllowed" : true
+      }, {
+        "type" : "drop",
+        "isAllowed" : true
+      }, {
+        "type" : "alter",
+        "isAllowed" : true
+      }, {
+        "type" : "index",
+        "isAllowed" : true
+      }, {
+        "type" : "lock",
+        "isAllowed" : true
+      }, {
+        "type" : "all",
+        "isAllowed" : true
+      }, {
+        "type" : "read",
+        "isAllowed" : true
+      }, {
+        "type" : "write",
+        "isAllowed" : true
+      } ],
+      "users" : [ "admin" ],
+      "groups" : [ ],
+      "roles" : [ ],
+      "conditions" : [ ],
+      "delegateAdmin" : true
+    } ],
+    "denyPolicyItems" : [ ],
+    "allowExceptions" : [ ],
+    "denyExceptions" : [ ],
+    "dataMaskPolicyItems" : [ ],
+    "rowFilterPolicyItems" : [ ],
+    "options" : { },
+    "validitySchedules" : [ ],
+    "policyLabels" : [ ],
+    "isDenyAllElse" : false
+  }, {
+    "id" : 2,
+    "guid" : "c81e728d-9d4c-3f63-af06-7f89cc14862c",
+    "isEnabled" : true,
+    "version" : 1,
+    "service" : "hive_jenkins",
+    "name" : "all - database, table, column",
+    "policyType" : 0,
+    "policyPriority" : 0,
+    "description" : "Policy for all - database, table, column",
+    "isAuditEnabled" : true,
+    "resources" : {
+      "database" : {
+        "values" : [ "*" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      },
+      "column" : {
+        "values" : [ "*" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      },
+      "table" : {
+        "values" : [ "*" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      }
     },
-    "id": 3,
-    "guid": "3e1afb5a-184a-4e82-9d9c-87a5cacc243c",
-    "isEnabled": true,
-    "createTime": "20190401-20:14:36.000-+0800",
-    "updateTime": "20190401-20:14:36.000-+0800",
-    "version": 1
+    "conditions" : [ ],
+    "policyItems" : [ {
+      "accesses" : [ {
+        "type" : "select",
+        "isAllowed" : true
+      }, {
+        "type" : "update",
+        "isAllowed" : true
+      }, {
+        "type" : "create",
+        "isAllowed" : true
+      }, {
+        "type" : "drop",
+        "isAllowed" : true
+      }, {
+        "type" : "alter",
+        "isAllowed" : true
+      }, {
+        "type" : "index",
+        "isAllowed" : true
+      }, {
+        "type" : "lock",
+        "isAllowed" : true
+      }, {
+        "type" : "all",
+        "isAllowed" : true
+      }, {
+        "type" : "read",
+        "isAllowed" : true
+      }, {
+        "type" : "write",
+        "isAllowed" : true
+      } ],
+      "users" : [ "admin" ],
+      "groups" : [ ],
+      "roles" : [ ],
+      "conditions" : [ ],
+      "delegateAdmin" : true
+    } ],
+    "denyPolicyItems" : [ ],
+    "allowExceptions" : [ ],
+    "denyExceptions" : [ ],
+    "dataMaskPolicyItems" : [ ],
+    "rowFilterPolicyItems" : [ ],
+    "options" : { },
+    "validitySchedules" : [ ],
+    "policyLabels" : [ ],
+    "isDenyAllElse" : false
+  }, {
+    "id" : 3,
+    "guid" : "eccbc87e-4b5c-32fe-a830-8fd9f2a7baf3",
+    "isEnabled" : true,
+    "version" : 1,
+    "service" : "hive_jenkins",
+    "name" : "all - database, udf",
+    "policyType" : 0,
+    "policyPriority" : 0,
+    "description" : "Policy for all - database, udf",
+    "isAuditEnabled" : true,
+    "resources" : {
+      "database" : {
+        "values" : [ "*" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      },
+      "udf" : {
+        "values" : [ "*" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      }
+    },
+    "conditions" : [ ],
+    "policyItems" : [ {
+      "accesses" : [ {
+        "type" : "select",
+        "isAllowed" : true
+      }, {
+        "type" : "update",
+        "isAllowed" : true
+      }, {
+        "type" : "create",
+        "isAllowed" : true
+      }, {
+        "type" : "drop",
+        "isAllowed" : true
+      }, {
+        "type" : "alter",
+        "isAllowed" : true
+      }, {
+        "type" : "index",
+        "isAllowed" : true
+      }, {
+        "type" : "lock",
+        "isAllowed" : true
+      }, {
+        "type" : "all",
+        "isAllowed" : true
+      }, {
+        "type" : "read",
+        "isAllowed" : true
+      }, {
+        "type" : "write",
+        "isAllowed" : true
+      } ],
+      "users" : [ "admin" ],
+      "groups" : [ ],
+      "roles" : [ ],
+      "conditions" : [ ],
+      "delegateAdmin" : true
+    } ],
+    "denyPolicyItems" : [ ],
+    "allowExceptions" : [ ],
+    "denyExceptions" : [ ],
+    "dataMaskPolicyItems" : [ ],
+    "rowFilterPolicyItems" : [ ],
+    "options" : { },
+    "validitySchedules" : [ ],
+    "policyLabels" : [ ],
+    "isDenyAllElse" : false
+  }, {
+    "id" : 4,
+    "guid" : "a87ff679-a2f3-371d-9181-a67b7542122c",
+    "isEnabled" : true,
+    "version" : 1,
+    "service" : "hive_jenkins",
+    "name" : "all - database, udf",
+    "policyType" : 0,
+    "policyPriority" : 0,
+    "description" : "Policy for all - database, udf",
+    "isAuditEnabled" : true,
+    "resources" : {
+      "database" : {
+        "values" : [ "default", "spark_catalog", "iceberg_ns", "ns1" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      },
+      "column" : {
+        "values" : [ "*" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      },
+      "table" : {
+        "values" : [ "*" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      }
+    },
+    "conditions" : [ ],
+    "policyItems" : [ {
+      "accesses" : [ {
+        "type" : "select",
+        "isAllowed" : true
+      }, {
+        "type" : "update",
+        "isAllowed" : true
+      }, {
+        "type" : "create",
+        "isAllowed" : true
+      }, {
+        "type" : "drop",
+        "isAllowed" : true
+      }, {
+        "type" : "alter",
+        "isAllowed" : true
+      }, {
+        "type" : "index",
+        "isAllowed" : true
+      }, {
+        "type" : "lock",
+        "isAllowed" : true
+      }, {
+        "type" : "all",
+        "isAllowed" : true
+      }, {
+        "type" : "read",
+        "isAllowed" : true
+      }, {
+        "type" : "write",
+        "isAllowed" : true
+      } ],
+      "users" : [ "bob", "perm_view_user", "{OWNER}" ],
+      "groups" : [ ],
+      "roles" : [ ],
+      "conditions" : [ ],
+      "delegateAdmin" : true
+    }, {
+      "accesses" : [ {
+        "type" : "create",
+        "isAllowed" : true
+      } ],
+      "users" : [ "default_table_owner", "create_only_user" ],
+      "groups" : [ ],
+      "roles" : [ ],
+      "conditions" : [ ],
+      "delegateAdmin" : true
+    } ],
+    "denyPolicyItems" : [ ],
+    "allowExceptions" : [ ],
+    "denyExceptions" : [ ],
+    "dataMaskPolicyItems" : [ ],
+    "rowFilterPolicyItems" : [ ],
+    "options" : { },
+    "validitySchedules" : [ ],
+    "policyLabels" : [ ],
+    "isDenyAllElse" : false
+  }, {
+    "id" : 5,
+    "guid" : "e4da3b7f-bbce-3345-9777-2b0674a318d5",
+    "isEnabled" : true,
+    "version" : 1,
+    "service" : "hive_jenkins",
+    "name" : "default_kent",
+    "policyType" : 0,
+    "policyPriority" : 0,
+    "description" : "",
+    "isAuditEnabled" : true,
+    "resources" : {
+      "database" : {
+        "values" : [ "default", "spark_catalog" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      },
+      "column" : {
+        "values" : [ "key" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      },
+      "table" : {
+        "values" : [ "src" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      }
+    },
+    "conditions" : [ ],
+    "policyItems" : [ {
+      "accesses" : [ {
+        "type" : "select",
+        "isAllowed" : true
+      }, {
+        "type" : "update",
+        "isAllowed" : true
+      }, {
+        "type" : "create",
+        "isAllowed" : true
+      }, {
+        "type" : "drop",
+        "isAllowed" : true
+      }, {
+        "type" : "alter",
+        "isAllowed" : true
+      }, {
+        "type" : "index",
+        "isAllowed" : true
+      }, {
+        "type" : "lock",
+        "isAllowed" : true
+      }, {
+        "type" : "all",
+        "isAllowed" : true
+      }, {
+        "type" : "read",
+        "isAllowed" : true
+      }, {
+        "type" : "write",
+        "isAllowed" : true
+      } ],
+      "users" : [ "kent" ],
+      "groups" : [ ],
+      "roles" : [ ],
+      "conditions" : [ ],
+      "delegateAdmin" : true
+    }, {
+      "accesses" : [ {
+        "type" : "create",
+        "isAllowed" : true
+      } ],
+      "users" : [ "default_table_owner", "create_only_user" ],
+      "groups" : [ ],
+      "roles" : [ ],
+      "conditions" : [ ],
+      "delegateAdmin" : true
+    } ],
+    "denyPolicyItems" : [ ],
+    "allowExceptions" : [ ],
+    "denyExceptions" : [ ],
+    "dataMaskPolicyItems" : [ ],
+    "rowFilterPolicyItems" : [ ],
+    "options" : { },
+    "validitySchedules" : [ ],
+    "policyLabels" : [ ],
+    "isDenyAllElse" : false
+  }, {
+    "id" : 6,
+    "guid" : "1679091c-5a88-3faf-afb5-e6087eb1b2dc",
+    "isEnabled" : true,
+    "version" : 1,
+    "service" : "hive_jenkins",
+    "name" : "default_bob_use",
+    "policyType" : 0,
+    "policyPriority" : 0,
+    "description" : "",
+    "isAuditEnabled" : true,
+    "resources" : {
+      "database" : {
+        "values" : [ "default_bob", "spark_catalog" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      },
+      "column" : {
+        "values" : [ "*" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      },
+      "table" : {
+        "values" : [ "table_use*" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      }
+    },
+    "conditions" : [ ],
+    "policyItems" : [ {
+      "accesses" : [ {
+        "type" : "update",
+        "isAllowed" : true
+      } ],
+      "users" : [ "bob" ],
+      "groups" : [ ],
+      "roles" : [ ],
+      "conditions" : [ ],
+      "delegateAdmin" : true
+    } ],
+    "denyPolicyItems" : [ ],
+    "allowExceptions" : [ ],
+    "denyExceptions" : [ ],
+    "dataMaskPolicyItems" : [ ],
+    "rowFilterPolicyItems" : [ ],
+    "options" : { },
+    "validitySchedules" : [ ],
+    "policyLabels" : [ ],
+    "isDenyAllElse" : false
+  }, {
+    "id" : 7,
+    "guid" : "8f14e45f-ceea-367a-9a36-dedd4bea2543",
+    "isEnabled" : true,
+    "version" : 1,
+    "service" : "hive_jenkins",
+    "name" : "default_bob_select",
+    "policyType" : 0,
+    "policyPriority" : 0,
+    "description" : "",
+    "isAuditEnabled" : true,
+    "resources" : {
+      "database" : {
+        "values" : [ "default_bob", "spark_catalog" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      },
+      "column" : {
+        "values" : [ "*" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      },
+      "table" : {
+        "values" : [ "table_select*" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      }
+    },
+    "conditions" : [ ],
+    "policyItems" : [ {
+      "accesses" : [ {
+        "type" : "select",
+        "isAllowed" : true
+      }, {
+        "type" : "use",
+        "isAllowed" : true
+      } ],
+      "users" : [ "bob" ],
+      "groups" : [ ],
+      "roles" : [ ],
+      "conditions" : [ ],
+      "delegateAdmin" : true
+    } ],
+    "denyPolicyItems" : [ ],
+    "allowExceptions" : [ ],
+    "denyExceptions" : [ ],
+    "dataMaskPolicyItems" : [ ],
+    "rowFilterPolicyItems" : [ ],
+    "options" : { },
+    "validitySchedules" : [ ],
+    "policyLabels" : [ ],
+    "isDenyAllElse" : false
+  }, {
+    "id" : 8,
+    "guid" : "c9f0f895-fb98-3b91-99f5-1fd0297e236d",
+    "isEnabled" : true,
+    "version" : 1,
+    "service" : "hive_jenkins",
+    "name" : "someone_access_perm_view",
+    "policyType" : 0,
+    "policyPriority" : 0,
+    "description" : "",
+    "isAuditEnabled" : true,
+    "resources" : {
+      "database" : {
+        "values" : [ "default" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      },
+      "column" : {
+        "values" : [ "*" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      },
+      "table" : {
+        "values" : [ "perm_view" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      }
+    },
+    "conditions" : [ ],
+    "policyItems" : [ {
+      "accesses" : [ {
+        "type" : "select",
+        "isAllowed" : true
+      } ],
+      "users" : [ "user_perm_view_only" ],
+      "groups" : [ ],
+      "roles" : [ ],
+      "conditions" : [ ],
+      "delegateAdmin" : true
+    } ],
+    "denyPolicyItems" : [ ],
+    "allowExceptions" : [ ],
+    "denyExceptions" : [ ],
+    "dataMaskPolicyItems" : [ ],
+    "rowFilterPolicyItems" : [ ],
+    "options" : { },
+    "validitySchedules" : [ ],
+    "policyLabels" : [ ],
+    "isDenyAllElse" : false
+  }, {
+    "id" : 9,
+    "guid" : "45c48cce-2e2d-3fbd-aa1a-fc51c7c6ad26",
+    "isEnabled" : true,
+    "version" : 1,
+    "service" : "hive_jenkins",
+    "name" : "src_key_less_than_20",
+    "policyType" : 2,
+    "policyPriority" : 0,
+    "description" : "",
+    "isAuditEnabled" : true,
+    "resources" : {
+      "database" : {
+        "values" : [ "default" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      },
+      "table" : {
+        "values" : [ "src" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      }
+    },
+    "conditions" : [ ],
+    "policyItems" : [ ],
+    "denyPolicyItems" : [ ],
+    "allowExceptions" : [ ],
+    "denyExceptions" : [ ],
+    "dataMaskPolicyItems" : [ ],
+    "rowFilterPolicyItems" : [ {
+      "accesses" : [ {
+        "type" : "select",
+        "isAllowed" : true
+      } ],
+      "users" : [ "bob", "perm_view_user" ],
+      "groups" : [ ],
+      "roles" : [ ],
+      "conditions" : [ ],
+      "delegateAdmin" : false,
+      "rowFilterInfo" : {
+        "filterExpr" : "key<20"
+      }
+    } ],
+    "options" : { },
+    "validitySchedules" : [ ],
+    "policyLabels" : [ ],
+    "isDenyAllElse" : false
+  }, {
+    "id" : 10,
+    "guid" : "d3d94468-02a4-3259-b55d-38e6d163e820",
+    "isEnabled" : true,
+    "version" : 1,
+    "service" : "hive_jenkins",
+    "name" : "perm_view_key_less_than_20",
+    "policyType" : 2,
+    "policyPriority" : 0,
+    "description" : "",
+    "isAuditEnabled" : true,
+    "resources" : {
+      "database" : {
+        "values" : [ "default" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      },
+      "table" : {
+        "values" : [ "perm_view" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      }
+    },
+    "conditions" : [ ],
+    "policyItems" : [ ],
+    "denyPolicyItems" : [ ],
+    "allowExceptions" : [ ],
+    "denyExceptions" : [ ],
+    "dataMaskPolicyItems" : [ ],
+    "rowFilterPolicyItems" : [ {
+      "accesses" : [ {
+        "type" : "select",
+        "isAllowed" : true
+      } ],
+      "users" : [ "perm_view_user" ],
+      "groups" : [ ],
+      "roles" : [ ],
+      "conditions" : [ ],
+      "delegateAdmin" : false,
+      "rowFilterInfo" : {
+        "filterExpr" : "key<20"
+      }
+    } ],
+    "options" : { },
+    "validitySchedules" : [ ],
+    "policyLabels" : [ ],
+    "isDenyAllElse" : false
+  }, {
+    "id" : 11,
+    "guid" : "6512bd43-d9ca-36e0-ac99-0b0a82652dca",
+    "isEnabled" : true,
+    "version" : 1,
+    "service" : "hive_jenkins",
+    "name" : "src_value_hash_perm_view",
+    "policyType" : 1,
+    "policyPriority" : 0,
+    "description" : "",
+    "isAuditEnabled" : true,
+    "resources" : {
+      "database" : {
+        "values" : [ "default", "spark_catalog" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      },
+      "column" : {
+        "values" : [ "value1" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      },
+      "table" : {
+        "values" : [ "src" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      }
+    },
+    "conditions" : [ ],
+    "policyItems" : [ ],
+    "denyPolicyItems" : [ ],
+    "allowExceptions" : [ ],
+    "denyExceptions" : [ ],
+    "dataMaskPolicyItems" : [ {
+      "accesses" : [ {
+        "type" : "select",
+        "isAllowed" : true
+      } ],
+      "users" : [ "bob" ],
+      "groups" : [ ],
+      "roles" : [ ],
+      "conditions" : [ ],
+      "delegateAdmin" : true,
+      "dataMaskInfo" : {
+        "dataMaskType" : "MASK_HASH"
+      }
+    } ],
+    "rowFilterPolicyItems" : [ ],
+    "options" : { },
+    "validitySchedules" : [ ],
+    "policyLabels" : [ ],
+    "isDenyAllElse" : false
+  }, {
+    "id" : 12,
+    "guid" : "c20ad4d7-6fe9-3759-aa27-a0c99bff6710",
+    "isEnabled" : true,
+    "version" : 1,
+    "service" : "hive_jenkins",
+    "name" : "src_value_hash",
+    "policyType" : 1,
+    "policyPriority" : 0,
+    "description" : "",
+    "isAuditEnabled" : true,
+    "resources" : {
+      "database" : {
+        "values" : [ "default", "spark_catalog" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      },
+      "column" : {
+        "values" : [ "value1" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      },
+      "table" : {
+        "values" : [ "perm_view" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      }
+    },
+    "conditions" : [ ],
+    "policyItems" : [ ],
+    "denyPolicyItems" : [ ],
+    "allowExceptions" : [ ],
+    "denyExceptions" : [ ],
+    "dataMaskPolicyItems" : [ {
+      "accesses" : [ {
+        "type" : "select",
+        "isAllowed" : true
+      } ],
+      "users" : [ "perm_view_user" ],
+      "groups" : [ ],
+      "roles" : [ ],
+      "conditions" : [ ],
+      "delegateAdmin" : true,
+      "dataMaskInfo" : {
+        "dataMaskType" : "MASK_HASH"
+      }
+    } ],
+    "rowFilterPolicyItems" : [ ],
+    "options" : { },
+    "validitySchedules" : [ ],
+    "policyLabels" : [ ],
+    "isDenyAllElse" : false
+  }, {
+    "id" : 13,
+    "guid" : "c51ce410-c124-310e-8db5-e4b97fc2af39",
+    "isEnabled" : true,
+    "version" : 1,
+    "service" : "hive_jenkins",
+    "name" : "src_value2_nullify",
+    "policyType" : 1,
+    "policyPriority" : 0,
+    "description" : "",
+    "isAuditEnabled" : true,
+    "resources" : {
+      "database" : {
+        "values" : [ "default", "spark_catalog", "iceberg_ns", "ns1" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      },
+      "column" : {
+        "values" : [ "value2" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      },
+      "table" : {
+        "values" : [ "src" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      }
+    },
+    "conditions" : [ ],
+    "policyItems" : [ ],
+    "denyPolicyItems" : [ ],
+    "allowExceptions" : [ ],
+    "denyExceptions" : [ ],
+    "dataMaskPolicyItems" : [ {
+      "accesses" : [ {
+        "type" : "select",
+        "isAllowed" : true
+      } ],
+      "users" : [ "bob" ],
+      "groups" : [ ],
+      "roles" : [ ],
+      "conditions" : [ ],
+      "delegateAdmin" : true,
+      "dataMaskInfo" : {
+        "dataMaskType" : "MASK"
+      }
+    } ],
+    "rowFilterPolicyItems" : [ ],
+    "options" : { },
+    "validitySchedules" : [ ],
+    "policyLabels" : [ ],
+    "isDenyAllElse" : false
+  }, {
+    "id" : 14,
+    "guid" : "aab32389-22bc-325a-af60-6eb525ffdc56",
+    "isEnabled" : true,
+    "version" : 1,
+    "service" : "hive_jenkins",
+    "name" : "src_value3_sf4",
+    "policyType" : 1,
+    "policyPriority" : 0,
+    "description" : "",
+    "isAuditEnabled" : true,
+    "resources" : {
+      "database" : {
+        "values" : [ "default", "spark_catalog" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      },
+      "column" : {
+        "values" : [ "value3" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      },
+      "table" : {
+        "values" : [ "src" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      }
+    },
+    "conditions" : [ ],
+    "policyItems" : [ ],
+    "denyPolicyItems" : [ ],
+    "allowExceptions" : [ ],
+    "denyExceptions" : [ ],
+    "dataMaskPolicyItems" : [ {
+      "accesses" : [ {
+        "type" : "select",
+        "isAllowed" : true
+      } ],
+      "users" : [ "bob" ],
+      "groups" : [ ],
+      "roles" : [ ],
+      "conditions" : [ ],
+      "delegateAdmin" : true,
+      "dataMaskInfo" : {
+        "dataMaskType" : "MASK_SHOW_FIRST_4"
+      }
+    } ],
+    "rowFilterPolicyItems" : [ ],
+    "options" : { },
+    "validitySchedules" : [ ],
+    "policyLabels" : [ ],
+    "isDenyAllElse" : false
+  }, {
+    "id" : 15,
+    "guid" : "9bf31c7f-f062-336a-96d3-c8bd1f8f2ff3",
+    "isEnabled" : true,
+    "version" : 1,
+    "service" : "hive_jenkins",
+    "name" : "src_value4_sf4",
+    "policyType" : 1,
+    "policyPriority" : 0,
+    "description" : "",
+    "isAuditEnabled" : true,
+    "resources" : {
+      "database" : {
+        "values" : [ "default", "spark_catalog" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      },
+      "column" : {
+        "values" : [ "value4" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      },
+      "table" : {
+        "values" : [ "src" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      }
+    },
+    "conditions" : [ ],
+    "policyItems" : [ ],
+    "denyPolicyItems" : [ ],
+    "allowExceptions" : [ ],
+    "denyExceptions" : [ ],
+    "dataMaskPolicyItems" : [ {
+      "accesses" : [ {
+        "type" : "select",
+        "isAllowed" : true
+      } ],
+      "users" : [ "bob" ],
+      "groups" : [ ],
+      "roles" : [ ],
+      "conditions" : [ ],
+      "delegateAdmin" : true,
+      "dataMaskInfo" : {
+        "dataMaskType" : "MASK_DATE_SHOW_YEAR"
+      }
+    } ],
+    "rowFilterPolicyItems" : [ ],
+    "options" : { },
+    "validitySchedules" : [ ],
+    "policyLabels" : [ ],
+    "isDenyAllElse" : false
+  }, {
+    "id" : 16,
+    "guid" : "c74d97b0-1eae-357e-84aa-9d5bade97baf",
+    "isEnabled" : true,
+    "version" : 1,
+    "service" : "hive_jenkins",
+    "name" : "src_value5_sf4",
+    "policyType" : 1,
+    "policyPriority" : 0,
+    "description" : "",
+    "isAuditEnabled" : true,
+    "resources" : {
+      "database" : {
+        "values" : [ "default", "spark_catalog" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      },
+      "column" : {
+        "values" : [ "value5" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      },
+      "table" : {
+        "values" : [ "src" ],
+        "isExcludes" : false,
+        "isRecursive" : false
+      }
+    },
+    "conditions" : [ ],
+    "policyItems" : [ ],
+    "denyPolicyItems" : [ ],
+    "allowExceptions" : [ ],
+    "denyExceptions" : [ ],
+    "dataMaskPolicyItems" : [ {
+      "accesses" : [ {
+        "type" : "select",
+        "isAllowed" : true
+      } ],
+      "users" : [ "bob" ],
+      "groups" : [ ],
+      "roles" : [ ],
+      "conditions" : [ ],
+      "delegateAdmin" : true,
+      "dataMaskInfo" : {
+        "dataMaskType" : "MASK_SHOW_LAST_4"
+      }
+    } ],
+    "rowFilterPolicyItems" : [ ],
+    "options" : { },
+    "validitySchedules" : [ ],
+    "policyLabels" : [ ],
+    "isDenyAllElse" : false
+  } ],
+  "serviceDef" : {
+    "name" : "hive",
+    "implClass" : "org.apache.ranger.services.hive.RangerServiceHive",
+    "label" : "Hive Server2",
+    "description" : "Hive Server2",
+    "options" : {
+      "enableDenyAndExceptionsInPolicies" : "true"
+    },
+    "configs" : [ {
+      "itemId" : 1,
+      "name" : "username",
+      "type" : "string",
+      "mandatory" : true,
+      "validationRegEx" : "",
+      "validationMessage" : "",
+      "uiHint" : "",
+      "label" : "Username"
+    }, {
+      "itemId" : 2,
+      "name" : "password",
+      "type" : "password",
+      "mandatory" : true,
+      "validationRegEx" : "",
+      "validationMessage" : "",
+      "uiHint" : "",
+      "label" : "Password"
+    }, {
+      "itemId" : 3,
+      "name" : "jdbc.driverClassName",
+      "type" : "string",
+      "mandatory" : true,
+      "defaultValue" : "org.apache.hive.jdbc.HiveDriver",
+      "validationRegEx" : "",
+      "validationMessage" : "",
+      "uiHint" : ""
+    }, {
+      "itemId" : 4,
+      "name" : "jdbc.url",
+      "type" : "string",
+      "mandatory" : true,
+      "defaultValue" : "",
+      "validationRegEx" : "",
+      "validationMessage" : "",
+      "uiHint" : "{\"TextFieldWithIcon\":true, \"info\": \"1.For Remote Mode, eg.<br>jdbc:hive2://&lt;host&gt;:&lt;port&gt;<br>2.For Embedded Mode (no host or port), eg.<br>jdbc:hive2:///;initFile=&lt;file&gt;<br>3.For HTTP Mode, eg.<br>jdbc:hive2://&lt;host&gt;:&lt;port&gt;/;<br>transportMode=http;httpPath=&lt;httpPath&gt;<br>4.For SSL Mode, eg.<br>jdbc:hive2://&lt;host&gt;:&lt;port&gt;/;ssl=true;<br>sslTrustStore=tStore;trustStorePassword=pw<br>5.For ZooKeeper Mode, eg.<br>jdbc:hive2://&lt;host&gt;/;serviceDiscoveryMode=<br>zooKeeper;zooKeeperNamespace=hiveserver2<br>6.For Kerberos Mode, eg.<br>jdbc:hive2://&lt;host&gt;:&lt;port&gt;/;<br>principal=hive/domain@EXAMPLE.COM<br>\"}"
+    }, {
+      "itemId" : 5,
+      "name" : "commonNameForCertificate",
+      "type" : "string",
+      "mandatory" : false,
+      "validationRegEx" : "",
+      "validationMessage" : "",
+      "uiHint" : "",
+      "label" : "Common Name for Certificate"
+    } ],
+    "resources" : [ {
+      "itemId" : 1,
+      "name" : "database",
+      "type" : "string",
+      "level" : 10,
+      "mandatory" : true,
+      "lookupSupported" : true,
+      "recursiveSupported" : false,
+      "excludesSupported" : true,
+      "matcher" : "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+      "matcherOptions" : {
+        "wildCard" : "true",
+        "ignoreCase" : "true"
+      },
+      "validationRegEx" : "",
+      "validationMessage" : "",
+      "uiHint" : "",
+      "label" : "Hive Database",
+      "description" : "Hive Database",
+      "accessTypeRestrictions" : [ ],
+      "isValidLeaf" : false
+    }, {
+      "itemId" : 5,
+      "name" : "url",
+      "type" : "string",
+      "level" : 10,
+      "mandatory" : true,
+      "lookupSupported" : false,
+      "recursiveSupported" : true,
+      "excludesSupported" : false,
+      "matcher" : "org.apache.ranger.plugin.resourcematcher.RangerPathResourceMatcher",
+      "matcherOptions" : {
+        "wildCard" : "true",
+        "ignoreCase" : "false"
+      },
+      "validationRegEx" : "",
+      "validationMessage" : "",
+      "uiHint" : "",
+      "label" : "URL",
+      "description" : "URL",
+      "accessTypeRestrictions" : [ ],
+      "isValidLeaf" : true
+    }, {
+      "itemId" : 2,
+      "name" : "table",
+      "type" : "string",
+      "level" : 20,
+      "parent" : "database",
+      "mandatory" : true,
+      "lookupSupported" : true,
+      "recursiveSupported" : false,
+      "excludesSupported" : true,
+      "matcher" : "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+      "matcherOptions" : {
+        "wildCard" : "true",
+        "ignoreCase" : "true"
+      },
+      "validationRegEx" : "",
+      "validationMessage" : "",
+      "uiHint" : "",
+      "label" : "Hive Table",
+      "description" : "Hive Table",
+      "accessTypeRestrictions" : [ ],
+      "isValidLeaf" : false
+    }, {
+      "itemId" : 3,
+      "name" : "udf",
+      "type" : "string",
+      "level" : 20,
+      "parent" : "database",
+      "mandatory" : true,
+      "lookupSupported" : true,
+      "recursiveSupported" : false,
+      "excludesSupported" : true,
+      "matcher" : "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+      "matcherOptions" : {
+        "wildCard" : "true",
+        "ignoreCase" : "true"
+      },
+      "validationRegEx" : "",
+      "validationMessage" : "",
+      "uiHint" : "",
+      "label" : "Hive UDF",
+      "description" : "Hive UDF",
+      "accessTypeRestrictions" : [ ],
+      "isValidLeaf" : true
+    }, {
+      "itemId" : 4,
+      "name" : "column",
+      "type" : "string",
+      "level" : 30,
+      "parent" : "table",
+      "mandatory" : true,
+      "lookupSupported" : true,
+      "recursiveSupported" : false,
+      "excludesSupported" : true,
+      "matcher" : "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+      "matcherOptions" : {
+        "wildCard" : "true",
+        "ignoreCase" : "true"
+      },
+      "validationRegEx" : "",
+      "validationMessage" : "",
+      "uiHint" : "",
+      "label" : "Hive Column",
+      "description" : "Hive Column",
+      "accessTypeRestrictions" : [ ],
+      "isValidLeaf" : true
+    } ],
+    "accessTypes" : [ {
+      "itemId" : 1,
+      "name" : "select",
+      "label" : "select",
+      "impliedGrants" : [ ]
+    }, {
+      "itemId" : 2,
+      "name" : "update",
+      "label" : "update",
+      "impliedGrants" : [ ]
+    }, {
+      "itemId" : 3,
+      "name" : "create",
+      "label" : "Create",
+      "impliedGrants" : [ ]
+    }, {
+      "itemId" : 4,
+      "name" : "drop",
+      "label" : "Drop",
+      "impliedGrants" : [ ]
+    }, {
+      "itemId" : 5,
+      "name" : "alter",
+      "label" : "Alter",
+      "impliedGrants" : [ ]
+    }, {
+      "itemId" : 6,
+      "name" : "index",
+      "label" : "Index",
+      "impliedGrants" : [ ]
+    }, {
+      "itemId" : 7,
+      "name" : "lock",
+      "label" : "Lock",
+      "impliedGrants" : [ ]
+    }, {
+      "itemId" : 8,
+      "name" : "all",
+      "label" : "All",
+      "impliedGrants" : [ "select", "update", "create", "drop", "alter", "index", "lock", "read", "write" ]
+    }, {
+      "itemId" : 9,
+      "name" : "read",
+      "label" : "Read",
+      "impliedGrants" : [ ]
+    }, {
+      "itemId" : 10,
+      "name" : "write",
+      "label" : "Write",
+      "impliedGrants" : [ ]
+    } ],
+    "policyConditions" : [ ],
+    "contextEnrichers" : [ ],
+    "enums" : [ ],
+    "dataMaskDef" : {
+      "maskTypes" : [ {
+        "itemId" : 1,
+        "name" : "MASK",
+        "label" : "Redact",
+        "description" : "Replace lowercase with 'x', uppercase with 'X', digits with '0'",
+        "transformer" : "mask({col})",
+        "dataMaskOptions" : { }
+      }, {
+        "itemId" : 2,
+        "name" : "MASK_SHOW_LAST_4",
+        "label" : "Partial mask: show last 4",
+        "description" : "Show last 4 characters; replace rest with 'x'",
+        "transformer" : "mask_show_last_n({col}, 4, 'x', 'x', 'x', -1, '1')",
+        "dataMaskOptions" : { }
+      }, {
+        "itemId" : 3,
+        "name" : "MASK_SHOW_FIRST_4",
+        "label" : "Partial mask: show first 4",
+        "description" : "Show first 4 characters; replace rest with 'x'",
+        "transformer" : "mask_show_first_n({col}, 4, 'x', 'x', 'x', -1, '1')",
+        "dataMaskOptions" : { }
+      }, {
+        "itemId" : 4,
+        "name" : "MASK_HASH",
+        "label" : "Hash",
+        "description" : "Hash the value",
+        "transformer" : "mask_hash({col})",
+        "dataMaskOptions" : { }
+      }, {
+        "itemId" : 5,
+        "name" : "MASK_NULL",
+        "label" : "Nullify",
+        "description" : "Replace with NULL",
+        "dataMaskOptions" : { }
+      }, {
+        "itemId" : 6,
+        "name" : "MASK_NONE",
+        "label" : "Unmasked (retain original value)",
+        "description" : "No masking",
+        "dataMaskOptions" : { }
+      }, {
+        "itemId" : 12,
+        "name" : "MASK_DATE_SHOW_YEAR",
+        "label" : "Date: show only year",
+        "description" : "Date: show only year",
+        "transformer" : "mask({col}, 'x', 'x', 'x', -1, '1', 1, 0, -1)",
+        "dataMaskOptions" : { }
+      }, {
+        "itemId" : 13,
+        "name" : "CUSTOM",
+        "label" : "Custom",
+        "description" : "Custom",
+        "dataMaskOptions" : { }
+      } ],
+      "accessTypes" : [ {
+        "itemId" : 1,
+        "name" : "select",
+        "label" : "select",
+        "impliedGrants" : [ ]
+      } ],
+      "resources" : [ {
+        "itemId" : 1,
+        "name" : "database",
+        "type" : "string",
+        "level" : 10,
+        "mandatory" : true,
+        "lookupSupported" : true,
+        "recursiveSupported" : false,
+        "excludesSupported" : false,
+        "matcher" : "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+        "matcherOptions" : {
+          "wildCard" : "false",
+          "ignoreCase" : "true"
+        },
+        "validationRegEx" : "",
+        "validationMessage" : "",
+        "uiHint" : "{ \"singleValue\":true }",
+        "label" : "Hive Database",
+        "description" : "Hive Database",
+        "accessTypeRestrictions" : [ ],
+        "isValidLeaf" : false
+      }, {
+        "itemId" : 2,
+        "name" : "table",
+        "type" : "string",
+        "level" : 20,
+        "parent" : "database",
+        "mandatory" : true,
+        "lookupSupported" : true,
+        "recursiveSupported" : false,
+        "excludesSupported" : false,
+        "matcher" : "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+        "matcherOptions" : {
+          "wildCard" : "false",
+          "ignoreCase" : "true"
+        },
+        "validationRegEx" : "",
+        "validationMessage" : "",
+        "uiHint" : "{ \"singleValue\":true }",
+        "label" : "Hive Table",
+        "description" : "Hive Table",
+        "accessTypeRestrictions" : [ ],
+        "isValidLeaf" : false
+      }, {
+        "itemId" : 4,
+        "name" : "column",
+        "type" : "string",
+        "level" : 30,
+        "parent" : "table",
+        "mandatory" : true,
+        "lookupSupported" : true,
+        "recursiveSupported" : false,
+        "excludesSupported" : false,
+        "matcher" : "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+        "matcherOptions" : {
+          "wildCard" : "false",
+          "ignoreCase" : "true"
+        },
+        "validationRegEx" : "",
+        "validationMessage" : "",
+        "uiHint" : "{ \"singleValue\":true }",
+        "label" : "Hive Column",
+        "description" : "Hive Column",
+        "accessTypeRestrictions" : [ ],
+        "isValidLeaf" : true
+      } ]
+    },
+    "rowFilterDef" : {
+      "accessTypes" : [ {
+        "itemId" : 1,
+        "name" : "select",
+        "label" : "select",
+        "impliedGrants" : [ ]
+      } ],
+      "resources" : [ {
+        "itemId" : 1,
+        "name" : "database",
+        "type" : "string",
+        "level" : 10,
+        "mandatory" : true,
+        "lookupSupported" : true,
+        "recursiveSupported" : false,
+        "excludesSupported" : false,
+        "matcher" : "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+        "matcherOptions" : {
+          "wildCard" : "false",
+          "ignoreCase" : "true"
+        },
+        "validationRegEx" : "",
+        "validationMessage" : "",
+        "uiHint" : "{ \"singleValue\":true }",
+        "label" : "Hive Database",
+        "description" : "Hive Database",
+        "accessTypeRestrictions" : [ ],
+        "isValidLeaf" : false
+      }, {
+        "itemId" : 2,
+        "name" : "table",
+        "type" : "string",
+        "level" : 20,
+        "parent" : "database",
+        "mandatory" : true,
+        "lookupSupported" : true,
+        "recursiveSupported" : false,
+        "excludesSupported" : false,
+        "matcher" : "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+        "matcherOptions" : {
+          "wildCard" : "false",
+          "ignoreCase" : "true"
+        },
+        "validationRegEx" : "",
+        "validationMessage" : "",
+        "uiHint" : "{ \"singleValue\":true }",
+        "label" : "Hive Table",
+        "description" : "Hive Table",
+        "accessTypeRestrictions" : [ ],
+        "isValidLeaf" : true
+      } ]
+    },
+    "id" : 3,
+    "guid" : "3e1afb5a-184a-4e82-9d9c-87a5cacc243c",
+    "isEnabled" : true,
+    "createTime" : "20190401-20:14:36.000-+0800",
+    "updateTime" : "20190401-20:14:36.000-+0800",
+    "version" : 1
   },
-  "auditMode": "audit-default"
+  "auditMode" : "audit-default"
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- generate Authz policy file for testing to focus on  manage all the policies in the generator
- auto-increased `id` and related `guid` for each policy
- list and reused users, resources, for evaluation impacts when policy changes
- add `policies_base.json` as base template file of authz template including decoration details and service def



### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
