### PR TITLE
[K8S][HELM] Set IfNotPresent pullPolicy by default

### DIFF
--- a/charts/kyuubi/values.yaml
+++ b/charts/kyuubi/values.yaml
@@ -24,7 +24,7 @@ replicaCount: 2
 
 image:
   repository: apache/kyuubi
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
   tag: ~
 
 imagePullSecrets: []


### PR DESCRIPTION
### _Why are the changes needed?_
The change is needed to avoid pulling immutable image `apache/kyuubi:1.7.0` from image registry each time pod created.
Current `pullPolicy: Always` was important when mutable image `apache/kyuubi:master-snapshot` was used.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
