### PR TITLE
[K8S][HELM] Add command and args configuration support

### DIFF
--- a/charts/kyuubi/templates/kyuubi-deployment.yaml
+++ b/charts/kyuubi/templates/kyuubi-deployment.yaml
@@ -50,6 +50,12 @@ spec:
         - name: kyuubi-server
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.command }}
+          command: {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+          {{- with .Values.args }}
+          args: {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
           {{- with .Values.env }}
           env: {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}

--- a/charts/kyuubi/values.yaml
+++ b/charts/kyuubi/values.yaml
@@ -131,6 +131,11 @@ kyuubiConf:
   # See example at conf/log4j2.xml.template https://kyuubi.readthedocs.io/en/master/deployment/settings.html#logging for more details
   log4j2: ~
 
+# Command to launch Kyuubi server (templated)
+command: ~
+# Arguments to launch Kyuubi server (templated)
+args: ~
+
 # Environment variables (templated)
 env: []
 envFrom: []


### PR DESCRIPTION
### _Why are the changes needed?_
The change allows to change default command to launch Kyuubi and pass additional command line arguments.
It's needed if the chart user wants to print message, create files or similar in main container (`kyuubi-server`) when pod starts.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
