### PR TITLE
[CI] Add rule for labeler to tag `module:ui`

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -102,7 +102,8 @@
 
 "module:server":
   - "bin/kyuubi"
-  - "kyuubi-server/**/*"
+  - "kyuubi-server/src/**/*"
+  - "kyuubi-server/pom.xml"
   - "extension/server/kyuubi-server-plugin/**/*"
 
 "module:spark":
@@ -121,3 +122,6 @@
 
 "module:authz":
   - "extensions/spark/kyuubi-spark-authz/**/*"
+
+"module:UI":
+  - "kyuubi-server/web-ui/**/*"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -123,5 +123,5 @@
 "module:authz":
   - "extensions/spark/kyuubi-spark-authz/**/*"
 
-"module:UI":
+"module:ui":
   - "kyuubi-server/web-ui/**/*"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Current Labeler mis-tags `module:server` to changes about web-ui.

We should give `module:ui` tag to ui-related PR.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
