### PR TITLE
[KYUUBI #4530]  [AUTHZ] Support non-English chars for MASK, MASK_SHOW_FIRST_4, and MASK_SHOW_FIRST_4

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPlugin.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPlugin.scala
@@ -133,7 +133,7 @@ object SparkRangerAdminPlugin extends RangerBasePlugin("spark", "sparkSql")
 
   private def regexp_replace(expr: String, hasLen: Boolean = false): String = {
     val pos = if (hasLen) ", 5" else ""
-    val upper = s"regexp_replace($expr, '[A-Z]', 'X'$pos)"
+    val upper = s"regexp_replace($expr, '[A-Z\u4e00-\u9fa5]', 'X'$pos)"
     val lower = s"regexp_replace($upper, '[a-z]', 'x'$pos)"
     val digits = s"regexp_replace($lower, '[0-9]', 'n'$pos)"
     digits

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPlugin.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPlugin.scala
@@ -131,12 +131,14 @@ object SparkRangerAdminPlugin extends RangerBasePlugin("spark", "sparkSql")
     }
   }
 
-  private def regexp_replace(expr: String, hasLen: Boolean = false): String = {
+  // public for test
+  def regexp_replace(expr: String, hasLen: Boolean = false): String = {
     val pos = if (hasLen) ", 5" else ""
-    val upper = s"regexp_replace($expr, '[A-Z\u4e00-\u9fa5]', 'X'$pos)"
+    val upper = s"regexp_replace($expr, '[A-Z]', 'X'$pos)"
     val lower = s"regexp_replace($upper, '[a-z]', 'x'$pos)"
     val digits = s"regexp_replace($lower, '[0-9]', 'n'$pos)"
-    digits
+    val chinese = s"regexp_replace($digits, '[\u4e00-\u9fff]', '\u5bc6'$pos)"
+    chinese
   }
 
   /**

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPlugin.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPlugin.scala
@@ -136,7 +136,7 @@ object SparkRangerAdminPlugin extends RangerBasePlugin("spark", "sparkSql")
     val upper = s"regexp_replace($expr, '[A-Z]', 'X'$pos)"
     val lower = s"regexp_replace($upper, '[a-z]', 'x'$pos)"
     val digits = s"regexp_replace($lower, '[0-9]', 'n'$pos)"
-    val other = s"regexp_replace($digits, '[^A-Za-z0-9 ]', 'U'$pos)"
+    val other = s"regexp_replace($digits, '[^A-Za-z0-9]', 'U'$pos)"
     other
   }
 

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPlugin.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPlugin.scala
@@ -109,14 +109,8 @@ object SparkRangerAdminPlugin extends RangerBasePlugin("spark", "sparkSql")
       } else if (result.getMaskTypeDef != null) {
         result.getMaskTypeDef.getName match {
           case "MASK" => regexp_replace(col)
-          case "MASK_SHOW_FIRST_4" if isSparkVersionAtLeast("3.1") =>
-            regexp_replace(col, hasLen = true)
-          case "MASK_SHOW_FIRST_4" =>
-            val right = regexp_replace(s"substr($col, 5)")
-            s"concat(substr($col, 0, 4), $right)"
-          case "MASK_SHOW_LAST_4" =>
-            val left = regexp_replace(s"left($col, length($col) - 4)")
-            s"concat($left, right($col, 4))"
+          case "MASK_SHOW_FIRST_4" => maskShowFirst4(col, isSparkVersionAtLeast("3.1"))
+          case "MASK_SHOW_LAST_4" => maskShowLast4(col)
           case "MASK_HASH" => s"md5(cast($col as string))"
           case "MASK_DATE_SHOW_YEAR" => s"date_trunc('YEAR', $col)"
           case _ => result.getMaskTypeDef.getTransformer match {
@@ -137,8 +131,22 @@ object SparkRangerAdminPlugin extends RangerBasePlugin("spark", "sparkSql")
     val upper = s"regexp_replace($expr, '[A-Z]', 'X'$pos)"
     val lower = s"regexp_replace($upper, '[a-z]', 'x'$pos)"
     val digits = s"regexp_replace($lower, '[0-9]', 'n'$pos)"
-    val chinese = s"regexp_replace($digits, '[\u4e00-\u9fff]', '\u5bc6'$pos)"
-    chinese
+    val other = s"regexp_replace($digits, '[^A-Za-z0-9 ]', 'U'$pos)"
+    other
+  }
+
+  def maskShowFirst4(col: String, isSparkV31OrGreater: Boolean): String = {
+    if (isSparkV31OrGreater) {
+      regexp_replace(col, hasLen = true)
+    } else {
+      val right = regexp_replace(s"substr($col, 5)")
+      s"concat(substr($col, 0, 4), $right)"
+    }
+  }
+
+  def maskShowLast4(col: String): String = {
+    val left = regexp_replace(s"left($col, length($col) - 4)")
+    s"concat($left, right($col, 4))"
   }
 
   /**

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPluginSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPluginSuite.scala
@@ -50,11 +50,15 @@ class SparkRangerAdminPluginSuite extends AnyFunSuite {
     }
     assert(getMaskingExpr(buildAccessRequest(bob, "value1")).get === "md5(cast(value1 as string))")
     assert(getMaskingExpr(buildAccessRequest(bob, "value2")).get ===
-      "regexp_replace(regexp_replace(regexp_replace(value2, '[A-Z]', 'X'), '[a-z]', 'x')," +
-      " '[0-9]', 'n')")
+      "regexp_replace(regexp_replace(regexp_replace(regexp_replace(value2, '[A-Z]', 'X')," +
+        " '[a-z]', 'x'), '[0-9]', 'n'), '[^A-Za-z0-9 ]', 'U')")
     assert(getMaskingExpr(buildAccessRequest(bob, "value3")).get contains "regexp_replace")
     assert(getMaskingExpr(buildAccessRequest(bob, "value4")).get === "date_trunc('YEAR', value4)")
-    assert(getMaskingExpr(buildAccessRequest(bob, "value5")).get contains "regexp_replace")
+    assert(getMaskingExpr(buildAccessRequest(bob, "value5")).get ===
+      "concat(regexp_replace(regexp_replace(regexp_replace(regexp_replace(" +
+        "left(value5, length(value5) - 4), '[A-Z]', 'X'), '[a-z]', 'x')" +
+        ", '[0-9]', 'n'), '[^A-Za-z0-9 ]', 'U'), right(value5, 4))"
+    )
 
     Seq("admin", "alice").foreach { user =>
       val ugi = UserGroupInformation.createRemoteUser(user)

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPluginSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPluginSuite.scala
@@ -51,14 +51,13 @@ class SparkRangerAdminPluginSuite extends AnyFunSuite {
     assert(getMaskingExpr(buildAccessRequest(bob, "value1")).get === "md5(cast(value1 as string))")
     assert(getMaskingExpr(buildAccessRequest(bob, "value2")).get ===
       "regexp_replace(regexp_replace(regexp_replace(regexp_replace(value2, '[A-Z]', 'X')," +
-      " '[a-z]', 'x'), '[0-9]', 'n'), '[^A-Za-z0-9 ]', 'U')")
+      " '[a-z]', 'x'), '[0-9]', 'n'), '[^A-Za-z0-9]', 'U')")
     assert(getMaskingExpr(buildAccessRequest(bob, "value3")).get contains "regexp_replace")
     assert(getMaskingExpr(buildAccessRequest(bob, "value4")).get === "date_trunc('YEAR', value4)")
     assert(getMaskingExpr(buildAccessRequest(bob, "value5")).get ===
       "concat(regexp_replace(regexp_replace(regexp_replace(regexp_replace(" +
       "left(value5, length(value5) - 4), '[A-Z]', 'X'), '[a-z]', 'x')," +
-      " '[0-9]', 'n'), '[^A-Za-z0-9 ]', 'U'), right(value5, 4))"
-    )
+      " '[0-9]', 'n'), '[^A-Za-z0-9]', 'U'), right(value5, 4))")
 
     Seq("admin", "alice").foreach { user =>
       val ugi = UserGroupInformation.createRemoteUser(user)

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPluginSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPluginSuite.scala
@@ -51,13 +51,13 @@ class SparkRangerAdminPluginSuite extends AnyFunSuite {
     assert(getMaskingExpr(buildAccessRequest(bob, "value1")).get === "md5(cast(value1 as string))")
     assert(getMaskingExpr(buildAccessRequest(bob, "value2")).get ===
       "regexp_replace(regexp_replace(regexp_replace(regexp_replace(value2, '[A-Z]', 'X')," +
-        " '[a-z]', 'x'), '[0-9]', 'n'), '[^A-Za-z0-9 ]', 'U')")
+      " '[a-z]', 'x'), '[0-9]', 'n'), '[^A-Za-z0-9 ]', 'U')")
     assert(getMaskingExpr(buildAccessRequest(bob, "value3")).get contains "regexp_replace")
     assert(getMaskingExpr(buildAccessRequest(bob, "value4")).get === "date_trunc('YEAR', value4)")
     assert(getMaskingExpr(buildAccessRequest(bob, "value5")).get ===
       "concat(regexp_replace(regexp_replace(regexp_replace(regexp_replace(" +
-        "left(value5, length(value5) - 4), '[A-Z]', 'X'), '[a-z]', 'x')" +
-        ", '[0-9]', 'n'), '[^A-Za-z0-9 ]', 'U'), right(value5, 4))"
+      "left(value5, length(value5) - 4), '[A-Z]', 'X'), '[a-z]', 'x')," +
+      " '[0-9]', 'n'), '[^A-Za-z0-9 ]', 'U'), right(value5, 4))"
     )
 
     Seq("admin", "alice").foreach { user =>

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingTestBase.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingTestBase.scala
@@ -128,7 +128,7 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
       "bob",
       "SELECT coalesce(max(value1), 1), coalesce(max(value2), 1), coalesce(max(value3), 1), " +
         "coalesce(max(value4), timestamp '2018-01-01 22:33:44'), coalesce(max(value5), 1) " +
-        "FROM default.src  where key = 1",
+        "FROM default.src where key = 1",
       result)
   }
 
@@ -138,7 +138,7 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
     checkAnswer(
       "bob",
       "SELECT value1, value2, value3, value4, value5 FROM default.src WHERE value2 in " +
-        "(SELECT value2 as key FROM default.src  where key = 1)",
+        "(SELECT value2 as key FROM default.src where key = 1)",
       result)
   }
 
@@ -186,7 +186,7 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
 
   test("self join on a masked table") {
     val s = "SELECT a.value1, b.value1 FROM default.src a" +
-      " join default.src b on a.value1=b.value1  where a.key = 1 and b.key = 1 "
+      " join default.src b on a.value1=b.value1 where a.key = 1 and b.key = 1 "
     checkAnswer("bob", s, Seq(Row(md5Hex("1"), md5Hex("1"))))
     // just for testing query multiple times, don't delete it
     checkAnswer("bob", s, Seq(Row(md5Hex("1"), md5Hex("1"))))

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingTestBase.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingTestBase.scala
@@ -55,6 +55,17 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
       "SELECT 20, 2, 'kyuubi', 'y', timestamp'2018-11-17 12:34:56', 'world'")
     sql("INSERT INTO default.src " +
       "SELECT 30, 3, 'spark', 'a', timestamp'2018-11-17 12:34:56', 'world'")
+
+    // scalastyle:off
+    val value1 = "hello WORD 123 ~!@# AßþΔЙקم๗ቐあア叶葉엽"
+    val value2 = "AßþΔЙקم๗ቐあア叶葉엽 hello WORD 123 ~!@#"
+    // AßþΔЙקم๗ቐあア叶葉엽 reference https://zh.wikipedia.org/zh-cn/Unicode#XML.E5.92.8CUnicode
+    // scalastyle:on
+    sql(s"INSERT INTO default.src " +
+      s"SELECT 10, 4, '$value1', '$value1', timestamp'2018-11-17 12:34:56', '$value1'")
+    sql("INSERT INTO default.src " +
+      s"SELECT 11, 5, '$value2', '$value2', timestamp'2018-11-17 12:34:56', '$value2'")
+
     sql(s"CREATE TABLE default.unmasked $format AS SELECT * FROM default.src")
   }
 
@@ -74,23 +85,30 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
   }
 
   test("simple query with a user doesn't have mask rules") {
-    checkAnswer("kent", "SELECT key FROM default.src order by key", Seq(Row(1), Row(20), Row(30)))
+    checkAnswer(
+      "kent",
+      "SELECT key FROM default.src order by key",
+      Seq(Row(1), Row(10), Row(11), Row(20), Row(30)))
   }
 
   test("simple query with a user has mask rules") {
     val result =
       Seq(Row(md5Hex("1"), "xxxxx", "worlx", Timestamp.valueOf("2018-01-01 00:00:00"), "Xorld"))
-    checkAnswer("bob", "SELECT value1, value2, value3, value4, value5 FROM default.src", result)
     checkAnswer(
       "bob",
-      "SELECT value1 as key, value2, value3, value4, value5 FROM default.src",
+      "SELECT value1, value2, value3, value4, value5 FROM default.src " +
+        "where key = 1",
+      result)
+    checkAnswer(
+      "bob",
+      "SELECT value1 as key, value2, value3, value4, value5 FROM default.src where key = 1",
       result)
   }
 
   test("star") {
     val result =
       Seq(Row(1, md5Hex("1"), "xxxxx", "worlx", Timestamp.valueOf("2018-01-01 00:00:00"), "Xorld"))
-    checkAnswer("bob", "SELECT * FROM default.src", result)
+    checkAnswer("bob", "SELECT * FROM default.src where key = 1", result)
   }
 
   test("simple udf") {
@@ -98,7 +116,8 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
       Seq(Row(md5Hex("1"), "xxxxx", "worlx", Timestamp.valueOf("2018-01-01 00:00:00"), "Xorld"))
     checkAnswer(
       "bob",
-      "SELECT max(value1), max(value2), max(value3), max(value4), max(value5) FROM default.src",
+      "SELECT max(value1), max(value2), max(value3), max(value4), max(value5) FROM default.src" +
+        " where key = 1",
       result)
   }
 
@@ -109,7 +128,7 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
       "bob",
       "SELECT coalesce(max(value1), 1), coalesce(max(value2), 1), coalesce(max(value3), 1), " +
         "coalesce(max(value4), timestamp '2018-01-01 22:33:44'), coalesce(max(value5), 1) " +
-        "FROM default.src",
+        "FROM default.src  where key = 1",
       result)
   }
 
@@ -119,13 +138,16 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
     checkAnswer(
       "bob",
       "SELECT value1, value2, value3, value4, value5 FROM default.src WHERE value2 in " +
-        "(SELECT value2 as key FROM default.src)",
+        "(SELECT value2 as key FROM default.src  where key = 1)",
       result)
   }
 
   test("create a unmasked table as select from a masked one") {
     withCleanTmpResources(Seq(("default.src2", "table"))) {
-      doAs("bob", sql(s"CREATE TABLE default.src2 $format AS SELECT value1 FROM default.src"))
+      doAs(
+        "bob",
+        sql(s"CREATE TABLE default.src2 $format AS SELECT value1 FROM default.src " +
+          s"where key = 1"))
       checkAnswer("bob", "SELECT value1 FROM default.src2", Seq(Row(md5Hex("1"))))
     }
   }
@@ -133,12 +155,24 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
   test("insert into a unmasked table from a masked one") {
     withCleanTmpResources(Seq(("default.src2", "table"), ("default.src3", "table"))) {
       doAs("bob", sql(s"CREATE TABLE default.src2 (value1 string) $format"))
-      doAs("bob", sql(s"INSERT INTO default.src2 SELECT value1 from default.src"))
-      doAs("bob", sql(s"INSERT INTO default.src2 SELECT value1 as v from default.src"))
+      doAs(
+        "bob",
+        sql(s"INSERT INTO default.src2 SELECT value1 from default.src " +
+          s"where key = 1"))
+      doAs(
+        "bob",
+        sql(s"INSERT INTO default.src2 SELECT value1 as v from default.src " +
+          s"where key = 1"))
       checkAnswer("bob", "SELECT value1 FROM default.src2", Seq(Row(md5Hex("1")), Row(md5Hex("1"))))
       doAs("bob", sql(s"CREATE TABLE default.src3 (k int, value string) $format"))
-      doAs("bob", sql(s"INSERT INTO default.src3 SELECT key, value1 from default.src"))
-      doAs("bob", sql(s"INSERT INTO default.src3 SELECT key, value1 as v from default.src"))
+      doAs(
+        "bob",
+        sql(s"INSERT INTO default.src3 SELECT key, value1 from default.src  " +
+          s"where key = 1"))
+      doAs(
+        "bob",
+        sql(s"INSERT INTO default.src3 SELECT key, value1 as v from default.src " +
+          s"where key = 1"))
       checkAnswer("bob", "SELECT value FROM default.src3", Seq(Row(md5Hex("1")), Row(md5Hex("1"))))
     }
   }
@@ -152,7 +186,7 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
 
   test("self join on a masked table") {
     val s = "SELECT a.value1, b.value1 FROM default.src a" +
-      " join default.src b on a.value1=b.value1"
+      " join default.src b on a.value1=b.value1  where a.key = 1 and b.key = 1 "
     checkAnswer("bob", s, Seq(Row(md5Hex("1"), md5Hex("1"))))
     // just for testing query multiple times, don't delete it
     checkAnswer("bob", s, Seq(Row(md5Hex("1"), md5Hex("1"))))
@@ -228,17 +262,18 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
   test("union an unmasked table") {
     val s = """
       SELECT value1 from (
-           SELECT a.value1 FROM default.src a
+           SELECT a.value1 FROM default.src a where a.key = 1
            union
           (SELECT b.value1 FROM default.unmasked b)
       ) c order by value1
       """
-    checkAnswer("bob", s, Seq(Row("1"), Row("2"), Row("3"), Row(md5Hex("1"))))
+    doAs("bob", sql(s).show)
+    checkAnswer("bob", s, Seq(Row("1"), Row("2"), Row("3"), Row("4"), Row("5"), Row(md5Hex("1"))))
   }
 
   test("union a masked table") {
-    val s = "SELECT a.value1 FROM default.src a union" +
-      " (SELECT b.value1 FROM default.src b)"
+    val s = "SELECT a.value1 FROM default.src a where a.key = 1 union" +
+      " (SELECT b.value1 FROM default.src b where b.key = 1)"
     checkAnswer("bob", s, Seq(Row(md5Hex("1"))))
   }
 
@@ -252,35 +287,18 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
     withCleanTmpResources(Seq(("default.perm_view", "view"))) {
       checkAnswer(
         "perm_view_user",
-        "SELECT value1, value2 FROM default.src where key < 20",
+        "SELECT value1, value2 FROM default.src where key = 1",
         Seq(Row(1, "hello")))
       checkAnswer(
         "perm_view_user",
-        "SELECT value1, value2 FROM default.perm_view where key < 20",
+        "SELECT value1, value2 FROM default.perm_view where key = 1",
         Seq(Row(md5Hex("1"), "hello")))
     }
   }
 
-  // This test method must be executed as the last one,
-  //  otherwise it may cause errors in the above test methods.
+  // This test only includes a small subset of UCS-2 characters.
+  // But in theory, it should work for all characters
   test("test MASK,MASK_SHOW_FIRST_4,MASK_SHOW_LAST_4 rule  with non-English character set") {
-    /* Although not all language character sets have been tested,
-       it applies to all non-English character sets.
-       This test mainly includes the UCS-2 character set.
-     */
-    // scalastyle:off
-    // AßþΔЙקم๗ቐあア叶葉엽 reference https://zh.wikipedia.org/zh-cn/Unicode#XML.E5.92.8CUnicode
-    val value1 = "hello WORD 123 ~!@# AßþΔЙקم๗ቐあア叶葉엽"
-    val value2 = "AßþΔЙקم๗ቐあア叶葉엽 hello WORD 123 ~!@#"
-    // scalastyle:on
-    doAs(
-      "admin",
-      sql(s"INSERT INTO default.src " +
-        s"SELECT 10, 4, '$value1', '$value1', timestamp'2018-11-17 12:34:56', '$value1'"))
-    doAs(
-      "admin",
-      sql("INSERT INTO default.src " +
-        s"SELECT 11, 5, '$value2', '$value2', timestamp'2018-11-17 12:34:56', '$value2'"))
     val s1 = s"SELECT * FROM default.src where key = 10"
     val s2 = s"SELECT * FROM default.src where key = 11"
     // scalastyle:off

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingTestBase.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingTestBase.scala
@@ -50,7 +50,8 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
 
     // NOTICE: `bob` has a row filter `key < 20`
     sql("INSERT INTO default.src " +
-      "SELECT 1, 1, 'hello', 'world', timestamp'2018-11-17 12:34:56', 'World'")
+      "SELECT 1, 1, 'hello', '\u6d4b\u8bd5world', " +
+      "timestamp'2018-11-17 12:34:56', 'World\u6d4b\u8bd5'")
     sql("INSERT INTO default.src " +
       "SELECT 20, 2, 'kyuubi', 'y', timestamp'2018-11-17 12:34:56', 'world'")
     sql("INSERT INTO default.src " +
@@ -76,10 +77,12 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
   test("simple query with a user doesn't have mask rules") {
     checkAnswer("kent", "SELECT key FROM default.src order by key", Seq(Row(1), Row(20), Row(30)))
   }
-
+  // SELECT 1, 1, 'hello', 'world', timestamp'2018-11-17 12:34:56', 'World'
   test("simple query with a user has mask rules") {
     val result =
-      Seq(Row(md5Hex("1"), "xxxxx", "worlx", Timestamp.valueOf("2018-01-01 00:00:00"), "Xorld"))
+      Seq(Row(md5Hex("1"), "xxxxx", "\u6d4b\u8bd5woxxx",
+        Timestamp.valueOf("2018-01-01 00:00:00"), "Xxxld\u6d4b\u8bd5"))
+    doAs("bob", sql("SELECT value1, value2, value3, value4, value5 FROM default.src").show)
     checkAnswer("bob", "SELECT value1, value2, value3, value4, value5 FROM default.src", result)
     checkAnswer(
       "bob",
@@ -89,13 +92,15 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
 
   test("star") {
     val result =
-      Seq(Row(1, md5Hex("1"), "xxxxx", "worlx", Timestamp.valueOf("2018-01-01 00:00:00"), "Xorld"))
+      Seq(Row(1, md5Hex("1"), "xxxxx", "\u6d4b\u8bd5woxxx",
+        Timestamp.valueOf("2018-01-01 00:00:00"), "Xxxld\u6d4b\u8bd5"))
     checkAnswer("bob", "SELECT * FROM default.src", result)
   }
 
   test("simple udf") {
     val result =
-      Seq(Row(md5Hex("1"), "xxxxx", "worlx", Timestamp.valueOf("2018-01-01 00:00:00"), "Xorld"))
+      Seq(Row(md5Hex("1"), "xxxxx", "\u6d4b\u8bd5woxxx",
+        Timestamp.valueOf("2018-01-01 00:00:00"), "Xxxld\u6d4b\u8bd5"))
     checkAnswer(
       "bob",
       "SELECT max(value1), max(value2), max(value3), max(value4), max(value5) FROM default.src",
@@ -104,7 +109,8 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
 
   test("complex udf") {
     val result =
-      Seq(Row(md5Hex("1"), "xxxxx", "worlx", Timestamp.valueOf("2018-01-01 00:00:00"), "Xorld"))
+      Seq(Row(md5Hex("1"), "xxxxx", "\u6d4b\u8bd5woxxx",
+        Timestamp.valueOf("2018-01-01 00:00:00"), "Xxxld\u6d4b\u8bd5"))
     checkAnswer(
       "bob",
       "SELECT coalesce(max(value1), 1), coalesce(max(value2), 1), coalesce(max(value3), 1), " +
@@ -115,7 +121,8 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
 
   test("in subquery") {
     val result =
-      Seq(Row(md5Hex("1"), "xxxxx", "worlx", Timestamp.valueOf("2018-01-01 00:00:00"), "Xorld"))
+      Seq(Row(md5Hex("1"), "xxxxx", "\u6d4b\u8bd5woxxx",
+        Timestamp.valueOf("2018-01-01 00:00:00"), "Xxxld\u6d4b\u8bd5"))
     checkAnswer(
       "bob",
       "SELECT value1, value2, value3, value4, value5 FROM default.src WHERE value2 in " +

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingTestBase.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingTestBase.scala
@@ -28,7 +28,7 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.kyuubi.plugin.spark.authz.SparkSessionProvider
-import org.apache.kyuubi.plugin.spark.authz.ranger.{RangerSparkExtension, SparkRangerAdminPlugin}
+import org.apache.kyuubi.plugin.spark.authz.ranger.RangerSparkExtension
 
 /**
  * Base trait for data masking tests, derivative classes shall name themselves following:
@@ -261,75 +261,46 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
     }
   }
 
-  test("test regexp_replace") {
+  test("test MASK rule with non-English character set") {
     /* Although not all language character sets have been tested,
        it applies to all non-English character sets.
        This test mainly includes the UCS-2 character set.
      */
     // scalastyle:off
     // AßþΔЙקم๗ቐあア叶葉엽 reference https://zh.wikipedia.org/zh-cn/Unicode#XML.E5.92.8CUnicode
-    val col="'hello WORD 123 ~!@# AßþΔЙקم๗ቐあア叶葉엽'"
+    val col = "'hello WORD 123 ~!@# AßþΔЙקم๗ቐあア叶葉엽'"
     // scalastyle:on
-    val exp1 = SparkRangerAdminPlugin.regexp_replace(col)
-    assert(exp1 ==
-      "regexp_replace(" +
-        "regexp_replace(" +
-          "regexp_replace(" +
-            s"regexp_replace($col, '[A-Z]', 'X')" +
-            ", '[a-z]', 'x')" +
-          ", '[0-9]', 'n')" +
-        ", '[^A-Za-z0-9 ]', 'U')")
+    val exp1 = s"regexp_replace(regexp_replace(regexp_replace(regexp_replace($col, " +
+      "'[A-Z]', 'X'), '[a-z]', 'x'), '[0-9]', 'n'), '[^A-Za-z0-9 ]', 'U')"
     val s1 = s"SELECT $exp1 as value1"
     checkAnswer("admin", s1, Seq(Row("xxxxx XXXX nnn UUUU XUUUUUUUUUUUUU")))
-
   }
 
-  test("test maskShowFirst4") {
+  test("test MASK_SHOW_FIRST_4 rule with non-English character set") {
     // scalastyle:off
-    val col="'hello WORD 123 ~!@# AßþΔЙקم๗ቐあア叶葉엽'"
+    val col = "'hello WORD 123 ~!@# AßþΔЙקم๗ቐあア叶葉엽'"
     // scalastyle:on
-    val exp1 = SparkRangerAdminPlugin.maskShowFirst4(col, true)
-    assert(exp1 ==
-        "regexp_replace(" +
-          "regexp_replace(" +
-            "regexp_replace(" +
-              s"regexp_replace($col, '[A-Z]', 'X', 5)" +
-            ", '[a-z]', 'x', 5)" +
-          ", '[0-9]', 'n', 5)" +
-        ", '[^A-Za-z0-9 ]', 'U', 5)")
-    val exp2 = SparkRangerAdminPlugin.maskShowFirst4(col, false)
-    assert(exp2 ==
-        s"concat(substr($col, 0, 4), " +
-          "regexp_replace(" +
-            "regexp_replace(" +
-              "regexp_replace(" +
-                s"regexp_replace(substr($col, 5), '[A-Z]', 'X')" +
-              ", '[a-z]', 'x')" +
-            ", '[0-9]', 'n')" +
-          ", '[^A-Za-z0-9 ]', 'U')" +
-        ")")
-    val exp3 = SparkRangerAdminPlugin.maskShowFirst4(col, isSparkV31OrGreater)
-    val s1 = s"SELECT $exp3 as value1"
-    checkAnswer("admin", s1, Seq(Row("hellx XXXX nnn UUUU XUUUUUUUUUUUUU")))
+    val exp1 = s"regexp_replace(regexp_replace(regexp_replace(regexp_replace($col," +
+      s" '[A-Z]', 'X', 5), '[a-z]', 'x', 5), '[0-9]', 'n', 5), '[^A-Za-z0-9 ]', 'U', 5)"
+    val exp2 = s"concat(substr($col, 0, 4), regexp_replace(regexp_replace(regexp_replace(" +
+      s"regexp_replace(substr($col, 5), '[A-Z]', 'X'), '[a-z]', 'x'), " +
+      s"'[0-9]', 'n'), '[^A-Za-z0-9 ]', 'U'))"
+
     val s2 = s"SELECT $exp2 as value1"
     checkAnswer("admin", s2, Seq(Row("hellx XXXX nnn UUUU XUUUUUUUUUUUUU")))
+
+    assume(isSparkV31OrGreater)
+    val s1 = s"SELECT $exp1 as value1"
+    checkAnswer("admin", s1, Seq(Row("hellx XXXX nnn UUUU XUUUUUUUUUUUUU")))
   }
 
-  test("test maskShowLast4") {
+  test("test MASK_SHOW_LAST_4 rule with non-English character set") {
     // scalastyle:off
-    val col="'hello WORD 123 ~!@# AßþΔЙקم๗ቐあア叶葉엽'"
+    val col = "'hello WORD 123 ~!@# AßþΔЙקم๗ቐあア叶葉엽'"
     // scalastyle:on
-    val exp1 = SparkRangerAdminPlugin.maskShowLast4(col)
-    assert(exp1 ==
-        "concat(regexp_replace(" +
-          "regexp_replace(" +
-            "regexp_replace(" +
-              s"regexp_replace(left($col, length($col) - 4), '[A-Z]', 'X')" +
-              ", '[a-z]', 'x')" +
-            ", '[0-9]', 'n')" +
-          ", '[^A-Za-z0-9 ]', 'U')" +
-        s", right($col, 4))")
-
+    val exp1 = s"concat(regexp_replace(regexp_replace(regexp_replace(regexp_replace(" +
+      s"left($col, length($col) - 4), '[A-Z]', 'X'), '[a-z]', 'x'), " +
+      s"'[0-9]', 'n'), '[^A-Za-z0-9 ]', 'U'), right($col, 4))"
     val s1 = s"SELECT $exp1 as value1"
     // scalastyle:off
     checkAnswer("admin", s1, Seq(Row("xxxxx XXXX nnn UUUU XUUUUUUUUUア叶葉엽")))

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingTestBase.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingTestBase.scala
@@ -19,16 +19,14 @@ package org.apache.kyuubi.plugin.spark.authz.ranger.datamasking
 
 // scalastyle:off
 import java.sql.Timestamp
-
 import scala.util.Try
-
 import org.apache.commons.codec.digest.DigestUtils.md5Hex
 import org.apache.spark.sql.{Row, SparkSessionExtensions}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuite
-
 import org.apache.kyuubi.plugin.spark.authz.SparkSessionProvider
-import org.apache.kyuubi.plugin.spark.authz.ranger.RangerSparkExtension
+import org.apache.kyuubi.plugin.spark.authz.ranger.{RangerSparkExtension, SparkRangerAdminPlugin}
+import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils.isSparkVersionAtLeast
 
 /**
  * Base trait for data masking tests, derivative classes shall name themselves following:
@@ -50,8 +48,8 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
 
     // NOTICE: `bob` has a row filter `key < 20`
     sql("INSERT INTO default.src " +
-      "SELECT 1, 1, 'hello', '\u6d4b\u8bd5world', " +
-      "timestamp'2018-11-17 12:34:56', 'World\u6d4b\u8bd5'")
+      "SELECT 1, 1, 'hello', '\u6d4b\u8bd5world\u4e2d\u6587', " +
+      "timestamp'2018-11-17 12:34:56', '\u4e2d\u6587World\u6d4b\u8bd5'")
     sql("INSERT INTO default.src " +
       "SELECT 20, 2, 'kyuubi', 'y', timestamp'2018-11-17 12:34:56', 'world'")
     sql("INSERT INTO default.src " +
@@ -77,12 +75,11 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
   test("simple query with a user doesn't have mask rules") {
     checkAnswer("kent", "SELECT key FROM default.src order by key", Seq(Row(1), Row(20), Row(30)))
   }
-  // SELECT 1, 1, 'hello', 'world', timestamp'2018-11-17 12:34:56', 'World'
+
   test("simple query with a user has mask rules") {
     val result =
-      Seq(Row(md5Hex("1"), "xxxxx", "\u6d4b\u8bd5woxxx",
-        Timestamp.valueOf("2018-01-01 00:00:00"), "Xxxld\u6d4b\u8bd5"))
-    doAs("bob", sql("SELECT value1, value2, value3, value4, value5 FROM default.src").show)
+      Seq(Row(md5Hex("1"), "xxxxx", "\u6d4b\u8bd5woxxx\u5bc6\u5bc6",
+        Timestamp.valueOf("2018-01-01 00:00:00"), "\u5bc6\u5bc6Xxxld\u6d4b\u8bd5"))
     checkAnswer("bob", "SELECT value1, value2, value3, value4, value5 FROM default.src", result)
     checkAnswer(
       "bob",
@@ -92,15 +89,15 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
 
   test("star") {
     val result =
-      Seq(Row(1, md5Hex("1"), "xxxxx", "\u6d4b\u8bd5woxxx",
-        Timestamp.valueOf("2018-01-01 00:00:00"), "Xxxld\u6d4b\u8bd5"))
+      Seq(Row(1, md5Hex("1"), "xxxxx", "\u6d4b\u8bd5woxxx\u5bc6\u5bc6",
+        Timestamp.valueOf("2018-01-01 00:00:00"), "\u5bc6\u5bc6Xxxld\u6d4b\u8bd5"))
     checkAnswer("bob", "SELECT * FROM default.src", result)
   }
 
   test("simple udf") {
     val result =
-      Seq(Row(md5Hex("1"), "xxxxx", "\u6d4b\u8bd5woxxx",
-        Timestamp.valueOf("2018-01-01 00:00:00"), "Xxxld\u6d4b\u8bd5"))
+      Seq(Row(md5Hex("1"), "xxxxx", "\u6d4b\u8bd5woxxx\u5bc6\u5bc6",
+        Timestamp.valueOf("2018-01-01 00:00:00"), "\u5bc6\u5bc6Xxxld\u6d4b\u8bd5"))
     checkAnswer(
       "bob",
       "SELECT max(value1), max(value2), max(value3), max(value4), max(value5) FROM default.src",
@@ -109,8 +106,8 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
 
   test("complex udf") {
     val result =
-      Seq(Row(md5Hex("1"), "xxxxx", "\u6d4b\u8bd5woxxx",
-        Timestamp.valueOf("2018-01-01 00:00:00"), "Xxxld\u6d4b\u8bd5"))
+      Seq(Row(md5Hex("1"), "xxxxx", "\u6d4b\u8bd5woxxx\u5bc6\u5bc6",
+        Timestamp.valueOf("2018-01-01 00:00:00"), "\u5bc6\u5bc6Xxxld\u6d4b\u8bd5"))
     checkAnswer(
       "bob",
       "SELECT coalesce(max(value1), 1), coalesce(max(value2), 1), coalesce(max(value3), 1), " +
@@ -121,8 +118,8 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
 
   test("in subquery") {
     val result =
-      Seq(Row(md5Hex("1"), "xxxxx", "\u6d4b\u8bd5woxxx",
-        Timestamp.valueOf("2018-01-01 00:00:00"), "Xxxld\u6d4b\u8bd5"))
+      Seq(Row(md5Hex("1"), "xxxxx", "\u6d4b\u8bd5woxxx\u5bc6\u5bc6",
+        Timestamp.valueOf("2018-01-01 00:00:00"), "\u5bc6\u5bc6Xxxld\u6d4b\u8bd5"))
     checkAnswer(
       "bob",
       "SELECT value1, value2, value3, value4, value5 FROM default.src WHERE value2 in " +
@@ -266,5 +263,37 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
         "SELECT value1, value2 FROM default.perm_view where key < 20",
         Seq(Row(md5Hex("1"), "hello")))
     }
+  }
+
+  test("test regexp_replace method") {
+    val exp = SparkRangerAdminPlugin.regexp_replace("'hello WORD 123\u6d4b\u8bd5\u4e2d\u6587'")
+    assert(exp ==
+      "regexp_replace(" +
+          "regexp_replace(" +
+            "regexp_replace(" +
+              "regexp_replace('hello WORD 123\u6d4b\u8bd5\u4e2d\u6587', '[A-Z]', 'X')" +
+              ", '[a-z]', 'x')" +
+            ", '[0-9]', 'n')" +
+          ", '[\u4e00-\u9fff]', '\u5bc6')")
+    val exp2 = SparkRangerAdminPlugin.regexp_replace(
+                "'hello WORD 123\u6d4b\u8bd5\u4e2d\u6587'", true)
+    assert(exp2 ==
+      "regexp_replace(" +
+        "regexp_replace(" +
+            "regexp_replace(" +
+                "regexp_replace('hello WORD 123\u6d4b\u8bd5\u4e2d\u6587', '[A-Z]', 'X', 5)" +
+                ", '[a-z]', 'x', 5)" +
+            ", '[0-9]', 'n', 5)" +
+        ", '[\u4e00-\u9fff]', '\u5bc6', 5)")
+    val s = s"SELECT $exp as value1"
+    val s2 = s"SELECT $exp2 as value1"
+    if(isSparkVersionAtLeast("3.1") == true) {
+      checkAnswer("admin", s2, Seq(Row("hellx XXXX nnn\u5bc6\u5bc6\u5bc6\u5bc6")))
+      checkAnswer("admin", s, Seq(Row("xxxxx XXXX nnn\u5bc6\u5bc6\u5bc6\u5bc6")))
+    } else {
+      checkAnswer("admin", s, Seq(Row("xxxxx XXXX nnn\u5bc6\u5bc6\u5bc6\u5bc6")))
+    }
+
+
   }
 }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingTestBase.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingTestBase.scala
@@ -298,7 +298,5 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
       checkAnswer("admin", s1, Seq(Row("xxxxx XXXX nnn\u5bc6\u5bc6\u5bc6\u5bc6")))
       checkAnswer("admin", s3, Seq(Row("\u5bc6\u5bc6xxxxx XXXX nnn")))
     }
-
-
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
To fix https://github.com/apache/kyuubi/issues/4530.
1. The reason for issue https://github.com/apache/kyuubi/issues/4530  is that MASK_SHOW_FIRST_4 and MASK_SHOW_LAST_4 mask types are currently implemented using the regexp_replace method, which only replaces English letters and digits, but ignores other languages, such as Chinese.
2. To fix this issue, I modified the regexp_replace method to replace no-english characters to 'U' letters, so they will also be masked properly.



### _How was this patch tested?_

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
