### PR TITLE
Manually terminate the Py4JServer during engine shutdown

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/session/SparkSQLSessionManager.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/session/SparkSQLSessionManager.scala
@@ -20,6 +20,7 @@ package org.apache.kyuubi.engine.spark.session
 import java.util.concurrent.{ScheduledExecutorService, TimeUnit}
 
 import org.apache.hive.service.rpc.thrift.TProtocolVersion
+import org.apache.spark.api.python.KyuubiPythonGatewayServer
 import org.apache.spark.sql.SparkSession
 
 import org.apache.kyuubi.KyuubiSQLException
@@ -94,6 +95,7 @@ class SparkSQLSessionManager private (name: String, spark: SparkSession)
 
   override def stop(): Unit = {
     super.stop()
+    KyuubiPythonGatewayServer.shutdown()
     userIsolatedSparkSessionThread.foreach(_.shutdown())
   }
 

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/api/python/KyuubiPythonGatewayServer.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/api/python/KyuubiPythonGatewayServer.scala
@@ -32,7 +32,7 @@ object KyuubiPythonGatewayServer extends Logging {
 
   private var gatewayServer: Py4JServer = _
 
-  def start(): Unit = {
+  def start(): Unit = synchronized {
 
     val sparkConf = new SparkConf()
     gatewayServer = new Py4JServer(sparkConf)
@@ -68,7 +68,7 @@ object KyuubiPythonGatewayServer extends Logging {
     }
   }
 
-  def shutdown(): Unit = {
+  def shutdown(): Unit = synchronized {
     if (gatewayServer != null) {
       logInfo("shutting down the python gateway server.")
       gatewayServer.shutdown()

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/api/python/KyuubiPythonGatewayServer.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/api/python/KyuubiPythonGatewayServer.scala
@@ -30,10 +30,12 @@ object KyuubiPythonGatewayServer extends Logging {
 
   val CONNECTION_FILE_PATH = Utils.createTempDir() + "/connection.info"
 
+  private var gatewayServer: Py4JServer = _
+
   def start(): Unit = {
 
     val sparkConf = new SparkConf()
-    val gatewayServer: Py4JServer = new Py4JServer(sparkConf)
+    gatewayServer = new Py4JServer(sparkConf)
 
     gatewayServer.start()
     val boundPort: Int = gatewayServer.getListeningPort
@@ -63,6 +65,13 @@ object KyuubiPythonGatewayServer extends Logging {
     if (!tmpPath.renameTo(connectionInfoPath)) {
       logError(s"Unable to write connection information to $connectionInfoPath.")
       System.exit(1)
+    }
+  }
+
+  def shutdown(): Unit = {
+    if (gatewayServer != null) {
+      logInfo("shutting down the python gateway server.")
+      gatewayServer.shutdown()
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Due to the Py4JServer initiating with a non-daemon thread, there is a possibility of it impeding the engine's termination. Therefore, it is imperative to manually terminate the Py4JServer during engine shutdown.

```
"Thread-23" #96 prio=5 os_prio=0 cpu=7.93ms elapsed=187532.67s tid=0x00007fee840cf000 nid=0x8f runnable  [0x00007fedca6bf000]
   java.lang.Thread.State: RUNNABLE
	at java.net.PlainSocketImpl.socketAccept(java.base@11.0.16/Native Method)
	at java.net.AbstractPlainSocketImpl.accept(java.base@11.0.16/Unknown Source)
	at java.net.ServerSocket.implAccept(java.base@11.0.16/Unknown Source)
	at java.net.ServerSocket.accept(java.base@11.0.16/Unknown Source)
	at py4j.GatewayServer.run(GatewayServer.java:685)
	at java.lang.Thread.run(java.base@11.0.16/Unknown Source)
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
