### PR TITLE
Building rest client to kyuubi instance including original host urls

### DIFF
--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/RestClientFactory.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/RestClientFactory.scala
@@ -18,6 +18,8 @@ package org.apache.kyuubi.ctl
 
 import java.util.{Map => JMap}
 
+import scala.collection.JavaConverters._
+
 import org.apache.commons.lang3.StringUtils
 
 import org.apache.kyuubi.KyuubiException
@@ -45,7 +47,8 @@ object RestClientFactory {
       kyuubiRestClient: KyuubiRestClient,
       kyuubiInstance: String)(f: KyuubiRestClient => Unit): Unit = {
     val kyuubiInstanceRestClient = kyuubiRestClient.clone()
-    kyuubiInstanceRestClient.setHostUrls(s"http://${kyuubiInstance}")
+    val hostUrls = Seq(s"http://$kyuubiInstance") ++ kyuubiRestClient.getHostUrls.asScala
+    kyuubiInstanceRestClient.setHostUrls(hostUrls.asJava)
     try {
       f(kyuubiInstanceRestClient)
     } finally {

--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/KyuubiRestClient.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/KyuubiRestClient.java
@@ -81,6 +81,10 @@ public class KyuubiRestClient implements AutoCloseable, Cloneable {
     this.httpClient = RetryableRestClient.getRestClient(baseUrls, this.conf);
   }
 
+  public List<String> getHostUrls() {
+    return baseUrls;
+  }
+
   private KyuubiRestClient() {}
 
   private KyuubiRestClient(Builder builder) {

--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/KyuubiRestClient.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/KyuubiRestClient.java
@@ -30,6 +30,8 @@ public class KyuubiRestClient implements AutoCloseable, Cloneable {
 
   private RestClientConf conf;
 
+  private List<String> hostUrls;
+
   private List<String> baseUrls;
 
   private ApiVersion version;
@@ -77,18 +79,20 @@ public class KyuubiRestClient implements AutoCloseable, Cloneable {
     if (hostUrls.isEmpty()) {
       throw new IllegalArgumentException("hostUrls cannot be blank.");
     }
+    this.hostUrls = hostUrls;
     List<String> baseUrls = initBaseUrls(hostUrls, version);
     this.httpClient = RetryableRestClient.getRestClient(baseUrls, this.conf);
   }
 
   public List<String> getHostUrls() {
-    return baseUrls;
+    return hostUrls;
   }
 
   private KyuubiRestClient() {}
 
   private KyuubiRestClient(Builder builder) {
     this.version = builder.version;
+    this.hostUrls = builder.hostUrls;
     this.baseUrls = initBaseUrls(builder.hostUrls, builder.version);
 
     RestClientConf conf = new RestClientConf();


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Usually, the host url to create a batch is the load balancer uri.

To reduce the internal rest redirection when fetching log, we support to call the kyuubi instance that created the batch directly.

It is better to add original host urls when building the rest client to kyuubi instance, in case that there is firewall to the kyuubi instance directly.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
