### PR TITLE
LDAP authentication allows auth user contains domain when bind.dn/pw enabled

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/LdapAuthenticationProviderImpl.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/LdapAuthenticationProviderImpl.scala
@@ -27,6 +27,7 @@ import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.service.ServiceUtils
 import org.apache.kyuubi.service.authentication.LdapAuthenticationProviderImpl.FILTER_FACTORIES
 import org.apache.kyuubi.service.authentication.ldap._
+import org.apache.kyuubi.service.authentication.ldap.LdapUtils.getUserName
 
 class LdapAuthenticationProviderImpl(
     conf: KyuubiConf,
@@ -70,7 +71,8 @@ class LdapAuthenticationProviderImpl(
       if (usedBind) {
         // If we used the bind user, then we need to authenticate again,
         // this time using the full user name we got during the bind process.
-        createDirSearch(search.findUserDn(user), password)
+        val username = getUserName(user)
+        createDirSearch(search.findUserDn(username), password)
       }
     } catch {
       case e: NamingException =>
@@ -108,8 +110,7 @@ class LdapAuthenticationProviderImpl(
 
   @throws[AuthenticationException]
   private def applyFilter(client: DirSearch, user: String): Unit = filterOpt.foreach { filter =>
-    val username = if (LdapUtils.hasDomain(user)) LdapUtils.extractUserName(user) else user
-    filter.apply(client, username)
+    filter.apply(client, getUserName(user))
   }
 }
 

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/ldap/LdapUtils.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/ldap/LdapUtils.scala
@@ -105,11 +105,24 @@ object LdapUtils extends Logging {
    * </pre>
    *
    * @param userName username
-   * @return true if `userName`` contains `@<domain>` part
+   * @return true if `userName` contains `@<domain>` part
    */
   def hasDomain(userName: String): Boolean = {
     ServiceUtils.indexOfDomainMatch(userName) > 0
   }
+
+  /**
+   * Get the username part in the provided user.
+   * <br>
+   * <b>Example:</b>
+   * <br>
+   * For user "user1@mycorp.com"" this method will return "user1"
+   *
+   * @param user user
+   * @return the username part in the provided user
+   */
+  def getUserName(user: String): String =
+    if (LdapUtils.hasDomain(user)) LdapUtils.extractUserName(user) else user
 
   /**
    * Detects DN names.

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/ldap/LdapUtils.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/ldap/LdapUtils.scala
@@ -116,7 +116,7 @@ object LdapUtils extends Logging {
    * <br>
    * <b>Example:</b>
    * <br>
-   * For user "user1@mycorp.com"" this method will return "user1"
+   * For user "user1@mycorp.com" this method will return "user1"
    *
    * @param user user
    * @return the username part in the provided user

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/service/authentication/LdapAuthenticationProviderImplSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/service/authentication/LdapAuthenticationProviderImplSuite.scala
@@ -27,6 +27,7 @@ import org.scalatestplus.mockito.MockitoSugar.mock
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf._
 import org.apache.kyuubi.service.authentication.ldap.{DirSearch, DirSearchFactory, LdapSearchFactory}
+import org.apache.kyuubi.service.authentication.ldap.LdapUtils.getUserName
 
 class LdapAuthenticationProviderImplSuite extends WithLdapServer {
 
@@ -309,6 +310,32 @@ class LdapAuthenticationProviderImplSuite extends WithLdapServer {
       mockEq(authFullUser),
       mockEq(authPass))
     verify(search, times(1)).findUserDn(mockEq(authUser))
+  }
+
+  test("AuthenticateWithBindDomainUserPasses") {
+    val bindUser = "cn=BindUser,ou=Users,ou=branch1,dc=mycorp,dc=com"
+    val bindPass = "Blah"
+    val authFullUser = "cn=user1,ou=Users,ou=branch1,dc=mycorp,dc=com"
+    val authUser = "user1@mydomain.com"
+    val authPass = "Blah2"
+    conf.set(AUTHENTICATION_LDAP_BIND_USER, bindUser)
+    conf.set(AUTHENTICATION_LDAP_BIND_PASSWORD, bindPass)
+
+    val username = getUserName(authUser)
+    when(search.findUserDn(mockEq(username))).thenReturn(authFullUser)
+
+    auth = new LdapAuthenticationProviderImpl(conf, factory)
+    auth.authenticate(authUser, authPass)
+
+    verify(factory, times(1)).getInstance(
+      isA(classOf[KyuubiConf]),
+      mockEq(bindUser),
+      mockEq(bindPass))
+    verify(factory, times(1)).getInstance(
+      isA(classOf[KyuubiConf]),
+      mockEq(authFullUser),
+      mockEq(authPass))
+    verify(search, times(1)).findUserDn(mockEq(username))
   }
 
   test("AuthenticateWithBindUserFailsOnAuthentication") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Now, with binduser and bindpw enabled, the user authentication pass is incompatible with the domain user. 

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
