### PR TITLE
[AUTHZ] Reuse users and namespaces in both tests and policy file generation

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/test/gen/scala/org/apache/kyuubi/plugin/spark/authz/gen/PolicyJsonFileGenerator.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/gen/scala/org/apache/kyuubi/plugin/spark/authz/gen/PolicyJsonFileGenerator.scala
@@ -31,7 +31,9 @@ import org.apache.ranger.plugin.model.RangerPolicy
 // scalastyle:off
 import org.scalatest.funsuite.AnyFunSuite
 
-import org.apache.kyuubi.plugin.spark.authz.gen.KRangerPolicyItemAccess._
+import org.apache.kyuubi.plugin.spark.authz.RangerTestNamespace._
+import org.apache.kyuubi.plugin.spark.authz.RangerTestUsers._
+import org.apache.kyuubi.plugin.spark.authz.gen.KRangerPolicyItemAccess.allowTypes
 import org.apache.kyuubi.plugin.spark.authz.gen.KRangerPolicyResource._
 import org.apache.kyuubi.plugin.spark.authz.gen.RangerAccessType._
 import org.apache.kyuubi.plugin.spark.authz.gen.RangerClassConversions._
@@ -126,22 +128,6 @@ class PolicyJsonFileGenerator extends AnyFunSuite {
           p
       }
   }
-
-  // users
-  private val admin = "admin"
-  private val bob = "bob"
-  private val kent = "kent"
-  private val permViewUser = "perm_view_user"
-  private val ownerPlaceHolder = "{OWNER}"
-  private val createOnlyUser = "create_only_user"
-  private val defaultTableOwner = "default_table_owner"
-  private val permViewOnlyUser = "user_perm_view_only"
-
-  // db
-  private val defaultDb = "default"
-  private val sparkCatalog = "spark_catalog"
-  private val icebergNamespace = "iceberg_ns"
-  private val namespace1 = "ns1"
 
   // resources
   private val allDatabaseRes = databaseRes("*")

--- a/extensions/spark/kyuubi-spark-authz/src/test/gen/scala/org/apache/kyuubi/plugin/spark/authz/gen/RangerGenWrapper.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/gen/scala/org/apache/kyuubi/plugin/spark/authz/gen/RangerGenWrapper.scala
@@ -22,7 +22,7 @@ import scala.language.implicitConversions
 import org.apache.ranger.plugin.model.RangerPolicy
 import org.apache.ranger.plugin.model.RangerPolicy._
 
-import org.apache.kyuubi.plugin.spark.authz.gen.RangerClassConversions.getRangerObject
+import org.apache.kyuubi.plugin.spark.authz.gen.RangerClassConversions._
 
 trait RangerObjectGenerator[T] {
   def get: T

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilderSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilderSuite.scala
@@ -30,6 +30,8 @@ import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.kyuubi.plugin.spark.authz.OperationType._
+import org.apache.kyuubi.plugin.spark.authz.RangerTestNamespace._
+import org.apache.kyuubi.plugin.spark.authz.RangerTestUsers._
 import org.apache.kyuubi.plugin.spark.authz.ranger.AccessType
 import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils
 import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils.isSparkVersionAtMost
@@ -122,8 +124,8 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
     assert(po.actionType === PrivilegeObjectActionType.OTHER)
     assert(po.privilegeObjectType === PrivilegeObjectType.DATABASE)
     assert(po.catalog.isEmpty)
-    assert(po.dbname === "default")
-    assert(po.objectName === "default")
+    assert(po.dbname === defaultDb)
+    assert(po.objectName === defaultDb)
     assert(po.columns.isEmpty)
   }
 
@@ -365,7 +367,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
     assert(po.actionType === PrivilegeObjectActionType.OTHER)
     assert(po.privilegeObjectType === PrivilegeObjectType.TABLE_OR_VIEW)
     assert(po.catalog.isEmpty)
-    assert(po.dbname === (if (isSparkV2) null else "default"))
+    assert(po.dbname === (if (isSparkV2) null else defaultDb))
     assert(po.objectName === "AlterViewAsCommand")
     checkTableOwner(po)
     assert(po.columns.isEmpty)
@@ -521,7 +523,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
     assert(po.actionType === PrivilegeObjectActionType.OTHER)
     assert(po.privilegeObjectType === PrivilegeObjectType.TABLE_OR_VIEW)
     assert(po.catalog.isEmpty)
-    assert(po.dbname === (if (isSparkV2) null else "default"))
+    assert(po.dbname === (if (isSparkV2) null else defaultDb))
     assert(po.objectName === "CreateViewCommand")
     assert(po.columns.isEmpty)
     val accessType = ranger.AccessType(po, operationType, isInput = false)
@@ -541,7 +543,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
       assert(po.actionType === PrivilegeObjectActionType.OTHER)
       assert(po.privilegeObjectType === PrivilegeObjectType.TABLE_OR_VIEW)
       assert(po.catalog.isEmpty)
-      assert(po.dbname === (if (isSparkV2) null else "default"))
+      assert(po.dbname === (if (isSparkV2) null else defaultDb))
       assert(po.objectName === tableName)
       assert(po.columns.isEmpty)
       val accessType = ranger.AccessType(po, operationType, isInput = false)
@@ -588,7 +590,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
     assert(po.actionType === PrivilegeObjectActionType.OTHER)
     assert(po.privilegeObjectType === PrivilegeObjectType.FUNCTION)
     assert(po.catalog.isEmpty)
-    val db = if (isSparkV33OrGreater) "default" else null
+    val db = if (isSparkV33OrGreater) defaultDb else null
     assert(po.dbname === db)
     assert(po.objectName === "CreateFunctionCommand")
     assert(po.columns.isEmpty)
@@ -620,7 +622,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
     assert(po.actionType === PrivilegeObjectActionType.OTHER)
     assert(po.privilegeObjectType === PrivilegeObjectType.FUNCTION)
     assert(po.catalog.isEmpty)
-    val db = if (isSparkV33OrGreater) "default" else null
+    val db = if (isSparkV33OrGreater) defaultDb else null
     assert(po.dbname === db)
     assert(po.objectName === "DropFunctionCommand")
     assert(po.columns.isEmpty)
@@ -641,7 +643,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
     assert(po.actionType === PrivilegeObjectActionType.OTHER)
     assert(po.privilegeObjectType === PrivilegeObjectType.FUNCTION)
     assert(po.catalog.isEmpty)
-    val db = if (isSparkV33OrGreater) "default" else null
+    val db = if (isSparkV33OrGreater) defaultDb else null
     assert(po.dbname === db)
     assert(po.objectName === "RefreshFunctionCommand")
     assert(po.columns.isEmpty)
@@ -1267,8 +1269,8 @@ class InMemoryPrivilegeBuilderSuite extends PrivilegesBuilderSuite {
     assert(po.actionType === PrivilegeObjectActionType.OTHER)
     assert(po.privilegeObjectType === PrivilegeObjectType.DATABASE)
     assert(po.catalog.isEmpty)
-    assert(po.dbname === "default")
-    assert(po.objectName === "default")
+    assert(po.dbname === defaultDb)
+    assert(po.objectName === defaultDb)
     assert(po.columns.isEmpty)
     val accessType = ranger.AccessType(po, operationType, isInput = false)
     assert(accessType === AccessType.ALTER)
@@ -1296,7 +1298,7 @@ class InMemoryPrivilegeBuilderSuite extends PrivilegesBuilderSuite {
     assert(po.actionType === PrivilegeObjectActionType.OTHER)
     assert(po.privilegeObjectType === PrivilegeObjectType.TABLE_OR_VIEW)
     assert(po.catalog.isEmpty)
-    assert(po.dbname === (if (isSparkV2) null else "default"))
+    assert(po.dbname === (if (isSparkV2) null else defaultDb))
     assert(po.objectName === "CreateDataSourceTableAsSelectCommand")
     if (catalogImpl == "hive") {
       assert(po.columns === Seq("key", "value"))
@@ -1328,7 +1330,7 @@ class HiveCatalogPrivilegeBuilderSuite extends PrivilegesBuilderSuite {
       assert(po.actionType === PrivilegeObjectActionType.OTHER)
       assert(po.privilegeObjectType === PrivilegeObjectType.TABLE_OR_VIEW)
       assert(po.catalog.isEmpty)
-      assert(po.dbname === "default")
+      assert(po.dbname === defaultDb)
       assert(po.objectName === t)
       assert(po.columns.head === "pid")
       checkTableOwner(po)
@@ -1350,7 +1352,7 @@ class HiveCatalogPrivilegeBuilderSuite extends PrivilegesBuilderSuite {
       assert(po.actionType === PrivilegeObjectActionType.OTHER)
       assert(po.privilegeObjectType === PrivilegeObjectType.TABLE_OR_VIEW)
       assert(po.catalog.isEmpty)
-      assert(po.dbname === "default")
+      assert(po.dbname === defaultDb)
       assert(po.objectName === "CreateTableCommand")
       assert(po.columns.isEmpty)
       val accessType = ranger.AccessType(po, operationType, isInput = false)
@@ -1382,7 +1384,7 @@ class HiveCatalogPrivilegeBuilderSuite extends PrivilegesBuilderSuite {
     assert(po.actionType === PrivilegeObjectActionType.OTHER)
     assert(po.privilegeObjectType === PrivilegeObjectType.TABLE_OR_VIEW)
     assert(po.catalog.isEmpty)
-    assert(po.dbname === "default")
+    assert(po.dbname === defaultDb)
     assert(po.objectName === "CreateHiveTableAsSelectCommand")
     assert(po.columns === Seq("key", "value"))
     val accessType = ranger.AccessType(po, operationType, isInput = false)
@@ -1493,7 +1495,7 @@ class HiveCatalogPrivilegeBuilderSuite extends PrivilegesBuilderSuite {
         assert(po.actionType === PrivilegeObjectActionType.INSERT)
         assert(po.privilegeObjectType === PrivilegeObjectType.TABLE_OR_VIEW)
         assert(po.catalog.isEmpty)
-        assert(po.dbname equalsIgnoreCase "default")
+        assert(po.dbname equalsIgnoreCase defaultDb)
         assert(po.objectName equalsIgnoreCase tableName)
         assert(po.columns.isEmpty)
         checkTableOwner(po)
@@ -1536,7 +1538,7 @@ class HiveCatalogPrivilegeBuilderSuite extends PrivilegesBuilderSuite {
         assert(po.actionType === PrivilegeObjectActionType.INSERT)
         assert(po.privilegeObjectType === PrivilegeObjectType.TABLE_OR_VIEW)
         assert(po.catalog.isEmpty)
-        assert(po.dbname equalsIgnoreCase "default")
+        assert(po.dbname equalsIgnoreCase defaultDb)
         assert(po.objectName equalsIgnoreCase tableName)
         assert(po.columns === Seq("a", "b"))
         checkTableOwner(po)
@@ -1618,7 +1620,7 @@ class HiveCatalogPrivilegeBuilderSuite extends PrivilegesBuilderSuite {
         assert(po.actionType === PrivilegeObjectActionType.INSERT)
         assert(po.privilegeObjectType === PrivilegeObjectType.TABLE_OR_VIEW)
         assert(po.catalog.isEmpty)
-        assert(po.dbname equalsIgnoreCase "default")
+        assert(po.dbname equalsIgnoreCase defaultDb)
         assert(po.objectName equalsIgnoreCase tableName)
         assert(po.columns === Seq("a", "b"))
         checkTableOwner(po)
@@ -1639,7 +1641,7 @@ class HiveCatalogPrivilegeBuilderSuite extends PrivilegesBuilderSuite {
       val po0 = in.head
       assert(po0.actionType === PrivilegeObjectActionType.OTHER)
       assert(po0.privilegeObjectType === PrivilegeObjectType.TABLE_OR_VIEW)
-      assert(po0.dbname === "default")
+      assert(po0.dbname === defaultDb)
       assert(po0.objectName === t)
       assert(po0.columns.isEmpty)
       checkTableOwner(po0)
@@ -1665,7 +1667,7 @@ class HiveCatalogPrivilegeBuilderSuite extends PrivilegesBuilderSuite {
     assert(po.actionType === PrivilegeObjectActionType.OTHER)
     assert(po.privilegeObjectType === PrivilegeObjectType.TABLE_OR_VIEW)
     assert(po.catalog.isEmpty)
-    assert(po.dbname === "default")
+    assert(po.dbname === defaultDb)
     assert(po.objectName === "OptimizedCreateHiveTableAsSelectCommand")
     assert(po.columns === Seq("a"))
     val accessType = ranger.AccessType(po, operationType, isInput = false)

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/RangerTestResources.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/RangerTestResources.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.plugin.spark.authz
+
+object RangerTestUsers {
+  // authorized users used in policy generation
+  val admin = "admin"
+  val alice = "alice"
+  val bob = "bob"
+  val kent = "kent"
+  val permViewUser = "perm_view_user"
+  val ownerPlaceHolder = "{OWNER}"
+  val createOnlyUser = "create_only_user"
+  val defaultTableOwner = "default_table_owner"
+  val permViewOnlyUser = "user_perm_view_only"
+
+  // non-authorized users
+  val invisibleUser = "i_am_invisible"
+  val denyUser = "denyuser"
+  val denyUser2 = "denyuser2"
+  val someone = "someone"
+}
+
+object RangerTestNamespace {
+  val defaultDb = "default"
+  val sparkCatalog = "spark_catalog"
+  val icebergNamespace = "iceberg_ns"
+  val namespace1 = "ns1"
+  val namespace2 = "ns2"
+}

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/SparkSessionProvider.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/SparkSessionProvider.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.{DataFrame, Row, SparkSession, SparkSessionExtension
 import org.scalatest.Assertions.convertToEqualizer
 
 import org.apache.kyuubi.Utils
+import org.apache.kyuubi.plugin.spark.authz.RangerTestUsers._
 import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
 
 trait SparkSessionProvider {
@@ -39,7 +40,6 @@ trait SparkSessionProvider {
   protected val extension: SparkSessionExtensions => Unit = _ => Unit
   protected val sqlExtensions: String = ""
 
-  protected val defaultTableOwner = "default_table_owner"
   protected val extraSparkConf: SparkConf = new SparkConf()
 
   protected lazy val spark: SparkSession = {
@@ -83,12 +83,12 @@ trait SparkSessionProvider {
       f
     } finally {
       res.foreach {
-        case (t, "table") => doAs("admin", sql(s"DROP TABLE IF EXISTS $t"))
-        case (db, "database") => doAs("admin", sql(s"DROP DATABASE IF EXISTS $db"))
-        case (fn, "function") => doAs("admin", sql(s"DROP FUNCTION IF EXISTS $fn"))
-        case (view, "view") => doAs("admin", sql(s"DROP VIEW IF EXISTS $view"))
+        case (t, "table") => doAs(admin, sql(s"DROP TABLE IF EXISTS $t"))
+        case (db, "database") => doAs(admin, sql(s"DROP DATABASE IF EXISTS $db"))
+        case (fn, "function") => doAs(admin, sql(s"DROP FUNCTION IF EXISTS $fn"))
+        case (view, "view") => doAs(admin, sql(s"DROP VIEW IF EXISTS $view"))
         case (cacheTable, "cache") => if (isSparkV32OrGreater) {
-            doAs("admin", sql(s"UNCACHE TABLE IF EXISTS $cacheTable"))
+            doAs(admin, sql(s"UNCACHE TABLE IF EXISTS $cacheTable"))
           }
         case (_, e) =>
           throw new RuntimeException(s"the resource whose resource type is $e cannot be cleared")

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/V2CommandsPrivilegesSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/V2CommandsPrivilegesSuite.scala
@@ -23,6 +23,7 @@ import org.apache.hadoop.security.UserGroupInformation
 import org.apache.spark.sql.execution.QueryExecution
 
 import org.apache.kyuubi.plugin.spark.authz.OperationType._
+import org.apache.kyuubi.plugin.spark.authz.RangerTestNamespace._
 import org.apache.kyuubi.plugin.spark.authz.ranger.AccessType
 import org.apache.kyuubi.plugin.spark.authz.serde.{Database, DB_COMMAND_SPECS}
 
@@ -688,8 +689,8 @@ abstract class V2CommandsPrivilegesSuite extends PrivilegesBuilderSuite {
     assert(po.actionType === PrivilegeObjectActionType.OTHER)
     assert(po.privilegeObjectType === PrivilegeObjectType.DATABASE)
     assert(po.catalog.get === sparkSessionCatalogName)
-    assert(po.dbname === "default")
-    assert(po.objectName === "default")
+    assert(po.dbname === defaultDb)
+    assert(po.objectName === defaultDb)
     assert(po.columns.isEmpty)
   }
 
@@ -732,8 +733,8 @@ abstract class V2CommandsPrivilegesSuite extends PrivilegesBuilderSuite {
     assert(po.actionType === PrivilegeObjectActionType.OTHER)
     assert(po.privilegeObjectType === PrivilegeObjectType.DATABASE)
     assert(po.catalog.get === sparkSessionCatalogName)
-    assert(po.dbname === "default")
-    assert(po.objectName === "default")
+    assert(po.dbname === defaultDb)
+    assert(po.objectName === defaultDb)
     assert(po.columns.isEmpty)
     val accessType = ranger.AccessType(po, operationType, isInput = false)
     assert(accessType === AccessType.ALTER)

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/IcebergCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/IcebergCatalogRangerSparkExtensionSuite.scala
@@ -23,6 +23,8 @@ import org.scalatest.Outcome
 
 import org.apache.kyuubi.Utils
 import org.apache.kyuubi.plugin.spark.authz.AccessControlException
+import org.apache.kyuubi.plugin.spark.authz.RangerTestNamespace._
+import org.apache.kyuubi.plugin.spark.authz.RangerTestUsers._
 
 /**
  * Tests for RangerSparkExtensionSuite
@@ -36,7 +38,7 @@ class IcebergCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite 
     else ""
 
   val catalogV2 = "local"
-  val namespace1 = "iceberg_ns"
+  val namespace1 = icebergNamespace
   val table1 = "table1"
   val outputTable1 = "outputTable1"
 
@@ -57,18 +59,18 @@ class IcebergCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite 
 
       super.beforeAll()
 
-      doAs("admin", sql(s"CREATE DATABASE IF NOT EXISTS $catalogV2.$namespace1"))
+      doAs(admin, sql(s"CREATE DATABASE IF NOT EXISTS $catalogV2.$namespace1"))
       doAs(
-        "admin",
+        admin,
         sql(s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table1" +
           " (id int, name string, city string) USING iceberg"))
 
       doAs(
-        "admin",
+        admin,
         sql(s"INSERT INTO $catalogV2.$namespace1.$table1" +
           " (id , name , city ) VALUES (1, 'liangbowen','Guangzhou')"))
       doAs(
-        "admin",
+        admin,
         sql(s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$outputTable1" +
           " (id int, name string, city string) USING iceberg"))
     }
@@ -93,7 +95,7 @@ class IcebergCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite 
     // MergeIntoTable:  Using a MERGE INTO Statement
     val e1 = intercept[AccessControlException](
       doAs(
-        "someone",
+        someone,
         sql(mergeIntoSql)))
     assert(e1.getMessage.contains(s"does not have [select] privilege" +
       s" on [$namespace1/$table1/id]"))
@@ -104,7 +106,7 @@ class IcebergCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite 
         true)
       val e2 = intercept[AccessControlException](
         doAs(
-          "someone",
+          someone,
           sql(mergeIntoSql)))
       assert(e2.getMessage.contains(s"does not have" +
         s" [select] privilege" +
@@ -116,21 +118,21 @@ class IcebergCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite 
         false)
     }
 
-    doAs("admin", sql(mergeIntoSql))
+    doAs(admin, sql(mergeIntoSql))
   }
 
   test("[KYUUBI #3515] UPDATE TABLE") {
     // UpdateTable
     val e1 = intercept[AccessControlException](
       doAs(
-        "someone",
+        someone,
         sql(s"UPDATE $catalogV2.$namespace1.$table1 SET city='Guangzhou' " +
           " WHERE id=1")))
     assert(e1.getMessage.contains(s"does not have [update] privilege" +
       s" on [$namespace1/$table1]"))
 
     doAs(
-      "admin",
+      admin,
       sql(s"UPDATE $catalogV2.$namespace1.$table1 SET city='Guangzhou' " +
         " WHERE id=1"))
   }
@@ -138,11 +140,11 @@ class IcebergCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite 
   test("[KYUUBI #3515] DELETE FROM TABLE") {
     // DeleteFromTable
     val e6 = intercept[AccessControlException](
-      doAs("someone", sql(s"DELETE FROM $catalogV2.$namespace1.$table1 WHERE id=2")))
+      doAs(someone, sql(s"DELETE FROM $catalogV2.$namespace1.$table1 WHERE id=2")))
     assert(e6.getMessage.contains(s"does not have [update] privilege" +
       s" on [$namespace1/$table1]"))
 
-    doAs("admin", sql(s"DELETE FROM $catalogV2.$namespace1.$table1 WHERE id=2"))
+    doAs(admin, sql(s"DELETE FROM $catalogV2.$namespace1.$table1 WHERE id=2"))
   }
 
   test("[KYUUBI #3666] Support {OWNER} variable for queries run on CatalogV2") {
@@ -163,7 +165,7 @@ class IcebergCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite 
         }.isSuccess))
 
       doAs(
-        "create_only_user", {
+        createOnlyUser, {
           val e = intercept[AccessControlException](sql(select).collect())
           assert(e.getMessage === errorMessage("select", s"$namespace1/$table/key"))
         })
@@ -178,17 +180,17 @@ class IcebergCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite 
       (s"$catalogV2.default.src", "table"),
       (s"$catalogV2.default.outputTable2", "table"))) {
       doAs(
-        "admin",
+        admin,
         sql(s"CREATE TABLE IF NOT EXISTS $catalogV2.default.src" +
           " (id int, name string, key string) USING iceberg"))
       doAs(
-        "admin",
+        admin,
         sql(s"INSERT INTO $catalogV2.default.src" +
           " (id , name , key ) VALUES " +
           "(1, 'liangbowen1','10')" +
           ", (2, 'liangbowen2','20')"))
       doAs(
-        "admin",
+        admin,
         sql(s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$outputTable2" +
           " (id int, name string, key string) USING iceberg"))
 
@@ -200,20 +202,20 @@ class IcebergCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite 
            |WHEN NOT MATCHED THEN INSERT (id, name, key) VALUES (source.id, source.name, source.key)
         """.stripMargin
 
-      doAs("admin", sql(mergeIntoSql))
+      doAs(admin, sql(mergeIntoSql))
       doAs(
-        "admin", {
+        admin, {
           val countOutputTable =
             sql(s"select count(1) from $catalogV2.$namespace1.$outputTable2").collect()
           val rowCount = countOutputTable(0).get(0)
           assert(rowCount === 2)
         })
-      doAs("admin", sql(s"truncate table $catalogV2.$namespace1.$outputTable2"))
+      doAs(admin, sql(s"truncate table $catalogV2.$namespace1.$outputTable2"))
 
       // source table with row filter `key`<20
-      doAs("bob", sql(mergeIntoSql))
+      doAs(bob, sql(mergeIntoSql))
       doAs(
-        "admin", {
+        admin, {
           val countOutputTable =
             sql(s"select count(1) from $catalogV2.$namespace1.$outputTable2").collect()
           val rowCount = countOutputTable(0).get(0)
@@ -224,7 +226,7 @@ class IcebergCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite 
 
   test("[KYUUBI #4255] DESCRIBE TABLE") {
     val e1 = intercept[AccessControlException](
-      doAs("someone", sql(s"DESCRIBE TABLE $catalogV2.$namespace1.$table1").explain()))
+      doAs(someone, sql(s"DESCRIBE TABLE $catalogV2.$namespace1.$table1").explain()))
     assert(e1.getMessage.contains(s"does not have [select] privilege" +
       s" on [$namespace1/$table1]"))
   }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPluginSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPluginSuite.scala
@@ -22,6 +22,8 @@ import org.apache.hadoop.security.UserGroupInformation
 import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.kyuubi.plugin.spark.authz.{ObjectType, OperationType}
+import org.apache.kyuubi.plugin.spark.authz.RangerTestNamespace._
+import org.apache.kyuubi.plugin.spark.authz.RangerTestUsers._
 import org.apache.kyuubi.plugin.spark.authz.ranger.SparkRangerAdminPlugin._
 
 class SparkRangerAdminPluginSuite extends AnyFunSuite {
@@ -29,13 +31,13 @@ class SparkRangerAdminPluginSuite extends AnyFunSuite {
 
   test("get filter expression") {
     val bob = UserGroupInformation.createRemoteUser("bob")
-    val are = AccessResource(ObjectType.TABLE, "default", "src", null)
+    val are = AccessResource(ObjectType.TABLE, defaultDb, "src", null)
     def buildAccessRequest(ugi: UserGroupInformation): AccessRequest = {
       AccessRequest(are, ugi, OperationType.QUERY, AccessType.SELECT)
     }
     val maybeString = getFilterExpr(buildAccessRequest(bob))
     assert(maybeString.get === "key<20")
-    Seq("admin", "alice").foreach { user =>
+    Seq(admin, alice).foreach { user =>
       val ugi = UserGroupInformation.createRemoteUser(user)
       val maybeString = getFilterExpr(buildAccessRequest(ugi))
       assert(maybeString.isEmpty)
@@ -45,7 +47,7 @@ class SparkRangerAdminPluginSuite extends AnyFunSuite {
   test("get data masker") {
     val bob = UserGroupInformation.createRemoteUser("bob")
     def buildAccessRequest(ugi: UserGroupInformation, column: String): AccessRequest = {
-      val are = AccessResource(ObjectType.COLUMN, "default", "src", column)
+      val are = AccessResource(ObjectType.COLUMN, defaultDb, "src", column)
       AccessRequest(are, ugi, OperationType.QUERY, AccessType.SELECT)
     }
     assert(getMaskingExpr(buildAccessRequest(bob, "value1")).get === "md5(cast(value1 as string))")
@@ -59,7 +61,7 @@ class SparkRangerAdminPluginSuite extends AnyFunSuite {
       "left(value5, length(value5) - 4), '[A-Z]', 'X'), '[a-z]', 'x')," +
       " '[0-9]', 'n'), '[^A-Za-z0-9]', 'U'), right(value5, 4))")
 
-    Seq("admin", "alice").foreach { user =>
+    Seq(admin, alice).foreach { user =>
       val ugi = UserGroupInformation.createRemoteUser(user)
       val maybeString = getMaskingExpr(buildAccessRequest(ugi, "value1"))
       assert(maybeString.isEmpty)

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
@@ -22,6 +22,8 @@ import scala.util.Try
 
 // scalastyle:off
 import org.apache.kyuubi.plugin.spark.authz.AccessControlException
+import org.apache.kyuubi.plugin.spark.authz.RangerTestNamespace._
+import org.apache.kyuubi.plugin.spark.authz.RangerTestUsers._
 
 /**
  * Tests for RangerSparkExtensionSuite
@@ -32,8 +34,6 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
 
   val catalogV2 = "testcat"
   val jdbcCatalogV2 = "jdbc2"
-  val namespace1 = "ns1"
-  val namespace2 = "ns2"
   val table1 = "table1"
   val table2 = "table2"
   val outputTable1 = "outputTable1"
@@ -54,13 +54,13 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
 
       super.beforeAll()
 
-      doAs("admin", sql(s"CREATE DATABASE IF NOT EXISTS $catalogV2.$namespace1"))
+      doAs(admin, sql(s"CREATE DATABASE IF NOT EXISTS $catalogV2.$namespace1"))
       doAs(
-        "admin",
+        admin,
         sql(s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table1" +
           " (id int, name string, city string)"))
       doAs(
-        "admin",
+        admin,
         sql(s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$outputTable1" +
           " (id int, name string, city string)"))
     }
@@ -82,7 +82,7 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
 
     // create database
     val e1 = intercept[AccessControlException](
-      doAs("someone", sql(s"CREATE DATABASE IF NOT EXISTS $catalogV2.$namespace2").explain()))
+      doAs(someone, sql(s"CREATE DATABASE IF NOT EXISTS $catalogV2.$namespace2").explain()))
     assert(e1.getMessage.contains(s"does not have [create] privilege" +
       s" on [$namespace2]"))
   }
@@ -92,7 +92,7 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
 
     // create database
     val e1 = intercept[AccessControlException](
-      doAs("someone", sql(s"DROP DATABASE IF EXISTS $catalogV2.$namespace2").explain()))
+      doAs(someone, sql(s"DROP DATABASE IF EXISTS $catalogV2.$namespace2").explain()))
     assert(e1.getMessage.contains(s"does not have [drop] privilege" +
       s" on [$namespace2]"))
   }
@@ -102,7 +102,7 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
 
     // select
     val e1 = intercept[AccessControlException](
-      doAs("someone", sql(s"select city, id from $catalogV2.$namespace1.$table1").explain()))
+      doAs(someone, sql(s"select city, id from $catalogV2.$namespace1.$table1").explain()))
     assert(e1.getMessage.contains(s"does not have [select] privilege" +
       s" on [$namespace1/$table1/city]"))
   }
@@ -110,7 +110,7 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
   test("[KYUUBI #4255] DESCRIBE TABLE") {
     assume(isSparkV31OrGreater)
     val e1 = intercept[AccessControlException](
-      doAs("someone", sql(s"DESCRIBE TABLE $catalogV2.$namespace1.$table1").explain()))
+      doAs(someone, sql(s"DESCRIBE TABLE $catalogV2.$namespace1.$table1").explain()))
     assert(e1.getMessage.contains(s"does not have [select] privilege" +
       s" on [$namespace1/$table1]"))
   }
@@ -120,14 +120,14 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
 
     // CreateTable
     val e2 = intercept[AccessControlException](
-      doAs("someone", sql(s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table2")))
+      doAs(someone, sql(s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table2")))
     assert(e2.getMessage.contains(s"does not have [create] privilege" +
       s" on [$namespace1/$table2]"))
 
     // CreateTableAsSelect
     val e21 = intercept[AccessControlException](
       doAs(
-        "someone",
+        someone,
         sql(s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table2" +
           s" AS select * from $catalogV2.$namespace1.$table1")))
     assert(e21.getMessage.contains(s"does not have [select] privilege" +
@@ -139,7 +139,7 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
 
     // DropTable
     val e3 = intercept[AccessControlException](
-      doAs("someone", sql(s"DROP TABLE $catalogV2.$namespace1.$table1")))
+      doAs(someone, sql(s"DROP TABLE $catalogV2.$namespace1.$table1")))
     assert(e3.getMessage.contains(s"does not have [drop] privilege" +
       s" on [$namespace1/$table1]"))
   }
@@ -150,7 +150,7 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
     // AppendData: Insert Using a VALUES Clause
     val e4 = intercept[AccessControlException](
       doAs(
-        "someone",
+        someone,
         sql(s"INSERT INTO $catalogV2.$namespace1.$outputTable1 (id, name, city)" +
           s" VALUES (1, 'bowenliang123', 'Guangzhou')")))
     assert(e4.getMessage.contains(s"does not have [update] privilege" +
@@ -159,7 +159,7 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
     // AppendData: Insert Using a TABLE Statement
     val e42 = intercept[AccessControlException](
       doAs(
-        "someone",
+        someone,
         sql(s"INSERT INTO $catalogV2.$namespace1.$outputTable1 (id, name, city)" +
           s" TABLE $catalogV2.$namespace1.$table1")))
     assert(e42.getMessage.contains(s"does not have [select] privilege" +
@@ -168,7 +168,7 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
     // AppendData: Insert Using a SELECT Statement
     val e43 = intercept[AccessControlException](
       doAs(
-        "someone",
+        someone,
         sql(s"INSERT INTO $catalogV2.$namespace1.$outputTable1 (id, name, city)" +
           s" SELECT * from $catalogV2.$namespace1.$table1")))
     assert(e43.getMessage.contains(s"does not have [select] privilege" +
@@ -177,7 +177,7 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
     // OverwriteByExpression: Insert Overwrite
     val e44 = intercept[AccessControlException](
       doAs(
-        "someone",
+        someone,
         sql(s"INSERT OVERWRITE $catalogV2.$namespace1.$outputTable1 (id, name, city)" +
           s" VALUES (1, 'bowenliang123', 'Guangzhou')")))
     assert(e44.getMessage.contains(s"does not have [update] privilege" +
@@ -199,7 +199,7 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
     // MergeIntoTable:  Using a MERGE INTO Statement
     val e1 = intercept[AccessControlException](
       doAs(
-        "someone",
+        someone,
         sql(mergeIntoSql)))
     assert(e1.getMessage.contains(s"does not have [select] privilege" +
       s" on [$namespace1/$table1/id]"))
@@ -210,7 +210,7 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
         true)
       val e2 = intercept[AccessControlException](
         doAs(
-          "someone",
+          someone,
           sql(mergeIntoSql)))
       assert(e2.getMessage.contains(s"does not have" +
         s" [select] privilege" +
@@ -229,7 +229,7 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
     // UpdateTable
     val e5 = intercept[AccessControlException](
       doAs(
-        "someone",
+        someone,
         sql(s"UPDATE $catalogV2.$namespace1.$table1 SET city='Hangzhou' " +
           " WHERE id=1")))
     assert(e5.getMessage.contains(s"does not have [update] privilege" +
@@ -241,7 +241,7 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
 
     // DeleteFromTable
     val e6 = intercept[AccessControlException](
-      doAs("someone", sql(s"DELETE FROM $catalogV2.$namespace1.$table1 WHERE id=1")))
+      doAs(someone, sql(s"DELETE FROM $catalogV2.$namespace1.$table1 WHERE id=1")))
     assert(e6.getMessage.contains(s"does not have [update] privilege" +
       s" on [$namespace1/$table1]"))
   }
@@ -252,7 +252,7 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
     // CacheTable
     val e7 = intercept[AccessControlException](
       doAs(
-        "someone",
+        someone,
         sql(s"CACHE TABLE $cacheTable1" +
           s" AS select * from $catalogV2.$namespace1.$table1")))
     if (isSparkV32OrGreater) {
@@ -269,7 +269,7 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
 
     val e1 = intercept[AccessControlException](
       doAs(
-        "someone",
+        someone,
         sql(s"TRUNCATE TABLE $catalogV2.$namespace1.$table1")))
     assert(e1.getMessage.contains(s"does not have [update] privilege" +
       s" on [$namespace1/$table1]"))
@@ -280,7 +280,7 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
 
     val e1 = intercept[AccessControlException](
       doAs(
-        "someone",
+        someone,
         sql(s"MSCK REPAIR TABLE $catalogV2.$namespace1.$table1")))
     assert(e1.getMessage.contains(s"does not have [alter] privilege" +
       s" on [$namespace1/$table1]"))
@@ -292,7 +292,7 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
     // AddColumns
     val e61 = intercept[AccessControlException](
       doAs(
-        "someone",
+        someone,
         sql(s"ALTER TABLE $catalogV2.$namespace1.$table1 ADD COLUMNS (age int) ").explain()))
     assert(e61.getMessage.contains(s"does not have [alter] privilege" +
       s" on [$namespace1/$table1]"))
@@ -300,7 +300,7 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
     // DropColumns
     val e62 = intercept[AccessControlException](
       doAs(
-        "someone",
+        someone,
         sql(s"ALTER TABLE $catalogV2.$namespace1.$table1 DROP COLUMNS city ").explain()))
     assert(e62.getMessage.contains(s"does not have [alter] privilege" +
       s" on [$namespace1/$table1]"))
@@ -308,7 +308,7 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
     // RenameColumn
     val e63 = intercept[AccessControlException](
       doAs(
-        "someone",
+        someone,
         sql(s"ALTER TABLE $catalogV2.$namespace1.$table1 RENAME COLUMN city TO city2 ").explain()))
     assert(e63.getMessage.contains(s"does not have [alter] privilege" +
       s" on [$namespace1/$table1]"))
@@ -316,7 +316,7 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
     // AlterColumn
     val e64 = intercept[AccessControlException](
       doAs(
-        "someone",
+        someone,
         sql(s"ALTER TABLE $catalogV2.$namespace1.$table1 " +
           s"ALTER COLUMN city COMMENT 'city' ")))
     assert(e64.getMessage.contains(s"does not have [alter] privilege" +
@@ -329,7 +329,7 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
     // CommentOnNamespace
     val e1 = intercept[AccessControlException](
       doAs(
-        "someone",
+        someone,
         sql(s"COMMENT ON DATABASE $catalogV2.$namespace1 IS 'xYz' ").explain()))
     assert(e1.getMessage.contains(s"does not have [alter] privilege" +
       s" on [$namespace1]"))
@@ -337,7 +337,7 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
     // CommentOnNamespace
     val e2 = intercept[AccessControlException](
       doAs(
-        "someone",
+        someone,
         sql(s"COMMENT ON NAMESPACE $catalogV2.$namespace1 IS 'xYz' ").explain()))
     assert(e2.getMessage.contains(s"does not have [alter] privilege" +
       s" on [$namespace1]"))
@@ -345,7 +345,7 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
     // CommentOnTable
     val e3 = intercept[AccessControlException](
       doAs(
-        "someone",
+        someone,
         sql(s"COMMENT ON TABLE $catalogV2.$namespace1.$table1 IS 'xYz' ").explain()))
     assert(e3.getMessage.contains(s"does not have [alter] privilege" +
       s" on [$namespace1/$table1]"))

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingTestBase.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingTestBase.scala
@@ -17,16 +17,17 @@
 
 package org.apache.kyuubi.plugin.spark.authz.ranger.datamasking
 
-// scalastyle:off
 import java.sql.Timestamp
 
 import scala.util.Try
 
+// scalastyle:off
 import org.apache.commons.codec.digest.DigestUtils.md5Hex
 import org.apache.spark.sql.{Row, SparkSessionExtensions}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuite
 
+import org.apache.kyuubi.plugin.spark.authz.RangerTestUsers._
 import org.apache.kyuubi.plugin.spark.authz.SparkSessionProvider
 import org.apache.kyuubi.plugin.spark.authz.ranger.RangerSparkExtension
 
@@ -75,18 +76,18 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
   }
 
   override def beforeAll(): Unit = {
-    doAs("admin", setup())
+    doAs(admin, setup())
     super.beforeAll()
   }
   override def afterAll(): Unit = {
-    doAs("admin", cleanup())
+    doAs(admin, cleanup())
     spark.stop
     super.afterAll()
   }
 
   test("simple query with a user doesn't have mask rules") {
     checkAnswer(
-      "kent",
+      kent,
       "SELECT key FROM default.src order by key",
       Seq(Row(1), Row(10), Row(11), Row(20), Row(30)))
   }
@@ -95,12 +96,12 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
     val result =
       Seq(Row(md5Hex("1"), "xxxxx", "worlx", Timestamp.valueOf("2018-01-01 00:00:00"), "Xorld"))
     checkAnswer(
-      "bob",
+      bob,
       "SELECT value1, value2, value3, value4, value5 FROM default.src " +
         "where key = 1",
       result)
     checkAnswer(
-      "bob",
+      bob,
       "SELECT value1 as key, value2, value3, value4, value5 FROM default.src where key = 1",
       result)
   }
@@ -108,14 +109,14 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
   test("star") {
     val result =
       Seq(Row(1, md5Hex("1"), "xxxxx", "worlx", Timestamp.valueOf("2018-01-01 00:00:00"), "Xorld"))
-    checkAnswer("bob", "SELECT * FROM default.src where key = 1", result)
+    checkAnswer(bob, "SELECT * FROM default.src where key = 1", result)
   }
 
   test("simple udf") {
     val result =
       Seq(Row(md5Hex("1"), "xxxxx", "worlx", Timestamp.valueOf("2018-01-01 00:00:00"), "Xorld"))
     checkAnswer(
-      "bob",
+      bob,
       "SELECT max(value1), max(value2), max(value3), max(value4), max(value5) FROM default.src" +
         " where key = 1",
       result)
@@ -125,7 +126,7 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
     val result =
       Seq(Row(md5Hex("1"), "xxxxx", "worlx", Timestamp.valueOf("2018-01-01 00:00:00"), "Xorld"))
     checkAnswer(
-      "bob",
+      bob,
       "SELECT coalesce(max(value1), 1), coalesce(max(value2), 1), coalesce(max(value3), 1), " +
         "coalesce(max(value4), timestamp '2018-01-01 22:33:44'), coalesce(max(value5), 1) " +
         "FROM default.src where key = 1",
@@ -136,7 +137,7 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
     val result =
       Seq(Row(md5Hex("1"), "xxxxx", "worlx", Timestamp.valueOf("2018-01-01 00:00:00"), "Xorld"))
     checkAnswer(
-      "bob",
+      bob,
       "SELECT value1, value2, value3, value4, value5 FROM default.src WHERE value2 in " +
         "(SELECT value2 as key FROM default.src where key = 1)",
       result)
@@ -145,59 +146,59 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
   test("create a unmasked table as select from a masked one") {
     withCleanTmpResources(Seq(("default.src2", "table"))) {
       doAs(
-        "bob",
+        bob,
         sql(s"CREATE TABLE default.src2 $format AS SELECT value1 FROM default.src " +
           s"where key = 1"))
-      checkAnswer("bob", "SELECT value1 FROM default.src2", Seq(Row(md5Hex("1"))))
+      checkAnswer(bob, "SELECT value1 FROM default.src2", Seq(Row(md5Hex("1"))))
     }
   }
 
   test("insert into a unmasked table from a masked one") {
     withCleanTmpResources(Seq(("default.src2", "table"), ("default.src3", "table"))) {
-      doAs("bob", sql(s"CREATE TABLE default.src2 (value1 string) $format"))
+      doAs(bob, sql(s"CREATE TABLE default.src2 (value1 string) $format"))
       doAs(
-        "bob",
+        bob,
         sql(s"INSERT INTO default.src2 SELECT value1 from default.src " +
           s"where key = 1"))
       doAs(
-        "bob",
+        bob,
         sql(s"INSERT INTO default.src2 SELECT value1 as v from default.src " +
           s"where key = 1"))
-      checkAnswer("bob", "SELECT value1 FROM default.src2", Seq(Row(md5Hex("1")), Row(md5Hex("1"))))
-      doAs("bob", sql(s"CREATE TABLE default.src3 (k int, value string) $format"))
+      checkAnswer(bob, "SELECT value1 FROM default.src2", Seq(Row(md5Hex("1")), Row(md5Hex("1"))))
+      doAs(bob, sql(s"CREATE TABLE default.src3 (k int, value string) $format"))
       doAs(
-        "bob",
+        bob,
         sql(s"INSERT INTO default.src3 SELECT key, value1 from default.src  " +
           s"where key = 1"))
       doAs(
-        "bob",
+        bob,
         sql(s"INSERT INTO default.src3 SELECT key, value1 as v from default.src " +
           s"where key = 1"))
-      checkAnswer("bob", "SELECT value FROM default.src3", Seq(Row(md5Hex("1")), Row(md5Hex("1"))))
+      checkAnswer(bob, "SELECT value FROM default.src3", Seq(Row(md5Hex("1")), Row(md5Hex("1"))))
     }
   }
 
   test("join on an unmasked table") {
     val s = "SELECT a.value1, b.value1 FROM default.src a" +
       " join default.unmasked b on a.value1=b.value1"
-    checkAnswer("bob", s, Nil)
-    checkAnswer("bob", s, Nil) // just for testing query multiple times, don't delete it
+    checkAnswer(bob, s, Nil)
+    checkAnswer(bob, s, Nil) // just for testing query multiple times, don't delete it
   }
 
   test("self join on a masked table") {
     val s = "SELECT a.value1, b.value1 FROM default.src a" +
       " join default.src b on a.value1=b.value1 where a.key = 1 and b.key = 1 "
-    checkAnswer("bob", s, Seq(Row(md5Hex("1"), md5Hex("1"))))
+    checkAnswer(bob, s, Seq(Row(md5Hex("1"), md5Hex("1"))))
     // just for testing query multiple times, don't delete it
-    checkAnswer("bob", s, Seq(Row(md5Hex("1"), md5Hex("1"))))
+    checkAnswer(bob, s, Seq(Row(md5Hex("1"), md5Hex("1"))))
   }
 
   test("self join on a masked table and filter the masked column with original value") {
     val s = "SELECT a.value1, b.value1 FROM default.src a" +
       " join default.src b on a.value1=b.value1" +
       " where a.value1='1' and b.value1='1'"
-    checkAnswer("bob", s, Nil)
-    checkAnswer("bob", s, Nil) // just for testing query multiple times, don't delete it
+    checkAnswer(bob, s, Nil)
+    checkAnswer(bob, s, Nil) // just for testing query multiple times, don't delete it
   }
 
   test("self join on a masked table and filter the masked column with masked value") {
@@ -245,7 +246,7 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
     //                  +- DataMaskingStage0Marker Relation default.src[key#60,value1#61,value2#62,value3#63,value4#64,value5#65] parquet
     //                     +- Project [key#153, md5(cast(cast(value1#154 as string) as binary)) AS value1#148, regexp_replace(regexp_replace(regexp_replace(value2#155, [A-Z], X, 1), [a-z], x, 1), [0-9], n, 1) AS value2#149, regexp_replace(regexp_replace(regexp_replace(value3#156, [A-Z], X, 5), [a-z], x, 5), [0-9], n, 5) AS value3#150, date_trunc(YEAR, value4#157, Some(Asia/Shanghai)) AS value4#151, concat(regexp_replace(regexp_replace(regexp_replace(left(value5#158, (length(value5#158) - 4)), [A-Z], X, 1), [a-z], x, 1), [0-9], n, 1), right(value5#158, 4)) AS value5#152]
     //                        +- Relation default.src[key#153,value1#154,value2#155,value3#156,value4#157,value5#158] parquet
-    // checkAnswer("bob", s, Seq(Row(md5Hex("1"), md5Hex("1"))))
+    // checkAnswer(bob, s, Seq(Row(md5Hex("1"), md5Hex("1"))))
     //
     //
     // scalastyle:on
@@ -254,9 +255,9 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
     val s2 = "SELECT a.value1, b.value1 FROM default.src a" +
       " join default.src b on a.value1=b.value1" +
       s" where a.value2='xxxxx' and b.value2='xxxxx'"
-    checkAnswer("bob", s2, Seq(Row(md5Hex("1"), md5Hex("1"))))
+    checkAnswer(bob, s2, Seq(Row(md5Hex("1"), md5Hex("1"))))
     // just for testing query multiple times, don't delete it
-    checkAnswer("bob", s2, Seq(Row(md5Hex("1"), md5Hex("1"))))
+    checkAnswer(bob, s2, Seq(Row(md5Hex("1"), md5Hex("1"))))
   }
 
   test("union an unmasked table") {
@@ -267,30 +268,30 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
           (SELECT b.value1 FROM default.unmasked b)
       ) c order by value1
       """
-    doAs("bob", sql(s).show)
-    checkAnswer("bob", s, Seq(Row("1"), Row("2"), Row("3"), Row("4"), Row("5"), Row(md5Hex("1"))))
+    doAs(bob, sql(s).show)
+    checkAnswer(bob, s, Seq(Row("1"), Row("2"), Row("3"), Row("4"), Row("5"), Row(md5Hex("1"))))
   }
 
   test("union a masked table") {
     val s = "SELECT a.value1 FROM default.src a where a.key = 1 union" +
       " (SELECT b.value1 FROM default.src b where b.key = 1)"
-    checkAnswer("bob", s, Seq(Row(md5Hex("1"))))
+    checkAnswer(bob, s, Seq(Row(md5Hex("1"))))
   }
 
   test("KYUUBI #3581: permanent view should lookup rule on itself not the raw table") {
     assume(isSparkV31OrGreater)
     val supported = doAs(
-      "perm_view_user",
+      permViewUser,
       Try(sql("CREATE OR REPLACE VIEW default.perm_view AS SELECT * FROM default.src")).isSuccess)
     assume(supported, s"view support for '$format' has not been implemented yet")
 
     withCleanTmpResources(Seq(("default.perm_view", "view"))) {
       checkAnswer(
-        "perm_view_user",
+        permViewUser,
         "SELECT value1, value2 FROM default.src where key = 1",
         Seq(Row(1, "hello")))
       checkAnswer(
-        "perm_view_user",
+        permViewUser,
         "SELECT value1, value2 FROM default.perm_view where key = 1",
         Seq(Row(md5Hex("1"), "hello")))
     }
@@ -303,7 +304,7 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
     val s2 = s"SELECT * FROM default.src where key = 11"
     // scalastyle:off
     checkAnswer(
-      "bob",
+      bob,
       s1,
       Seq(Row(
         10,
@@ -313,7 +314,7 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
         Timestamp.valueOf("2018-01-01 00:00:00"),
         "xxxxxUXXXXUnnnUUUUUUXUUUUUUUUUア叶葉엽")))
     checkAnswer(
-      "bob",
+      bob,
       s2,
       Seq(Row(
         11,

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/rowfiltering/RowFilteringTestBase.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/rowfiltering/RowFilteringTestBase.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.{Row, SparkSessionExtensions}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuite
 
+import org.apache.kyuubi.plugin.spark.authz.RangerTestUsers._
 import org.apache.kyuubi.plugin.spark.authz.SparkSessionProvider
 import org.apache.kyuubi.plugin.spark.authz.ranger.RangerSparkExtension
 
@@ -47,72 +48,72 @@ trait RowFilteringTestBase extends AnyFunSuite with SparkSessionProvider with Be
   }
 
   override def beforeAll(): Unit = {
-    doAs("admin", setup())
+    doAs(admin, setup())
     super.beforeAll()
   }
   override def afterAll(): Unit = {
-    doAs("admin", cleanup())
+    doAs(admin, cleanup())
     spark.stop
     super.afterAll()
   }
 
   test("user without row filtering rule") {
     checkAnswer(
-      "kent",
+      kent,
       "SELECT key FROM default.src order order by key",
       Seq(Row(1), Row(20), Row(30)))
   }
 
   test("simple query projecting filtering column") {
-    checkAnswer("bob", "SELECT key FROM default.src", Seq(Row(1)))
+    checkAnswer(bob, "SELECT key FROM default.src", Seq(Row(1)))
   }
 
   test("simple query projecting non filtering column") {
-    checkAnswer("bob", "SELECT value FROM default.src", Seq(Row(1)))
+    checkAnswer(bob, "SELECT value FROM default.src", Seq(Row(1)))
   }
 
   test("simple query projecting non filtering column with udf max") {
-    checkAnswer("bob", "SELECT max(value) FROM default.src", Seq(Row(1)))
+    checkAnswer(bob, "SELECT max(value) FROM default.src", Seq(Row(1)))
   }
 
   test("simple query projecting non filtering column with udf coalesce") {
-    checkAnswer("bob", "SELECT coalesce(max(value), 1) FROM default.src", Seq(Row(1)))
+    checkAnswer(bob, "SELECT coalesce(max(value), 1) FROM default.src", Seq(Row(1)))
   }
 
   test("in subquery") {
     checkAnswer(
-      "bob",
+      bob,
       "SELECT value FROM default.src WHERE value in (SELECT value as key FROM default.src)",
       Seq(Row(1)))
   }
 
   test("ctas") {
     withCleanTmpResources(Seq(("default.src2", "table"))) {
-      doAs("bob", sql(s"CREATE TABLE default.src2 $format AS SELECT value FROM default.src"))
+      doAs(bob, sql(s"CREATE TABLE default.src2 $format AS SELECT value FROM default.src"))
       val query = "select value from default.src2"
-      checkAnswer("admin", query, Seq(Row(1)))
-      checkAnswer("bob", query, Seq(Row(1)))
+      checkAnswer(admin, query, Seq(Row(1)))
+      checkAnswer(bob, query, Seq(Row(1)))
     }
   }
 
   test("[KYUUBI #3581]: row level filter on permanent view") {
     assume(isSparkV31OrGreater)
     val supported = doAs(
-      "perm_view_user",
+      permViewUser,
       Try(sql("CREATE OR REPLACE VIEW default.perm_view AS SELECT * FROM default.src")).isSuccess)
     assume(supported, s"view support for '$format' has not been implemented yet")
 
     withCleanTmpResources(Seq((s"default.perm_view", "view"))) {
       checkAnswer(
-        "admin",
+        admin,
         "SELECT key FROM default.perm_view order order by key",
         Seq(Row(1), Row(20), Row(30)))
-      checkAnswer("bob", "SELECT key FROM default.perm_view", Seq(Row(1)))
-      checkAnswer("bob", "SELECT value FROM default.perm_view", Seq(Row(1)))
-      checkAnswer("bob", "SELECT max(value) FROM default.perm_view", Seq(Row(1)))
-      checkAnswer("bob", "SELECT coalesce(max(value), 1) FROM default.perm_view", Seq(Row(1)))
+      checkAnswer(bob, "SELECT key FROM default.perm_view", Seq(Row(1)))
+      checkAnswer(bob, "SELECT value FROM default.perm_view", Seq(Row(1)))
+      checkAnswer(bob, "SELECT max(value) FROM default.perm_view", Seq(Row(1)))
+      checkAnswer(bob, "SELECT coalesce(max(value), 1) FROM default.perm_view", Seq(Row(1)))
       checkAnswer(
-        "bob",
+        bob,
         "SELECT value FROM default.perm_view WHERE value in " +
           "(SELECT value as key FROM default.perm_view)",
         Seq(Row(1)))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- align the same list of users and namespaces used in tests and in policy file generation, as users and namespaces are the most important elements of Ranger policy's conditions and resources.
- help to improve and simplify the decision in Authz testing and make a clear view of what's exactly tested and authorized, and very handy and easy to see the usage link in IDE
- reduce possible abuse and untracable uses of authorized and unauthorized users, rules, resources. (We have up to 4 unauthorized users in separated tests!)

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
