### PR TITLE
Skip to get the batch application status when creating batch

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
@@ -71,10 +71,10 @@ private[v1] class BatchesResource extends ApiRequestContext with Logging {
 
   private def sessionManager = fe.be.sessionManager.asInstanceOf[KyuubiSessionManager]
 
-  private def buildBatch(session: KyuubiBatchSessionImpl): Batch = {
+  private def buildBatch(session: KyuubiBatchSessionImpl, needAppStatus: Boolean = true): Batch = {
     val batchOp = session.batchJobSubmissionOp
     val batchOpStatus = batchOp.getStatus
-    val batchAppStatus = batchOp.getOrFetchCurrentApplicationInfo
+    val batchAppStatus = if (needAppStatus) batchOp.getOrFetchCurrentApplicationInfo else None
 
     val name = Option(batchOp.batchName).getOrElse(batchAppStatus.map(_.name).orNull)
     var appId: String = null
@@ -254,7 +254,7 @@ private[v1] class BatchesResource extends ApiRequestContext with Logging {
             request)
         } match {
           case Success(sessionHandle) =>
-            buildBatch(sessionManager.getBatchSessionImpl(sessionHandle))
+            buildBatch(sessionManager.getBatchSessionImpl(sessionHandle), false)
           case Failure(cause) if JdbcUtils.isDuplicatedKeyDBErr(cause) =>
             val batch = sessionManager.getBatchFromMetadataStore(batchId)
             assert(batch != null, s"can not find duplicated batch $batchId from metadata store")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

To prevent the `POST /batches` operation stuck when getting batch application status.

For example: the yarn client always failover because of resource manager issue.

And it is also not needed that get the batch app status info when creating batch.
### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
