### PR TITLE
[INFRA] Switch Maven's resolver transport to legacy Wagon

### DIFF
--- a/build/mvn
+++ b/build/mvn
@@ -25,7 +25,7 @@ _CALLING_DIR="$(pwd)"
 _COMPILE_JVM_OPTS="-Xms2g -Xmx2g -XX:ReservedCodeCacheSize=1g -Xss128m"
 
 if [ "$CI" ]; then
-  export MAVEN_CLI_OPTS="--no-transfer-progress --errors --fail-fast"
+  export MAVEN_CLI_OPTS="--no-transfer-progress --errors --fail-fast -Dmaven.resolver.transport=wagon"
 fi
 
 # Installs any application tarball given a URL, the expected tarball name,

--- a/build/mvnd
+++ b/build/mvnd
@@ -25,7 +25,7 @@ _CALLING_DIR="$(pwd)"
 _COMPILE_JVM_OPTS="-Xms2g -Xmx2g -XX:ReservedCodeCacheSize=1g -Xss128m"
 
 if [ "$CI" ]; then
-  export MAVEN_CLI_OPTS="-Dmvnd.minThreads=4 --no-transfer-progress --errors --fail-fast -Dstyle.color=always"
+  export MAVEN_CLI_OPTS="-Dmvnd.minThreads=4 --no-transfer-progress --errors --fail-fast -Dstyle.color=always -Dmaven.resolver.transport=wagon"
 fi
 
 # Installs any application tarball given a URL, the expected tarball name,

--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,6 @@
         <maven.plugin.scalastyle.version>1.0.0</maven.plugin.scalastyle.version>
         <maven.plugin.shade.version>3.4.1</maven.plugin.shade.version>
         <maven.plugin.silencer.version>1.7.10</maven.plugin.silencer.version>
-        <maven.resolver.transport>wagon</maven.resolver.transport>
 
         <maven.scaladoc.skip>false</maven.scaladoc.skip>
         <maven.scalastyle.skip>false</maven.scalastyle.skip>

--- a/pom.xml
+++ b/pom.xml
@@ -233,6 +233,7 @@
         <maven.plugin.scalastyle.version>1.0.0</maven.plugin.scalastyle.version>
         <maven.plugin.shade.version>3.4.1</maven.plugin.shade.version>
         <maven.plugin.silencer.version>1.7.10</maven.plugin.silencer.version>
+        <maven.resolver.transport>wagon</maven.resolver.transport>
 
         <maven.scaladoc.skip>false</maven.scaladoc.skip>
         <maven.scalastyle.skip>false</maven.scalastyle.skip>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- since Mavn 3.9.x, default resolver transport changed to `native` and the default connection timeout shrinked from 60s to 10s.
- Switch back to legacy Wagon to avoid causing frequent connection timeout when resolving dependencies
https://maven.apache.org/guides/mini/guide-resolver-transport.html#switching-between-transports

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
