### PR TITLE
[KYUUBI #4083] Flink returns duplicate results when executing query statement

### DIFF
--- a/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/ExecuteStatement.scala
@@ -115,8 +115,7 @@ class ExecuteStatement(
       while (loop) {
         Thread.sleep(50) // slow the processing down
 
-        val pageSize = Math.min(500, resultMaxRows)
-        val result = executor.snapshotResult(sessionId, resultId, pageSize)
+        val result = executor.snapshotResult(sessionId, resultId, resultMaxRows)
         result.getType match {
           case TypedResult.ResultType.PAYLOAD =>
             if (rows.size >= resultMaxRows) {

--- a/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/ExecuteStatement.scala
@@ -119,12 +119,13 @@ class ExecuteStatement(
         val result = executor.snapshotResult(sessionId, resultId, pageSize)
         result.getType match {
           case TypedResult.ResultType.PAYLOAD =>
-            (1 to result.getPayload).foreach { page =>
-              if (rows.size < resultMaxRows) {
+            if (rows.size >= resultMaxRows) {
+              loop = false
+            } else {
+              rows.clear()
+              (1 to result.getPayload).foreach { page =>
                 val result = executor.retrieveResultPage(resultId, page)
                 rows ++= result.asScala.map(r => convertToRow(r, dataTypes))
-              } else {
-                loop = false
               }
             }
           case TypedResult.ResultType.EOS => loop = false

--- a/externals/kyuubi-flink-sql-engine/src/test/scala/org/apache/kyuubi/engine/flink/operation/FlinkOperationSuite.scala
+++ b/externals/kyuubi-flink-sql-engine/src/test/scala/org/apache/kyuubi/engine/flink/operation/FlinkOperationSuite.scala
@@ -36,7 +36,6 @@ import org.apache.kyuubi.jdbc.hive.KyuubiStatement
 import org.apache.kyuubi.operation.HiveJDBCTestHelper
 import org.apache.kyuubi.operation.meta.ResultSetSchemaConstant._
 
-
 abstract class FlinkOperationSuite extends HiveJDBCTestHelper with WithFlinkTestResources {
 
   test("get catalogs") {

--- a/externals/kyuubi-flink-sql-engine/src/test/scala/org/apache/kyuubi/engine/flink/operation/FlinkOperationSuite.scala
+++ b/externals/kyuubi-flink-sql-engine/src/test/scala/org/apache/kyuubi/engine/flink/operation/FlinkOperationSuite.scala
@@ -17,11 +17,11 @@
 
 package org.apache.kyuubi.engine.flink.operation
 
-import scala.collection.mutable.ListBuffer
 import java.sql.DatabaseMetaData
 import java.util.UUID
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable.ListBuffer
 
 import org.apache.flink.api.common.JobID
 import org.apache.flink.table.types.logical.LogicalTypeRoot

--- a/externals/kyuubi-flink-sql-engine/src/test/scala/org/apache/kyuubi/engine/flink/operation/FlinkOperationSuite.scala
+++ b/externals/kyuubi-flink-sql-engine/src/test/scala/org/apache/kyuubi/engine/flink/operation/FlinkOperationSuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.kyuubi.engine.flink.operation
 
+import scala.collection.mutable.ListBuffer
 import java.sql.DatabaseMetaData
 import java.util.UUID
 
@@ -34,6 +35,7 @@ import org.apache.kyuubi.engine.flink.util.TestUserClassLoaderJar
 import org.apache.kyuubi.jdbc.hive.KyuubiStatement
 import org.apache.kyuubi.operation.HiveJDBCTestHelper
 import org.apache.kyuubi.operation.meta.ResultSetSchemaConstant._
+
 
 abstract class FlinkOperationSuite extends HiveJDBCTestHelper with WithFlinkTestResources {
 
@@ -1071,20 +1073,20 @@ abstract class FlinkOperationSuite extends HiveJDBCTestHelper with WithFlinkTest
       withJdbcStatement() { statement =>
         statement.execute(
           """
-            |create table tbl_src (
-            |           a bigint
-            |           ) with (
-            |           'connector' = 'datagen',
-            |          'rows-per-second'='1',
-            |          'fields.a.kind'='sequence',
-            |          'fields.a.start'='1',
-            |          'fields.a.end'='5'
-            |          )
+            |CREATE TABLE tbl_src (
+            |  a bigint
+            |) WITH (
+            |  'connector' = 'datagen',
+            |  'rows-per-second'='1',
+            |  'fields.a.kind'='sequence',
+            |  'fields.a.start'='1',
+            |  'fields.a.end'='5'
+            |)
             |""".stripMargin)
-        val resultSet = statement.executeQuery(s"select a from tbl_src")
-        var rows = List[Long]()
+        val resultSet = statement.executeQuery("select a from tbl_src")
+        var rows = ListBuffer[Long]()
         while (resultSet.next()) {
-          rows :+= resultSet.getLong("a")
+          rows += resultSet.getLong("a")
         }
         // rows size more than the input data
         assert(rows.size == 5)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Fix #4083


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible
1. set kyuubi.session.engine.flink.max.rows to appropriate value (eg: 500).
2. whatever earliest kafkaTable or latest kafkaTable, when select * from yourtable,  you can get line number equal to kyuubi.session.engine.flink.max.rows.
3. https://kyuubi.readthedocs.io/en/v1.7.0/deployment/settings.html#session
   Suggest kyuubi.session.engine.flink.max.rows default value change to 500.
   And explanation: too large may trigger OOM
- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
