### PR TITLE
[WIP] [INFRA] Validate bash scripts with `error` severity in super-linter

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -113,7 +113,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Super Linter Checks
-        uses: github/super-linter/slim@latest
+        uses: super-linter/super-linter/slim@v5
         env:
           CREATE_LOG_FILE: true
           ERROR_ON_MISSING_EXEC_BIT: true

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -113,7 +113,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Super Linter Checks
-        uses: github/super-linter/slim@v5
+        uses: github/super-linter/slim@latest
         env:
           CREATE_LOG_FILE: true
           ERROR_ON_MISSING_EXEC_BIT: true
@@ -123,6 +123,8 @@ jobs:
           LINTER_RULES_PATH: /
           LOG_LEVEL: NOTICE
           SUPPRESS_POSSUM: true
+          BASH_SEVERITY: error
+          VALIDATE_BASH: true
           VALIDATE_BASH_EXEC: true
           VALIDATE_ENV: true
           VALIDATE_JSONC: true


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- `super-linter` now supports setting severity for `shellcheck` rather than `style` level only, with https://github.com/github/super-linter/pull/3984
-  use the `latest` tag temporarily. will change to use `v5` until `5.0.1` is released.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
