### PR TITLE
Correct the submit time for BatchJobSubmission and check applicationInfo if submitted application

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
@@ -139,21 +139,20 @@ class BatchJobSubmission(
 
     if (isTerminalState(state)) {
       if (_applicationInfo.isEmpty) {
-        _applicationInfo =
-          Option(ApplicationInfo(id = null, name = null, state = ApplicationState.NOT_FOUND))
+        _applicationInfo = Some(ApplicationInfo.NOT_FOUND)
       }
     }
 
-    _applicationInfo.foreach { status =>
+    _applicationInfo.foreach { appInfo =>
       val metadataToUpdate = Metadata(
         identifier = batchId,
         state = state.toString,
         engineOpenTime = appStartTime,
-        engineId = status.id,
-        engineName = status.name,
-        engineUrl = status.url.orNull,
-        engineState = status.state.toString,
-        engineError = status.error,
+        engineId = appInfo.id,
+        engineName = appInfo.name,
+        engineUrl = appInfo.url.orNull,
+        engineState = appInfo.state.toString,
+        engineError = appInfo.error,
         endTime = endTime)
       session.sessionManager.updateMetadata(metadataToUpdate)
     }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
@@ -78,10 +78,8 @@ class BatchJobSubmission(
 
   @volatile private var _appStartTime = recoveryMetadata.map(_.engineOpenTime).getOrElse(0L)
   def appStartTime: Long = _appStartTime
-  def appStarted: Boolean = _appStartTime > 0
 
   private lazy val _submitTime = if (_appStartTime > 0) _appStartTime else System.currentTimeMillis
-  @volatile private var _submitApplication: Boolean = false
 
   @VisibleForTesting
   private[kyuubi] val builder: ProcBuilder = {
@@ -208,11 +206,7 @@ class BatchJobSubmission(
             submitAndMonitorBatchJob()
           }
 
-          if (_submitApplication && !appStarted) {
-            setStateIfNotCanceled(OperationState.ERROR)
-          } else {
-            setStateIfNotCanceled(OperationState.FINISHED)
-          }
+          setStateIfNotCanceled(OperationState.FINISHED)
         }
       } catch {
         onError()
@@ -234,7 +228,6 @@ class BatchJobSubmission(
   }
 
   private def submitAndMonitorBatchJob(): Unit = {
-    _submitApplication = true
     var appStatusFirstUpdated = false
     var lastStarvationCheckTime = createTime
     try {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
@@ -205,7 +205,6 @@ class BatchJobSubmission(
           }.getOrElse {
             submitAndMonitorBatchJob()
           }
-
           setStateIfNotCanceled(OperationState.FINISHED)
         }
       } catch {
@@ -273,9 +272,10 @@ class BatchJobSubmission(
 
         applicationId(_applicationInfo) match {
           case Some(appId) => monitorBatchJob(appId)
-          case None =>
+          case None if _appStartTime == 0 =>
             throw new RuntimeException(
               s"$batchType batch[$batchId] job failed: ${_applicationInfo}")
+          case _ =>
         }
       }
     } finally {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
@@ -255,7 +255,7 @@ class BatchJobSubmission(
 
       if (applicationFailed(_applicationInfo)) {
         process.destroyForcibly()
-        throw new RuntimeException(s"Batch job failed: ${_applicationInfo}")
+        throw new KyuubiException(s"Batch job failed: ${_applicationInfo}")
       } else {
         process.waitFor()
         if (process.exitValue() != 0) {
@@ -271,8 +271,7 @@ class BatchJobSubmission(
         applicationId(_applicationInfo) match {
           case Some(appId) => monitorBatchJob(appId)
           case None if !appStarted =>
-            throw new RuntimeException(
-              s"$batchType batch[$batchId] job failed: ${_applicationInfo}")
+            throw new KyuubiException(s"$batchType batch[$batchId] job failed: ${_applicationInfo}")
           case None =>
         }
       }
@@ -293,7 +292,7 @@ class BatchJobSubmission(
     if (_applicationInfo.isEmpty) {
       info(s"The $batchType batch[$batchId] job: $appId not found, assume that it has finished.")
     } else if (applicationFailed(_applicationInfo)) {
-      throw new RuntimeException(s"$batchType batch[$batchId] job failed: ${_applicationInfo}")
+      throw new KyuubiException(s"$batchType batch[$batchId] job failed: ${_applicationInfo}")
     } else {
       updateBatchMetadata()
       // TODO: add limit for max batch job submission lifetime
@@ -303,7 +302,7 @@ class BatchJobSubmission(
       }
 
       if (applicationFailed(_applicationInfo)) {
-        throw new RuntimeException(s"$batchType batch[$batchId] job failed: ${_applicationInfo}")
+        throw new KyuubiException(s"$batchType batch[$batchId] job failed: ${_applicationInfo}")
       }
     }
   }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
@@ -78,6 +78,7 @@ class BatchJobSubmission(
 
   @volatile private var _appStartTime = recoveryMetadata.map(_.engineOpenTime).getOrElse(0L)
   def appStartTime: Long = _appStartTime
+  def appStarted: Boolean = _appStartTime > 0
 
   private lazy val _submitTime = if (_appStartTime > 0) _appStartTime else System.currentTimeMillis
   @volatile private var _submitApplication: Boolean = false
@@ -207,7 +208,7 @@ class BatchJobSubmission(
             submitAndMonitorBatchJob()
           }
 
-          if (_submitApplication && _applicationInfo == Some(ApplicationInfo.NOT_FOUND)) {
+          if (_submitApplication && !appStarted) {
             setStateIfNotCanceled(OperationState.ERROR)
           } else {
             setStateIfNotCanceled(OperationState.FINISHED)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
@@ -266,7 +266,9 @@ class BatchJobSubmission(
         while (applicationId(_applicationInfo).isEmpty &&
           !applicationTerminated(_applicationInfo)) {
           updateApplicationInfoMetadataIfNeeded()
-          Thread.sleep(applicationCheckInterval)
+          if (applicationId(_applicationInfo).isEmpty && !applicationTerminated(_applicationInfo)) {
+            Thread.sleep(applicationCheckInterval)
+          }
         }
 
         applicationId(_applicationInfo) match {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
@@ -261,8 +261,8 @@ class BatchJobSubmission(
           throw new KyuubiException(s"Process exit with value ${process.exitValue()}")
         }
 
-        // wait the application id ready to monitor
-        while (applicationId(_applicationInfo).isEmpty &&
+        while (_appStartTime == 0 &&
+          applicationId(_applicationInfo).isEmpty &&
           !applicationTerminated(_applicationInfo)) {
           updateApplicationInfoMetadataIfNeeded()
           if (applicationId(_applicationInfo).isEmpty && !applicationTerminated(_applicationInfo)) {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
@@ -80,7 +80,7 @@ class BatchJobSubmission(
   def appStartTime: Long = _appStartTime
   def appStarted: Boolean = _appStartTime > 0
 
-  private lazy val _submitTime = if (_appStartTime > 0) _appStartTime else System.currentTimeMillis
+  private lazy val _submitTime = if (appStarted) _appStartTime else System.currentTimeMillis
 
   @VisibleForTesting
   private[kyuubi] val builder: ProcBuilder = {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
@@ -76,9 +76,10 @@ class BatchJobSubmission(
   private var killMessage: KillResponse = (false, "UNKNOWN")
   def getKillMessage: KillResponse = killMessage
 
-  private lazy val _submitTime = System.currentTimeMillis()
   @volatile private var _appStartTime = recoveryMetadata.map(_.engineOpenTime).getOrElse(0L)
   def appStartTime: Long = _appStartTime
+
+  private lazy val _submitTime = if (_appStartTime > 0) _appStartTime else System.currentTimeMillis
 
   @VisibleForTesting
   private[kyuubi] val builder: ProcBuilder = {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
@@ -262,8 +262,8 @@ class BatchJobSubmission(
           throw new KyuubiException(s"Process exit with value ${process.exitValue()}")
         }
 
-        while (!appStarted && applicationId(_applicationInfo).isEmpty && !applicationTerminated(
-            _applicationInfo)) {
+        while (!appStarted && applicationId(_applicationInfo).isEmpty &&
+          !applicationTerminated(_applicationInfo)) {
           Thread.sleep(applicationCheckInterval)
           updateApplicationInfoMetadataIfNeeded()
         }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
@@ -297,7 +297,7 @@ private[v1] class BatchesResource extends ApiRequestContext with Logging {
               val batchAppStatus = sessionManager.applicationManager.getApplicationInfo(
                 metadata.clusterManager,
                 batchId,
-                Some(metadata.createTime))
+                None)
               buildBatch(metadata, batchAppStatus)
           }
         }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
@@ -298,7 +298,7 @@ private[v1] class BatchesResource extends ApiRequestContext with Logging {
                 metadata.clusterManager,
                 batchId,
                 // prevent that the batch be marked as terminated if application state is NOT_FOUND
-                Some(System.currentTimeMillis()))
+                Some(metadata.engineOpenTime).filter(_ > 0).orElse(Some(System.currentTimeMillis)))
               buildBatch(metadata, batchAppStatus)
           }
         }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
@@ -297,7 +297,8 @@ private[v1] class BatchesResource extends ApiRequestContext with Logging {
               val batchAppStatus = sessionManager.applicationManager.getApplicationInfo(
                 metadata.clusterManager,
                 batchId,
-                None)
+                // prevent that the batch be marked as terminated if application state is NOT_FOUND
+                Some(System.currentTimeMillis()))
               buildBatch(metadata, batchAppStatus)
           }
         }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

- if the kyuubi instance is unreachable, we should not transfer the  batch metadata create time as batch submit time
  - we should always wait the kyuubi instance recovery 
  - here using a fake submit time to prevent that the batch be marked  as terminated if application state is NOT_FOUND
- Inside the BatchJobSubmission, using the first get application info time as batch submit time.

In this pr, I also record whether the batch operation submit batch.

If it did submit batch application and the app is not started, we need to mark the batch state as ERROR.
### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
