### PR TITLE
[K8S][HELM] Add Spark engine configuration support

### DIFF
--- a/charts/kyuubi/templates/NOTES.txt
+++ b/charts/kyuubi/templates/NOTES.txt
@@ -25,13 +25,13 @@ In order to check the release status, use:
 ************************
 ******* Services *******
 ************************
-{{- range $name, $frontend := .Values.server }}
+{{- range $name, $frontend := .Values.api }}
 {{- if $frontend.enabled }}
 {{ $name | snakecase | upper }}:
 - To access {{ $.Release.Name }}-{{ $name | kebabcase }} service within the cluster, use the following URL:
     {{ $.Release.Name }}-{{ $name | kebabcase }}.{{ $.Release.Namespace }}.svc.cluster.local
-{{- if $.Values.kyuubiConf.kyuubiDefaults }}
-{{- if regexMatch "(^|\\s)kyuubi.frontend.bind.host\\s*=?\\s*(localhost|127\\.0\\.0\\.1)($|\\s)" $.Values.kyuubiConf.kyuubiDefaults }}
+{{- if $.Values.server.conf.kyuubiDefaults }}
+{{- if regexMatch "(^|\\s)kyuubi.frontend.bind.host\\s*=?\\s*(localhost|127\\.0\\.0\\.1)($|\\s)" $.Values.server.conf.kyuubiDefaults }}
 - To access {{ $.Release.Name }}-{{ $name | kebabcase }} service from outside the cluster for debugging, run the following command:
     kubectl port-forward svc/{{ $.Release.Name }}-{{ $name | kebabcase }} {{ tpl $frontend.service.port $ }}:{{ tpl $frontend.service.port $ }} -n {{ $.Release.Namespace }}
   and use 127.0.0.1:{{ tpl $frontend.service.port $ }}

--- a/charts/kyuubi/templates/_helpers.tpl
+++ b/charts/kyuubi/templates/_helpers.tpl
@@ -21,7 +21,7 @@ For details, see 'kyuubi.frontend.protocols': https://kyuubi.readthedocs.io/en/m
 */}}
 {{- define "kyuubi.frontend.protocols" -}}
   {{- $protocols := list }}
-  {{- range $name, $frontend := .Values.server }}
+  {{- range $name, $frontend := .Values.api }}
     {{- if $frontend.enabled }}
       {{- $protocols = $name | snakecase | upper | append $protocols }}
     {{- end }}

--- a/charts/kyuubi/templates/kyuubi-configmap.yaml
+++ b/charts/kyuubi/templates/kyuubi-configmap.yaml
@@ -19,29 +19,30 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}
-  labels:
-    {{- include "kyuubi.labels" . | nindent 4 }}
+  labels: {{- include "kyuubi.labels" . | nindent 4 }}
 data:
-  {{- with .Values.kyuubiConf.kyuubiEnv }}
+  {{- with .Values.server.conf.kyuubiEnv }}
   kyuubi-env.sh: |
     #!/usr/bin/env bash
     {{- tpl . $ | nindent 4 }}
   {{- end }}
+
   kyuubi-defaults.conf: |
     ## Helm chart provided Kyuubi configurations
     kyuubi.kubernetes.namespace={{ .Release.Namespace }}
     kyuubi.frontend.connection.url.use.hostname=false
-    kyuubi.frontend.thrift.binary.bind.port={{ .Values.server.thriftBinary.port }}
-    kyuubi.frontend.thrift.http.bind.port={{ .Values.server.thriftHttp.port }}
-    kyuubi.frontend.rest.bind.port={{ .Values.server.rest.port }}
-    kyuubi.frontend.mysql.bind.port={{ .Values.server.mysql.port }}
+    kyuubi.frontend.thrift.binary.bind.port={{ .Values.api.thriftBinary.port }}
+    kyuubi.frontend.thrift.http.bind.port={{ .Values.api.thriftHttp.port }}
+    kyuubi.frontend.rest.bind.port={{ .Values.api.rest.port }}
+    kyuubi.frontend.mysql.bind.port={{ .Values.api.mysql.port }}
     kyuubi.frontend.protocols={{ include "kyuubi.frontend.protocols" . }}
 
     ## User provided Kyuubi configurations
-    {{- with .Values.kyuubiConf.kyuubiDefaults }}
+    {{- with .Values.server.conf.kyuubiDefaults }}
       {{- tpl . $ | nindent 4 }}
     {{- end }}
-  {{- with .Values.kyuubiConf.log4j2 }}
+
+  {{- with .Values.server.conf.log4j2 }}
   log4j2.xml: |
     {{- tpl . $ | nindent 4 }}
   {{- end }}

--- a/charts/kyuubi/templates/kyuubi-deployment.yaml
+++ b/charts/kyuubi/templates/kyuubi-deployment.yaml
@@ -19,17 +19,14 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}
-  labels:
-    {{- include "kyuubi.labels" . | nindent 4 }}
+  labels: {{- include "kyuubi.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.server.replicas }}
   selector:
-    matchLabels:
-      {{- include "kyuubi.selectorLabels" . | nindent 6 }}
+    matchLabels: {{- include "kyuubi.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      labels:
-        {{- include "kyuubi.selectorLabels" . | nindent 8 }}
+      labels: {{- include "kyuubi.selectorLabels" . | nindent 8 }}
       annotations:
         checksum/conf: {{ include (print $.Template.BasePath "/kyuubi-configmap.yaml") . | sha256sum }}
     spec:
@@ -39,80 +36,85 @@ spec:
       {{- if or .Values.serviceAccount.name .Values.serviceAccount.create }}
       serviceAccountName: {{ .Values.serviceAccount.name | default .Release.Name }}
       {{- end }}
-      {{- with .Values.initContainers }}
+      {{- with .Values.server.initContainers }}
       initContainers: {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
       containers:
         - name: kyuubi-server
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- with .Values.command }}
+          {{- with .Values.server.command }}
           command: {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
-          {{- with .Values.args }}
+          {{- with .Values.server.args }}
           args: {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
-          {{- with .Values.env }}
+          {{- with .Values.server.env }}
           env: {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
-          {{- with .Values.envFrom }}
+          {{- with .Values.server.envFrom }}
           envFrom: {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
           ports:
-            {{- range $name, $frontend := .Values.server }}
+            {{- range $name, $frontend := .Values.api }}
             {{- if $frontend.enabled }}
             - name: {{ $name | kebabcase }}
               containerPort: {{ $frontend.port }}
             {{- end }}
             {{- end }}
-          {{- if .Values.probe.liveness.enabled }}
+          {{- if .Values.server.livenessProbe.enabled }}
           livenessProbe:
             exec:
               command: ["/bin/bash", "-c", "bin/kyuubi status"]
-            initialDelaySeconds: {{ .Values.probe.liveness.initialDelaySeconds }}
-            periodSeconds: {{ .Values.probe.liveness.periodSeconds }}
-            timeoutSeconds: {{ .Values.probe.liveness.timeoutSeconds }}
-            failureThreshold: {{ .Values.probe.liveness.failureThreshold }}
-            successThreshold: {{ .Values.probe.liveness.successThreshold }}
+            initialDelaySeconds: {{ .Values.server.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.server.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.server.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.server.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.server.livenessProbe.successThreshold }}
           {{- end }}
-          {{- if .Values.probe.readiness.enabled }}
+          {{- if .Values.server.readinessProbe.enabled }}
           readinessProbe:
             exec:
               command: ["/bin/bash", "-c", "$KYUUBI_HOME/bin/kyuubi status"]
-            initialDelaySeconds: {{ .Values.probe.readiness.initialDelaySeconds }}
-            periodSeconds: {{ .Values.probe.readiness.periodSeconds }}
-            timeoutSeconds: {{ .Values.probe.readiness.timeoutSeconds }}
-            failureThreshold: {{ .Values.probe.readiness.failureThreshold }}
-            successThreshold: {{ .Values.probe.readiness.successThreshold }}
+            initialDelaySeconds: {{ .Values.server.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.server.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.server.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.server.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.server.readinessProbe.successThreshold }}
           {{- end }}
-          {{- with .Values.resources }}
+          {{- with .Values.server.resources }}
           resources: {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: conf
-              mountPath: {{ .Values.kyuubiConfDir }}
-            {{- with .Values.volumeMounts }}
+              mountPath: {{ .Values.server.confDir }}
+            - name: conf-spark
+              mountPath: {{ .Values.engine.spark.confDir }}
+            {{- with .Values.server.volumeMounts }}
               {{- tpl (toYaml .) $ | nindent 12 }}
             {{- end }}
-        {{- with .Values.containers }}
+        {{- with .Values.server.containers }}
           {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
       volumes:
         - name: conf
           configMap:
             name: {{ .Release.Name }}
-        {{- with .Values.volumes }}
+        - name: conf-spark
+          configMap:
+            name: {{ .Release.Name }}-spark
+        {{- with .Values.server.volumes }}
           {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.server.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.server.affinity }}
       affinity: {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.server.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.securityContext }}
+      {{- with .Values.server.securityContext }}
       securityContext: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/kyuubi/templates/kyuubi-role.yaml
+++ b/charts/kyuubi/templates/kyuubi-role.yaml
@@ -20,7 +20,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ .Release.Name }}
-  labels:
-    {{- include "kyuubi.labels" . | nindent 4 }}
+  labels: {{- include "kyuubi.labels" . | nindent 4 }}
 rules: {{- toYaml .Values.rbac.rules | nindent 2 }}
 {{- end }}

--- a/charts/kyuubi/templates/kyuubi-rolebinding.yaml
+++ b/charts/kyuubi/templates/kyuubi-rolebinding.yaml
@@ -20,8 +20,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ .Release.Name }}
-  labels:
-    {{- include "kyuubi.labels" . | nindent 4 }}
+  labels: {{- include "kyuubi.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.serviceAccount.name | default .Release.Name }}

--- a/charts/kyuubi/templates/kyuubi-serviceaccount.yaml
+++ b/charts/kyuubi/templates/kyuubi-serviceaccount.yaml
@@ -20,6 +20,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccount.name | default .Release.Name }}
-  labels:
-    {{- include "kyuubi.labels" . | nindent 4 }}
+  labels: {{- include "kyuubi.labels" . | nindent 4 }}
 {{- end }}

--- a/charts/kyuubi/templates/spark-configmap.yaml
+++ b/charts/kyuubi/templates/spark-configmap.yaml
@@ -1,0 +1,91 @@
+{{/*
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-spark
+  labels: {{- include "kyuubi.labels" . | nindent 4 }}
+data:
+  {{- with .Values.engine.spark.conf.sparkEnv }}
+  spark-env.sh: |
+    #!/usr/bin/env bash
+    {{- tpl . $ | nindent 4 }}
+  {{- end }}
+
+  spark-defaults.conf: |
+    ## Helm chart provided Spark configurations
+    spark.submit.deployMode=cluster
+
+    spark.master={{ .Values.engine.spark.master }}
+    spark.kubernetes.namespace={{ .Values.engine.spark.namespace | default .Release.Namespace }}
+
+    spark.kubernetes.authenticate.driver.serviceAccountName={{ .Values.engine.spark.serviceAccount.name | default (printf "%s-spark" .Release.Name) }}
+    spark.kubernetes.authenticate.executor.serviceAccountName={{ .Values.engine.spark.serviceAccount.name | default (printf "%s-spark" .Release.Name) }}
+
+    ### Image properties
+    spark.kubernetes.container.image={{ .Values.engine.spark.image.repository }}:{{ .Values.engine.spark.image.tag }}
+    spark.kubernetes.container.image.pullPolicy={{ .Values.engine.spark.image.pullPolicy }}
+    spark.kubernetes.container.image.pullSecrets={{ range .Values.imagePullSecrets }}{{ print .name "," }}{{ end }}
+
+    ### Driver resources
+    spark.driver.cores={{ .Values.engine.spark.driver.resources.cores }}
+    {{- with .Values.engine.spark.driver.resources.coresRequest }}
+    spark.kubernetes.driver.request.cores={{ . }}
+    {{- end }}
+    {{- with .Values.engine.spark.driver.resources.coresLimit }}
+    spark.kubernetes.driver.limit.cores={{ . }}
+    {{- end }}
+    spark.driver.memory={{ .Values.engine.spark.driver.resources.memory }}
+    {{- with .Values.engine.spark.driver.resources.memoryOverhead }}
+    spark.driver.memoryOverhead={{ . }}
+    {{- end }}
+    {{- with .Values.engine.spark.driver.resources.memoryOverheadFactor }}
+    spark.driver.memoryOverheadFactor={{ . }}
+    {{- end }}
+
+    ### Executor resources
+    spark.executor.instances={{ .Values.engine.spark.executor.instances }}
+    spark.executor.cores={{ .Values.engine.spark.executor.resources.cores }}
+    {{- with .Values.engine.spark.executor.resources.coresRequest }}
+    spark.kubernetes.executor.request.cores={{ . }}
+    {{- end }}
+    {{- with .Values.engine.spark.executor.resources.coresLimit }}
+    spark.kubernetes.executor.limit.cores={{ . }}
+    {{- end }}
+    spark.executor.memory={{ .Values.engine.spark.executor.resources.memory }}
+    {{- with .Values.engine.spark.executor.resources.memoryOverhead }}
+    spark.executor.memoryOverhead={{ . }}
+    {{- end }}
+    {{- with .Values.engine.spark.executor.resources.memoryOverheadFactor }}
+    spark.executor.memoryOverheadFactor={{ . }}
+    {{- end }}
+
+    ## User provided Spark configurations
+    {{- with .Values.engine.spark.conf.sparkDefaults }}
+      {{- tpl . $ | nindent 4 }}
+    {{- end }}
+
+  {{- with .Values.engine.spark.conf.driverPodTemplate }}
+  driver-pod-template.yaml: |
+    {{- tpl . $ | nindent 4 }}
+  {{- end }}
+
+  {{- with .Values.engine.spark.conf.executorPodTemplate }}
+  executor-pod-template.yaml: |
+    {{- tpl . $ | nindent 4 }}
+  {{- end }}

--- a/charts/kyuubi/templates/spark-role.yaml
+++ b/charts/kyuubi/templates/spark-role.yaml
@@ -15,27 +15,17 @@
   limitations under the License.
 */}}
 
-{{- range $name, $frontend := .Values.api }}
-{{- if $frontend.enabled }}
-apiVersion: v1
-kind: Service
+{{- if .Values.engine.spark.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
 metadata:
-  name: {{ $.Release.Name }}-{{ $name | kebabcase }}
-  labels: {{- include "kyuubi.labels" $ | nindent 4 }}
-  {{- with $frontend.service.annotations }}
-  annotations: {{- toYaml . | nindent 4 }}
+  name: {{ .Release.Name }}-spark
+  {{- if .Values.engine.spark.namespace }}
+  namespace: {{ .Values.engine.spark.namespace }}
   {{- end }}
-spec:
-  type: {{ $frontend.service.type }}
-  ports:
-    - name: {{ $name | kebabcase }}
-      port: {{ tpl $frontend.service.port $ }}
-      targetPort: {{ $frontend.port }}
-      {{- if and (eq $frontend.service.type "NodePort") ($frontend.service.nodePort) }}
-      nodePort: {{ $frontend.service.nodePort }}
-      {{- end }}
-  selector:
-    {{- include "kyuubi.selectorLabels" $ | nindent 4 }}
----
-{{- end }}
+  labels: {{- include "kyuubi.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps", "pods", "services"]
+    verbs: ["list", "create", "get", "watch", "delete"]
 {{- end }}

--- a/charts/kyuubi/templates/spark-rolebinding.yaml
+++ b/charts/kyuubi/templates/spark-rolebinding.yaml
@@ -15,27 +15,20 @@
   limitations under the License.
 */}}
 
-{{- range $name, $frontend := .Values.api }}
-{{- if $frontend.enabled }}
-apiVersion: v1
-kind: Service
+{{- if .Values.engine.spark.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
 metadata:
-  name: {{ $.Release.Name }}-{{ $name | kebabcase }}
-  labels: {{- include "kyuubi.labels" $ | nindent 4 }}
-  {{- with $frontend.service.annotations }}
-  annotations: {{- toYaml . | nindent 4 }}
+  name: {{ .Release.Name }}-spark
+  {{- if .Values.engine.spark.namespace }}
+  namespace: {{ .Values.engine.spark.namespace }}
   {{- end }}
-spec:
-  type: {{ $frontend.service.type }}
-  ports:
-    - name: {{ $name | kebabcase }}
-      port: {{ tpl $frontend.service.port $ }}
-      targetPort: {{ $frontend.port }}
-      {{- if and (eq $frontend.service.type "NodePort") ($frontend.service.nodePort) }}
-      nodePort: {{ $frontend.service.nodePort }}
-      {{- end }}
-  selector:
-    {{- include "kyuubi.selectorLabels" $ | nindent 4 }}
----
-{{- end }}
+  labels: {{- include "kyuubi.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.engine.spark.serviceAccount.name | default (printf "%s-spark" .Release.Name) }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-spark
 {{- end }}

--- a/charts/kyuubi/templates/spark-serviceaccount.yaml
+++ b/charts/kyuubi/templates/spark-serviceaccount.yaml
@@ -15,27 +15,13 @@
   limitations under the License.
 */}}
 
-{{- range $name, $frontend := .Values.api }}
-{{- if $frontend.enabled }}
+{{- if .Values.engine.spark.serviceAccount.create }}
 apiVersion: v1
-kind: Service
+kind: ServiceAccount
 metadata:
-  name: {{ $.Release.Name }}-{{ $name | kebabcase }}
-  labels: {{- include "kyuubi.labels" $ | nindent 4 }}
-  {{- with $frontend.service.annotations }}
-  annotations: {{- toYaml . | nindent 4 }}
+  name: {{ .Values.engine.spark.serviceAccount.name | default (printf "%s-spark" .Release.Name) }}
+  {{- if .Values.engine.spark.namespace }}
+  namespace: {{ .Values.engine.spark.namespace }}
   {{- end }}
-spec:
-  type: {{ $frontend.service.type }}
-  ports:
-    - name: {{ $name | kebabcase }}
-      port: {{ tpl $frontend.service.port $ }}
-      targetPort: {{ $frontend.port }}
-      {{- if and (eq $frontend.service.type "NodePort") ($frontend.service.nodePort) }}
-      nodePort: {{ $frontend.service.nodePort }}
-      {{- end }}
-  selector:
-    {{- include "kyuubi.selectorLabels" $ | nindent 4 }}
----
-{{- end }}
+  labels: {{- include "kyuubi.labels" . | nindent 4 }}
 {{- end }}

--- a/charts/kyuubi/values.yaml
+++ b/charts/kyuubi/values.yaml
@@ -19,9 +19,6 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# Kyuubi server numbers
-replicaCount: 2
-
 image:
   repository: apache/kyuubi
   pullPolicy: IfNotPresent
@@ -29,42 +26,31 @@ image:
 
 imagePullSecrets: []
 
-# ServiceAccount used for Kyuubi create/list/delete pod in kubernetes
+# Role-based access control
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+  # RBAC rules
+  rules:
+    - apiGroups: [""]
+      resources: ["configmaps", "pods", "services"]
+      verbs: ["list", "create", "get", "watch", "delete"]
+
+# ServiceAccount used by Kyuubi for requesting Kubernetes API server
 serviceAccount:
+  # Specifies whether a ServiceAccount should be created
   create: true
   name: ~
 
-rbac:
-  create: true
-  rules:
-    - apiGroups: [""]
-      resources: ["pods"]
-      verbs: ["create", "list", "delete"]
-
-probe:
-  liveness:
-    enabled: true
-    initialDelaySeconds: 30
-    periodSeconds: 10
-    timeoutSeconds: 2
-    failureThreshold: 10
-    successThreshold: 1
-  readiness:
-    enabled: true
-    initialDelaySeconds: 30
-    periodSeconds: 10
-    timeoutSeconds: 2
-    failureThreshold: 10
-    successThreshold: 1
-
-server:
+# APIs for connectivity and interoperation between supported clients and Kyuubi server
+api:
   # Thrift Binary protocol (HiveServer2 compatible)
   thriftBinary:
     enabled: true
     port: 10009
     service:
       type: ClusterIP
-      port: "{{ .Values.server.thriftBinary.port }}"
+      port: "{{ .Values.api.thriftBinary.port }}"
       nodePort: ~
       annotations: {}
 
@@ -74,7 +60,7 @@ server:
     port: 10010
     service:
       type: ClusterIP
-      port: "{{ .Values.server.thriftHttp.port }}"
+      port: "{{ .Values.api.thriftHttp.port }}"
       nodePort: ~
       annotations: {}
 
@@ -84,7 +70,7 @@ server:
     port: 10099
     service:
       type: ClusterIP
-      port: "{{ .Values.server.rest.port }}"
+      port: "{{ .Values.api.rest.port }}"
       nodePort: ~
       annotations: {}
 
@@ -94,77 +80,176 @@ server:
     port: 3309
     service:
       type: ClusterIP
-      port: "{{ .Values.server.mysql.port }}"
+      port: "{{ .Values.api.mysql.port }}"
       nodePort: ~
       annotations: {}
 
-kyuubiConfDir: /opt/kyuubi/conf
-kyuubiConf:
-  # The value (templated string) is used for kyuubi-env.sh file
+# Kyuubi server configuration
+server:
+  # Number of servers
+  replicas: 2
+
+  # Command to launch Kyuubi server (templated)
+  command: ~
+  # Arguments to launch Kyuubi server (templated)
+  args: ~
+
+  # Environment variables (templated)
+  env: []
+  # Environment variables from ConfigMaps and Secrets (templated)
+  envFrom: []
+
+  # Additional volumes for Kyuubi pod (templated)
+  volumes: []
+  # Additional volumeMounts for Kyuubi container (templated)
+  volumeMounts: []
+
+  # Additional init containers for Kyuubi pod (templated)
+  initContainers: []
+  # Additional containers for Kyuubi pod (templated)
+  containers: []
+
+  # Resource requests and limits
+  resources: {}
   # Example:
   #
-  # kyuubiEnv: |
-  #   export JAVA_HOME=/usr/jdk64/jdk1.8.0_152
-  #   export SPARK_HOME=/opt/spark
-  #   export FLINK_HOME=/opt/flink
-  #   export HIVE_HOME=/opt/hive
-  #
-  # See example at conf/kyuubi-env.sh.template and https://kyuubi.readthedocs.io/en/master/deployment/settings.html#environments for more details
-  kyuubiEnv: ~
+  #  resources:
+  #    limits:
+  #      cpu: 4
+  #      memory: 10Gi
+  #    requests:
+  #      cpu: 2
+  #      memory: 4Gi
 
-  # The value (templated string) is used for kyuubi-defaults.conf file
+  # Liveness probe
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 2
+    failureThreshold: 10
+    successThreshold: 1
+  # Readiness probe
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 2
+    failureThreshold: 10
+    successThreshold: 1
+
+  # Constrain server pods to nodes with specific node labels
+  nodeSelector: {}
+  # Constrain server pods to nodes by complex affinity/anti-affinity rules
+  affinity: {}
+  # Allow to schedule server pods on nodes with matching taints
+  tolerations: []
+
+  # Pod security context
+  securityContext: {}
   # Example:
   #
-  # kyuubiDefaults: |
-  #   kyuubi.authentication=NONE
-  #   kyuubi.frontend.bind.host=10.0.0.1
-  #   kyuubi.engine.type=SPARK_SQL
-  #   kyuubi.engine.share.level=USER
-  #   kyuubi.session.engine.initialize.timeout=PT3M
-  #   kyuubi.ha.addresses=zk1:2181,zk2:2181,zk3:2181
-  #   kyuubi.ha.namespace=kyuubi
-  #
-  # See https://kyuubi.readthedocs.io/en/master/deployment/settings.html#kyuubi-configurations for more details
-  kyuubiDefaults: ~
+  #  securityContext:
+  #    runAsUser: 1000
+  #    fsGroup: 1000
+  #    runAsGroup: 1000
 
-  # The value (templated string) is used for log4j2.xml file
-  # See example at conf/log4j2.xml.template https://kyuubi.readthedocs.io/en/master/deployment/settings.html#logging for more details
-  log4j2: ~
+  # $KYUUBI_CONF_DIR directory
+  confDir: /opt/kyuubi/conf
+  # Kyuubi configurations files
+  conf:
+    # The value (templated string) is used for kyuubi-env.sh file
+    # See example at conf/kyuubi-env.sh.template and https://kyuubi.readthedocs.io/en/master/deployment/settings.html#environments for more details
+    kyuubiEnv: ~
+    # Example:
+    #
+    #  kyuubiEnv: |
+    #    export JAVA_HOME=/usr/jdk64/jdk1.8.0_152
+    #    export SPARK_HOME=/opt/spark
+    #    export FLINK_HOME=/opt/flink
+    #    export HIVE_HOME=/opt/hive
+    #
 
-# Command to launch Kyuubi server (templated)
-command: ~
-# Arguments to launch Kyuubi server (templated)
-args: ~
+    # The value (templated string) is used for kyuubi-defaults.conf file
+    # See https://kyuubi.readthedocs.io/en/master/deployment/settings.html#kyuubi-configurations for more details
+    kyuubiDefaults: ~
+    # Example:
+    #
+    #  kyuubiDefaults: |
+    #    kyuubi.authentication=NONE
+    #    kyuubi.frontend.bind.host=10.0.0.1
+    #    kyuubi.engine.type=SPARK_SQL
+    #    kyuubi.engine.share.level=USER
+    #    kyuubi.session.engine.initialize.timeout=PT3M
+    #    kyuubi.ha.addresses=zk1:2181,zk2:2181,zk3:2181
+    #    kyuubi.ha.namespace=kyuubi
+    #
 
-# Environment variables (templated)
-env: []
-envFrom: []
+    # The value (templated string) is used for log4j2.xml file
+    # See example at conf/log4j2.xml.template https://kyuubi.readthedocs.io/en/master/deployment/settings.html#logging for more details
+    log4j2: ~
 
-# Additional volumes for Kyuubi pod (templated)
-volumes: []
-# Additional volumeMounts for Kyuubi container (templated)
-volumeMounts: []
-
-# Additional init containers for Kyuubi pod (templated)
-initContainers: []
-# Additional containers for Kyuubi pod (templated)
-containers: []
-
-resources: {}
-  # Used to specify resource, default unlimited.
-  # If you do want to specify resources:
-  #   1. remove the curly braces after 'resources:'
-  #   2. uncomment the following lines
-  # limits:
-  #   cpu: 4
-  #   memory: 10Gi
-  # requests:
-  #   cpu: 2
-  #   memory: 4Gi
-
-# Constrain Kyuubi server pods to specific nodes
-nodeSelector: {}
-tolerations: []
-affinity: {}
-
-securityContext: {}
+# Query engines
+engine:
+  # Apache Spark default configuration
+  spark:
+    # Spark master - spark.master
+    master: k8s://https://kubernetes.default.svc
+    # Namespace to be used for running pods - spark.kubernetes.namespace
+    namespace: ~
+    # Spark image
+    image:
+      repository: apache/spark
+      pullPolicy: IfNotPresent
+      tag: v3.3.2
+    # Role-based access control
+    rbac:
+      # Specifies whether RBAC resources should be created
+      create: true
+    # ServiceAccount used by Spark for requesting Kubernetes API server
+    serviceAccount:
+      # Specifies whether a ServiceAccount should be created
+      create: true
+      name: ~
+    # Driver configuration
+    driver:
+      resources:
+        cores: 1
+        coresRequest: ~
+        coresLimit: ~
+        memory: 1g
+        memoryOverhead: ~
+        memoryOverheadFactor: ~
+    # Executor configuration
+    executor:
+      instances: 1
+      resources:
+        cores: 1
+        coresRequest: ~
+        coresLimit: ~
+        memory: 1g
+        memoryOverhead: ~
+        memoryOverheadFactor: ~
+    # $SPARK_CONF_DIR directory
+    confDir: /opt/kyuubi/externals/spark-3.3.2-bin-hadoop3/conf
+    # Spark configuration files
+    conf:
+      # The value (templated string) is used for $SPARK_HOME/conf/spark-env.sh file
+      # See example template https://github.com/apache/spark/blob/master/conf/spark-env.sh.template for more details
+      sparkEnv: ~
+      # The value (templated string) is used for $SPARK_HOME/conf/spark-defaults.conf file
+      # See example template https://github.com/apache/spark/blob/master/conf/spark-defaults.conf.template for more details
+      sparkDefaults: ~
+      # The value (templated string) is used for $SPARK_HOME/conf/driver-pod-template.yaml file
+      driverPodTemplate: ~
+      # Example:
+      #
+      #  driverPodTemplate: |
+      #    apiVersion: v1
+      #    kind: Pod
+      #    spec:
+      #      tolerations:
+      #        - key: "spark-node"
+      #          operator: "Exists"
+      # The value (templated string) is used for $SPARK_HOME/conf/executor-pod-template.yaml file
+      executorPodTemplate: ~


### PR DESCRIPTION
### _Why are the changes needed?_
The PR is needed to configure default properties to be used by Apache Spark as query engine.

The PR also changes `values.yaml` file structure:
```yaml
# APIs for connectivity and interoperation between supported clients and Kyuubi server
api:
  # Thrift Binary protocol (HiveServer2 compatible)
  thriftBinary:
    ...

# Kyuubi server configuration
server:
  replicas: 2
  ...

# Query engines
engine:
  # Apache Spark default configuration
  spark:
    ...
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
