### PR TITLE
Deregister event handlers when stopping server with event handler made auto-closeable

### DIFF
--- a/kyuubi-events/src/main/scala/org/apache/kyuubi/events/EventBus.scala
+++ b/kyuubi-events/src/main/scala/org/apache/kyuubi/events/EventBus.scala
@@ -40,6 +40,8 @@ sealed trait EventBus {
   def register[T <: KyuubiEvent: ClassTag](eventHandler: EventHandler[T]): EventBus
 
   def registerAsync[T <: KyuubiEvent: ClassTag](eventHandler: EventHandler[T]): EventBus
+
+  def deregisterAll(): Unit = {}
 }
 
 object EventBus extends Logging {
@@ -67,6 +69,10 @@ object EventBus extends Logging {
 
   def registerAsync[T <: KyuubiEvent: ClassTag](et: EventHandler[T]): EventBus =
     defaultEventBus.registerAsync[T](et)
+
+  def deregisterAll(): Unit = {
+    defaultEventBus.deregisterAll()
+  }
 
   private case class EventBusLive() extends EventBus {
     private[this] lazy val eventHandlerRegistry = new Registry
@@ -96,6 +102,11 @@ object EventBus extends Logging {
       asyncEventHandlerRegistry.register(et)
       this
     }
+
+    override def deregisterAll(): Unit = {
+      eventHandlerRegistry.deregisterAll()
+      asyncEventHandlerRegistry.deregisterAll()
+    }
   }
 
   private class Registry {
@@ -121,6 +132,11 @@ object EventBus extends Logging {
         parent <- getAllParentsClass(cls)
       } yield parent
       clazz :: parents
+    }
+
+    def deregisterAll(): Unit = {
+      eventHandlers.values.flatten.foreach(_.close())
+      eventHandlers.clear()
     }
   }
 }

--- a/kyuubi-events/src/main/scala/org/apache/kyuubi/events/EventBus.scala
+++ b/kyuubi-events/src/main/scala/org/apache/kyuubi/events/EventBus.scala
@@ -70,7 +70,7 @@ object EventBus extends Logging {
   def registerAsync[T <: KyuubiEvent: ClassTag](et: EventHandler[T]): EventBus =
     defaultEventBus.registerAsync[T](et)
 
-  def deregisterAll(): Unit = {
+  def deregisterAll(): Unit = synchronized {
     defaultEventBus.deregisterAll()
   }
 

--- a/kyuubi-events/src/main/scala/org/apache/kyuubi/events/handler/package.scala
+++ b/kyuubi-events/src/main/scala/org/apache/kyuubi/events/handler/package.scala
@@ -18,5 +18,9 @@
 package org.apache.kyuubi.events
 
 package object handler {
-  type EventHandler[T <: KyuubiEvent] = T => Unit
+  trait EventHandler[T <: KyuubiEvent] extends AutoCloseable {
+    def apply(event: T): Unit
+
+    def close(): Unit = {}
+  }
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiServer.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiServer.scala
@@ -193,5 +193,7 @@ class KyuubiServer(name: String) extends Serverable(name) {
     ServerEventHandlerRegister.registerEventLoggers(conf)
   }
 
-  override protected def stopServer(): Unit = {}
+  override protected def stopServer(): Unit = {
+    EventBus.deregisterAll()
+  }
 }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/events/handler/ServerJsonLoggingEventHandlerSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/events/handler/ServerJsonLoggingEventHandlerSuite.scala
@@ -198,7 +198,7 @@ class ServerJsonLoggingEventHandlerSuite extends WithKyuubiServer with HiveJDBCT
     server.initialize(conf)
     server.start()
     server.stop()
-    ServerEventHandlerRegister.registerEventLoggers(conf)   // register event loggers again
+    ServerEventHandlerRegister.registerEventLoggers(conf) // register event loggers again
 
     val hostName = InetAddress.getLocalHost.getCanonicalHostName
     val kyuubiServerInfoPath =

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/events/handler/ServerJsonLoggingEventHandlerSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/events/handler/ServerJsonLoggingEventHandlerSuite.scala
@@ -33,6 +33,7 @@ import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
 import org.apache.kyuubi._
 import org.apache.kyuubi.client.util.BatchUtils._
 import org.apache.kyuubi.config.KyuubiConf
+import org.apache.kyuubi.events.ServerEventHandlerRegister
 import org.apache.kyuubi.operation.HiveJDBCTestHelper
 import org.apache.kyuubi.operation.OperationState._
 import org.apache.kyuubi.server.KyuubiServer
@@ -197,6 +198,7 @@ class ServerJsonLoggingEventHandlerSuite extends WithKyuubiServer with HiveJDBCT
     server.initialize(conf)
     server.start()
     server.stop()
+    ServerEventHandlerRegister.registerEventLoggers(conf)   // register event loggers again
 
     val hostName = InetAddress.getLocalHost.getCanonicalHostName
     val kyuubiServerInfoPath =


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- deregister event handlers when stopping Kyuubiserver, by deregister them from EventBus's handler Registry
- change `EventHandler` from `type` to `trait` and make it extending  `AutoCloseable`
- implement `close` method in `JsonLoggingEventHandler` for closing writers and streams

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
