### PR TITLE
Use nodejs v18 in CI builds and maven web-ui builds

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -89,7 +89,7 @@ jobs:
       - name: setup npm
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - name: Web UI Style with node
         run: |
           cd ./kyuubi-server/web-ui

--- a/.github/workflows/web-ui.yml
+++ b/.github/workflows/web-ui.yml
@@ -24,7 +24,7 @@ jobs:
       - name: setup npm
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - name: npm run coverage & build
         run: |
           cd ./kyuubi-server/web-ui

--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@
 
         <!-- webui -->
         <webui.skip>true</webui.skip>
-        <node.version>v16.19.1</node.version>
+        <node.version>v18.16.0</node.version>
         <pnpm.version>v7.27.1</pnpm.version>
 
         <!-- apply to kyuubi-hive-jdbc/kyuubi-hive-beeline module -->


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- nodejs v18 is the current active LTS version of nodejs since October 2022, while v16 is in maintenance mode and no longer in the active status

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
