### PR TITLE
Log error when handling session exception

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSession.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSession.scala
@@ -49,6 +49,7 @@ abstract class KyuubiSession(
       f
     } catch {
       case t: Throwable =>
+        error(s"Handling $user session[$handle] exception:", t)
         getSessionEvent.foreach { sessionEvent =>
           sessionEvent.exception = Some(t)
           EventBus.post(sessionEvent)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
@@ -171,7 +171,7 @@ class KyuubiSessionImpl(
             case e: Throwable =>
               error(
                 s"Opening engine [${engine.defaultEngineName} $host:$port]" +
-                  s" for $user session failed",
+                  s" for $user session[$handle] failed",
                 e)
               openSessionError = Some(e)
               throw e


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Log the session exception when handling it, otherwise, we can only lookup it from events.

<img width="920" alt="image" src="https://user-images.githubusercontent.com/6757692/236364243-3182b371-fb78-4b39-85f9-8ef9f24139fc.png">


For example, if the exception thrown by `engine.getOrCreate(discoveryClient, extraEngineLog)`, now there is no log for that.
### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
