### PR TITLE
Expose JVM attributes to metrics

### DIFF
--- a/kyuubi-metrics/src/main/scala/org/apache/kyuubi/metrics/MetricsConstants.scala
+++ b/kyuubi-metrics/src/main/scala/org/apache/kyuubi/metrics/MetricsConstants.scala
@@ -26,6 +26,7 @@ object MetricsConstants {
   final val BUFFER_POOL: String = KYUUBI + "buffer_pool"
   final val THREAD_STATE: String = KYUUBI + "thread_state"
   final val CLASS_LOADING: String = KYUUBI + "class_loading"
+  final val JVM_ATTR: String = KYUUBI + "jvm_attr"
 
   final val EXEC_POOL_ALIVE: String = KYUUBI + "exec.pool.threads.alive"
   final val EXEC_POOL_ACTIVE: String = KYUUBI + "exec.pool.threads.active"

--- a/kyuubi-metrics/src/main/scala/org/apache/kyuubi/metrics/MetricsConstants.scala
+++ b/kyuubi-metrics/src/main/scala/org/apache/kyuubi/metrics/MetricsConstants.scala
@@ -26,7 +26,7 @@ object MetricsConstants {
   final val BUFFER_POOL: String = KYUUBI + "buffer_pool"
   final val THREAD_STATE: String = KYUUBI + "thread_state"
   final val CLASS_LOADING: String = KYUUBI + "class_loading"
-  final val JVM_ATTR: String = KYUUBI + "jvm_attr"
+  final val JVM: String = KYUUBI + "jvm"
 
   final val EXEC_POOL_ALIVE: String = KYUUBI + "exec.pool.threads.alive"
   final val EXEC_POOL_ACTIVE: String = KYUUBI + "exec.pool.threads.active"

--- a/kyuubi-metrics/src/main/scala/org/apache/kyuubi/metrics/MetricsSystem.scala
+++ b/kyuubi-metrics/src/main/scala/org/apache/kyuubi/metrics/MetricsSystem.scala
@@ -67,7 +67,7 @@ class MetricsSystem extends CompositeService("MetricsSystem") {
   }
 
   override def initialize(conf: KyuubiConf): Unit = synchronized {
-    registry.registerAll(MetricsConstants.JVM_ATTR, new JvmAttributeGaugeSet)
+    registry.registerAll(MetricsConstants.JVM, new JvmAttributeGaugeSet)
     registry.registerAll(MetricsConstants.GC_METRIC, new GarbageCollectorMetricSet)
     registry.registerAll(MetricsConstants.MEMORY_USAGE, new MemoryUsageGaugeSet)
     registry.registerAll(

--- a/kyuubi-metrics/src/main/scala/org/apache/kyuubi/metrics/MetricsSystem.scala
+++ b/kyuubi-metrics/src/main/scala/org/apache/kyuubi/metrics/MetricsSystem.scala
@@ -67,6 +67,7 @@ class MetricsSystem extends CompositeService("MetricsSystem") {
   }
 
   override def initialize(conf: KyuubiConf): Unit = synchronized {
+    registry.registerAll(MetricsConstants.JVM_ATTR, new JvmAttributeGaugeSet)
     registry.registerAll(MetricsConstants.GC_METRIC, new GarbageCollectorMetricSet)
     registry.registerAll(MetricsConstants.MEMORY_USAGE, new MemoryUsageGaugeSet)
     registry.registerAll(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
related issue : #2526 
i  just  make the grafana dashboard of kyuubi , but i can not get the metrics of kyuubi server start time. 

![图片](https://user-images.githubusercontent.com/18548053/236595754-b839e608-a087-43e6-8c31-9b6639e94138.png)

we can add JvmAttributeGaugeSet to get the uptime metrics of kyuubi .

![图片](https://user-images.githubusercontent.com/18548053/236595818-d0b6958d-f660-403f-8f72-a1ef6f679383.png)


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
