### PR TITLE
[ARROW] Reflective calls to the function `ArrowUtils#toArrowSchema`

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/sql/execution/arrow/KyuubiArrowConverters.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/sql/execution/arrow/KyuubiArrowConverters.scala
@@ -338,8 +338,8 @@ object KyuubiArrowConverters extends SQLConfHelper with Logging {
       errorOnDuplicatedFieldNames: Boolean): ArrowSchema = {
     toArrowSchemaMethod.invoke[ArrowSchema](
       ArrowUtils,
-      schema.asInstanceOf[Object],
-      timeZone.asInstanceOf[Object],
+      schema,
+      timeZone,
       errorOnDuplicatedFieldNames.asInstanceOf[Object])
   }
 

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/sql/execution/arrow/KyuubiArrowConverters.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/sql/execution/arrow/KyuubiArrowConverters.scala
@@ -26,6 +26,7 @@ import scala.collection.mutable.ArrayBuffer
 import org.apache.arrow.vector._
 import org.apache.arrow.vector.ipc.{ArrowStreamWriter, ReadChannel, WriteChannel}
 import org.apache.arrow.vector.ipc.message.{IpcOption, MessageSerializer}
+import org.apache.arrow.vector.types.pojo.{Schema => ArrowSchema}
 import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
@@ -35,6 +36,8 @@ import org.apache.spark.sql.execution.CollectLimitExec
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.ArrowUtils
 import org.apache.spark.util.Utils
+
+import org.apache.kyuubi.reflection.DynMethods
 
 object KyuubiArrowConverters extends SQLConfHelper with Logging {
 
@@ -60,7 +63,7 @@ object KyuubiArrowConverters extends SQLConfHelper with Logging {
       "slice",
       0,
       Long.MaxValue)
-    val arrowSchema = ArrowUtils.toArrowSchema(schema, timeZoneId)
+    val arrowSchema = toArrowSchema(schema, timeZoneId, true)
     vectorSchemaRoot = VectorSchemaRoot.create(arrowSchema, sliceAllocator)
     try {
       val recordBatch = MessageSerializer.deserializeRecordBatch(
@@ -238,7 +241,7 @@ object KyuubiArrowConverters extends SQLConfHelper with Logging {
       context: TaskContext)
     extends Iterator[Array[Byte]] {
 
-    protected val arrowSchema = ArrowUtils.toArrowSchema(schema, timeZoneId)
+    protected val arrowSchema = toArrowSchema(schema, timeZoneId, true)
     private val allocator =
       ArrowUtils.rootAllocator.newChildAllocator(
         s"to${this.getClass.getSimpleName}",
@@ -310,6 +313,47 @@ object KyuubiArrowConverters extends SQLConfHelper with Logging {
 
       out.toByteArray
     }
+  }
+
+  // the signature of function [[ArrowUtils.toArrowSchema]] is changed in SPARK-41971 (since Spark
+  // 3.5)
+  // before Spark 3.5
+  // {{
+  //   def toArrowSchema(schema: StructType, timeZoneId: String): Schema
+  // }}
+  // Spark 3.5
+  // {{
+  //   def toArrowSchema(
+  //      schema: StructType,
+  //      timeZoneId: String,
+  //      errorOnDuplicatedFieldNames: Boolean): Schema
+  // }}
+  private lazy val toArrowSchemaMethod = DynMethods.builder("toArrowSchema")
+    // for Spark 3.4 or previous
+    .impl(
+      "org.apache.spark.sql.util.ArrowUtils",
+      classOf[StructType],
+      classOf[String])
+    // for Spark 3.5 or later
+    .impl(
+      "org.apache.spark.sql.util.ArrowUtils",
+      classOf[StructType],
+      classOf[String],
+      classOf[Boolean])
+    .build()
+
+  /**
+   * this function uses reflective calls to the [[ArrowUtils.toArrowSchema]].
+   */
+  private def toArrowSchema(
+      schema: StructType,
+      timeZone: String,
+      errorOnDuplicatedFieldNames: Boolean): ArrowSchema = {
+    toArrowSchemaMethod.invoke[ArrowSchema](
+      ArrowUtils,
+      schema.asInstanceOf[Object],
+      timeZone.asInstanceOf[Object],
+      errorOnDuplicatedFieldNames.asInstanceOf[Object])
   }
 
   // for testing

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/sql/execution/arrow/KyuubiArrowConverters.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/sql/execution/arrow/KyuubiArrowConverters.scala
@@ -336,12 +336,12 @@ object KyuubiArrowConverters extends SQLConfHelper with Logging {
   private def toArrowSchema(
       schema: StructType,
       timeZone: String,
-      errorOnDuplicatedFieldNames: Boolean): ArrowSchema = {
+      errorOnDuplicatedFieldNames: JBoolean): ArrowSchema = {
     toArrowSchemaMethod.invoke[ArrowSchema](
       ArrowUtils,
       schema,
       timeZone,
-      new JBoolean(errorOnDuplicatedFieldNames))
+      errorOnDuplicatedFieldNames)
   }
 
   // for testing

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/sql/execution/arrow/KyuubiArrowConverters.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/sql/execution/arrow/KyuubiArrowConverters.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution.arrow
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+import java.lang.{Boolean => JBoolean}
 import java.nio.channels.Channels
 
 import scala.collection.JavaConverters._
@@ -338,9 +339,9 @@ object KyuubiArrowConverters extends SQLConfHelper with Logging {
       errorOnDuplicatedFieldNames: Boolean): ArrowSchema = {
     toArrowSchemaMethod.invoke[ArrowSchema](
       ArrowUtils,
-      schema.asInstanceOf[Object],
-      timeZone.asInstanceOf[Object],
-      errorOnDuplicatedFieldNames.asInstanceOf[Object])
+      schema,
+      timeZone,
+      new JBoolean(errorOnDuplicatedFieldNames))
   }
 
   // for testing

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/sql/execution/arrow/KyuubiArrowConverters.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/sql/execution/arrow/KyuubiArrowConverters.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution.arrow
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+import java.lang.{Boolean => JBoolean}
 import java.nio.channels.Channels
 
 import scala.collection.JavaConverters._
@@ -340,7 +341,7 @@ object KyuubiArrowConverters extends SQLConfHelper with Logging {
       ArrowUtils,
       schema,
       timeZone,
-      errorOnDuplicatedFieldNames.asInstanceOf[Object])
+      new JBoolean(errorOnDuplicatedFieldNames))
   }
 
   // for testing

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/sql/execution/arrow/KyuubiArrowConverters.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/sql/execution/arrow/KyuubiArrowConverters.scala
@@ -317,25 +317,12 @@ object KyuubiArrowConverters extends SQLConfHelper with Logging {
 
   // the signature of function [[ArrowUtils.toArrowSchema]] is changed in SPARK-41971 (since Spark
   // 3.5)
-  // before Spark 3.5
-  // {{
-  //   def toArrowSchema(schema: StructType, timeZoneId: String): Schema
-  // }}
-  // Spark 3.5
-  // {{
-  //   def toArrowSchema(
-  //      schema: StructType,
-  //      timeZoneId: String,
-  //      errorOnDuplicatedFieldNames: Boolean): Schema
-  // }}
   private lazy val toArrowSchemaMethod = DynMethods.builder("toArrowSchema")
-    // for Spark 3.4 or previous
-    .impl(
+    .impl( // for Spark 3.4 or previous
       "org.apache.spark.sql.util.ArrowUtils",
       classOf[StructType],
       classOf[String])
-    // for Spark 3.5 or later
-    .impl(
+    .impl( // for Spark 3.5 or later
       "org.apache.spark.sql.util.ArrowUtils",
       classOf[StructType],
       classOf[String],

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/sql/execution/arrow/KyuubiArrowConverters.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/sql/execution/arrow/KyuubiArrowConverters.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.execution.arrow
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
-import java.lang.{Boolean => JBoolean}
 import java.nio.channels.Channels
 
 import scala.collection.JavaConverters._
@@ -339,9 +338,9 @@ object KyuubiArrowConverters extends SQLConfHelper with Logging {
       errorOnDuplicatedFieldNames: Boolean): ArrowSchema = {
     toArrowSchemaMethod.invoke[ArrowSchema](
       ArrowUtils,
-      schema,
-      timeZone,
-      new JBoolean(errorOnDuplicatedFieldNames))
+      schema.asInstanceOf[Object],
+      timeZone.asInstanceOf[Object],
+      errorOnDuplicatedFieldNames.asInstanceOf[Object])
   }
 
   // for testing


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

to adapt Spark 3.5

the signature of function `ArrowUtils#toArrowSchema` is changed in https://github.com/apache/spark/pull/40988 (since Spark3.5)

Spark 3.4 or previous

```scala
   def toArrowSchema(schema: StructType, timeZoneId: String): Schema
```

Spark 3.5 or later
```scala
   def toArrowSchema(
      schema: StructType,
      timeZoneId: String,
      errorOnDuplicatedFieldNames: Boolean): Schema
```

Kyuubi is not affected by the issue of duplicated nested field names, as it consistently converts struct types to string types in Arrow mode

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
