### PR TITLE
[CHAT] Set session user in ChatGPT request

### DIFF
--- a/externals/kyuubi-chat-engine/src/main/scala/org/apache/kyuubi/engine/chat/provider/ChatProvider.scala
+++ b/externals/kyuubi-chat-engine/src/main/scala/org/apache/kyuubi/engine/chat/provider/ChatProvider.scala
@@ -28,7 +28,7 @@ import org.apache.kyuubi.reflection.DynConstructors
 
 trait ChatProvider {
 
-  def open(sessionId: String): Unit
+  def open(sessionId: String, user: Option[String] = None): Unit
 
   def ask(sessionId: String, q: String): String
 

--- a/externals/kyuubi-chat-engine/src/main/scala/org/apache/kyuubi/engine/chat/provider/EchoProvider.scala
+++ b/externals/kyuubi-chat-engine/src/main/scala/org/apache/kyuubi/engine/chat/provider/EchoProvider.scala
@@ -19,7 +19,7 @@ package org.apache.kyuubi.engine.chat.provider
 
 class EchoProvider extends ChatProvider {
 
-  override def open(sessionId: String): Unit = {}
+  override def open(sessionId: String, user: Option[String]): Unit = {}
 
   override def ask(sessionId: String, q: String): String =
     "This is ChatKyuubi, nice to meet you!"

--- a/externals/kyuubi-chat-engine/src/main/scala/org/apache/kyuubi/engine/chat/session/ChatSessionImpl.scala
+++ b/externals/kyuubi-chat-engine/src/main/scala/org/apache/kyuubi/engine/chat/session/ChatSessionImpl.scala
@@ -38,7 +38,7 @@ class ChatSessionImpl(
 
   override def open(): Unit = {
     info(s"Starting to open chat session.")
-    chatProvider.open(handle.identifier.toString)
+    chatProvider.open(handle.identifier.toString, Some(user))
     super.open()
     info(s"The chat session is started.")
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- set session user when opening instance of ChatProvider
- use session user in ChatGPT request, to identify user of message and better monitor and abuse detection by OpenAI report( https://platform.openai.com/docs/api-reference/chat/create#chat/create-user)

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
