### PR TITLE
[CHAT] Request and use a sginle choice for chat completion

### DIFF
--- a/externals/kyuubi-chat-engine/src/main/scala/org/apache/kyuubi/engine/chat/provider/ChatGPTProvider.scala
+++ b/externals/kyuubi-chat-engine/src/main/scala/org/apache/kyuubi/engine/chat/provider/ChatGPTProvider.scala
@@ -83,9 +83,10 @@ class ChatGPTProvider(conf: KyuubiConf) extends ChatProvider {
         .model(conf.get(KyuubiConf.ENGINE_CHAT_GPT_MODEL))
         .messages(messages.asScala.toList.asJava)
         .user(sessionUser.orNull)
+        .n(1)
         .build()
-      val responseText = openAiService.createChatCompletion(completionRequest).getChoices.asScala
-        .map(c => c.getMessage.getContent).mkString
+      val responseText = openAiService.createChatCompletion(completionRequest)
+        .getChoices.get(0).getMessage.getContent
       responseText
     } catch {
       case e: Throwable =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- explicitly set `n` to 1 in ChatGPT chat completion request (default to 1, https://platform.openai.com/docs/api-reference/chat/create#chat/create-n)
- use the only one choice of the chat completion response

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
