### PR TITLE
[K8S][HELM] Refactor liveness and readiness probes

### DIFF
--- a/charts/kyuubi/templates/kyuubi-deployment.yaml
+++ b/charts/kyuubi/templates/kyuubi-deployment.yaml
@@ -65,25 +65,25 @@ spec:
               containerPort: {{ $frontend.port }}
             {{- end }}
             {{- end }}
-          {{- if .Values.probe.liveness.enabled }}
+          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             exec:
               command: ["/bin/bash", "-c", "bin/kyuubi status"]
-            initialDelaySeconds: {{ .Values.probe.liveness.initialDelaySeconds }}
-            periodSeconds: {{ .Values.probe.liveness.periodSeconds }}
-            timeoutSeconds: {{ .Values.probe.liveness.timeoutSeconds }}
-            failureThreshold: {{ .Values.probe.liveness.failureThreshold }}
-            successThreshold: {{ .Values.probe.liveness.successThreshold }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
           {{- end }}
-          {{- if .Values.probe.readiness.enabled }}
+          {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             exec:
               command: ["/bin/bash", "-c", "$KYUUBI_HOME/bin/kyuubi status"]
-            initialDelaySeconds: {{ .Values.probe.readiness.initialDelaySeconds }}
-            periodSeconds: {{ .Values.probe.readiness.periodSeconds }}
-            timeoutSeconds: {{ .Values.probe.readiness.timeoutSeconds }}
-            failureThreshold: {{ .Values.probe.readiness.failureThreshold }}
-            successThreshold: {{ .Values.probe.readiness.successThreshold }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
           {{- end }}
           {{- with .Values.resources }}
           resources: {{- toYaml . | nindent 12 }}

--- a/charts/kyuubi/values.yaml
+++ b/charts/kyuubi/values.yaml
@@ -41,22 +41,6 @@ rbac:
       resources: ["pods"]
       verbs: ["create", "list", "delete"]
 
-probe:
-  liveness:
-    enabled: true
-    initialDelaySeconds: 30
-    periodSeconds: 10
-    timeoutSeconds: 2
-    failureThreshold: 10
-    successThreshold: 1
-  readiness:
-    enabled: true
-    initialDelaySeconds: 30
-    periodSeconds: 10
-    timeoutSeconds: 2
-    failureThreshold: 10
-    successThreshold: 1
-
 server:
   # Thrift Binary protocol (HiveServer2 compatible)
   thriftBinary:
@@ -161,6 +145,24 @@ resources: {}
   # requests:
   #   cpu: 2
   #   memory: 4Gi
+
+# Liveness probe
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 2
+  failureThreshold: 10
+  successThreshold: 1
+
+# Readiness probe
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 2
+  failureThreshold: 10
+  successThreshold: 1
 
 # Constrain Kyuubi server pods to specific nodes
 nodeSelector: {}


### PR DESCRIPTION
### _Why are the changes needed?_
The changes are needed to follow common flat structure pattern for liveness and readiness probes, for example:
- [Airflow](https://github.com/apache/airflow/blob/584a9f5dae5b29a1968fbdbc9b1edd01ae2be4d2/chart/values.yaml#L961-L973)
- [Superset](https://github.com/apache/superset/blob/e3719a1b076228dcfae3cdd82844bdfe48b552ec/helm/superset/values.yaml#L300-L317)
- [Bitnami PostgreSQL](https://github.com/bitnami/charts/blob/8f2277440b976d52785ba9149762ad8620a73d1f/bitnami/postgresql/values.yaml#L390-L410)
- [ArgoCD](https://github.com/argoproj/argo-helm/blob/b37a9e72a68d8fafe3cddd14cf2b3ed6722eff4a/charts/argo-cd/values.yaml#L1631-L1653)

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
