### PR TITLE
[KYUUBI #4821] Avoid socket leak in KyuubiSessionImpl

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
@@ -249,7 +249,16 @@ class KyuubiSessionImpl(
     super.close()
     sessionManager.credentialsManager.removeSessionCredentialsEpoch(handle.identifier.toString)
     try {
-      if (_client != null) _client.closeSession()
+      if (_client != null) {
+        _client.closeSession()
+      } else {
+        Option(launchEngineOp).foreach { op =>
+          if (op.getBackgroundHandle != null) {
+            logSessionInfo(s"Abort background engine launch task due to session closed")
+            op.getBackgroundHandle.cancel(true)
+          }
+        }
+      }
     } finally {
       openSessionError.foreach { _ => if (engine != null) engine.close() }
       sessionEvent.endTime = System.currentTimeMillis()


### PR DESCRIPTION


### _Why are the changes needed?_
See [KYUUBI #4821] 


### _How was this patch tested?_
![image](https://github.com/apache/kyuubi/assets/57993550/4fca4cf0-3d34-474f-94b9-c6f618a23be5)
Picture indicates that backgroup engine launch task was canceled
