### PR TITLE
Move "broken engine test" ut to connection share  level test suite

### DIFF
--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
@@ -313,7 +313,7 @@ class KyuubiOperationPerConnectionSuite extends WithKyuubiServer with HiveJDBCTe
         session.client.getEngineAliveProbeProtocol.foreach(_.getTransport.close())
 
         val exitReq = new TExecuteStatementReq()
-        exitReq.setStatement("SELECT java_method('java.lang.Thread', 'sleep', 50L)," +
+        exitReq.setStatement("SELECT java_method('java.lang.Thread', 'sleep', 1000L)," +
           "java_method('java.lang.System', 'exit', 1)")
         exitReq.setSessionHandle(handle)
         exitReq.setRunAsync(true)
@@ -334,6 +334,7 @@ class KyuubiOperationPerConnectionSuite extends WithKyuubiServer with HiveJDBCTe
             "connection does not exist"))
         val elapsedTime = System.currentTimeMillis() - startTime
         assert(elapsedTime < 20 * 1000)
+        Thread.sleep(1000)    // wait until the async exitReq forced closing the engine
         assert(session.client.asyncRequestInterrupted)
       }
     }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
@@ -313,7 +313,7 @@ class KyuubiOperationPerConnectionSuite extends WithKyuubiServer with HiveJDBCTe
         session.client.getEngineAliveProbeProtocol.foreach(_.getTransport.close())
 
         val exitReq = new TExecuteStatementReq()
-        exitReq.setStatement("SELECT java_method('java.lang.Thread', 'sleep', 10L)," +
+        exitReq.setStatement("SELECT java_method('java.lang.Thread', 'sleep', 1L)," +
           "java_method('java.lang.System', 'exit', 1)")
         exitReq.setSessionHandle(handle)
         exitReq.setRunAsync(true)

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
@@ -313,7 +313,7 @@ class KyuubiOperationPerConnectionSuite extends WithKyuubiServer with HiveJDBCTe
         session.client.getEngineAliveProbeProtocol.foreach(_.getTransport.close())
 
         val exitReq = new TExecuteStatementReq()
-        exitReq.setStatement("SELECT java_method('java.lang.Thread', 'sleep', 1L)," +
+        exitReq.setStatement("SELECT java_method('java.lang.Thread', 'sleep', 50L)," +
           "java_method('java.lang.System', 'exit', 1)")
         exitReq.setSessionHandle(handle)
         exitReq.setRunAsync(true)

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
@@ -313,7 +313,7 @@ class KyuubiOperationPerConnectionSuite extends WithKyuubiServer with HiveJDBCTe
         session.client.getEngineAliveProbeProtocol.foreach(_.getTransport.close())
 
         val exitReq = new TExecuteStatementReq()
-        exitReq.setStatement("SELECT java_method('java.lang.Thread', 'sleep', 1000L)," +
+        exitReq.setStatement("SELECT java_method('java.lang.Thread', 'sleep', 10L)," +
           "java_method('java.lang.System', 'exit', 1)")
         exitReq.setSessionHandle(handle)
         exitReq.setRunAsync(true)

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
@@ -34,12 +34,13 @@ import org.apache.kyuubi.jdbc.KyuubiHiveDriver
 import org.apache.kyuubi.jdbc.hive.{KyuubiConnection, KyuubiSQLException}
 import org.apache.kyuubi.metrics.{MetricsConstants, MetricsSystem}
 import org.apache.kyuubi.plugin.SessionConfAdvisor
-import org.apache.kyuubi.session.{KyuubiSessionManager, SessionType}
+import org.apache.kyuubi.session.{KyuubiSessionImpl, KyuubiSessionManager, SessionHandle, SessionType}
 
 /**
  * UT with Connection level engine shared cost much time, only run basic jdbc tests.
  */
-class KyuubiOperationPerConnectionSuite extends WithKyuubiServer with HiveJDBCTestHelper {
+class KyuubiOperationPerConnectionSuite extends WithKyuubiServer with HiveJDBCTestHelper
+  with SparkQueryTests {
 
   override protected def jdbcUrl: String =
     s"jdbc:kyuubi://${server.frontendServices.head.connectionUrl}/;"
@@ -289,6 +290,52 @@ class KyuubiOperationPerConnectionSuite extends WithKyuubiServer with HiveJDBCTe
         "SELECT raise_error('client should catch this exception');")
       val e = intercept[KyuubiSQLException](resultSet.next())
       assert(e.getMessage.contains("client should catch this exception"))
+    }
+  }
+
+  test("support to interrupt the thrift request if remote engine is broken") {
+    assume(!httpMode)
+    withSessionConf(Map(
+      KyuubiConf.ENGINE_ALIVE_PROBE_ENABLED.key -> "true",
+      KyuubiConf.ENGINE_ALIVE_PROBE_INTERVAL.key -> "1000",
+      KyuubiConf.ENGINE_ALIVE_TIMEOUT.key -> "1000"))(Map.empty)(
+      Map.empty) {
+      withSessionHandle { (client, handle) =>
+        val preReq = new TExecuteStatementReq()
+        preReq.setStatement("select engine_name()")
+        preReq.setSessionHandle(handle)
+        preReq.setRunAsync(false)
+        client.ExecuteStatement(preReq)
+
+        val sessionHandle = SessionHandle(handle)
+        val session = server.backendService.sessionManager.asInstanceOf[KyuubiSessionManager]
+          .getSession(sessionHandle).asInstanceOf[KyuubiSessionImpl]
+        session.client.getEngineAliveProbeProtocol.foreach(_.getTransport.close())
+
+        val exitReq = new TExecuteStatementReq()
+        exitReq.setStatement("SELECT java_method('java.lang.Thread', 'sleep', 1000L)," +
+          "java_method('java.lang.System', 'exit', 1)")
+        exitReq.setSessionHandle(handle)
+        exitReq.setRunAsync(true)
+        client.ExecuteStatement(exitReq)
+
+        val executeStmtReq = new TExecuteStatementReq()
+        executeStmtReq.setStatement("SELECT java_method('java.lang.Thread', 'sleep', 30000l)")
+        executeStmtReq.setSessionHandle(handle)
+        executeStmtReq.setRunAsync(false)
+        val startTime = System.currentTimeMillis()
+        val executeStmtResp = client.ExecuteStatement(executeStmtReq)
+        assert(executeStmtResp.getStatus.getStatusCode === TStatusCode.ERROR_STATUS)
+        assert(executeStmtResp.getStatus.getErrorMessage.contains(
+          "java.net.SocketException") ||
+          executeStmtResp.getStatus.getErrorMessage.contains(
+            "org.apache.thrift.transport.TTransportException") ||
+          executeStmtResp.getStatus.getErrorMessage.contains(
+            "connection does not exist"))
+        val elapsedTime = System.currentTimeMillis() - startTime
+        assert(elapsedTime < 20 * 1000)
+        assert(session.client.asyncRequestInterrupted)
+      }
     }
   }
 }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
@@ -334,7 +334,7 @@ class KyuubiOperationPerConnectionSuite extends WithKyuubiServer with HiveJDBCTe
             "connection does not exist"))
         val elapsedTime = System.currentTimeMillis() - startTime
         assert(elapsedTime < 20 * 1000)
-        Thread.sleep(1000)    // wait until the async exitReq forced closing the engine
+        Thread.sleep(1000) // wait until the async exitReq forced closing the engine
         assert(session.client.asyncRequestInterrupted)
       }
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- Move "support to interrupt the thrift request if remote engine is broken" test case into connection share-level test suite
- in order to avoid the async action of shutdown / restart engine fails the following test case , e.g. "max result rows" case.


```
- support to interrupt the thrift request if remote engine is broken
- max result rows *** FAILED ***
  org.apache.kyuubi.jdbc.hive.KyuubiSQLException: Error operating ExecuteStatement: org.apache.thrift.transport.TTransportException: java.net.SocketException: Broken pipe (Write failed)
	at org.apache.thrift.transport.TIOStreamTransport.flush(TIOStreamTransport.java:161)
	at org.apache.thrift.transport.TSaslTransport.flush(TSaslTransport.java:501)
	at org.apache.thrift.transport.TSaslClientTransport.flush(TSaslClientTransport.java:37)
	at org.apache.thrift.TServiceClient.sendBase(TServiceClient.java:73)
	at org.apache.thrift.TServiceClient.sendBase(TServiceClient.java:62)
	at org.apache.hive.service.rpc.thrift.TCLIService$Client.send_ExecuteStatement(TCLIService.java:239)
	at org.apache.hive.service.rpc.thrift.TCLIService$Client.ExecuteStatement(TCLIService.java:231)
	at org.apache.kyuubi.client.KyuubiSyncThriftClient.$anonfun$executeStatement$1(KyuubiSyncThriftClient.scala:250)
	at org.apache.kyuubi.client.KyuubiSyncThriftClient.$anonfun$withLockAcquiredAsyncRequest$2(KyuubiSyncThriftClient.scala:149)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.net.SocketException: Broken pipe (Write failed)
	at java.base/java.net.SocketOutputStream.socketWrite0(Native Method)
	at java.base/java.net.SocketOutputStream.socketWrite(SocketOutputStream.java:110)
	at java.base/java.net.SocketOutputStream.write(SocketOutputStream.java:150)
	at java.base/java.io.BufferedOutputStream.flushBuffer(BufferedOutputStream.java:81)
	at java.base/java.io.BufferedOutputStream.flush(BufferedOutputStream.java:142)
	at org.apache.thrift.transport.TIOStreamTransport.flush(TIOStreamTransport.java:159)
	... 13 more
  at org.apache.kyuubi.jdbc.hive.Utils.verifySuccess(Utils.java:90)
  at org.apache.kyuubi.jdbc.hive.Utils.verifySuccessWithInfo(Utils.java:76)
  at org.apache.kyuubi.jdbc.hive.KyuubiStatement.runAsyncOnServer(KyuubiStatement.java:339)
  at org.apache.kyuubi.jdbc.hive.KyuubiStatement.executeWithConfOverlay(KyuubiStatement.java:199)
  at org.apache.kyuubi.jdbc.hive.KyuubiStatement.execute(KyuubiStatement.java:194)
  at org.apache.kyuubi.operation.JDBCTestHelper.$anonfun$withMultipleConnectionJdbcStatement$4(JDBCTestHelper.scala:66)
  at org.apache.kyuubi.operation.JDBCTestHelper.$anonfun$withMultipleConnectionJdbcStatement$4$adapted(JDBCTestHelper.scala:62)
  at scala.collection.IndexedSeqOptimized.foreach(IndexedSeqOptimized.scala:36)
  at scala.collection.IndexedSeqOptimized.foreach$(IndexedSeqOptimized.scala:33)
  at scala.collection.mutable.WrappedArray.foreach(WrappedArray.scala:38)
  ...
  Cause: java.lang.RuntimeException: org.apache.kyuubi.KyuubiSQLException:Error operating ExecuteStatement: org.apache.thrift.transport.TTransportException: java.net.SocketException: Broken pipe (Write failed)
	at org.apache.thrift.transport.TIOStreamTransport.flush(TIOStreamTransport.java:161)
	at org.apache.thrift.transport.TSaslTransport.flush(TSaslTransport.java:501)
	at org.apache.thrift.transport.TSaslClientTransport.flush(TSaslClientTransport.java:37)
	at org.apache.thrift.TServiceClient.sendBase(TServiceClient.java:73)
	at org.apache.thrift.TServiceClient.sendBase(TServiceClient.java:62)
	at org.apache.hive.service.rpc.thrift.TCLIService$Client.send_ExecuteStatement(TCLIService.java:239)
	at org.apache.hive.service.rpc.thrift.TCLIService$Client.ExecuteStatement(TCLIService.java:231)
	at org.apache.kyuubi.client.KyuubiSyncThriftClient.$anonfun$executeStatement$1(KyuubiSyncThriftClient.scala:250)
	at org.apache.kyuubi.client.KyuubiSyncThriftClient.$anonfun$withLockAcquiredAsyncRequest$2(KyuubiSyncThriftClient.scala:149)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.net.SocketException: Broken pipe (Write failed)
	at java.base/java.net.SocketOutputStream.socketWrite0(Native Method)
	at java.base/java.net.SocketOutputStream.socketWrite(SocketOutputStream.java:110)
	at java.base/java.net.SocketOutputStream.write(SocketOutputStream.java:150)
	at java.base/java.io.BufferedOutputStream.flushBuffer(BufferedOutputStream.java:81)
	at java.base/java.io.BufferedOutputStream.flush(BufferedOutputStream.java:142)
	at org.apache.thrift.transport.TIOStreamTransport.flush(TIOStreamTransport.java:159)
	... 13 more
  at org.apache.kyuubi.KyuubiSQLException$.apply(KyuubiSQLException.scala:69)
  at org.apache.kyuubi.operation.KyuubiOperation$$anonfun$onError$1.$anonfun$applyOrElse$1(KyuubiOperation.scala:79)
  at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
  at org.apache.kyuubi.Utils$.withLockRequired(Utils.scala:415)
  at org.apache.kyuubi.operation.AbstractOperation.withLockRequired(AbstractOperation.scala:51)
  at org.apache.kyuubi.operation.KyuubiOperation$$anonfun$onError$1.applyOrElse(KyuubiOperation.scala:63)
  at org.apache.kyuubi.operation.KyuubiOperation$$anonfun$onError$1.applyOrElse(KyuubiOperation.scala:60)
  at scala.runtime.AbstractPartialFunction.apply(AbstractPartialFunction.scala:38)
  at org.apache.kyuubi.operation.ExecuteStatement.executeStatement(ExecuteStatement.scala:69)
  at org.apache.kyuubi.operation.ExecuteStatement.runInternal(ExecuteStatement.scala:160)
  ...
  Cause: org.apache.thrift.transport.TTransportException: java.net.SocketException: Broken pipe (Write failed)
  at org.apache.thrift.transport.TIOStreamTransport.flush(TIOStreamTransport.java:161)
  at org.apache.thrift.transport.TSaslTransport.flush(TSaslTransport.java:501)
  at org.apache.thrift.transport.TSaslClientTransport.flush(TSaslClientTransport.java:37)
  at org.apache.thrift.TServiceClient.sendBase(TServiceClient.java:73)
  at org.apache.thrift.TServiceClient.sendBase(TServiceClient.java:62)
  at org.apache.hive.service.rpc.thrift.TCLIService$Client.send_ExecuteStatement(TCLIService.java:239)
  at org.apache.hive.service.rpc.thrift.TCLIService$Client.ExecuteStatement(TCLIService.java:231)
  at org.apache.kyuubi.client.KyuubiSyncThriftClient.$anonfun$executeStatement$1(KyuubiSyncThriftClient.scala:250)
  at org.apache.kyuubi.client.KyuubiSyncThriftClient.$anonfun$withLockAcquiredAsyncRequest$2(KyuubiSyncThriftClient.scala:149)
  at java.util.concurrent.FutureTask.run(FutureTask.java:264)
  ...
  Cause: java.net.SocketException: Broken pipe (Write failed)
  at java.net.SocketOutputStream.socketWrite0(Native Method)
  at java.net.SocketOutputStream.socketWrite(SocketOutputStream.java:110)
  at java.net.SocketOutputStream.write(SocketOutputStream.java:150)
  at java.io.BufferedOutputStream.flushBuffer(BufferedOutputStream.java:81)
  at java.io.BufferedOutputStream.flush(BufferedOutputStream.java:142)
  at org.apache.thrift.transport.TIOStreamTransport.flush(TIOStreamTransport.java:159)
  at org.apache.thrift.transport.TSaslTransport.flush(TSaslTransport.java:501)
  at org.apache.thrift.transport.TSaslClientTransport.flush(TSaslClientTransport.java:37)
  at org.apache.thrift.TServiceClient.sendBase(TServiceClient.java:73)
  at org.apache.thrift.TServiceClient.sendBase(TServiceClient.java:62)
  ...
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
