### PR TITLE
Fix operation exception leak issue

### DIFF
--- a/externals/kyuubi-chat-engine/src/main/scala/org/apache/kyuubi/engine/chat/operation/ChatOperation.scala
+++ b/externals/kyuubi-chat-engine/src/main/scala/org/apache/kyuubi/engine/chat/operation/ChatOperation.scala
@@ -58,7 +58,7 @@ abstract class ChatOperation(session: Session) extends AbstractOperation(session
     cleanup(OperationState.CLOSED)
   }
 
-  protected def onError(cancel: Boolean = false): PartialFunction[Throwable, Unit] = {
+  protected def onError(): PartialFunction[Throwable, Unit] = {
     // We should use Throwable instead of Exception since `java.lang.NoClassDefFoundError`
     // could be thrown.
     case e: Throwable =>

--- a/externals/kyuubi-chat-engine/src/main/scala/org/apache/kyuubi/engine/chat/operation/ChatOperation.scala
+++ b/externals/kyuubi-chat-engine/src/main/scala/org/apache/kyuubi/engine/chat/operation/ChatOperation.scala
@@ -58,7 +58,7 @@ abstract class ChatOperation(session: Session) extends AbstractOperation(session
     cleanup(OperationState.CLOSED)
   }
 
-  protected def onError(): PartialFunction[Throwable, Unit] = {
+  override protected def onError(): PartialFunction[Throwable, Unit] = {
     // We should use Throwable instead of Exception since `java.lang.NoClassDefFoundError`
     // could be thrown.
     case e: Throwable =>

--- a/externals/kyuubi-chat-engine/src/main/scala/org/apache/kyuubi/engine/chat/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-chat-engine/src/main/scala/org/apache/kyuubi/engine/chat/operation/ExecuteStatement.scala
@@ -40,7 +40,7 @@ class ExecuteStatement(
         executeStatement()
       }
     }
-    val backgroundHandle = submitBackgroundOperation(asyncOperation)
+    val backgroundHandle = submitInBackground(asyncOperation)
     setBackgroundHandle(backgroundHandle)
     if (!shouldRunAsync) getBackgroundHandle.get()
   }

--- a/externals/kyuubi-chat-engine/src/main/scala/org/apache/kyuubi/engine/chat/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-chat-engine/src/main/scala/org/apache/kyuubi/engine/chat/operation/ExecuteStatement.scala
@@ -57,8 +57,6 @@ class ExecuteStatement(
       iter = new ArrayFetchIterator(Array(Array(reply)))
 
       setState(OperationState.FINISHED)
-    } catch {
-      onError(true)
     } finally {
       shutdownTimeoutMonitor()
     }

--- a/externals/kyuubi-chat-engine/src/main/scala/org/apache/kyuubi/engine/chat/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-chat-engine/src/main/scala/org/apache/kyuubi/engine/chat/operation/ExecuteStatement.scala
@@ -35,18 +35,14 @@ class ExecuteStatement(
 
   override protected def runInternal(): Unit = {
     addTimeoutMonitor(queryTimeout)
-    if (shouldRunAsync) {
-      val asyncOperation = new Runnable {
-        override def run(): Unit = {
-          executeStatement()
-        }
+    val asyncOperation = new Runnable {
+      override def run(): Unit = {
+        executeStatement()
       }
-      val chatSessionManager = session.sessionManager
-      val backgroundHandle = chatSessionManager.submitBackgroundOperation(asyncOperation)
-      setBackgroundHandle(backgroundHandle)
-    } else {
-      executeStatement()
     }
+    val backgroundHandle = submitBackgroundOperation(asyncOperation)
+    setBackgroundHandle(backgroundHandle)
+    if (!shouldRunAsync) getBackgroundHandle.get()
   }
 
   private def executeStatement(): Unit = {

--- a/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/ExecuteStatement.scala
@@ -66,8 +66,6 @@ class ExecuteStatement(
       jobId = FlinkEngineUtils.getResultJobId(resultFetcher)
       resultSet = ResultSetUtil.fromResultFetcher(resultFetcher, resultMaxRows)
       setState(OperationState.FINISHED)
-    } catch {
-      onError(cancel = true)
     } finally {
       shutdownTimeoutMonitor()
     }

--- a/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/FlinkOperation.scala
+++ b/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/FlinkOperation.scala
@@ -117,7 +117,7 @@ abstract class FlinkOperation(session: Session) extends AbstractOperation(sessio
 
   override def shouldRunAsync: Boolean = false
 
-  protected def onError(cancel: Boolean = false): PartialFunction[Throwable, Unit] = {
+  protected def onError(): PartialFunction[Throwable, Unit] = {
     // We should use Throwable instead of Exception since `java.lang.NoClassDefFoundError`
     // could be thrown.
     case e: Throwable =>

--- a/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/FlinkOperation.scala
+++ b/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/FlinkOperation.scala
@@ -117,7 +117,7 @@ abstract class FlinkOperation(session: Session) extends AbstractOperation(sessio
 
   override def shouldRunAsync: Boolean = false
 
-  protected def onError(): PartialFunction[Throwable, Unit] = {
+  override protected def onError(): PartialFunction[Throwable, Unit] = {
     // We should use Throwable instead of Exception since `java.lang.NoClassDefFoundError`
     // could be thrown.
     case e: Throwable =>

--- a/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/GetCatalogs.scala
+++ b/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/GetCatalogs.scala
@@ -26,10 +26,8 @@ import org.apache.kyuubi.session.Session
 class GetCatalogs(session: Session) extends FlinkOperation(session) {
 
   override protected def runInternal(): Unit = {
-    try {
-      val catalogManager = sessionContext.getSessionState.catalogManager
-      val catalogs = catalogManager.listCatalogs.toList
-      resultSet = ResultSetUtil.stringListToResultSet(catalogs, TABLE_CAT)
-    } catch onError()
+    val catalogManager = sessionContext.getSessionState.catalogManager
+    val catalogs = catalogManager.listCatalogs.toList
+    resultSet = ResultSetUtil.stringListToResultSet(catalogs, TABLE_CAT)
   }
 }

--- a/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/GetCurrentCatalog.scala
+++ b/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/GetCurrentCatalog.scala
@@ -30,9 +30,7 @@ class GetCurrentCatalog(session: Session) extends FlinkOperation(session) {
   override def getOperationLog: Option[OperationLog] = Option(operationLog)
 
   override protected def runInternal(): Unit = {
-    try {
-      val catalog = executor.getCurrentCatalog
-      resultSet = ResultSetUtil.stringListToResultSet(List(catalog), TABLE_CAT)
-    } catch onError()
+    val catalog = executor.getCurrentCatalog
+    resultSet = ResultSetUtil.stringListToResultSet(List(catalog), TABLE_CAT)
   }
 }

--- a/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/GetCurrentDatabase.scala
+++ b/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/GetCurrentDatabase.scala
@@ -30,9 +30,7 @@ class GetCurrentDatabase(session: Session) extends FlinkOperation(session) {
   override def getOperationLog: Option[OperationLog] = Option(operationLog)
 
   override protected def runInternal(): Unit = {
-    try {
-      val database = sessionContext.getSessionState.catalogManager.getCurrentDatabase
-      resultSet = ResultSetUtil.stringListToResultSet(List(database), TABLE_SCHEM)
-    } catch onError()
+    val database = sessionContext.getSessionState.catalogManager.getCurrentDatabase
+    resultSet = ResultSetUtil.stringListToResultSet(List(database), TABLE_SCHEM)
   }
 }

--- a/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/GetSchemas.scala
+++ b/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/GetSchemas.scala
@@ -34,24 +34,20 @@ class GetSchemas(session: Session, catalogName: String, schema: String)
   extends FlinkOperation(session) {
 
   override protected def runInternal(): Unit = {
-    try {
-      val schemaPattern = toJavaRegex(schema)
-      val catalogManager = sessionContext.getSessionState.catalogManager
-      val schemas = catalogManager.listCatalogs()
-        .filter { c => StringUtils.isEmpty(catalogName) || c == catalogName }
-        .flatMap { c =>
-          val catalog = catalogManager.getCatalog(c).get()
-          filterPattern(catalog.listDatabases().asScala, schemaPattern)
-            .map { d => Row.of(d, c) }
-        }.toArray
-      resultSet = ResultSet.builder.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
-        .columns(
-          Column.physical(TABLE_SCHEM, DataTypes.STRING()),
-          Column.physical(TABLE_CATALOG, DataTypes.STRING()))
-        .data(schemas)
-        .build
-    } catch {
-      onError()
-    }
+    val schemaPattern = toJavaRegex(schema)
+    val catalogManager = sessionContext.getSessionState.catalogManager
+    val schemas = catalogManager.listCatalogs()
+      .filter { c => StringUtils.isEmpty(catalogName) || c == catalogName }
+      .flatMap { c =>
+        val catalog = catalogManager.getCatalog(c).get()
+        filterPattern(catalog.listDatabases().asScala, schemaPattern)
+          .map { d => Row.of(d, c) }
+      }.toArray
+    resultSet = ResultSet.builder.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
+      .columns(
+        Column.physical(TABLE_SCHEM, DataTypes.STRING()),
+        Column.physical(TABLE_CATALOG, DataTypes.STRING()))
+      .data(schemas)
+      .build
   }
 }

--- a/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/GetTypeInfo.scala
+++ b/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/GetTypeInfo.scala
@@ -60,61 +60,57 @@ class GetTypeInfo(session: Session) extends FlinkOperation(session) {
   }
 
   override protected def runInternal(): Unit = {
-    try {
-      val dataTypes: Array[Row] = Array(
-        toRow(LogicalTypeRoot.CHAR.name(), CHAR),
-        toRow(LogicalTypeRoot.VARCHAR.name(), VARCHAR),
-        toRow(LogicalTypeRoot.BOOLEAN.name(), BOOLEAN),
-        toRow(LogicalTypeRoot.BINARY.name(), BINARY),
-        toRow(LogicalTypeRoot.VARBINARY.name(), VARBINARY),
-        toRow(LogicalTypeRoot.DECIMAL.name(), DECIMAL, 38),
-        toRow(LogicalTypeRoot.TINYINT.name(), TINYINT, 3),
-        toRow(LogicalTypeRoot.SMALLINT.name(), SMALLINT, 5),
-        toRow(LogicalTypeRoot.INTEGER.name(), INTEGER, 10),
-        toRow(LogicalTypeRoot.BIGINT.name(), BIGINT, 19),
-        toRow(LogicalTypeRoot.FLOAT.name(), FLOAT, 7),
-        toRow(LogicalTypeRoot.DOUBLE.name(), DOUBLE, 15),
-        toRow(LogicalTypeRoot.DATE.name(), DATE),
-        toRow(LogicalTypeRoot.TIME_WITHOUT_TIME_ZONE.name(), TIME),
-        toRow(LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE.name(), TIMESTAMP),
-        toRow(LogicalTypeRoot.TIMESTAMP_WITH_TIME_ZONE.name(), TIMESTAMP_WITH_TIMEZONE),
-        toRow(LogicalTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE.name(), TIMESTAMP_WITH_TIMEZONE),
-        toRow(LogicalTypeRoot.INTERVAL_YEAR_MONTH.name(), OTHER),
-        toRow(LogicalTypeRoot.INTERVAL_DAY_TIME.name(), OTHER),
-        toRow(LogicalTypeRoot.ARRAY.name(), ARRAY),
-        toRow(LogicalTypeRoot.MULTISET.name(), JAVA_OBJECT),
-        toRow(LogicalTypeRoot.MAP.name(), JAVA_OBJECT),
-        toRow(LogicalTypeRoot.ROW.name(), JAVA_OBJECT),
-        toRow(LogicalTypeRoot.DISTINCT_TYPE.name(), OTHER),
-        toRow(LogicalTypeRoot.STRUCTURED_TYPE.name(), OTHER),
-        toRow(LogicalTypeRoot.NULL.name(), NULL),
-        toRow(LogicalTypeRoot.RAW.name(), OTHER),
-        toRow(LogicalTypeRoot.SYMBOL.name(), OTHER),
-        toRow(LogicalTypeRoot.UNRESOLVED.name(), OTHER))
-      resultSet = ResultSet.builder.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
-        .columns(
-          Column.physical(TYPE_NAME, DataTypes.STRING()),
-          Column.physical(DATA_TYPE, DataTypes.INT()),
-          Column.physical(PRECISION, DataTypes.INT()),
-          Column.physical("LITERAL_PREFIX", DataTypes.STRING()),
-          Column.physical("LITERAL_SUFFIX", DataTypes.STRING()),
-          Column.physical("CREATE_PARAMS", DataTypes.STRING()),
-          Column.physical(NULLABLE, DataTypes.SMALLINT()),
-          Column.physical(CASE_SENSITIVE, DataTypes.BOOLEAN()),
-          Column.physical(SEARCHABLE, DataTypes.SMALLINT()),
-          Column.physical("UNSIGNED_ATTRIBUTE", DataTypes.BOOLEAN()),
-          Column.physical("FIXED_PREC_SCALE", DataTypes.BOOLEAN()),
-          Column.physical("AUTO_INCREMENT", DataTypes.BOOLEAN()),
-          Column.physical("LOCAL_TYPE_NAME", DataTypes.STRING()),
-          Column.physical("MINIMUM_SCALE", DataTypes.SMALLINT()),
-          Column.physical("MAXIMUM_SCALE", DataTypes.SMALLINT()),
-          Column.physical(SQL_DATA_TYPE, DataTypes.INT()),
-          Column.physical(SQL_DATETIME_SUB, DataTypes.INT()),
-          Column.physical(NUM_PREC_RADIX, DataTypes.INT()))
-        .data(dataTypes)
-        .build
-    } catch {
-      onError()
-    }
+    val dataTypes: Array[Row] = Array(
+      toRow(LogicalTypeRoot.CHAR.name(), CHAR),
+      toRow(LogicalTypeRoot.VARCHAR.name(), VARCHAR),
+      toRow(LogicalTypeRoot.BOOLEAN.name(), BOOLEAN),
+      toRow(LogicalTypeRoot.BINARY.name(), BINARY),
+      toRow(LogicalTypeRoot.VARBINARY.name(), VARBINARY),
+      toRow(LogicalTypeRoot.DECIMAL.name(), DECIMAL, 38),
+      toRow(LogicalTypeRoot.TINYINT.name(), TINYINT, 3),
+      toRow(LogicalTypeRoot.SMALLINT.name(), SMALLINT, 5),
+      toRow(LogicalTypeRoot.INTEGER.name(), INTEGER, 10),
+      toRow(LogicalTypeRoot.BIGINT.name(), BIGINT, 19),
+      toRow(LogicalTypeRoot.FLOAT.name(), FLOAT, 7),
+      toRow(LogicalTypeRoot.DOUBLE.name(), DOUBLE, 15),
+      toRow(LogicalTypeRoot.DATE.name(), DATE),
+      toRow(LogicalTypeRoot.TIME_WITHOUT_TIME_ZONE.name(), TIME),
+      toRow(LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE.name(), TIMESTAMP),
+      toRow(LogicalTypeRoot.TIMESTAMP_WITH_TIME_ZONE.name(), TIMESTAMP_WITH_TIMEZONE),
+      toRow(LogicalTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE.name(), TIMESTAMP_WITH_TIMEZONE),
+      toRow(LogicalTypeRoot.INTERVAL_YEAR_MONTH.name(), OTHER),
+      toRow(LogicalTypeRoot.INTERVAL_DAY_TIME.name(), OTHER),
+      toRow(LogicalTypeRoot.ARRAY.name(), ARRAY),
+      toRow(LogicalTypeRoot.MULTISET.name(), JAVA_OBJECT),
+      toRow(LogicalTypeRoot.MAP.name(), JAVA_OBJECT),
+      toRow(LogicalTypeRoot.ROW.name(), JAVA_OBJECT),
+      toRow(LogicalTypeRoot.DISTINCT_TYPE.name(), OTHER),
+      toRow(LogicalTypeRoot.STRUCTURED_TYPE.name(), OTHER),
+      toRow(LogicalTypeRoot.NULL.name(), NULL),
+      toRow(LogicalTypeRoot.RAW.name(), OTHER),
+      toRow(LogicalTypeRoot.SYMBOL.name(), OTHER),
+      toRow(LogicalTypeRoot.UNRESOLVED.name(), OTHER))
+    resultSet = ResultSet.builder.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
+      .columns(
+        Column.physical(TYPE_NAME, DataTypes.STRING()),
+        Column.physical(DATA_TYPE, DataTypes.INT()),
+        Column.physical(PRECISION, DataTypes.INT()),
+        Column.physical("LITERAL_PREFIX", DataTypes.STRING()),
+        Column.physical("LITERAL_SUFFIX", DataTypes.STRING()),
+        Column.physical("CREATE_PARAMS", DataTypes.STRING()),
+        Column.physical(NULLABLE, DataTypes.SMALLINT()),
+        Column.physical(CASE_SENSITIVE, DataTypes.BOOLEAN()),
+        Column.physical(SEARCHABLE, DataTypes.SMALLINT()),
+        Column.physical("UNSIGNED_ATTRIBUTE", DataTypes.BOOLEAN()),
+        Column.physical("FIXED_PREC_SCALE", DataTypes.BOOLEAN()),
+        Column.physical("AUTO_INCREMENT", DataTypes.BOOLEAN()),
+        Column.physical("LOCAL_TYPE_NAME", DataTypes.STRING()),
+        Column.physical("MINIMUM_SCALE", DataTypes.SMALLINT()),
+        Column.physical("MAXIMUM_SCALE", DataTypes.SMALLINT()),
+        Column.physical(SQL_DATA_TYPE, DataTypes.INT()),
+        Column.physical(SQL_DATETIME_SUB, DataTypes.INT()),
+        Column.physical(NUM_PREC_RADIX, DataTypes.INT()))
+      .data(dataTypes)
+      .build
   }
 }

--- a/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/PlanOnlyStatement.scala
+++ b/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/PlanOnlyStatement.scala
@@ -46,24 +46,20 @@ class PlanOnlyStatement(
   }
 
   override protected def runInternal(): Unit = {
-    try {
-      val operations = executor.getTableEnvironment.getParser.parse(statement)
-      Preconditions.checkArgument(
-        operations.size() == 1,
-        "Plan-only mode supports single statement only",
-        null)
-      val operation = operations.get(0)
-      operation match {
-        case _: SetOperation | _: ResetOperation | _: AddJarOperation | _: RemoveJarOperation |
-            _: ShowJarsOperation =>
-          val resultFetcher = executor.executeStatement(
-            new OperationHandle(getHandle.identifier),
-            statement)
-          resultSet = ResultSetUtil.fromResultFetcher(resultFetcher);
-        case _ => explainOperation(statement)
-      }
-    } catch {
-      onError()
+    val operations = executor.getTableEnvironment.getParser.parse(statement)
+    Preconditions.checkArgument(
+      operations.size() == 1,
+      "Plan-only mode supports single statement only",
+      null)
+    val operation = operations.get(0)
+    operation match {
+      case _: SetOperation | _: ResetOperation | _: AddJarOperation | _: RemoveJarOperation |
+          _: ShowJarsOperation =>
+        val resultFetcher = executor.executeStatement(
+          new OperationHandle(getHandle.identifier),
+          statement)
+        resultSet = ResultSetUtil.fromResultFetcher(resultFetcher);
+      case _ => explainOperation(statement)
     }
   }
 

--- a/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/SetCurrentCatalog.scala
+++ b/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/SetCurrentCatalog.scala
@@ -29,10 +29,8 @@ class SetCurrentCatalog(session: Session, catalog: String)
   override def getOperationLog: Option[OperationLog] = Option(operationLog)
 
   override protected def runInternal(): Unit = {
-    try {
-      val catalogManager = sessionContext.getSessionState.catalogManager
-      catalogManager.setCurrentCatalog(catalog)
-      setHasResultSet(false)
-    } catch onError()
+    val catalogManager = sessionContext.getSessionState.catalogManager
+    catalogManager.setCurrentCatalog(catalog)
+    setHasResultSet(false)
   }
 }

--- a/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/SetCurrentDatabase.scala
+++ b/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/SetCurrentDatabase.scala
@@ -29,10 +29,8 @@ class SetCurrentDatabase(session: Session, database: String)
   override def getOperationLog: Option[OperationLog] = Option(operationLog)
 
   override protected def runInternal(): Unit = {
-    try {
-      val catalogManager = sessionContext.getSessionState.catalogManager
-      catalogManager.setCurrentDatabase(database)
-      setHasResultSet(false)
-    } catch onError()
+    val catalogManager = sessionContext.getSessionState.catalogManager
+    catalogManager.setCurrentDatabase(database)
+    setHasResultSet(false)
   }
 }

--- a/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/operation/ExecuteStatement.scala
@@ -39,18 +39,14 @@ class ExecuteStatement(
 
   override protected def runInternal(): Unit = {
     addTimeoutMonitor(queryTimeout)
-    if (shouldRunAsync) {
-      val asyncOperation = new Runnable {
-        override def run(): Unit = {
-          executeStatement()
-        }
+    val asyncOperation = new Runnable {
+      override def run(): Unit = {
+        executeStatement()
       }
-      val jdbcSessionManager = session.sessionManager
-      val backgroundHandle = jdbcSessionManager.submitBackgroundOperation(asyncOperation)
-      setBackgroundHandle(backgroundHandle)
-    } else {
-      executeStatement()
     }
+    val backgroundHandle = submitBackgroundOperation(asyncOperation)
+    setBackgroundHandle(backgroundHandle)
+    if (!shouldRunAsync)  getBackgroundHandle.get()
   }
 
   private def executeStatement(): Unit = {

--- a/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/operation/ExecuteStatement.scala
@@ -46,7 +46,7 @@ class ExecuteStatement(
     }
     val backgroundHandle = submitBackgroundOperation(asyncOperation)
     setBackgroundHandle(backgroundHandle)
-    if (!shouldRunAsync)  getBackgroundHandle.get()
+    if (!shouldRunAsync) getBackgroundHandle.get()
   }
 
   private def executeStatement(): Unit = {

--- a/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/operation/ExecuteStatement.scala
@@ -44,7 +44,7 @@ class ExecuteStatement(
         executeStatement()
       }
     }
-    val backgroundHandle = submitBackgroundOperation(asyncOperation)
+    val backgroundHandle = submitInBackground(asyncOperation)
     setBackgroundHandle(backgroundHandle)
     if (!shouldRunAsync) getBackgroundHandle.get()
   }

--- a/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/operation/ExecuteStatement.scala
@@ -86,8 +86,6 @@ class ExecuteStatement(
           Row(List(jdbcStatement.getUpdateCount))))
       }
       setState(OperationState.FINISHED)
-    } catch {
-      onError(true)
     } finally {
       if (jdbcStatement != null) {
         jdbcStatement.closeOnCompletion()

--- a/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/operation/JdbcOperation.scala
+++ b/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/operation/JdbcOperation.scala
@@ -62,7 +62,7 @@ abstract class JdbcOperation(session: Session) extends AbstractOperation(session
     cleanup(OperationState.CLOSED)
   }
 
-  protected def onError(): PartialFunction[Throwable, Unit] = {
+  override protected def onError(): PartialFunction[Throwable, Unit] = {
     // We should use Throwable instead of Exception since `java.lang.NoClassDefFoundError`
     // could be thrown.
     case e: Throwable =>

--- a/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/operation/JdbcOperation.scala
+++ b/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/operation/JdbcOperation.scala
@@ -62,7 +62,7 @@ abstract class JdbcOperation(session: Session) extends AbstractOperation(session
     cleanup(OperationState.CLOSED)
   }
 
-  protected def onError(cancel: Boolean = false): PartialFunction[Throwable, Unit] = {
+  protected def onError(): PartialFunction[Throwable, Unit] = {
     // We should use Throwable instead of Exception since `java.lang.NoClassDefFoundError`
     // could be thrown.
     case e: Throwable =>

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
@@ -17,7 +17,7 @@
 
 package org.apache.kyuubi.engine.spark.operation
 
-import java.io.{BufferedReader, File, FileOutputStream, FilenameFilter, InputStreamReader, PrintWriter}
+import java.io.{BufferedReader, File, FilenameFilter, FileOutputStream, InputStreamReader, PrintWriter}
 import java.lang.ProcessBuilder.Redirect
 import java.net.URI
 import java.nio.file.{Files, Path, Paths}
@@ -25,7 +25,9 @@ import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.locks.ReentrantLock
 import javax.ws.rs.core.UriBuilder
+
 import scala.collection.JavaConverters._
+
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import org.apache.commons.lang3.StringUtils
@@ -33,6 +35,7 @@ import org.apache.spark.SparkFiles
 import org.apache.spark.api.python.KyuubiPythonGatewayServer
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.types.StructType
+
 import org.apache.kyuubi.{KyuubiException, KyuubiSQLException, Logging, Utils}
 import org.apache.kyuubi.config.KyuubiConf.{ENGINE_SPARK_PYTHON_ENV_ARCHIVE, ENGINE_SPARK_PYTHON_ENV_ARCHIVE_EXEC_PATH, ENGINE_SPARK_PYTHON_HOME_ARCHIVE}
 import org.apache.kyuubi.config.KyuubiReservedKeys.{KYUUBI_SESSION_USER_KEY, KYUUBI_STATEMENT_ID_KEY}

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
@@ -35,7 +35,7 @@ import org.apache.spark.api.python.KyuubiPythonGatewayServer
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.types.StructType
 
-import org.apache.kyuubi.{KyuubiException, KyuubiSQLException, Logging, Utils}
+import org.apache.kyuubi.{KyuubiSQLException, Logging, Utils}
 import org.apache.kyuubi.config.KyuubiConf.{ENGINE_SPARK_PYTHON_ENV_ARCHIVE, ENGINE_SPARK_PYTHON_ENV_ARCHIVE_EXEC_PATH, ENGINE_SPARK_PYTHON_HOME_ARCHIVE}
 import org.apache.kyuubi.config.KyuubiReservedKeys.{KYUUBI_SESSION_USER_KEY, KYUUBI_STATEMENT_ID_KEY}
 import org.apache.kyuubi.engine.spark.KyuubiSparkUtil._

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
@@ -113,7 +113,7 @@ class ExecutePython(
     }
 
     try {
-      val backgroundHandle = submitBackgroundOperation(asyncOperation)
+      val backgroundHandle = submitInBackground(asyncOperation)
       setBackgroundHandle(backgroundHandle)
     } catch {
       case rejected: RejectedExecutionException =>

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
@@ -77,6 +77,8 @@ class ExecutePython(
     OperationLog.removeCurrentOperationLog()
   }
 
+  override protected def cancelOnError: Boolean = true
+
   private def executePython(): Unit = withLocalProperties {
     try {
       setState(OperationState.RUNNING)
@@ -95,8 +97,6 @@ class ExecutePython(
       } else {
         throw KyuubiSQLException(s"Interpret error:\n$statement\n $response")
       }
-    } catch {
-      onError(cancel = true)
     } finally {
       shutdownTimeoutMonitor()
     }

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
@@ -17,7 +17,7 @@
 
 package org.apache.kyuubi.engine.spark.operation
 
-import java.io.{BufferedReader, File, FilenameFilter, FileOutputStream, InputStreamReader, PrintWriter}
+import java.io.{BufferedReader, File, FileOutputStream, FilenameFilter, InputStreamReader, PrintWriter}
 import java.lang.ProcessBuilder.Redirect
 import java.net.URI
 import java.nio.file.{Files, Path, Paths}
@@ -25,9 +25,7 @@ import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.locks.ReentrantLock
 import javax.ws.rs.core.UriBuilder
-
 import scala.collection.JavaConverters._
-
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import org.apache.commons.lang3.StringUtils
@@ -35,8 +33,7 @@ import org.apache.spark.SparkFiles
 import org.apache.spark.api.python.KyuubiPythonGatewayServer
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.types.StructType
-
-import org.apache.kyuubi.{KyuubiSQLException, Logging, Utils}
+import org.apache.kyuubi.{KyuubiException, KyuubiSQLException, Logging, Utils}
 import org.apache.kyuubi.config.KyuubiConf.{ENGINE_SPARK_PYTHON_ENV_ARCHIVE, ENGINE_SPARK_PYTHON_ENV_ARCHIVE_EXEC_PATH, ENGINE_SPARK_PYTHON_HOME_ARCHIVE}
 import org.apache.kyuubi.config.KyuubiReservedKeys.{KYUUBI_SESSION_USER_KEY, KYUUBI_STATEMENT_ID_KEY}
 import org.apache.kyuubi.engine.spark.KyuubiSparkUtil._
@@ -112,17 +109,8 @@ class ExecutePython(
       }
     }
 
-    try {
-      val backgroundHandle = submitInBackground(asyncOperation)
-      setBackgroundHandle(backgroundHandle)
-    } catch {
-      case rejected: RejectedExecutionException =>
-        setState(OperationState.ERROR)
-        val ke =
-          KyuubiSQLException("Error submitting python in background", rejected)
-        setOperationException(ke)
-        throw ke
-    }
+    val backgroundHandle = submitInBackground(asyncOperation)
+    setBackgroundHandle(backgroundHandle)
     if (!shouldRunAsync) getBackgroundHandle.get()
   }
 

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
@@ -21,7 +21,6 @@ import java.io.{BufferedReader, File, FilenameFilter, FileOutputStream, InputStr
 import java.lang.ProcessBuilder.Redirect
 import java.net.URI
 import java.nio.file.{Files, Path, Paths}
-import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.locks.ReentrantLock
 import javax.ws.rs.core.UriBuilder

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteScala.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteScala.scala
@@ -76,6 +76,8 @@ class ExecuteScala(
     OperationLog.removeCurrentOperationLog()
   }
 
+  override protected def cancelOnError: Boolean = true
+
   private def executeScala(): Unit = withLocalProperties {
     try {
       setState(OperationState.RUNNING)
@@ -122,8 +124,6 @@ class ExecuteScala(
           throw KyuubiSQLException(s"Incomplete code:\n$statement")
       }
       setState(OperationState.FINISHED)
-    } catch {
-      onError(cancel = true)
     } finally {
       repl.clearResult(statementId)
       shutdownTimeoutMonitor()

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteScala.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteScala.scala
@@ -18,7 +18,6 @@
 package org.apache.kyuubi.engine.spark.operation
 
 import java.io.File
-import java.util.concurrent.RejectedExecutionException
 
 import scala.reflect.internal.util.ScalaClassLoader.URLClassLoader
 import scala.tools.nsc.interpreter.Results.{Error, Incomplete, Success}

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteScala.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteScala.scala
@@ -139,17 +139,8 @@ class ExecuteScala(
       }
     }
 
-    try {
-      val backgroundHandle = submitInBackground(asyncOperation)
-      setBackgroundHandle(backgroundHandle)
-    } catch {
-      case rejected: RejectedExecutionException =>
-        setState(OperationState.ERROR)
-        val ke =
-          KyuubiSQLException("Error submitting scala in background", rejected)
-        setOperationException(ke)
-        throw ke
-    }
+    val backgroundHandle = submitInBackground(asyncOperation)
+    setBackgroundHandle(backgroundHandle)
     if (!shouldRunAsync) getBackgroundHandle.get()
   }
 }

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteScala.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteScala.scala
@@ -140,7 +140,7 @@ class ExecuteScala(
     }
 
     try {
-      val backgroundHandle = submitBackgroundOperation(asyncOperation)
+      val backgroundHandle = submitInBackground(asyncOperation)
       setBackgroundHandle(backgroundHandle)
     } catch {
       case rejected: RejectedExecutionException =>

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
@@ -101,17 +101,8 @@ class ExecuteStatement(
       }
     }
 
-    try {
-      val backgroundHandle = submitInBackground(asyncOperation)
-      setBackgroundHandle(backgroundHandle)
-    } catch {
-      case rejected: RejectedExecutionException =>
-        setState(OperationState.ERROR)
-        val ke =
-          KyuubiSQLException("Error submitting query in background, query rejected", rejected)
-        setOperationException(ke)
-        throw ke
-    }
+    val backgroundHandle = submitInBackground(asyncOperation)
+    setBackgroundHandle(backgroundHandle)
     if (!shouldRunAsync) getBackgroundHandle.get()
   }
 

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
@@ -17,15 +17,13 @@
 
 package org.apache.kyuubi.engine.spark.operation
 
-import java.util.concurrent.RejectedExecutionException
-
 import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.kyuubi.SparkDatasetHelper._
 import org.apache.spark.sql.types._
 
-import org.apache.kyuubi.{KyuubiSQLException, Logging}
+import org.apache.kyuubi.Logging
 import org.apache.kyuubi.config.KyuubiConf.OPERATION_RESULT_MAX_ROWS
 import org.apache.kyuubi.engine.spark.KyuubiSparkUtil._
 import org.apache.kyuubi.operation.{ArrayFetchIterator, FetchIterator, IterableFetchIterator, OperationHandle, OperationState}

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
@@ -102,7 +102,7 @@ class ExecuteStatement(
     }
 
     try {
-      val backgroundHandle = submitBackgroundOperation(asyncOperation)
+      val backgroundHandle = submitInBackground(asyncOperation)
       setBackgroundHandle(backgroundHandle)
     } catch {
       case rejected: RejectedExecutionException =>

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
@@ -75,6 +75,8 @@ class ExecuteStatement(
     resultDF.take(maxRows)
   }
 
+  override protected def cancelOnError: Boolean = true
+
   protected def executeStatement(): Unit = withLocalProperties {
     try {
       setState(OperationState.RUNNING)
@@ -85,8 +87,6 @@ class ExecuteStatement(
       iter = collectAsIterator(result)
       setCompiledStateIfNeeded()
       setState(OperationState.FINISHED)
-    } catch {
-      onError(cancel = true)
     } finally {
       shutdownTimeoutMonitor()
     }

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/GetCatalogs.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/GetCatalogs.scala
@@ -32,8 +32,6 @@ class GetCatalogs(session: Session) extends SparkOperation(session) {
   }
 
   override protected def runInternal(): Unit = {
-    try {
-      iter = new IterableFetchIterator(SparkCatalogShim().getCatalogs(spark).toList)
-    } catch onError()
+    iter = new IterableFetchIterator(SparkCatalogShim().getCatalogs(spark).toList)
   }
 }

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/GetColumns.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/GetColumns.scala
@@ -111,14 +111,10 @@ class GetColumns(
   }
 
   override protected def runInternal(): Unit = {
-    try {
-      val schemaPattern = toJavaRegex(schemaName)
-      val tablePattern = toJavaRegex(tableName)
-      val columnPattern = toJavaRegex(columnName)
-      iter = new IterableFetchIterator(SparkCatalogShim()
-        .getColumns(spark, catalogName, schemaPattern, tablePattern, columnPattern).toList)
-    } catch {
-      onError()
-    }
+    val schemaPattern = toJavaRegex(schemaName)
+    val tablePattern = toJavaRegex(tableName)
+    val columnPattern = toJavaRegex(columnName)
+    iter = new IterableFetchIterator(SparkCatalogShim()
+      .getColumns(spark, catalogName, schemaPattern, tablePattern, columnPattern).toList)
   }
 }

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/GetCurrentCatalog.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/GetCurrentCatalog.scala
@@ -37,8 +37,6 @@ class GetCurrentCatalog(session: Session) extends SparkOperation(session) {
   }
 
   override protected def runInternal(): Unit = {
-    try {
-      iter = new IterableFetchIterator(Seq(SparkCatalogShim().getCurrentCatalog(spark)))
-    } catch onError()
+    iter = new IterableFetchIterator(Seq(SparkCatalogShim().getCurrentCatalog(spark)))
   }
 }

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/GetCurrentDatabase.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/GetCurrentDatabase.scala
@@ -37,8 +37,6 @@ class GetCurrentDatabase(session: Session) extends SparkOperation(session) {
   }
 
   override protected def runInternal(): Unit = {
-    try {
-      iter = new IterableFetchIterator(Seq(SparkCatalogShim().getCurrentDatabase(spark)))
-    } catch onError()
+    iter = new IterableFetchIterator(Seq(SparkCatalogShim().getCurrentDatabase(spark)))
   }
 }

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/GetFunctions.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/GetFunctions.scala
@@ -61,25 +61,21 @@ class GetFunctions(
   }
 
   override protected def runInternal(): Unit = {
-    try {
-      val schemaPattern = toJavaRegex(schemaName)
-      val functionPattern = toJavaRegex(functionName)
-      val catalog = spark.sessionState.catalog
-      val a: Seq[Row] = catalog.listDatabases(schemaPattern).flatMap { db =>
-        catalog.listFunctions(db, functionPattern).map { case (f, _) =>
-          val info = catalog.lookupFunctionInfo(f)
-          Row(
-            "",
-            info.getDb,
-            info.getName,
-            s"Usage: ${info.getUsage}\nExtended Usage:${info.getExtended}",
-            DatabaseMetaData.functionResultUnknown,
-            info.getClassName)
-        }
+    val schemaPattern = toJavaRegex(schemaName)
+    val functionPattern = toJavaRegex(functionName)
+    val catalog = spark.sessionState.catalog
+    val a: Seq[Row] = catalog.listDatabases(schemaPattern).flatMap { db =>
+      catalog.listFunctions(db, functionPattern).map { case (f, _) =>
+        val info = catalog.lookupFunctionInfo(f)
+        Row(
+          "",
+          info.getDb,
+          info.getName,
+          s"Usage: ${info.getUsage}\nExtended Usage:${info.getExtended}",
+          DatabaseMetaData.functionResultUnknown,
+          info.getClassName)
       }
-      iter = new IterableFetchIterator(a.toList)
-    } catch {
-      onError()
     }
+    iter = new IterableFetchIterator(a.toList)
   }
 }

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/GetSchemas.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/GetSchemas.scala
@@ -38,10 +38,8 @@ class GetSchemas(session: Session, catalogName: String, schema: String)
   }
 
   override protected def runInternal(): Unit = {
-    try {
-      val schemaPattern = toJavaRegex(schema)
-      val rows = SparkCatalogShim().getSchemas(spark, catalogName, schemaPattern)
-      iter = new IterableFetchIterator(rows)
-    } catch onError()
+    val schemaPattern = toJavaRegex(schema)
+    val rows = SparkCatalogShim().getSchemas(spark, catalogName, schemaPattern)
+    iter = new IterableFetchIterator(rows)
   }
 }

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/GetTables.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/GetTables.scala
@@ -70,29 +70,25 @@ class GetTables(
   }
 
   override protected def runInternal(): Unit = {
-    try {
-      val schemaPattern = toJavaRegex(schema)
-      val tablePattern = toJavaRegex(tableName)
-      val sparkShim = SparkCatalogShim()
-      val catalogTablesAndViews =
-        sparkShim.getCatalogTablesOrViews(
-          spark,
-          catalog,
-          schemaPattern,
-          tablePattern,
-          tableTypes,
-          ignoreTableProperties)
+    val schemaPattern = toJavaRegex(schema)
+    val tablePattern = toJavaRegex(tableName)
+    val sparkShim = SparkCatalogShim()
+    val catalogTablesAndViews =
+      sparkShim.getCatalogTablesOrViews(
+        spark,
+        catalog,
+        schemaPattern,
+        tablePattern,
+        tableTypes,
+        ignoreTableProperties)
 
-      val allTableAndViews =
-        if (tableTypes.exists("VIEW".equalsIgnoreCase)) {
-          catalogTablesAndViews ++
-            sparkShim.getTempViews(spark, catalog, schemaPattern, tablePattern)
-        } else {
-          catalogTablesAndViews
-        }
-      iter = new IterableFetchIterator(allTableAndViews)
-    } catch {
-      onError()
-    }
+    val allTableAndViews =
+      if (tableTypes.exists("VIEW".equalsIgnoreCase)) {
+        catalogTablesAndViews ++
+          sparkShim.getTempViews(spark, catalog, schemaPattern, tablePattern)
+      } else {
+        catalogTablesAndViews
+      }
+    iter = new IterableFetchIterator(allTableAndViews)
   }
 }

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/PlanOnlyStatement.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/PlanOnlyStatement.scala
@@ -66,25 +66,21 @@ class PlanOnlyStatement(
   }
 
   override protected def runInternal(): Unit = withLocalProperties {
-    try {
-      SQLConf.withExistingConf(spark.sessionState.conf) {
-        val parsed = spark.sessionState.sqlParser.parsePlan(statement)
+    SQLConf.withExistingConf(spark.sessionState.conf) {
+      val parsed = spark.sessionState.sqlParser.parsePlan(statement)
 
-        parsed match {
-          case cmd if planExcludes.contains(cmd.getClass.getSimpleName) =>
-            result = spark.sql(statement)
-            iter = new ArrayFetchIterator(result.collect())
+      parsed match {
+        case cmd if planExcludes.contains(cmd.getClass.getSimpleName) =>
+          result = spark.sql(statement)
+          iter = new ArrayFetchIterator(result.collect())
 
-          case plan => style match {
-              case PlainStyle => explainWithPlainStyle(plan)
-              case JsonStyle => explainWithJsonStyle(plan)
-              case UnknownStyle => unknownStyleError(style)
-              case other => throw notSupportedStyleError(other, "Spark SQL")
-            }
-        }
+        case plan => style match {
+            case PlainStyle => explainWithPlainStyle(plan)
+            case JsonStyle => explainWithJsonStyle(plan)
+            case UnknownStyle => unknownStyleError(style)
+            case other => throw notSupportedStyleError(other, "Spark SQL")
+          }
       }
-    } catch {
-      onError()
     }
   }
 

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SetCurrentCatalog.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SetCurrentCatalog.scala
@@ -34,9 +34,7 @@ class SetCurrentCatalog(session: Session, catalog: String) extends SparkOperatio
   }
 
   override protected def runInternal(): Unit = {
-    try {
-      SparkCatalogShim().setCurrentCatalog(spark, catalog)
-      setHasResultSet(false)
-    } catch onError()
+    SparkCatalogShim().setCurrentCatalog(spark, catalog)
+    setHasResultSet(false)
   }
 }

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SetCurrentDatabase.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SetCurrentDatabase.scala
@@ -35,9 +35,7 @@ class SetCurrentDatabase(session: Session, database: String)
   }
 
   override protected def runInternal(): Unit = {
-    try {
-      SparkCatalogShim().setCurrentDatabase(spark, database)
-      setHasResultSet(false)
-    } catch onError()
+    SparkCatalogShim().setCurrentDatabase(spark, database)
+    setHasResultSet(false)
   }
 }

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkOperation.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkOperation.scala
@@ -171,7 +171,7 @@ abstract class SparkOperation(session: Session)
 
   protected def cancelJobGroupOnError: Boolean = false
 
-  protected def onError(): PartialFunction[Throwable, Unit] = {
+  override protected def onError(): PartialFunction[Throwable, Unit] = {
     // We should use Throwable instead of Exception since `java.lang.NoClassDefFoundError`
     // could be thrown.
     case e: Throwable =>

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkOperation.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkOperation.scala
@@ -169,14 +169,15 @@ abstract class SparkOperation(session: Session)
     }
   }
 
-  protected def cancelOnError: Boolean = false
+  protected def cancelJobGroupOnError: Boolean = false
 
   protected def onError(): PartialFunction[Throwable, Unit] = {
     // We should use Throwable instead of Exception since `java.lang.NoClassDefFoundError`
     // could be thrown.
     case e: Throwable =>
-      if (cancelOnError && !spark.sparkContext.isStopped)
+      if (cancelJobGroupOnError && !spark.sparkContext.isStopped) {
         spark.sparkContext.cancelJobGroup(statementId)
+      }
       withLockRequired {
         val errMsg = Utils.stringifyException(e)
         if (state == OperationState.TIMEOUT) {

--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/ExecuteStatement.scala
@@ -116,8 +116,6 @@ class ExecuteStatement(
           new ArrayFetchIterator(resultSet.toArray)
         }
       setState(OperationState.FINISHED)
-    } catch {
-      onError(cancel = true)
     } finally {
       shutdownTimeoutMonitor()
     }

--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/ExecuteStatement.scala
@@ -65,17 +65,8 @@ class ExecuteStatement(
       }
     }
 
-    try {
-      val backgroundHandle = submitInBackground(asyncOperation)
-      setBackgroundHandle(backgroundHandle)
-    } catch {
-      case rejected: RejectedExecutionException =>
-        setState(OperationState.ERROR)
-        val ke =
-          KyuubiSQLException("Error submitting query in background, query rejected", rejected)
-        setOperationException(ke)
-        throw ke
-    }
+    val backgroundHandle = submitInBackground(asyncOperation)
+    setBackgroundHandle(backgroundHandle)
     if (!shouldRunAsync) getBackgroundHandle.get()
   }
 

--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/ExecuteStatement.scala
@@ -66,7 +66,7 @@ class ExecuteStatement(
     }
 
     try {
-      val backgroundHandle = submitBackgroundOperation(asyncOperation)
+      val backgroundHandle = submitInBackground(asyncOperation)
       setBackgroundHandle(backgroundHandle)
     } catch {
       case rejected: RejectedExecutionException =>

--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/ExecuteStatement.scala
@@ -17,8 +17,6 @@
 
 package org.apache.kyuubi.engine.trino.operation
 
-import java.util.concurrent.RejectedExecutionException
-
 import org.apache.hive.service.rpc.thrift.TRowSet
 
 import org.apache.kyuubi.{KyuubiSQLException, Logging}

--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/ExecuteStatement.scala
@@ -76,7 +76,7 @@ class ExecuteStatement(
         setOperationException(ke)
         throw ke
     }
-    if (!shouldRunAsync)  getBackgroundHandle.get()
+    if (!shouldRunAsync) getBackgroundHandle.get()
   }
 
   override def getNextRowSet(order: FetchOrientation, rowSetSize: Int): TRowSet = {

--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/GetCatalogs.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/GetCatalogs.scala
@@ -24,14 +24,12 @@ import org.apache.kyuubi.session.Session
 class GetCatalogs(session: Session) extends TrinoOperation(session) {
 
   override protected def runInternal(): Unit = {
-    try {
-      val trinoStatement = TrinoStatement(
-        trinoContext,
-        session.sessionManager.getConf,
-        "SELECT TABLE_CAT FROM system.jdbc.catalogs")
-      schema = trinoStatement.getColumns
-      val resultSet = trinoStatement.execute()
-      iter = new ArrayFetchIterator(resultSet.toArray)
-    } catch onError()
+    val trinoStatement = TrinoStatement(
+      trinoContext,
+      session.sessionManager.getConf,
+      "SELECT TABLE_CAT FROM system.jdbc.catalogs")
+    schema = trinoStatement.getColumns
+    val resultSet = trinoStatement.execute()
+    iter = new ArrayFetchIterator(resultSet.toArray)
   }
 }

--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/GetColumns.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/GetColumns.scala
@@ -66,12 +66,10 @@ class GetColumns(
       query.append(filters.mkString(" AND "))
     }
 
-    try {
-      val trinoStatement =
-        TrinoStatement(trinoContext, session.sessionManager.getConf, query.toString)
-      schema = trinoStatement.getColumns
-      val resultSet = trinoStatement.execute()
-      iter = new ArrayFetchIterator(resultSet.toArray)
-    } catch onError()
+    val trinoStatement =
+      TrinoStatement(trinoContext, session.sessionManager.getConf, query.toString)
+    schema = trinoStatement.getColumns
+    val resultSet = trinoStatement.execute()
+    iter = new ArrayFetchIterator(resultSet.toArray)
   }
 }

--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/GetCurrentCatalog.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/GetCurrentCatalog.scala
@@ -34,16 +34,14 @@ class GetCurrentCatalog(session: Session)
   override def getOperationLog: Option[OperationLog] = Option(operationLog)
 
   override protected def runInternal(): Unit = {
-    try {
-      val session = trinoContext.clientSession.get
-      val catalog = session.getCatalog
+    val session = trinoContext.clientSession.get
+    val catalog = session.getCatalog
 
-      val clientTypeSignature = new ClientTypeSignature(
-        VARCHAR,
-        ImmutableList.of(ClientTypeSignatureParameter.ofLong(VARCHAR_UNBOUNDED_LENGTH)))
-      val column = new Column("TABLE_CAT", VARCHAR, clientTypeSignature)
-      schema = List[Column](column)
-      iter = new IterableFetchIterator(List(List(catalog)))
-    } catch onError()
+    val clientTypeSignature = new ClientTypeSignature(
+      VARCHAR,
+      ImmutableList.of(ClientTypeSignatureParameter.ofLong(VARCHAR_UNBOUNDED_LENGTH)))
+    val column = new Column("TABLE_CAT", VARCHAR, clientTypeSignature)
+    schema = List[Column](column)
+    iter = new IterableFetchIterator(List(List(catalog)))
   }
 }

--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/GetCurrentDatabase.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/GetCurrentDatabase.scala
@@ -34,16 +34,14 @@ class GetCurrentDatabase(session: Session)
   override def getOperationLog: Option[OperationLog] = Option(operationLog)
 
   override protected def runInternal(): Unit = {
-    try {
-      val session = trinoContext.clientSession.get
-      val catalog = session.getSchema
+    val session = trinoContext.clientSession.get
+    val catalog = session.getSchema
 
-      val clientTypeSignature = new ClientTypeSignature(
-        VARCHAR,
-        ImmutableList.of(ClientTypeSignatureParameter.ofLong(VARCHAR_UNBOUNDED_LENGTH)))
-      val column = new Column("TABLE_SCHEM", VARCHAR, clientTypeSignature)
-      schema = List[Column](column)
-      iter = new IterableFetchIterator(List(List(catalog)))
-    } catch onError()
+    val clientTypeSignature = new ClientTypeSignature(
+      VARCHAR,
+      ImmutableList.of(ClientTypeSignatureParameter.ofLong(VARCHAR_UNBOUNDED_LENGTH)))
+    val column = new Column("TABLE_SCHEM", VARCHAR, clientTypeSignature)
+    schema = List[Column](column)
+    iter = new IterableFetchIterator(List(List(catalog)))
   }
 }

--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/GetSchemas.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/GetSchemas.scala
@@ -47,14 +47,12 @@ class GetSchemas(session: Session, catalogName: String, schemaPattern: String)
       query.append(filters.mkString(" AND "))
     }
 
-    try {
-      val trinoStatement = TrinoStatement(
-        trinoContext,
-        session.sessionManager.getConf,
-        query.toString)
-      schema = trinoStatement.getColumns
-      val resultSet = trinoStatement.execute()
-      iter = new ArrayFetchIterator(resultSet.toArray)
-    } catch onError()
+    val trinoStatement = TrinoStatement(
+      trinoContext,
+      session.sessionManager.getConf,
+      query.toString)
+    schema = trinoStatement.getColumns
+    val resultSet = trinoStatement.execute()
+    iter = new ArrayFetchIterator(resultSet.toArray)
   }
 }

--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/GetTableTypes.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/GetTableTypes.scala
@@ -25,14 +25,12 @@ class GetTableTypes(session: Session)
   extends TrinoOperation(session) {
 
   override protected def runInternal(): Unit = {
-    try {
-      val trinoStatement = TrinoStatement(
-        trinoContext,
-        session.sessionManager.getConf,
-        "SELECT TABLE_TYPE FROM system.jdbc.table_types")
-      schema = trinoStatement.getColumns
-      val resultSet = trinoStatement.execute()
-      iter = new ArrayFetchIterator(resultSet.toArray)
-    } catch onError()
+    val trinoStatement = TrinoStatement(
+      trinoContext,
+      session.sessionManager.getConf,
+      "SELECT TABLE_TYPE FROM system.jdbc.table_types")
+    schema = trinoStatement.getColumns
+    val resultSet = trinoStatement.execute()
+    iter = new ArrayFetchIterator(resultSet.toArray)
   }
 }

--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/GetTables.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/GetTables.scala
@@ -65,12 +65,10 @@ class GetTables(
       query.append(filters.mkString(" AND "))
     }
 
-    try {
-      val trinoStatement =
-        TrinoStatement(trinoContext, session.sessionManager.getConf, query.toString)
-      schema = trinoStatement.getColumns
-      val resultSet = trinoStatement.execute()
-      iter = new ArrayFetchIterator(resultSet.toArray)
-    } catch onError()
+    val trinoStatement =
+      TrinoStatement(trinoContext, session.sessionManager.getConf, query.toString)
+    schema = trinoStatement.getColumns
+    val resultSet = trinoStatement.execute()
+    iter = new ArrayFetchIterator(resultSet.toArray)
   }
 }

--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/GetTypeInfo.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/GetTypeInfo.scala
@@ -25,20 +25,18 @@ class GetTypeInfo(session: Session)
   extends TrinoOperation(session) {
 
   override protected def runInternal(): Unit = {
-    try {
-      val trinoStatement = TrinoStatement(
-        trinoContext,
-        session.sessionManager.getConf,
-        """
-          |SELECT TYPE_NAME, DATA_TYPE, PRECISION, LITERAL_PREFIX, LITERAL_SUFFIX,
-          |CREATE_PARAMS, NULLABLE, CASE_SENSITIVE, SEARCHABLE, UNSIGNED_ATTRIBUTE,
-          |FIXED_PREC_SCALE, AUTO_INCREMENT, LOCAL_TYPE_NAME, MINIMUM_SCALE,
-          |MAXIMUM_SCALE, SQL_DATA_TYPE, SQL_DATETIME_SUB, NUM_PREC_RADIX
-          |FROM system.jdbc.types
-          |""".stripMargin)
-      schema = trinoStatement.getColumns
-      val resultSet = trinoStatement.execute()
-      iter = new ArrayFetchIterator(resultSet.toArray)
-    } catch onError()
+    val trinoStatement = TrinoStatement(
+      trinoContext,
+      session.sessionManager.getConf,
+      """
+        |SELECT TYPE_NAME, DATA_TYPE, PRECISION, LITERAL_PREFIX, LITERAL_SUFFIX,
+        |CREATE_PARAMS, NULLABLE, CASE_SENSITIVE, SEARCHABLE, UNSIGNED_ATTRIBUTE,
+        |FIXED_PREC_SCALE, AUTO_INCREMENT, LOCAL_TYPE_NAME, MINIMUM_SCALE,
+        |MAXIMUM_SCALE, SQL_DATA_TYPE, SQL_DATETIME_SUB, NUM_PREC_RADIX
+        |FROM system.jdbc.types
+        |""".stripMargin)
+    schema = trinoStatement.getColumns
+    val resultSet = trinoStatement.execute()
+    iter = new ArrayFetchIterator(resultSet.toArray)
   }
 }

--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/SetCurrentCatalog.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/SetCurrentCatalog.scala
@@ -30,12 +30,10 @@ class SetCurrentCatalog(session: Session, catalog: String)
   override def getOperationLog: Option[OperationLog] = Option(operationLog)
 
   override protected def runInternal(): Unit = {
-    try {
-      val session = trinoContext.clientSession.get
-      var builder = ClientSession.builder(session)
-      builder = builder.withCatalog(catalog)
-      trinoContext.clientSession.set(builder.build())
-      setHasResultSet(false)
-    } catch onError()
+    val session = trinoContext.clientSession.get
+    var builder = ClientSession.builder(session)
+    builder = builder.withCatalog(catalog)
+    trinoContext.clientSession.set(builder.build())
+    setHasResultSet(false)
   }
 }

--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/SetCurrentDatabase.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/SetCurrentDatabase.scala
@@ -30,12 +30,10 @@ class SetCurrentDatabase(session: Session, database: String)
   override def getOperationLog: Option[OperationLog] = Option(operationLog)
 
   override protected def runInternal(): Unit = {
-    try {
-      val session = trinoContext.clientSession.get
-      var builder = ClientSession.builder(session)
-      builder = builder.withSchema(database)
-      trinoContext.clientSession.set(builder.build())
-      setHasResultSet(false)
-    } catch onError()
+    val session = trinoContext.clientSession.get
+    var builder = ClientSession.builder(session)
+    builder = builder.withSchema(database)
+    trinoContext.clientSession.set(builder.build())
+    setHasResultSet(false)
   }
 }

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/AbstractOperation.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/AbstractOperation.scala
@@ -167,6 +167,15 @@ abstract class AbstractOperation(session: Session) extends Operation with Loggin
 
   protected def onError(): PartialFunction[Throwable, Unit]
 
+  protected def submitBackgroundOperation(r: Runnable): Future[_] = {
+    val onErrorRunnable = new Runnable {
+      override def run(): Unit = try {
+        r.run()
+      } catch onError()
+    }
+    session.sessionManager.submitBackgroundOperation(onErrorRunnable)
+  }
+
   override def run(): Unit = {
     try {
       beforeRun()

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/AbstractOperation.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/AbstractOperation.scala
@@ -17,15 +17,12 @@
 
 package org.apache.kyuubi.operation
 
-import java.util.concurrent.{Future, ScheduledExecutorService, TimeUnit}
+import java.util.concurrent.{Future, RejectedExecutionException, ScheduledExecutorService, TimeUnit}
 import java.util.concurrent.locks.ReentrantLock
-
 import scala.collection.JavaConverters._
-
 import org.apache.commons.lang3.StringUtils
 import org.apache.hive.service.rpc.thrift.{TGetResultSetMetadataResp, TProgressUpdateResp, TProtocolVersion, TRowSet, TStatus, TStatusCode}
-
-import org.apache.kyuubi.{KyuubiSQLException, Logging, Utils}
+import org.apache.kyuubi.{KyuubiException, KyuubiSQLException, Logging, Utils}
 import org.apache.kyuubi.config.KyuubiConf.OPERATION_IDLE_TIMEOUT
 import org.apache.kyuubi.operation.FetchOrientation.FetchOrientation
 import org.apache.kyuubi.operation.OperationState._
@@ -174,7 +171,12 @@ abstract class AbstractOperation(session: Session) extends Operation with Loggin
           r.run()
         } catch onError()
     }
-    session.sessionManager.submitBackgroundOperation(onErrorRunnable)
+    try {
+      session.sessionManager.submitBackgroundOperation(onErrorRunnable)
+    } catch {
+      case e: RejectedExecutionException =>
+        throw new KyuubiException(s"Error submitting $opType in background, request rejected", e)
+    }
   }
 
   override def run(): Unit = {

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/AbstractOperation.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/AbstractOperation.scala
@@ -169,9 +169,10 @@ abstract class AbstractOperation(session: Session) extends Operation with Loggin
 
   protected def submitBackgroundOperation(r: Runnable): Future[_] = {
     val onErrorRunnable = new Runnable {
-      override def run(): Unit = try {
-        r.run()
-      } catch onError()
+      override def run(): Unit =
+        try {
+          r.run()
+        } catch onError()
     }
     session.sessionManager.submitBackgroundOperation(onErrorRunnable)
   }

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/AbstractOperation.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/AbstractOperation.scala
@@ -19,9 +19,12 @@ package org.apache.kyuubi.operation
 
 import java.util.concurrent.{Future, RejectedExecutionException, ScheduledExecutorService, TimeUnit}
 import java.util.concurrent.locks.ReentrantLock
+
 import scala.collection.JavaConverters._
+
 import org.apache.commons.lang3.StringUtils
 import org.apache.hive.service.rpc.thrift.{TGetResultSetMetadataResp, TProgressUpdateResp, TProtocolVersion, TRowSet, TStatus, TStatusCode}
+
 import org.apache.kyuubi.{KyuubiException, KyuubiSQLException, Logging, Utils}
 import org.apache.kyuubi.config.KyuubiConf.OPERATION_IDLE_TIMEOUT
 import org.apache.kyuubi.operation.FetchOrientation.FetchOrientation

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/AbstractOperation.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/AbstractOperation.scala
@@ -165,7 +165,11 @@ abstract class AbstractOperation(session: Session) extends Operation with Loggin
 
   protected def afterRun(): Unit
 
-  protected def onError(): PartialFunction[Throwable, Unit]
+  protected def onError(): PartialFunction[Throwable, Unit] = {
+    case ke: KyuubiSQLException => throw ke
+    case kse: KyuubiException => throw kse
+    case e: Throwable => throw new KyuubiException("Error:", e)
+  }
 
   protected def submitInBackground(r: Runnable): Future[_] = {
     val onErrorRunnable = new Runnable {

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/AbstractOperation.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/AbstractOperation.scala
@@ -165,19 +165,19 @@ abstract class AbstractOperation(session: Session) extends Operation with Loggin
 
   protected def afterRun(): Unit
 
-  protected def onError(cancel: Boolean): PartialFunction[Throwable, Unit]
+  protected def onError(): PartialFunction[Throwable, Unit]
 
   override def run(): Unit = {
     try {
       beforeRun()
     } catch {
-      onError(true)
+      onError()
     }
 
     try {
       runInternal()
     } catch {
-      onError(true)
+      onError()
     } finally {
       afterRun()
     }

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/AbstractOperation.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/AbstractOperation.scala
@@ -167,7 +167,7 @@ abstract class AbstractOperation(session: Session) extends Operation with Loggin
 
   protected def onError(): PartialFunction[Throwable, Unit]
 
-  protected def submitBackgroundOperation(r: Runnable): Future[_] = {
+  protected def submitInBackground(r: Runnable): Future[_] = {
     val onErrorRunnable = new Runnable {
       override def run(): Unit =
         try {

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/AbstractOperation.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/AbstractOperation.scala
@@ -165,10 +165,19 @@ abstract class AbstractOperation(session: Session) extends Operation with Loggin
 
   protected def afterRun(): Unit
 
+  protected def onError(cancel: Boolean): PartialFunction[Throwable, Unit]
+
   override def run(): Unit = {
-    beforeRun()
+    try {
+      beforeRun()
+    } catch {
+      onError(true)
+    }
+
     try {
       runInternal()
+    } catch {
+      onError(true)
     } finally {
       afterRun()
     }

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/NoopOperation.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/NoopOperation.scala
@@ -53,10 +53,7 @@ class NoopOperation(session: Session, shouldFail: Boolean = false)
 
   override def cancel(): Unit = {
     setState(OperationState.CANCELED)
-  }
 
-  override protected def onError(): PartialFunction[Throwable, Unit] = {
-    case e: Throwable => throw e
   }
 
   override def close(): Unit = {

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/NoopOperation.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/NoopOperation.scala
@@ -53,7 +53,10 @@ class NoopOperation(session: Session, shouldFail: Boolean = false)
 
   override def cancel(): Unit = {
     setState(OperationState.CANCELED)
+  }
 
+  override protected def onError(): PartialFunction[Throwable, Unit] = {
+    case e: Throwable => throw e
   }
 
   override def close(): Unit = {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
@@ -197,8 +197,6 @@ class BatchJobSubmission(
             submitAndMonitorBatchJob()
         }
         setStateIfNotCanceled(OperationState.FINISHED)
-      } catch {
-        onError()
       } finally {
         updateBatchMetadata()
       }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
@@ -21,9 +21,11 @@ import java.io.IOException
 import java.nio.file.{Files, Paths}
 import java.util.Locale
 import java.util.concurrent.{RejectedExecutionException, TimeUnit}
+
 import com.codahale.metrics.MetricRegistry
 import com.google.common.annotations.VisibleForTesting
 import org.apache.hive.service.rpc.thrift._
+
 import org.apache.kyuubi.{KyuubiException, KyuubiSQLException}
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.engine.{ApplicationInfo, ApplicationState, KillResponse, ProcBuilder}
@@ -31,7 +33,7 @@ import org.apache.kyuubi.engine.spark.SparkBatchProcessBuilder
 import org.apache.kyuubi.metrics.MetricsConstants.OPERATION_OPEN
 import org.apache.kyuubi.metrics.MetricsSystem
 import org.apache.kyuubi.operation.FetchOrientation.FetchOrientation
-import org.apache.kyuubi.operation.OperationState.{CANCELED, OperationState, RUNNING, isTerminal}
+import org.apache.kyuubi.operation.OperationState.{isTerminal, CANCELED, OperationState, RUNNING}
 import org.apache.kyuubi.operation.log.OperationLog
 import org.apache.kyuubi.server.metadata.api.Metadata
 import org.apache.kyuubi.session.KyuubiBatchSessionImpl
@@ -175,7 +177,8 @@ class BatchJobSubmission(
   }
 
   override protected def runInternal(): Unit = session.handleSessionException {
-    val asyncOperation: Runnable = () => try {
+    val asyncOperation: Runnable = () =>
+      try {
         recoveryMetadata match {
           case Some(metadata) if metadata.peerInstanceClosed =>
             setState(OperationState.CANCELED)
@@ -204,7 +207,8 @@ class BatchJobSubmission(
     } catch {
       case e: RejectedExecutionException =>
         throw new KyuubiException(
-          "Error submitting batch job submission operation in background, request rejected", e)
+          "Error submitting batch job submission operation in background, request rejected",
+          e)
     } finally {
       if (isTerminalState(state)) {
         updateBatchMetadata()

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
@@ -20,12 +20,10 @@ package org.apache.kyuubi.operation
 import java.io.IOException
 import java.nio.file.{Files, Paths}
 import java.util.Locale
-import java.util.concurrent.TimeUnit
-
+import java.util.concurrent.{RejectedExecutionException, TimeUnit}
 import com.codahale.metrics.MetricRegistry
 import com.google.common.annotations.VisibleForTesting
 import org.apache.hive.service.rpc.thrift._
-
 import org.apache.kyuubi.{KyuubiException, KyuubiSQLException}
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.engine.{ApplicationInfo, ApplicationState, KillResponse, ProcBuilder}
@@ -33,7 +31,7 @@ import org.apache.kyuubi.engine.spark.SparkBatchProcessBuilder
 import org.apache.kyuubi.metrics.MetricsConstants.OPERATION_OPEN
 import org.apache.kyuubi.metrics.MetricsSystem
 import org.apache.kyuubi.operation.FetchOrientation.FetchOrientation
-import org.apache.kyuubi.operation.OperationState.{isTerminal, CANCELED, OperationState, RUNNING}
+import org.apache.kyuubi.operation.OperationState.{CANCELED, OperationState, RUNNING, isTerminal}
 import org.apache.kyuubi.operation.log.OperationLog
 import org.apache.kyuubi.server.metadata.api.Metadata
 import org.apache.kyuubi.session.KyuubiBatchSessionImpl
@@ -177,8 +175,7 @@ class BatchJobSubmission(
   }
 
   override protected def runInternal(): Unit = session.handleSessionException {
-    val asyncOperation: Runnable = () => {
-      try {
+    val asyncOperation: Runnable = () => try {
         recoveryMetadata match {
           case Some(metadata) if metadata.peerInstanceClosed =>
             setState(OperationState.CANCELED)
@@ -200,13 +197,14 @@ class BatchJobSubmission(
       } finally {
         updateBatchMetadata()
       }
-    }
 
     try {
-      val opHandle = session.sessionManager.submitBackgroundOperation(asyncOperation)
+      val opHandle = submitBackgroundOperation(asyncOperation)
       setBackgroundHandle(opHandle)
     } catch {
-      onError("submitting batch job submission operation in background, request rejected")
+      case e: RejectedExecutionException =>
+        throw new KyuubiException(
+          "Error submitting batch job submission operation in background, request rejected", e)
     } finally {
       if (isTerminalState(state)) {
         updateBatchMetadata()

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
@@ -202,7 +202,7 @@ class BatchJobSubmission(
       }
 
     try {
-      val opHandle = submitBackgroundOperation(asyncOperation)
+      val opHandle = submitInBackground(asyncOperation)
       setBackgroundHandle(opHandle)
     } catch {
       case e: RejectedExecutionException =>

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
@@ -204,11 +204,6 @@ class BatchJobSubmission(
     try {
       val opHandle = submitInBackground(asyncOperation)
       setBackgroundHandle(opHandle)
-    } catch {
-      case e: RejectedExecutionException =>
-        throw new KyuubiException(
-          "Error submitting batch job submission operation in background, request rejected",
-          e)
     } finally {
       if (isTerminalState(state)) {
         updateBatchMetadata()

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
@@ -20,7 +20,7 @@ package org.apache.kyuubi.operation
 import java.io.IOException
 import java.nio.file.{Files, Paths}
 import java.util.Locale
-import java.util.concurrent.{RejectedExecutionException, TimeUnit}
+import java.util.concurrent.TimeUnit
 
 import com.codahale.metrics.MetricRegistry
 import com.google.common.annotations.VisibleForTesting

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/ExecuteStatement.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/ExecuteStatement.scala
@@ -17,15 +17,13 @@
 
 package org.apache.kyuubi.operation
 
-import java.util.concurrent.RejectedExecutionException
-
 import scala.collection.JavaConverters._
 
 import com.codahale.metrics.MetricRegistry
 import org.apache.hive.service.rpc.thrift.{TGetOperationStatusResp, TOperationState, TProtocolVersion}
 import org.apache.hive.service.rpc.thrift.TOperationState._
 
-import org.apache.kyuubi.{KyuubiException, KyuubiSQLException}
+import org.apache.kyuubi.KyuubiSQLException
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.metrics.{MetricsConstants, MetricsSystem}
 import org.apache.kyuubi.operation.FetchOrientation.FETCH_NEXT

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/ExecuteStatement.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/ExecuteStatement.scala
@@ -158,13 +158,8 @@ class ExecuteStatement(
   override protected def runInternal(): Unit = {
     executeStatement()
     val asyncOperation: Runnable = () => waitStatementComplete()
-    try {
-      val opHandle = submitInBackground(asyncOperation)
-      setBackgroundHandle(opHandle)
-    } catch {
-      case e: RejectedExecutionException =>
-        throw new KyuubiException("Error submitting query in background, query rejected", e)
-    }
+    val opHandle = submitInBackground(asyncOperation)
+    setBackgroundHandle(opHandle)
 
     if (!shouldRunAsync) getBackgroundHandle.get()
   }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/ExecuteStatement.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/ExecuteStatement.scala
@@ -159,7 +159,7 @@ class ExecuteStatement(
     executeStatement()
     val asyncOperation: Runnable = () => waitStatementComplete()
     try {
-      val opHandle = submitBackgroundOperation(asyncOperation)
+      val opHandle = submitInBackground(asyncOperation)
       setBackgroundHandle(opHandle)
     } catch {
       case e: RejectedExecutionException =>

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/ExecutedCommandExec.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/ExecutedCommandExec.scala
@@ -63,8 +63,10 @@ class ExecutedCommandExec(
       setBackgroundHandle(opHandle)
     } catch {
       case e: RejectedExecutionException =>
-        throw new KyuubiException(s"Error submitting an operation ${command.name()} running" +
-          s" on the server in background, request rejected", e)
+        throw new KyuubiException(
+          s"Error submitting an operation ${command.name()} running" +
+            s" on the server in background, request rejected",
+          e)
     }
     if (!shouldRunAsync) getBackgroundHandle.get()
   }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/ExecutedCommandExec.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/ExecutedCommandExec.scala
@@ -59,7 +59,7 @@ class ExecutedCommandExec(
       setState(OperationState.FINISHED)
     }
     try {
-      val opHandle = submitBackgroundOperation(asyncOperation)
+      val opHandle = submitInBackground(asyncOperation)
       setBackgroundHandle(opHandle)
     } catch {
       case e: RejectedExecutionException =>

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/ExecutedCommandExec.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/ExecutedCommandExec.scala
@@ -55,18 +55,16 @@ class ExecutedCommandExec(
   override protected def runInternal(): Unit = session.handleSessionException {
     val asyncOperation: Runnable = () => {
       setState(OperationState.RUNNING)
-      try {
-        command.run(session)
-        setState(OperationState.FINISHED)
-      } catch onError()
+      command.run(session)
+      setState(OperationState.FINISHED)
     }
     try {
-      val opHandle = session.sessionManager.submitBackgroundOperation(asyncOperation)
+      val opHandle = submitBackgroundOperation(asyncOperation)
       setBackgroundHandle(opHandle)
     } catch {
-      case _: RejectedExecutionException =>
+      case e: RejectedExecutionException =>
         throw new KyuubiException(s"Error submitting an operation ${command.name()} running" +
-          s" on the server in background, request rejected")
+          s" on the server in background, request rejected", e)
     }
     if (!shouldRunAsync) getBackgroundHandle.get()
   }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/ExecutedCommandExec.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/ExecutedCommandExec.scala
@@ -58,16 +58,9 @@ class ExecutedCommandExec(
       command.run(session)
       setState(OperationState.FINISHED)
     }
-    try {
-      val opHandle = submitInBackground(asyncOperation)
-      setBackgroundHandle(opHandle)
-    } catch {
-      case e: RejectedExecutionException =>
-        throw new KyuubiException(
-          s"Error submitting an operation ${command.name()} running" +
-            s" on the server in background, request rejected",
-          e)
-    }
+    val opHandle = submitInBackground(asyncOperation)
+    setBackgroundHandle(opHandle)
+
     if (!shouldRunAsync) getBackgroundHandle.get()
   }
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/ExecutedCommandExec.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/ExecutedCommandExec.scala
@@ -17,11 +17,8 @@
 
 package org.apache.kyuubi.operation
 
-import java.util.concurrent.RejectedExecutionException
-
 import org.apache.hive.service.rpc.thrift.{TGetResultSetMetadataResp, TRowSet}
 
-import org.apache.kyuubi.KyuubiException
 import org.apache.kyuubi.operation.FetchOrientation.FetchOrientation
 import org.apache.kyuubi.operation.log.OperationLog
 import org.apache.kyuubi.session.KyuubiSessionImpl

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/GetCatalogs.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/GetCatalogs.scala
@@ -22,8 +22,6 @@ import org.apache.kyuubi.session.Session
 class GetCatalogs(session: Session) extends KyuubiOperation(session) {
 
   override protected def runInternal(): Unit = {
-    try {
-      _remoteOpHandle = client.getCatalogs
-    } catch onError()
+    _remoteOpHandle = client.getCatalogs
   }
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/GetColumns.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/GetColumns.scala
@@ -28,8 +28,6 @@ class GetColumns(
   extends KyuubiOperation(session) {
 
   override protected def runInternal(): Unit = {
-    try {
-      _remoteOpHandle = client.getColumns(catalogName, schemaName, tableName, columnName)
-    } catch onError()
+    _remoteOpHandle = client.getColumns(catalogName, schemaName, tableName, columnName)
   }
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/GetCrossReference.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/GetCrossReference.scala
@@ -30,14 +30,12 @@ class GetCrossReference(
   extends KyuubiOperation(session) {
 
   override protected def runInternal(): Unit = {
-    try {
-      _remoteOpHandle = client.getCrossReference(
-        primaryCatalog,
-        primarySchema,
-        primaryTable,
-        foreignCatalog,
-        foreignSchema,
-        foreignTable)
-    } catch onError()
+    _remoteOpHandle = client.getCrossReference(
+      primaryCatalog,
+      primarySchema,
+      primaryTable,
+      foreignCatalog,
+      foreignSchema,
+      foreignTable)
   }
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/GetFunctions.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/GetFunctions.scala
@@ -27,8 +27,6 @@ class GetFunctions(
   extends KyuubiOperation(session) {
 
   override protected def runInternal(): Unit = {
-    try {
-      _remoteOpHandle = client.getFunctions(catalogName, schemaName, functionName)
-    } catch onError()
+    _remoteOpHandle = client.getFunctions(catalogName, schemaName, functionName)
   }
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/GetPrimaryKeys.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/GetPrimaryKeys.scala
@@ -27,8 +27,6 @@ class GetPrimaryKeys(
   extends KyuubiOperation(session) {
 
   override protected def runInternal(): Unit = {
-    try {
-      _remoteOpHandle = client.getPrimaryKeys(catalogName, schemaName, tableName)
-    } catch onError()
+    _remoteOpHandle = client.getPrimaryKeys(catalogName, schemaName, tableName)
   }
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/GetSchemas.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/GetSchemas.scala
@@ -26,8 +26,6 @@ class GetSchemas(
   extends KyuubiOperation(session) {
 
   override protected def runInternal(): Unit = {
-    try {
-      _remoteOpHandle = client.getSchemas(catalogName, schemaName)
-    } catch onError()
+    _remoteOpHandle = client.getSchemas(catalogName, schemaName)
   }
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/GetTableTypes.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/GetTableTypes.scala
@@ -22,8 +22,6 @@ import org.apache.kyuubi.session.Session
 class GetTableTypes(session: Session) extends KyuubiOperation(session) {
 
   override protected def runInternal(): Unit = {
-    try {
-      _remoteOpHandle = client.getTableTypes
-    } catch onError()
+    _remoteOpHandle = client.getTableTypes
   }
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/GetTables.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/GetTables.scala
@@ -28,8 +28,6 @@ class GetTables(
   extends KyuubiOperation(session) {
 
   override protected def runInternal(): Unit = {
-    try {
-      _remoteOpHandle = client.getTables(catalogName, schemaName, tableName, tableTypes)
-    } catch onError()
+    _remoteOpHandle = client.getTables(catalogName, schemaName, tableName, tableTypes)
   }
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/GetTypeInfo.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/GetTypeInfo.scala
@@ -22,8 +22,6 @@ import org.apache.kyuubi.session.Session
 class GetTypeInfo(session: Session) extends KyuubiOperation(session) {
 
   override protected def runInternal(): Unit = {
-    try {
-      _remoteOpHandle = client.getTypeInfo
-    } catch onError()
+    _remoteOpHandle = client.getTypeInfo
   }
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/KyuubiOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/KyuubiOperation.scala
@@ -57,7 +57,7 @@ abstract class KyuubiOperation(session: Session) extends AbstractOperation(sessi
     ThriftUtils.verifyTStatus(tStatus)
   }
 
-  protected def onError(): PartialFunction[Throwable, Unit] = {
+  override protected def onError(): PartialFunction[Throwable, Unit] = {
     case e: Throwable =>
       withLockRequired {
         if (isTerminalState(state)) {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/KyuubiOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/KyuubiOperation.scala
@@ -57,7 +57,7 @@ abstract class KyuubiOperation(session: Session) extends AbstractOperation(sessi
     ThriftUtils.verifyTStatus(tStatus)
   }
 
-  protected def onError(action: String = "operating"): PartialFunction[Throwable, Unit] = {
+  protected def onError(): PartialFunction[Throwable, Unit] = {
     case e: Throwable =>
       withLockRequired {
         if (isTerminalState(state)) {
@@ -73,10 +73,10 @@ abstract class KyuubiOperation(session: Session) extends AbstractOperation(sessi
                   StringUtils.isEmpty(te.getMessage) =>
               // https://issues.apache.org/jira/browse/THRIFT-4858
               KyuubiSQLException(
-                s"Error $action $opType: Socket for ${session.handle} is closed",
+                s"Error operating $opType: Socket for ${session.handle} is closed",
                 e)
             case e =>
-              KyuubiSQLException(s"Error $action $opType: ${Utils.stringifyException(e)}", e)
+              KyuubiSQLException(s"Error operating $opType: ${Utils.stringifyException(e)}", e)
           }
           setOperationException(ke)
           setState(OperationState.ERROR)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/LaunchEngine.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/LaunchEngine.scala
@@ -63,12 +63,12 @@ class LaunchEngine(session: KyuubiSessionImpl, override val shouldRunAsync: Bool
       setState(OperationState.FINISHED)
     }
     try {
-      val opHandle = session.sessionManager.submitBackgroundOperation(asyncOperation)
+      val opHandle = submitBackgroundOperation(asyncOperation)
       setBackgroundHandle(opHandle)
     } catch {
-      case _: RejectedExecutionException =>
+      case e: RejectedExecutionException =>
         throw new KyuubiException(
-          "Error submitting open engine operation in background, request rejected")
+          "Error submitting open engine operation in background, request rejected", e)
     }
     if (!shouldRunAsync) getBackgroundHandle.get()
   }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/LaunchEngine.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/LaunchEngine.scala
@@ -63,7 +63,7 @@ class LaunchEngine(session: KyuubiSessionImpl, override val shouldRunAsync: Bool
       setState(OperationState.FINISHED)
     }
     try {
-      val opHandle = submitBackgroundOperation(asyncOperation)
+      val opHandle = submitInBackground(asyncOperation)
       setBackgroundHandle(opHandle)
     } catch {
       case e: RejectedExecutionException =>

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/LaunchEngine.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/LaunchEngine.scala
@@ -17,9 +17,6 @@
 
 package org.apache.kyuubi.operation
 
-import java.util.concurrent.RejectedExecutionException
-
-import org.apache.kyuubi.KyuubiException
 import org.apache.kyuubi.engine.{ApplicationInfo, ApplicationState}
 import org.apache.kyuubi.operation.log.OperationLog
 import org.apache.kyuubi.session.KyuubiSessionImpl

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/LaunchEngine.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/LaunchEngine.scala
@@ -62,15 +62,8 @@ class LaunchEngine(session: KyuubiSessionImpl, override val shouldRunAsync: Bool
       session.openEngineSession(getOperationLog)
       setState(OperationState.FINISHED)
     }
-    try {
-      val opHandle = submitInBackground(asyncOperation)
-      setBackgroundHandle(opHandle)
-    } catch {
-      case e: RejectedExecutionException =>
-        throw new KyuubiException(
-          "Error submitting open engine operation in background, request rejected",
-          e)
-    }
+    val opHandle = submitInBackground(asyncOperation)
+    setBackgroundHandle(opHandle)
     if (!shouldRunAsync) getBackgroundHandle.get()
   }
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/LaunchEngine.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/LaunchEngine.scala
@@ -68,7 +68,8 @@ class LaunchEngine(session: KyuubiSessionImpl, override val shouldRunAsync: Bool
     } catch {
       case e: RejectedExecutionException =>
         throw new KyuubiException(
-          "Error submitting open engine operation in background, request rejected", e)
+          "Error submitting open engine operation in background, request rejected",
+          e)
     }
     if (!shouldRunAsync) getBackgroundHandle.get()
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
For now, if some exception in the operation is not caught, it will cause the operation stuck in pending state.
For example, for `ExecutePython` operation.
https://github.com/apache/kyuubi/blob/474f0972a443c62c3d77a9977d61b59a18a0f0a6/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala#L139-L172

If exception thrown in `withLocalProperties` method, the operation will be stuck in pending state forever.
<img width="1314" alt="image" src="https://github.com/apache/kyuubi/assets/6757692/2929f0e4-dc64-4aa4-8d3e-e9d858f8e683">

To prevent the operation exception leak, I raised this pr.

In this pr:
- catch the exception in beforeRun
- catch the exception in runInternal
- catch the exception in operation backgroup thread 

BTW: for spark operation `getNextRestultSet` method, `catch onError()` is still needed.

BTW: in this pr, the operation is always submitted in background, if `shouldRunAsync`,  using `getBackgroundHandle.get` to block.
### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

After this pr:
<img width="1479" alt="image" src="https://github.com/apache/kyuubi/assets/6757692/e17aadfe-81a3-4ec7-a595-26eb978dd2b0">

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
