### PR TITLE
Fix spark operation exception leak in `withLocalProperties` method

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteScala.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteScala.scala
@@ -76,59 +76,60 @@ class ExecuteScala(
     OperationLog.removeCurrentOperationLog()
   }
 
-  private def executeScala(): Unit = withLocalProperties {
+  private def executeScala(): Unit =
     try {
-      setState(OperationState.RUNNING)
-      info(diagnostics)
-      Thread.currentThread().setContextClassLoader(spark.sharedState.jarClassLoader)
-      addOperationListener()
-      val legacyOutput = repl.getOutput
-      if (legacyOutput.nonEmpty) {
-        warn(s"Clearing legacy output from last interpreting:\n $legacyOutput")
-      }
-      val replUrls = repl.classLoader.getParent.asInstanceOf[URLClassLoader].getURLs
-      spark.sharedState.jarClassLoader.getURLs.filterNot(replUrls.contains).foreach { jar =>
-        try {
-          if ("file".equals(jar.toURI.getScheme)) {
-            repl.addUrlsToClassPath(jar)
-          } else {
-            spark.sparkContext.addFile(jar.toString)
-            val localJarFile = new File(SparkFiles.get(new Path(jar.toURI.getPath).getName))
-            val localJarUrl = localJarFile.toURI.toURL
-            if (!replUrls.contains(localJarUrl)) {
-              repl.addUrlsToClassPath(localJarUrl)
-            }
-          }
-        } catch {
-          case e: Throwable => error(s"Error adding $jar to repl class path", e)
+      withLocalProperties {
+        setState(OperationState.RUNNING)
+        info(diagnostics)
+        Thread.currentThread().setContextClassLoader(spark.sharedState.jarClassLoader)
+        addOperationListener()
+        val legacyOutput = repl.getOutput
+        if (legacyOutput.nonEmpty) {
+          warn(s"Clearing legacy output from last interpreting:\n $legacyOutput")
         }
-      }
-
-      repl.interpretWithRedirectOutError(statement) match {
-        case Success =>
-          iter = {
-            result = repl.getResult(statementId)
-            if (result != null) {
-              new ArrayFetchIterator[Row](result.collect())
+        val replUrls = repl.classLoader.getParent.asInstanceOf[URLClassLoader].getURLs
+        spark.sharedState.jarClassLoader.getURLs.filterNot(replUrls.contains).foreach { jar =>
+          try {
+            if ("file".equals(jar.toURI.getScheme)) {
+              repl.addUrlsToClassPath(jar)
             } else {
-              val output = repl.getOutput
-              debug("scala repl output:\n" + output)
-              new ArrayFetchIterator[Row](Array(Row(output)))
+              spark.sparkContext.addFile(jar.toString)
+              val localJarFile = new File(SparkFiles.get(new Path(jar.toURI.getPath).getName))
+              val localJarUrl = localJarFile.toURI.toURL
+              if (!replUrls.contains(localJarUrl)) {
+                repl.addUrlsToClassPath(localJarUrl)
+              }
             }
+          } catch {
+            case e: Throwable => error(s"Error adding $jar to repl class path", e)
           }
-        case Error =>
-          throw KyuubiSQLException(s"Interpret error:\n$statement\n ${repl.getOutput}")
-        case Incomplete =>
-          throw KyuubiSQLException(s"Incomplete code:\n$statement")
+        }
+
+        repl.interpretWithRedirectOutError(statement) match {
+          case Success =>
+            iter = {
+              result = repl.getResult(statementId)
+              if (result != null) {
+                new ArrayFetchIterator[Row](result.collect())
+              } else {
+                val output = repl.getOutput
+                debug("scala repl output:\n" + output)
+                new ArrayFetchIterator[Row](Array(Row(output)))
+              }
+            }
+          case Error =>
+            throw KyuubiSQLException(s"Interpret error:\n$statement\n ${repl.getOutput}")
+          case Incomplete =>
+            throw KyuubiSQLException(s"Incomplete code:\n$statement")
+        }
+        setState(OperationState.FINISHED)
       }
-      setState(OperationState.FINISHED)
     } catch {
       onError(cancel = true)
     } finally {
       repl.clearResult(statementId)
       shutdownTimeoutMonitor()
     }
-  }
 
   override protected def runInternal(): Unit = {
     addTimeoutMonitor(queryTimeout)

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
@@ -75,22 +75,23 @@ class ExecuteStatement(
     resultDF.take(maxRows)
   }
 
-  protected def executeStatement(): Unit = withLocalProperties {
+  protected def executeStatement(): Unit =
     try {
-      setState(OperationState.RUNNING)
-      info(diagnostics)
-      Thread.currentThread().setContextClassLoader(spark.sharedState.jarClassLoader)
-      addOperationListener()
-      result = spark.sql(statement)
-      iter = collectAsIterator(result)
-      setCompiledStateIfNeeded()
-      setState(OperationState.FINISHED)
+      withLocalProperties {
+        setState(OperationState.RUNNING)
+        info(diagnostics)
+        Thread.currentThread().setContextClassLoader(spark.sharedState.jarClassLoader)
+        addOperationListener()
+        result = spark.sql(statement)
+        iter = collectAsIterator(result)
+        setCompiledStateIfNeeded()
+        setState(OperationState.FINISHED)
+      }
     } catch {
       onError(cancel = true)
     } finally {
       shutdownTimeoutMonitor()
     }
-  }
 
   override protected def runInternal(): Unit = {
     addTimeoutMonitor(queryTimeout)

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/PlanOnlyStatement.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/PlanOnlyStatement.scala
@@ -65,28 +65,29 @@ class PlanOnlyStatement(
     super.beforeRun()
   }
 
-  override protected def runInternal(): Unit = withLocalProperties {
+  override protected def runInternal(): Unit =
     try {
-      SQLConf.withExistingConf(spark.sessionState.conf) {
-        val parsed = spark.sessionState.sqlParser.parsePlan(statement)
+      withLocalProperties {
+        SQLConf.withExistingConf(spark.sessionState.conf) {
+          val parsed = spark.sessionState.sqlParser.parsePlan(statement)
 
-        parsed match {
-          case cmd if planExcludes.contains(cmd.getClass.getSimpleName) =>
-            result = spark.sql(statement)
-            iter = new ArrayFetchIterator(result.collect())
+          parsed match {
+            case cmd if planExcludes.contains(cmd.getClass.getSimpleName) =>
+              result = spark.sql(statement)
+              iter = new ArrayFetchIterator(result.collect())
 
-          case plan => style match {
-              case PlainStyle => explainWithPlainStyle(plan)
-              case JsonStyle => explainWithJsonStyle(plan)
-              case UnknownStyle => unknownStyleError(style)
-              case other => throw notSupportedStyleError(other, "Spark SQL")
-            }
+            case plan => style match {
+                case PlainStyle => explainWithPlainStyle(plan)
+                case JsonStyle => explainWithJsonStyle(plan)
+                case UnknownStyle => unknownStyleError(style)
+                case other => throw notSupportedStyleError(other, "Spark SQL")
+              }
+          }
         }
       }
     } catch {
       onError()
     }
-  }
 
   private def explainWithPlainStyle(plan: LogicalPlan): Unit = {
     mode match {

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkOperation.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkOperation.scala
@@ -233,10 +233,10 @@ abstract class SparkOperation(session: Session)
     resp
   }
 
-  override def getNextRowSet(order: FetchOrientation, rowSetSize: Int): TRowSet =
-    withLocalProperties {
-      var resultRowSet: TRowSet = null
-      try {
+  override def getNextRowSet(order: FetchOrientation, rowSetSize: Int): TRowSet = {
+    var resultRowSet: TRowSet = null
+    try {
+      withLocalProperties {
         validateDefaultFetchOrientation(order)
         assertState(OperationState.FINISHED)
         setHasResultSet(true)
@@ -261,10 +261,11 @@ abstract class SparkOperation(session: Session)
               getProtocolVersion)
           }
         resultRowSet.setStartRowOffset(iter.getPosition)
-      } catch onError(cancel = true)
+      }
+    } catch onError(cancel = true)
 
-      resultRowSet
-    }
+    resultRowSet
+  }
 
   override def shouldRunAsync: Boolean = false
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
For `ExecutePython` operation.
https://github.com/apache/kyuubi/blob/474f0972a443c62c3d77a9977d61b59a18a0f0a6/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala#L139-L141

If exception thrown in `withLocalProperties` method(for example, python worker is died), the operation will be stuck in pending state forever.
<img width="1314" alt="image" src="https://github.com/apache/kyuubi/assets/6757692/2929f0e4-dc64-4aa4-8d3e-e9d858f8e683">

We need to catch exception thrown in `withLocalProperties` method.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

After this pr:
<img width="1479" alt="image" src="https://github.com/apache/kyuubi/assets/6757692/e17aadfe-81a3-4ec7-a595-26eb978dd2b0">

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
