### PR TITLE
[KYUUBI #4807][FOLLOWUP] Check batch status before getBatchLocalLog to fix flaky test "basic batch rest client"

### DIFF
--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/rest/client/BatchRestApiSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/rest/client/BatchRestApiSuite.scala
@@ -69,7 +69,7 @@ class BatchRestApiSuite extends RestClientTestHelper with BatchTestHelper {
     assert(batch.getBatchType === "SPARK")
 
     // get batch log
-    eventually(timeout(1.minutes)) { // check batch status first
+    eventually(timeout(30.seconds)) { // check batch status first
       val b = batchRestApi.getBatchById(batchId)
       assert(b.getAppState == "FINISHED" || b.getAppState == "RUNNING")
     }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/rest/client/BatchRestApiSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/rest/client/BatchRestApiSuite.scala
@@ -71,7 +71,7 @@ class BatchRestApiSuite extends RestClientTestHelper with BatchTestHelper {
     // get batch log
     eventually(timeout(30.seconds)) { // check batch status first
       val b = batchRestApi.getBatchById(batchId)
-      assert(b.getAppState == "FINISHED" || b.getAppState == "RUNNING")
+      assert(List("RUNNING", "FINISHED").contains(b.getAppState))
     }
     val log = batchRestApi.getBatchLocalLog(batchId, 0, 1)
     assert(log.getRowCount == 1)

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/rest/client/BatchRestApiSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/rest/client/BatchRestApiSuite.scala
@@ -68,6 +68,10 @@ class BatchRestApiSuite extends RestClientTestHelper with BatchTestHelper {
     assert(batch.getBatchType === "SPARK")
 
     // get batch log
+    eventually(timeout(1.minutes)) { // check batch status first
+      batch = batchRestApi.getBatchById(batch.getId())
+      assertResult("FINISHED")(batch.getAppState)
+    }
     val log = batchRestApi.getBatchLocalLog(batch.getId(), 0, 1)
     assert(log.getRowCount == 1)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- Check batch status for consistent result of  getBatchLocalLog,  to fix flaky test "basic batch rest client"

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
