### PR TITLE
Change default EC spec to secp521r1 for internal session variable signature

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/util/SignUtils.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/util/SignUtils.scala
@@ -27,7 +27,7 @@ object SignUtils {
 
   private lazy val ecKeyPairGenerator = {
     val g = KeyPairGenerator.getInstance(KEYPAIR_ALGORITHM_EC)
-    g.initialize(new ECGenParameterSpec("secp256k1"), new SecureRandom())
+    g.initialize(new ECGenParameterSpec("secp384r1"), new SecureRandom())
     g
   }
 

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/util/SignUtils.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/util/SignUtils.scala
@@ -27,7 +27,7 @@ object SignUtils {
 
   private lazy val ecKeyPairGenerator = {
     val g = KeyPairGenerator.getInstance(KEYPAIR_ALGORITHM_EC)
-    g.initialize(new ECGenParameterSpec("secp384r1"), new SecureRandom())
+    g.initialize(new ECGenParameterSpec("secp521r1"), new SecureRandom())
     g
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- change the default EC spec from secp256k1 to secp521r1, as secp256k1 not supported on Java 17

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
