### PR TITLE
[INFRA] Add `restore-keys` for `action/cache`

### DIFF
--- a/.github/actions/setup-maven/action.yaml
+++ b/.github/actions/setup-maven/action.yaml
@@ -25,8 +25,7 @@ runs:
       with:
         path: build/apache-maven-*
         key: setup-maven-${{ hashFiles('pom.xml') }}
-        restore-keys: |
-          setup-maven-
+        restore-keys: setup-maven-
     - name: Install Maven
       shell: bash
       run: build/mvn -v

--- a/.github/actions/setup-maven/action.yaml
+++ b/.github/actions/setup-maven/action.yaml
@@ -25,6 +25,8 @@ runs:
       with:
         path: build/apache-maven-*
         key: setup-maven-${{ hashFiles('pom.xml') }}
+        restore-keys: |
+          setup-maven-
     - name: Install Maven
       shell: bash
       run: build/mvn -v

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
+<!-- test restore-keys -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,6 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<!-- test restore-keys -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

add `restore-keys` to restore the most recently maven binary


[github docs](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#matching-a-cache-key)
> restore-keys allows you to specify a list of alternate restore keys to use when there is a cache miss on key. You can create multiple restore keys ordered from the most specific to least specific. The cache action searches the restore-keys in sequential order. When a key doesn't match directly, the action searches for keys prefixed with the restore key. If there are multiple partial matches for a restore key, the action returns the most recently created cache.

logs from [github action](https://github.com/apache/kyuubi/actions/runs/5020359871/jobs/9001759790?pr=4856) (after we update the file `pom.xml` hash)

```
Prepare all required actions
Getting action download info
Run ./.github/actions/setup-maven
Run actions/cache@v3
Received 0 of 8173297 (0.0%), 0.0 MBs/sec
Received 8173297 of 8173297 (100.0%), 6.5 MBs/sec
Cache Size: ~8 MB (8173297 B)
/usr/bin/tar -xf /home/runner/work/_temp/0e0ca716-97a4-4d83-af3b-9703003cdd33/cache.tzst -P -C /home/runner/work/kyuubi/kyuubi --use-compress-program unzstd
Cache restored successfully
Cache restored from key: setup-maven-e425be8ee60f158fc4f40b3c6b1a51cb2896e5c97dbbe7c61a96d91380342b89
Run build/mvn -v
Using `mvn` from path: /usr/bin/mvn
Apache Maven 3.8.8 (4c87b05d9aedce574290d1acc98575ed5eb6cd39)
Maven home: /usr/share/apache-maven-3.8.8
Java version: 1.8.0_362, vendor: Temurin, runtime: /usr/lib/jvm/temurin-8-jdk-amd64/jre
Default locale: en, platform encoding: UTF-8
OS name: "linux", version: "5.15.0-1037-azure", arch: "amd64", family: "unix"
```



### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
