### PR TITLE
[AUTHZ] Adapt plan changes for CreateNamespace and SetCatalogAndNamespace in Spark 3.4

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/resources/database_command_spec.json
+++ b/extensions/spark/kyuubi-spark-authz/src/main/resources/database_command_spec.json
@@ -51,6 +51,11 @@
   "classname" : "org.apache.spark.sql.catalyst.plans.logical.SetCatalogAndNamespace",
   "databaseDescs" : [ {
     "fieldName" : "child",
+    "fieldExtractor" : "ResolvedNamespaceDatabaseExtractor",
+    "catalogDesc" : null,
+    "isInput" : true
+  }, {
+    "fieldName" : "child",
     "fieldExtractor" : "ResolvedDBObjectNameDatabaseExtractor",
     "catalogDesc" : null,
     "isInput" : true
@@ -61,11 +66,6 @@
       "fieldName" : "catalogName",
       "fieldExtractor" : "StringOptionCatalogExtractor"
     },
-    "isInput" : true
-  }, {
-    "fieldName" : "child",
-    "fieldExtractor" : "ResolvedNamespaceDatabaseExtractor",
-    "catalogDesc" : null,
     "isInput" : true
   } ],
   "opType" : "SWITCHDATABASE"

--- a/extensions/spark/kyuubi-spark-authz/src/main/resources/database_command_spec.json
+++ b/extensions/spark/kyuubi-spark-authz/src/main/resources/database_command_spec.json
@@ -22,6 +22,11 @@
       "fieldExtractor" : "CatalogPluginCatalogExtractor"
     },
     "isInput" : false
+  }, {
+    "fieldName" : "name",
+    "fieldExtractor" : "ResolvedNamespaceDatabaseExtractor",
+    "catalogDesc" : null,
+    "isInput" : false
   } ],
   "opType" : "CREATEDATABASE"
 }, {
@@ -56,6 +61,11 @@
       "fieldName" : "catalogName",
       "fieldExtractor" : "StringOptionCatalogExtractor"
     },
+    "isInput" : true
+  }, {
+    "fieldName" : "child",
+    "fieldExtractor" : "ResolvedNamespaceDatabaseExtractor",
+    "catalogDesc" : null,
     "isInput" : true
   } ],
   "opType" : "SWITCHDATABASE"

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/DatabaseCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/DatabaseCommands.scala
@@ -98,12 +98,12 @@ object DatabaseCommands {
 
   val SetCatalogAndNamespace = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.SetCatalogAndNamespace"
-    val databaseDesc1 =
+    val resolvedDbObjectDatabaseDesc =
       DatabaseDesc(
         "child",
         classOf[ResolvedDBObjectNameDatabaseExtractor],
         isInput = true)
-    val databaseDesc2 =
+    val stringSeqOptionDatabaseDesc =
       DatabaseDesc(
         "namespace",
         classOf[StringSeqOptionDatabaseExtractor],
@@ -111,12 +111,15 @@ object DatabaseCommands {
           fieldName = "catalogName",
           fieldExtractor = classOf[StringOptionCatalogExtractor])),
         isInput = true)
-    val databaseDesc3 =
+    val resolvedNamespaceDatabaseDesc =
       DatabaseDesc(
         "child",
         classOf[ResolvedNamespaceDatabaseExtractor],
         isInput = true)
-    DatabaseCommandSpec(cmd, Seq(databaseDesc1, databaseDesc2, databaseDesc3), SWITCHDATABASE)
+    DatabaseCommandSpec(
+      cmd,
+      Seq(resolvedNamespaceDatabaseDesc, resolvedDbObjectDatabaseDesc, stringSeqOptionDatabaseDesc),
+      SWITCHDATABASE)
   }
 
   val SetNamespace = {

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/DatabaseCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/DatabaseCommands.scala
@@ -58,9 +58,10 @@ object DatabaseCommands {
         "namespace",
         classOf[StringSeqDatabaseExtractor],
         catalogDesc = Some(CatalogDesc()))
+    val databaseDesc3 = DatabaseDesc("name", classOf[ResolvedNamespaceDatabaseExtractor])
     DatabaseCommandSpec(
       "org.apache.spark.sql.catalyst.plans.logical.CreateNamespace",
-      Seq(databaseDesc1, databaseDesc2),
+      Seq(databaseDesc1, databaseDesc2, databaseDesc3),
       CREATEDATABASE)
   }
 
@@ -110,7 +111,12 @@ object DatabaseCommands {
           fieldName = "catalogName",
           fieldExtractor = classOf[StringOptionCatalogExtractor])),
         isInput = true)
-    DatabaseCommandSpec(cmd, Seq(databaseDesc1, databaseDesc2), SWITCHDATABASE)
+    val databaseDesc3 =
+      DatabaseDesc(
+        "child",
+        classOf[ResolvedNamespaceDatabaseExtractor],
+        isInput = true)
+    DatabaseCommandSpec(cmd, Seq(databaseDesc1, databaseDesc2, databaseDesc3), SWITCHDATABASE)
   }
 
   val SetNamespace = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- namespace changed from `Seq[String]` to `ResolvedNamespace` in Spark 3.4
- fixing uts in the name of `CreateNamespace` and `Extracting database info with ResolvedDBObjectNameDatabaseExtractor` w/ Spark 3.4 for  CreateNamespace and SetCatalogAndNamespace commands

Testing by running `build/mvn clean install -pl :kyuubi-spark-authz_2.12 -Pspark-3.4 -Dmaven.plugin.scalatest.exclude.tags=org.apache.kyuubi.tags.IcebergTest`.

Before:
```
- CreateNamespace *** FAILED ***
  0 did not equal 1 (V2CommandsPrivilegesSuite.scala:707)
...
- Extracting database info with ResolvedDBObjectNameDatabaseExtractor *** FAILED ***
  java.lang.NullPointerException:
  at org.apache.kyuubi.plugin.spark.authz.V2JdbcTableCatalogPrivilegesBuilderSuite.$anonfun$new$24(V2JdbcTableCatalogPrivilegesBuilderSuite.scala:151)
  at org.scalatest.Assertions.withClue(Assertions.scala:1065)
  at org.scalatest.Assertions.withClue$(Assertions.scala:1052)
  at org.scalatest.funsuite.AnyFunSuite.withClue(AnyFunSuite.scala:1564)
  at org.apache.kyuubi.plugin.spark.authz.V2JdbcTableCatalogPrivilegesBuilderSuite.$anonfun$new$21(V2JdbcTableCatalogPrivilegesBuilderSuite.scala:150)
  at scala.collection.immutable.List.foreach(List.scala:431)
  at org.apache.kyuubi.plugin.spark.authz.V2JdbcTableCatalogPrivilegesBuilderSuite.$anonfun$new$20(V2JdbcTableCatalogPrivilegesBuilderSuite.scala:143)
  at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
  at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
  at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
```

After:
```
- CreateNamespace
- Extracting database info with ResolvedDBObjectNameDatabaseExtractor
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
