### PR TITLE
[AUTHZ] Remove checking Spark v2 in tests since Spark v2 not supported

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/SparkSessionProvider.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/SparkSessionProvider.scala
@@ -32,7 +32,6 @@ import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
 trait SparkSessionProvider {
   protected val catalogImpl: String
   protected def format: String = if (catalogImpl == "hive") "hive" else "parquet"
-  protected val isSparkV2: Boolean = isSparkVersionAtMost("2.4")
   protected val isSparkV31OrGreater: Boolean = isSparkVersionAtLeast("3.1")
   protected val isSparkV32OrGreater: Boolean = isSparkVersionAtLeast("3.2")
   protected val isSparkV33OrGreater: Boolean = isSparkVersionAtLeast("3.3")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- remove assuming Spark v2 in Authz testing, since Spark v2 is marked not supported

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
