### PR TITLE
[BUILD] Skip compiling useless files when making distribution

### DIFF
--- a/build/dist
+++ b/build/dist
@@ -215,7 +215,7 @@ else
   echo "Making distribution for Kyuubi $VERSION in '$DISTDIR'..."
 fi
 
-MVN_DIST_OPT="-DskipTests"
+MVN_DIST_OPT="-DskipTests -Dmaven.javadoc.skip=true -Dmaven.scaladoc.skip=true -Dmaven.source.skip"
 
 if [[ "$ENABLE_WEBUI" == "true" ]]; then
   MVN_DIST_OPT="$MVN_DIST_OPT -Pweb-ui"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To speed up the making distribution.

Refer https://github.com/apache/spark/pull/41141

This PR add more skip properties when making distribution:

- -Dmaven.javadoc.skip=true to skip generating javadoc
- -Dmaven.scaladoc.skip=true to skip generating scaladoc. Please see: https://davidb.github.io/scala-maven-plugin/doc-jar-mojo.html#skip
- -Dmaven.source.skip to skip generating sources.jar

### _How was this patch tested?_
Manual test:
<img width="267" alt="image" src="https://github.com/apache/kyuubi/assets/6757692/af4e7bb5-10f1-4fa0-b212-b779b77c9ff3">

```
 ./build/dist --spark-provided --hive-provided --flink-provided
```

Before this pr:
```
[INFO] Total time:  09:20 min
```

After this pr:
```
[INFO] Total time:  06:46 min
```

