### PR TITLE
Fix test compilation error by reverting ScalaTest to 3.2.15 and Mockito to 4.6.1

### DIFF
--- a/kyuubi-common/pom.xml
+++ b/kyuubi-common/pom.xml
@@ -155,7 +155,7 @@
 
         <dependency>
             <groupId>org.scalatestplus</groupId>
-            <artifactId>mockito-4-11_${scala.binary.version}</artifactId>
+            <artifactId>mockito-4-6_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/kyuubi-server/pom.xml
+++ b/kyuubi-server/pom.xml
@@ -476,7 +476,7 @@
 
         <dependency>
             <groupId>org.scalatestplus</groupId>
-            <artifactId>mockito-4-11_${scala.binary.version}</artifactId>
+            <artifactId>mockito-4-6_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -183,8 +183,8 @@
         <protobuf.version>3.21.7</protobuf.version>
         <py4j.version>0.10.7</py4j.version>
         <ranger.version>2.4.0</ranger.version>
-        <scalatest.version>3.2.16</scalatest.version>
-        <scalatestplus.version>3.2.16.0</scalatestplus.version>
+        <scalatest.version>3.2.15</scalatest.version>
+        <scalatestplus.version>3.2.15.0</scalatestplus.version>
         <scopt.version>4.1.0</scopt.version>
         <slf4j.version>1.7.36</slf4j.version>
         <snakeyaml.version>1.33</snakeyaml.version>

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
         <ldapsdk.version>6.0.5</ldapsdk.version>
         <log4j.version>2.20.0</log4j.version>
         <mysql.jdbc.version>8.0.32</mysql.jdbc.version>
-        <mockito.version>4.11.0</mockito.version>
+        <mockito.version>4.6.1</mockito.version>
         <netty.version>4.1.89.Final</netty.version>
         <openai.java.version>0.12.0</openai.java.version>
         <parquet.version>1.10.1</parquet.version>
@@ -1043,7 +1043,7 @@
 
             <dependency>
                 <groupId>org.scalatestplus</groupId>
-                <artifactId>mockito-4-11_${scala.binary.version}</artifactId>
+                <artifactId>mockito-4-6_${scala.binary.version}</artifactId>
                 <version>${scalatestplus.version}</version>
             </dependency>
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- to fix comment https://github.com/apache/kyuubi/pull/4894#issuecomment-1566846117
- successfully built with `mvn clean install -pl :kyuubi-util-scala_2.12 -am`

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
