### PR TITLE
[AUTHZ] Extract function from FunctionIdentifier for CreateFunction and DropFunction in Spark 3.4

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/resources/function_command_spec.json
+++ b/extensions/spark/kyuubi-spark-authz/src/main/resources/function_command_spec.json
@@ -1,6 +1,16 @@
 [ {
   "classname" : "org.apache.spark.sql.execution.command.CreateFunctionCommand",
   "functionDescs" : [ {
+    "fieldName" : "identifier",
+    "fieldExtractor" : "FunctionIdentifierFunctionExtractor",
+    "databaseDesc" : null,
+    "functionTypeDesc" : {
+      "fieldName" : "isTemp",
+      "fieldExtractor" : "TempMarkerFunctionTypeExtractor",
+      "skipTypes" : [ "TEMP" ]
+    },
+    "isInput" : false
+  }, {
     "fieldName" : "functionName",
     "fieldExtractor" : "StringFunctionExtractor",
     "databaseDesc" : {
@@ -44,6 +54,16 @@
 }, {
   "classname" : "org.apache.spark.sql.execution.command.DropFunctionCommand",
   "functionDescs" : [ {
+    "fieldName" : "identifier",
+    "fieldExtractor" : "FunctionIdentifierFunctionExtractor",
+    "databaseDesc" : null,
+    "functionTypeDesc" : {
+      "fieldName" : "isTemp",
+      "fieldExtractor" : "TempMarkerFunctionTypeExtractor",
+      "skipTypes" : [ "TEMP" ]
+    },
+    "isInput" : false
+  }, {
     "fieldName" : "functionName",
     "fieldExtractor" : "StringFunctionExtractor",
     "databaseDesc" : {

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/FunctionCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/FunctionCommands.scala
@@ -35,8 +35,12 @@ object FunctionCommands {
       "functionName",
       classOf[StringFunctionExtractor],
       Some(databaseDesc),
-      Some(functionTypeDesc))
-    FunctionCommandSpec(cmd, Seq(functionDesc), CREATEFUNCTION)
+      functionTypeDesc = Some(functionTypeDesc))
+    val functionIdentifierDesc = FunctionDesc(
+      "identifier",
+      classOf[FunctionIdentifierFunctionExtractor],
+      functionTypeDesc = Some(functionTypeDesc))
+    FunctionCommandSpec(cmd, Seq(functionIdentifierDesc, functionDesc), CREATEFUNCTION)
   }
 
   val DescribeFunction = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- adapting changes in logical plan of CreateFunction/DropFunction  in Spark 3.4 by extracting table object from `FunctionIdentifier`, to fix tests on Spark 3.4
  - ut "CreateFunctionCommand"
  - ut "DropFunctionCommand"

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
