### PR TITLE
[AUTHZ] Fix exception when listing database in CatalogImpl in Spark 3.4

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/SparkSessionProvider.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/SparkSessionProvider.scala
@@ -60,7 +60,7 @@ trait SparkSessionProvider {
       // Ensure HiveExternalCatalog.client.userName is defaultTableOwner
       UserGroupInformation.createRemoteUser(defaultTableOwner).doAs(
         new PrivilegedExceptionAction[Unit] {
-          override def run(): Unit = ret.catalog.listDatabases()
+          override def run(): Unit = ret.sql("show databases").collect()
         })
     }
     ret

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/SparkSessionProvider.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/SparkSessionProvider.scala
@@ -60,7 +60,7 @@ trait SparkSessionProvider {
       // Ensure HiveExternalCatalog.client.userName is defaultTableOwner
       UserGroupInformation.createRemoteUser(defaultTableOwner).doAs(
         new PrivilegedExceptionAction[Unit] {
-          override def run(): Unit = ret.sql("show databases;").collect()
+          override def run(): Unit = ret.sql("SHOW DATABASES;").collect()
         })
     }
     ret

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/SparkSessionProvider.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/SparkSessionProvider.scala
@@ -60,7 +60,7 @@ trait SparkSessionProvider {
       // Ensure HiveExternalCatalog.client.userName is defaultTableOwner
       UserGroupInformation.createRemoteUser(defaultTableOwner).doAs(
         new PrivilegedExceptionAction[Unit] {
-          override def run(): Unit = ret.sql("SHOW DATABASES;").collect()
+          override def run(): Unit = ret.sql("SHOW DATABASES").collect()
         })
     }
     ret

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/SparkSessionProvider.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/SparkSessionProvider.scala
@@ -60,7 +60,7 @@ trait SparkSessionProvider {
       // Ensure HiveExternalCatalog.client.userName is defaultTableOwner
       UserGroupInformation.createRemoteUser(defaultTableOwner).doAs(
         new PrivilegedExceptionAction[Unit] {
-          override def run(): Unit = ret.sql("show databases").collect()
+          override def run(): Unit = ret.sql("show databases;").collect()
         })
     }
     ret


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- to fix errors when testing w/ Spark 3.4 as the  `CatalogImpl` gets `ResovledNamespace` from `ShowNamespace` logical plan 
```
 java.util.NoSuchElementException: None.get
  at scala.None$.get(Option.scala:529)
  at scala.None$.get(Option.scala:527)
  at org.apache.spark.sql.internal.CatalogImpl.listDatabases(CatalogImpl.scala:84)
  at org.apache.kyuubi.plugin.spark.authz.SparkSessionProvider$$anon$1.run(SparkSessionProvider.scala:63)
  at org.apache.kyuubi.plugin.spark.authz.SparkSessionProvider$$anon$1.run(SparkSessionProvider.scala:62)
  at java.security.AccessController.doPrivileged(Native Method)
  at javax.security.auth.Subject.doAs(Subject.java:422)
  at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1899)
  at org.apache.kyuubi.plugin.spark.authz.SparkSessionProvider.spark(SparkSessionProvider.scala:62)
  at org.apache.kyuubi.plugin.spark.authz.SparkSessionProvider.spark$(SparkSessionProvider.scala:41)
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
