### PR TITLE
[KYUUBI#4906][INFRA] Add a maven profile 'remote-debug'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,6 +231,7 @@
         <maven.plugin.scalatest.version>2.2.0</maven.plugin.scalatest.version>
         <maven.plugin.scalatest.exclude.tags>org.scalatest.tags.Slow</maven.plugin.scalatest.exclude.tags>
         <maven.plugin.scalatest.include.tags></maven.plugin.scalatest.include.tags>
+        <maven.plugin.scalatest.debug.enabled>false</maven.plugin.scalatest.debug.enabled>
         <maven.plugin.spotless.version>2.30.0</maven.plugin.spotless.version>
         <maven.plugin.jacoco.version>0.8.7</maven.plugin.jacoco.version>
         <maven.plugin.scalastyle.version>1.0.0</maven.plugin.scalastyle.version>
@@ -277,6 +278,7 @@
             --add-opens=java.base/sun.util.calendar=ALL-UNNAMED
             -Djdk.reflect.useDirectMethodHandle=false
             -Dio.netty.tryReflectionSetAccessible=true</extraJavaTestArgs>
+        <debugArgLine>-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005</debugArgLine>
     </properties>
 
     <dependencyManagement>
@@ -1712,6 +1714,8 @@
                         </systemProperties>
                         <tagsToExclude>${maven.plugin.scalatest.exclude.tags}</tagsToExclude>
                         <tagsToInclude>${maven.plugin.scalatest.include.tags}</tagsToInclude>
+                        <debugForkedProcess>${maven.plugin.scalatest.debug.enabled}</debugForkedProcess>
+                        <debugArgLine>${debugArgLine}</debugArgLine>
                     </configuration>
                     <executions>
                         <execution>
@@ -2263,6 +2267,14 @@
                 <flink.archive.download.skip>true</flink.archive.download.skip>
                 <hive.archive.download.skip>true</hive.archive.download.skip>
                 <spark.archive.download.skip>true</spark.archive.download.skip>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>remote-debug</id>
+            <properties>
+                <maven.surefire.debug>${debugArgLine}</maven.surefire.debug>
+                <maven.plugin.scalatest.debug.enabled>true</maven.plugin.scalatest.debug.enabled>
             </properties>
         </profile>
 


### PR DESCRIPTION
### _Why are the changes needed?_
IntelliJ IDEA can not use the right Spark version to run UT when we switches between multiple Spark versions.
This PR adds a maven profile 'remote-debug' to let UT open a debug port. So we can run UI using mvn cli and remote debug in IDEA.


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate
<img width="1273" alt="image" src="https://github.com/apache/kyuubi/assets/88070094/439164d7-c1b3-4233-a417-b34aa15b428a">


- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
