### PR TITLE
[KYUUBI#4935][Improvement] More than target num of executors may survive after FinalStageResourceManager did kill

### DIFF
--- a/extensions/spark/kyuubi-extension-spark-3-3/src/main/scala/org/apache/spark/sql/FinalStageResourceManager.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-3/src/main/scala/org/apache/spark/sql/FinalStageResourceManager.scala
@@ -170,7 +170,7 @@ case class FinalStageResourceManager(session: SparkSession)
 
     // Evict the rest executors according to the shuffle block size
     executorToBlockSize.toSeq.sortBy(_._2).foreach { case (id, _) =>
-      if (executorIdsToKill.length < expectedNumExecutorToKill) {
+      if (executorIdsToKill.length < expectedNumExecutorToKill && existedExecutors.contains(id)) {
         executorIdsToKill.append(id)
       }
     }


### PR DESCRIPTION
### _Why are the changes needed?_
When FinalStageResourceManager chooses executors to be killed, it may add dead executors to the kill list.
This will leave more than target num of executors survived and cause resource waste.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
