### PR TITLE
Bump pnpm version in maven's frontend plugin to 8.6.1 for lockfileVersion 6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@
         <!-- webui -->
         <webui.skip>true</webui.skip>
         <node.version>v18.16.0</node.version>
-        <pnpm.version>v8.4.0</pnpm.version>
+        <pnpm.version>v8.6.1</pnpm.version>
 
         <!-- apply to kyuubi-hive-jdbc/kyuubi-hive-beeline module -->
         <hive.client.jline.version>2.12</hive.client.jline.version>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- The current  lockfileVersion of the `pnpm` lock file has been bumped from 6.0 to 6.1 in #4931  (passed CI as it uses latest 8.x pnpm), which is incompatible with the currently `pnpm` version 8.4.1 in maven's frontend plugin 8.4.1
- Bump pnpm version to solve the conflicts

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
