### PR TITLE
[BUILD] Reuse versions of NodeJS and Pnpm from maven properties

### DIFF
--- a/.github/workflows/web-ui.yml
+++ b/.github/workflows/web-ui.yml
@@ -21,14 +21,35 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3
-      - name: setup npm
+      - name: Setup JDK 8
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 8
+      - name: Setup Maven
+        uses: ./.github/actions/setup-maven
+      - name: Get NodeJS and PNPM version
+        run: |
+          NODEJS_VERSION=$(build/mvn help:evaluate -Dexpression=node.version -q -DforceStdout)
+          PNPM_VERSION=$(build/mvn help:evaluate -Dexpression=pnpm.version -q -DforceStdout)
+          echo "NODEJS_VERSION=${NODEJS_VERSION}" >> "$GITHUB_ENV"
+          echo "PNPM_VERSION=${PNPM_VERSION}" >> "$GITHUB_ENV"
+      - name: Setup Nodejs and NPM
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: ${{env.NODEJS_VERSION}}
+          cache: npm
+          cache-dependency-path: ./kyuubi-server/web-ui/package.json
+      - name: Cache NPM dependencies
+        uses: actions/cache@v3
+        with:
+          path: ./kyuubi-server/web-ui/node_modules
+          key: webui-dependencies-${{ hashFiles('kyuubi-server/web-ui/pnpm-lock.yaml') }}
+          restore-keys: webui-dependencies-
       - name: npm run coverage & build
         run: |
           cd ./kyuubi-server/web-ui
-          npm install pnpm@8 -g
+          npm install pnpm@${PNPM_VERSION} -g
           pnpm install
           pnpm run coverage
           pnpm run build


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- fetch versions for NodeJS and Pnpm from Maven properties
- enabled npm dependency caching for global packages and web-ui module, as the step above takes extra time in builds.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
