### PR TITLE
Enhance AWS Glue default database does not exist error message on opening session 

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/session/SparkSessionImpl.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/session/SparkSessionImpl.scala
@@ -76,6 +76,11 @@ class SparkSessionImpl(
         case e
             if database == "default" &&
               StringUtils.containsAny(e.getMessage, "not found", "SCHEMA_NOT_FOUND") =>
+        case e
+            if database == "default" && StringUtils.containsAny(
+              e.getMessage,
+              "is not authorized to perform: glue:GetDatabase",
+              "database/default") =>
       }
     }
 

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/session/SparkSessionImpl.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/session/SparkSessionImpl.scala
@@ -75,12 +75,11 @@ class SparkSessionImpl(
       } catch {
         case e
             if database == "default" &&
-              StringUtils.containsAny(e.getMessage, "not found", "SCHEMA_NOT_FOUND") =>
-        case e
-            if database == "default" && StringUtils.containsAny(
-              e.getMessage,
-              "is not authorized to perform: glue:GetDatabase",
-              "database/default") =>
+              StringUtils.containsAny(
+                e.getMessage,
+                "not found",
+                "SCHEMA_NOT_FOUND",
+                "is not authorized to perform: glue:GetDatabase") =>
       }
     }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
When the default databases of glue do not exist, initializing the engine session failed.
```
Caused by: software.amazon.awssdk.services.glue.model.AccessDeniedException: User: arn:aws:iam::xxxxx:user/vault-token-wap-udp-int-readwrite-1686560253-eVgl3oauuaB7v0V6wX9 is not authorized to perform: glue:GetDatabase on resource: arn:aws:glue:us-east-1:xxxxx:database/default because no identity-based policy allows the glue:GetDatabase action (Service: Glue, Status Code: 400, Request ID: 3f816608-0cb2-467b-9181-05c5bfcd29b3, Extended Request ID: null)
```
![image](https://github.com/apache/kyuubi/assets/43336508/a0e9ccac-7fdb-4036-a4f3-2885d7bd0ac5)

The default initialize sql "SHOW DATABASES" when Kyuubi spark accesses the glue catalog. Try to change the initialize sql "use glue.wap" has the same error. 
```
kyuubi.engine.initialize.sql=use glue.wap
kyuubi.engine.session.initialize.sql=use glue.wap
```
The root cause is that hive defines a use:database, which will initialize access to the database default.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
