### PR TITLE
Backport HIVE-19048: Initscript errors are ignored

### DIFF
--- a/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/KyuubiBeeLine.java
+++ b/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/KyuubiBeeLine.java
@@ -36,6 +36,11 @@ public class KyuubiBeeLine extends BeeLine {
   protected KyuubiCommands commands = new KyuubiCommands(this);
   private Driver defaultDriver;
 
+  // copied from org.apache.hive.beeline.BeeLine
+  private static final int ERRNO_OK = 0;
+  private static final int ERRNO_ARGS = 1;
+  private static final int ERRNO_OTHER = 2;
+
   public KyuubiBeeLine() {
     this(true);
   }
@@ -158,6 +163,10 @@ public class KyuubiBeeLine extends BeeLine {
       }
     }
 
+    if (exit) {
+      return 1;
+    }
+
     int code = 0;
     if (cl.getOptionValues('e') != null) {
       commands = Arrays.asList(cl.getOptionValues('e'));
@@ -188,5 +197,53 @@ public class KyuubiBeeLine extends BeeLine {
       }
     }
     return code;
+  }
+
+  @Override
+  int runInit() {
+    String[] initFiles = getOpts().getInitFiles();
+
+    // executionResult will be ERRNO_OK only if all initFiles execute successfully
+    int executionResult = ERRNO_OK;
+    boolean exitOnError = !getOpts().getForce();
+    DynFields.BoundField<Boolean> exitField = null;
+
+    if (initFiles != null && initFiles.length != 0) {
+      for (String initFile : initFiles) {
+        info("Running init script " + initFile);
+        try {
+          int currentResult;
+          try {
+            currentResult =
+                DynMethods.builder("executeFile")
+                    .hiddenImpl(BeeLine.class, String.class)
+                    .buildChecked(this)
+                    .invoke(initFile);
+            exitField = DynFields.builder().hiddenImpl(BeeLine.class, "exit").buildChecked(this);
+          } catch (Exception t) {
+            error(t.getMessage());
+            currentResult = ERRNO_OTHER;
+          }
+
+          if (currentResult != ERRNO_OK) {
+            executionResult = currentResult;
+
+            if (exitOnError) {
+              return executionResult;
+            }
+          }
+        } finally {
+          // exit beeline if there is initScript failure and --force is not set
+          boolean exit = exitOnError && executionResult != ERRNO_OK;
+          try {
+            exitField.set(exit);
+          } catch (Exception t) {
+            error(t.getMessage());
+            return ERRNO_OTHER;
+          }
+        }
+      }
+    }
+    return executionResult;
   }
 }

--- a/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/KyuubiBeeLine.java
+++ b/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/KyuubiBeeLine.java
@@ -163,6 +163,7 @@ public class KyuubiBeeLine extends BeeLine {
       }
     }
 
+    // see HIVE-19048 : InitScript errors are ignored
     if (exit) {
       return 1;
     }
@@ -199,6 +200,7 @@ public class KyuubiBeeLine extends BeeLine {
     return code;
   }
 
+  // see HIVE-19048 : Initscript errors are ignored
   @Override
   int runInit() {
     String[] initFiles = getOpts().getInitFiles();

--- a/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/KyuubiCommands.java
+++ b/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/KyuubiCommands.java
@@ -490,7 +490,16 @@ public class KyuubiCommands extends Commands {
       if (!beeLine.isBeeLine()) {
         beeLine.updateOptsForCli();
       }
-      beeLine.runInit();
+
+      // see HIVE-19048 : Initscript errors are ignored
+      int initScriptExecutionResult = beeLine.runInit();
+
+      //if execution of the init script(s) return anything other than ERRNO_OK from beeline
+      //exit beeline with error unless --force is set
+      if(initScriptExecutionResult != 0 && !beeLine.getOpts().getForce()) {
+        return beeLine.error("init script execution failed.");
+      }
+
       if (beeLine.getOpts().getInitFiles() != null) {
         beeLine.initializeConsoleReader(null);
       }

--- a/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/KyuubiCommands.java
+++ b/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/KyuubiCommands.java
@@ -494,9 +494,9 @@ public class KyuubiCommands extends Commands {
       // see HIVE-19048 : Initscript errors are ignored
       int initScriptExecutionResult = beeLine.runInit();
 
-      //if execution of the init script(s) return anything other than ERRNO_OK from beeline
-      //exit beeline with error unless --force is set
-      if(initScriptExecutionResult != 0 && !beeLine.getOpts().getForce()) {
+      // if execution of the init script(s) return anything other than ERRNO_OK from beeline
+      // exit beeline with error unless --force is set
+      if (initScriptExecutionResult != 0 && !beeLine.getOpts().getForce()) {
         return beeLine.error("init script execution failed.");
       }
 

--- a/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/KyuubiBeeLineTest.java
+++ b/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/KyuubiBeeLineTest.java
@@ -29,4 +29,22 @@ public class KyuubiBeeLineTest {
     int result = kyuubiBeeLine.initArgs(new String[0]);
     assertEquals(0, result);
   }
+
+  @Test
+  public void testKyuubiBeelineExitCodeWithoutConnection() {
+    KyuubiBeeLine kyuubiBeeLine = new KyuubiBeeLine();
+    String scriptFile = getClass().getClassLoader().getResource("test.sql").getFile();
+
+    String[] args1 = {"-u", "badUrl", "-e", "show tables"};
+    int result1 = kyuubiBeeLine.initArgs(args1);
+    assertEquals(1, result1);
+
+    String[] args2 = {"-u", "badUrl", "-f", scriptFile};
+    int result2 = kyuubiBeeLine.initArgs(args2);
+    assertEquals(1, result2);
+
+    String[] args3 = {"-u", "badUrl", "-i", scriptFile};
+    int result3 = kyuubiBeeLine.initArgs(args3);
+    assertEquals(1, result3);
+  }
 }

--- a/kyuubi-hive-beeline/src/test/resources/test.sql
+++ b/kyuubi-hive-beeline/src/test/resources/test.sql
@@ -1,0 +1,17 @@
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+show tables;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

FYI: 
For hive-3.1.3, if failed to get connection, the return code of `beeline -f` is 0, the correct one should be non-zero.
And it works well for hive-4.0.0-alpha-2.
![image](https://github.com/apache/kyuubi/assets/6757692/35ba2329-6f04-4aed-b40b-3c47534554a5)

And the hive-beeline dependency version for kyuubi is 3.1.3.

This pr backports HIVE-19048: Initscript errors are ignored.

https://issues.apache.org/jira/browse/HIVE-19048
https://github.com/apache/hive/commit/006bf8a1a49aabf9930744c977fb0b9c91a5ef6c


### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
