### PR TITLE
[MINOR] Eliminate rawtypes compilation warning in KyuubiBeeLine

### DIFF
--- a/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/KyuubiBeeLine.java
+++ b/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/KyuubiBeeLine.java
@@ -145,6 +145,7 @@ public class KyuubiBeeLine extends BeeLine {
 
       beelineParser =
           new BeelineParser() {
+            @SuppressWarnings("rawtypes")
             @Override
             protected void processOption(String arg, ListIterator iter) throws ParseException {
               if (PYTHON_MODE_PREFIX.equals(arg)) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- Eliminate rawtypes compilation warning in `KyuubiBeeLine.java` by adding `SuppressWarnings` annotation of rule `rawtypes` to BeelineParser implementation
```
Warning:  [Warn] /home/runner/work/kyuubi/kyuubi/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/KyuubiBeeLine.java:148:53:  [rawtypes] found raw type: ListIterator
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
