### PR TITLE
Log error message when REST API invocation error occurs

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/api.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/api.scala
@@ -42,17 +42,17 @@ private[api] trait ApiRequestContext {
 @Provider
 class RestExceptionMapper extends ExceptionMapper[Exception] with Logging {
   override def toResponse(exception: Exception): Response = {
-    error("Error occurs on accessing REST API.", exception)
+    warn("Error occurs on accessing REST API.", exception)
     exception match {
       case e: WebApplicationException =>
         Response.status(e.getResponse.getStatus)
           .`type`(MediaType.APPLICATION_JSON)
-          .entity(Map("errorMessage" -> e.getMessage))
+          .entity(Map("message" -> e.getMessage))
           .build()
       case e =>
         Response.status(Response.Status.INTERNAL_SERVER_ERROR)
           .`type`(MediaType.APPLICATION_JSON)
-          .entity(Map("errorMessage" -> e.getMessage))
+          .entity(Map("message" -> e.getMessage))
           .build()
     }
   }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/api.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/api.scala
@@ -25,6 +25,7 @@ import javax.ws.rs.ext.{ExceptionMapper, Provider}
 
 import org.eclipse.jetty.server.handler.ContextHandler
 
+import org.apache.kyuubi.Logging
 import org.apache.kyuubi.server.KyuubiRestFrontendService
 
 private[api] trait ApiRequestContext {
@@ -39,18 +40,19 @@ private[api] trait ApiRequestContext {
 }
 
 @Provider
-class RestExceptionMapper extends ExceptionMapper[Exception] {
+class RestExceptionMapper extends ExceptionMapper[Exception] with Logging {
   override def toResponse(exception: Exception): Response = {
+    error("Error occurs on accessing REST API.", exception)
     exception match {
       case e: WebApplicationException =>
         Response.status(e.getResponse.getStatus)
-          .`type`(e.getResponse.getMediaType)
-          .entity(e.getMessage)
+          .`type`(MediaType.APPLICATION_JSON)
+          .entity(Map("errorMessage" -> e.getMessage))
           .build()
       case e =>
         Response.status(Response.Status.INTERNAL_SERVER_ERROR)
           .`type`(MediaType.APPLICATION_JSON)
-          .entity(e.getMessage)
+          .entity(Map("errorMessage" -> e.getMessage))
           .build()
     }
   }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/trino/api/api.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/trino/api/api.scala
@@ -25,6 +25,7 @@ import javax.ws.rs.ext.{ExceptionMapper, Provider}
 
 import org.eclipse.jetty.server.handler.ContextHandler
 
+import org.apache.kyuubi.Logging
 import org.apache.kyuubi.server.KyuubiTrinoFrontendService
 
 private[api] trait ApiRequestContext {
@@ -39,18 +40,19 @@ private[api] trait ApiRequestContext {
 }
 
 @Provider
-class RestExceptionMapper extends ExceptionMapper[Exception] {
+class RestExceptionMapper extends ExceptionMapper[Exception] with Logging {
   override def toResponse(exception: Exception): Response = {
+    warn("Error occurs on accessing REST API.", exception)
     exception match {
       case e: WebApplicationException =>
         Response.status(e.getResponse.getStatus)
-          .`type`(e.getResponse.getMediaType)
-          .entity(e.getMessage)
+          .`type`(MediaType.APPLICATION_JSON)
+          .entity(Map("message" -> e.getMessage))
           .build()
       case e =>
         Response.status(Response.Status.INTERNAL_SERVER_ERROR)
           .`type`(MediaType.APPLICATION_JSON)
-          .entity(e.getMessage)
+          .entity(Map("message" -> e.getMessage))
           .build()
     }
   }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/trino/api/api.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/trino/api/api.scala
@@ -42,7 +42,7 @@ private[api] trait ApiRequestContext {
 @Provider
 class RestExceptionMapper extends ExceptionMapper[Exception] with Logging {
   override def toResponse(exception: Exception): Response = {
-    warn("Error occurs on accessing REST API.", exception)
+    warn("Error occurs on accessing Trino API.", exception)
     exception match {
       case e: WebApplicationException =>
         Response.status(e.getResponse.getStatus)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Currently, there is no error message on Kyuubi server's log when REST API invocation error occurs, and since we are building REST API, all response media types should be JSON.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request
