### PR TITLE
Fix flaky test: close expired operations

### DIFF
--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/service/TFrontendServiceSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/service/TFrontendServiceSuite.scala
@@ -124,7 +124,7 @@ class TFrontendServiceSuite extends KyuubiFunSuite {
         val resp = client.OpenSession(req)
         val handle = resp.getSessionHandle
         assert(handle != null)
-        assert(resp.getStatus.getStatusCode == TStatusCode.SUCCESS_STATUS)
+        assert(resp.getStatus.getStatusCode === TStatusCode.SUCCESS_STATUS)
 
         req.setConfiguration(Map("kyuubi.test.should.fail" -> "true").asJava)
         val resp1 = client.OpenSession(req)
@@ -528,7 +528,7 @@ class TFrontendServiceSuite extends KyuubiFunSuite {
       val cancelOpReq = new TCancelOperationReq(resp.getOperationHandle)
       val cancelOpResp = client.CancelOperation(cancelOpReq)
       assert(cancelOpResp.getStatus.getStatusCode === TStatusCode.SUCCESS_STATUS)
-      assert(sessionManager.getOpenSessionCount == 1)
+      assert(sessionManager.getOpenSessionCount === 1)
       assert(session.lastIdleTime === 0)
       eventually(timeout(Span(60, Seconds)), interval(Span(1, Seconds))) {
         assert(lastAccessTime < session.lastAccessTime)
@@ -562,7 +562,7 @@ class TFrontendServiceSuite extends KyuubiFunSuite {
       Map(
         "session.engine.spark.main.resource" -> "org.apahce.kyuubi.test",
         "session.check.interval" -> "10000"))
-    assert(conf.size == 1)
-    assert(conf("session.check.interval") == "10000")
+    assert(conf.size === 1)
+    assert(conf("session.check.interval") === "10000")
   }
 }

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/service/TFrontendServiceSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/service/TFrontendServiceSuite.scala
@@ -514,41 +514,39 @@ class TFrontendServiceSuite extends KyuubiFunSuite {
 
   test("close expired operations") {
     withSessionHandle { (client, handle) =>
-      val req = new TCancelOperationReq()
-      val req1 = new TGetSchemasReq(handle)
-      val resp1 = client.GetSchemas(req1)
+      val req = new TGetSchemasReq(handle)
+      val resp = client.GetSchemas(req)
 
       val sessionManager = server.backendService.sessionManager
       val session = sessionManager
         .getSession(SessionHandle(handle))
         .asInstanceOf[AbstractSession]
       var lastAccessTime = session.lastAccessTime
-      assert(sessionManager.getOpenSessionCount == 1)
+      assert(sessionManager.getOpenSessionCount === 1)
       assert(session.lastIdleTime > 0)
 
-      resp1.getOperationHandle
-      req.setOperationHandle(resp1.getOperationHandle)
-      val resp2 = client.CancelOperation(req)
-      assert(resp2.getStatus.getStatusCode === TStatusCode.SUCCESS_STATUS)
+      val cancelOpReq = new TCancelOperationReq(resp.getOperationHandle)
+      val cancelOpResp = client.CancelOperation(cancelOpReq)
+      assert(cancelOpResp.getStatus.getStatusCode === TStatusCode.SUCCESS_STATUS)
       assert(sessionManager.getOpenSessionCount == 1)
-      assert(session.lastIdleTime == 0)
+      assert(session.lastIdleTime === 0)
       eventually(timeout(Span(60, Seconds)), interval(Span(1, Seconds))) {
         assert(lastAccessTime < session.lastAccessTime)
       }
       lastAccessTime = session.lastAccessTime
 
       eventually(timeout(Span(60, Seconds)), interval(Span(1, Seconds))) {
-        assert(session.lastIdleTime > lastAccessTime)
+        assert(lastAccessTime <= session.lastIdleTime)
       }
 
       info("operation is terminated")
-      assert(lastAccessTime == session.lastAccessTime)
-      assert(sessionManager.getOpenSessionCount == 1)
+      assert(lastAccessTime === session.lastAccessTime)
+      assert(sessionManager.getOpenSessionCount === 1)
 
       eventually(timeout(Span(60, Seconds)), interval(Span(1, Seconds))) {
         assert(session.lastAccessTime > lastAccessTime)
       }
-      assert(sessionManager.getOpenSessionCount == 0)
+      assert(sessionManager.getOpenSessionCount === 0)
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

https://github.com/apache/kyuubi/actions/runs/5302176227/jobs/9596926968
```
- close expired operations *** FAILED ***
  The code passed to eventually never returned normally. Attempted 70 times over 1.00037702345 minutes. Last failure message: 1687069174227 was not greater than 1687069174227. (TFrontendServiceSuite.scala:540)
```

Key change is 

from
```
assert(session.lastIdleTime > lastAccessTime)
```
to
```
assert(lastAccessTime <= session.lastIdleTime)
```

because there are updated nearly at the same time.

```
  private def release(userAccess: Boolean): Unit = {
    if (userAccess) {
      _lastAccessTime = System.currentTimeMillis
    }
    if (opHandleSet.isEmpty) {
      _lastIdleTime = System.currentTimeMillis
    }
  }
```

This PR also changes some assertion statements from `assert(actual == expected)` to `assert(actual === expected)`, the former is Scala assert syntax, the latter is scalatest method

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request
