### PR TITLE
Fix flaky test: support to interrupt the thrift request if remote engine is broken

### DIFF
--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
@@ -327,12 +327,11 @@ class KyuubiOperationPerConnectionSuite extends WithKyuubiServer with HiveJDBCTe
         val startTime = System.currentTimeMillis()
         val executeStmtResp = client.ExecuteStatement(executeStmtReq)
         assert(executeStmtResp.getStatus.getStatusCode === TStatusCode.ERROR_STATUS)
-        assert(executeStmtResp.getStatus.getErrorMessage.contains(
-          "java.net.SocketException") ||
-          executeStmtResp.getStatus.getErrorMessage.contains(
-            "org.apache.thrift.transport.TTransportException") ||
-          executeStmtResp.getStatus.getErrorMessage.contains(
-            "connection does not exist"))
+        val errorMsg = executeStmtResp.getStatus.getErrorMessage
+        assert(errorMsg.contains("java.net.SocketException") ||
+          errorMsg.contains("org.apache.thrift.transport.TTransportException") ||
+          errorMsg.contains("connection does not exist") ||
+          errorMsg.contains(s"Socket for ${SessionHandle(handle)} is closed"))
         val elapsedTime = System.currentTimeMillis() - startTime
         assert(elapsedTime < 20 * 1000)
         eventually(timeout(3.seconds)) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

https://github.com/apache/kyuubi/actions/runs/5307034060/jobs/9605209396
```
- support to interrupt the thrift request if remote engine is broken *** FAILED ***
  "org.apache.kyuubi.KyuubiSQLException: Error operating ExecuteStatement: Socket for SessionHandle [68f22014-c484-4279-8f79-81bd2e7f0eca] is closed" did not contain "java.net.SocketException", and "org.apache.kyuubi.KyuubiSQLException: Error operating ExecuteStatement: Socket for SessionHandle [68f22014-c484-4279-8f79-81bd2e7f0eca] is closed" did not contain "org.apache.thrift.transport.TTransportException", and "org.apache.kyuubi.KyuubiSQLException: Error operating ExecuteStatement: Socket for SessionHandle [68f22014-c484-4279-8f79-81bd2e7f0eca] is closed" did not contain "connection does not exist" (KyuubiOperationPerConnectionSuite.scala:330)
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request
