### PR TITLE
[KYUUBI #4946] Alter the order of initLoggerEventHandler

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiServer.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiServer.scala
@@ -164,8 +164,6 @@ class KyuubiServer(name: String) extends Serverable(name) {
     }
 
   override def initialize(conf: KyuubiConf): Unit = synchronized {
-    initLoggerEventHandler(conf)
-
     val kinit = new KinitAuxiliaryService()
     addService(kinit)
 
@@ -176,6 +174,8 @@ class KyuubiServer(name: String) extends Serverable(name) {
       addService(new MetricsSystem)
     }
     super.initialize(conf)
+
+    initLoggerEventHandler(conf)
   }
 
   override def start(): Unit = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Please see: https://github.com/apache/kyuubi/issues/4946
Simply put, the kinit service needs to be started before the initLoggerEventHandler, so that it can obtain the DELEGATION TOKEN, which is necessary for accessing the log path on HDFS.


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate
After this PR, confirmed the LoggerEventHandler can be initiated even kdestroy was executed beforehand. 
```
sudo -u kyuubi kdestroy
sudo -u kyuubi /opt/kyuubi/bin/kyuubi start

...

2023-06-19 22:18:36.581 INFO KyuubiTHttpFrontendService: Thread-101 org.eclipse.jetty.server.AbstractConnector: Started ServerConnector@50110971{HTTP/1.1, (http/1.1)}{0.0.0.0:10010}
2023-06-19 22:18:36.581 INFO KyuubiTHttpFrontendService: Thread-101 org.eclipse.jetty.server.Server: Started @6081ms
2023-06-19 22:18:36.669 INFO main org.apache.kyuubi.events.handler.ServerJsonLoggingEventHandler: Logging kyuubi events to viewfs://<namespace>/tmp/kyuubi_hive/events/kyuubi_server_info/day=20230619/server-<servername>.json
```

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request
Passed the test with kyuubi-server
```
./build/mvn clean install -pl kyuubi-server
```
