### PR TITLE
[KYUUBI #4982][UI] Add query string to forward requests to Engine UI

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/EngineUIProxyServlet.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/EngineUIProxyServlet.scala
@@ -33,13 +33,14 @@ private[api] class EngineUIProxyServlet extends ProxyServlet with Logging {
     val queryString = getQueryString(request)
     var targetURL = "/no-ui-error"
     extractTargetAddress(requestURI).foreach { case (host, port) =>
-      val targetURI = requestURI.stripPrefix(s"/engine-ui/$host:$port") match {
-        // for some reason, the proxy can not handle redirect well, as a workaround,
-        // we simulate the Spark UI redirection behavior and forcibly rewrite the
-        // empty URI to the Spark Jobs page.
-        case "" | "/" => "/jobs/" + queryString
-        case path => path + queryString
-      }
+      val targetURI =
+        (requestURI.stripPrefix(s"/engine-ui/$host:$port") match {
+          // for some reason, the proxy can not handle redirect well, as a workaround,
+          // we simulate the Spark UI redirection behavior and forcibly rewrite the
+          // empty URI to the Spark Jobs page.
+          case "" | "/" => "/jobs/"
+          case path => path
+        }) + queryString
       targetURL = new URL("http", host, port, targetURI).toString
     }
     debug(s"rewrite $requestURL => $targetURL")

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/EngineUIProxyServlet.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/EngineUIProxyServlet.scala
@@ -30,6 +30,7 @@ private[api] class EngineUIProxyServlet extends ProxyServlet with Logging {
   override def rewriteTarget(request: HttpServletRequest): String = {
     val requestURL = request.getRequestURL
     val requestURI = request.getRequestURI
+    val queryString = getQueryString(request)
     var targetURL = "/no-ui-error"
     extractTargetAddress(requestURI).foreach { case (host, port) =>
       val targetURI = requestURI.stripPrefix(s"/engine-ui/$host:$port") match {
@@ -37,7 +38,7 @@ private[api] class EngineUIProxyServlet extends ProxyServlet with Logging {
         // we simulate the Spark UI redirection behavior and forcibly rewrite the
         // empty URI to the Spark Jobs page.
         case "" | "/" => "/jobs/"
-        case path => path
+        case path => path + queryString
       }
       targetURL = new URL("http", host, port, targetURI).toString
     }
@@ -62,4 +63,16 @@ private[api] class EngineUIProxyServlet extends ProxyServlet with Logging {
       case r(host, port) => Some(host -> port.toInt)
       case _ => None
     }
+
+  def getQueryString(request: HttpServletRequest): String = {
+    val result = new StringBuilder()
+    val queryString = request.getQueryString()
+    if (queryString != null && queryString.length() > 0) {
+      info(queryString)
+      result.append("?")
+      result.append(queryString)
+    }
+    result.toString()
+  }
+
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/EngineUIProxyServlet.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/EngineUIProxyServlet.scala
@@ -66,14 +66,7 @@ private[api] class EngineUIProxyServlet extends ProxyServlet with Logging {
     }
 
   def getQueryString(request: HttpServletRequest): String = {
-    val result = new StringBuilder()
-    val queryString = request.getQueryString()
-    if (queryString != null && queryString.length() > 0) {
-      info(queryString)
-      result.append("?")
-      result.append(queryString)
-    }
-    result.toString()
+    val queryString = request.getQueryString
+    if (StringUtils.isNotEmpty(queryString)) s"?$queryString" else ""
   }
-
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/EngineUIProxyServlet.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/EngineUIProxyServlet.scala
@@ -37,7 +37,7 @@ private[api] class EngineUIProxyServlet extends ProxyServlet with Logging {
         // for some reason, the proxy can not handle redirect well, as a workaround,
         // we simulate the Spark UI redirection behavior and forcibly rewrite the
         // empty URI to the Spark Jobs page.
-        case "" | "/" => "/jobs/"
+        case "" | "/" => "/jobs/" + queryString
         case path => path + queryString
       }
       targetURL = new URL("http", host, port, targetURI).toString


### PR DESCRIPTION

### _Why are the changes needed?_

close #4982

The `targetURL` should include the query string so that kyuubi server can forward request to right page, eg: 

```
/engine-ui/spark-43efae88d766226a-driver-svc.kyuubi-dlssjc-canned.svc:4045/jobs/job/?id=4
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request

