### PR TITLE
[KYUUBI #4978][FOLLOWUP] Fix flaky test: close expired operations

### DIFF
--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/service/TFrontendServiceSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/service/TFrontendServiceSuite.scala
@@ -543,7 +543,7 @@ class TFrontendServiceSuite extends KyuubiFunSuite {
       eventually(timeout(Span(60, Seconds)), interval(Span(1, Seconds))) {
         assert(session.lastAccessTime > lastAccessTime)
       }
-      info("operation is terminated")
+      info("session is terminated")
       assert(sessionManager.getOpenSessionCount === 0)
     }
   }

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/service/TFrontendServiceSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/service/TFrontendServiceSuite.scala
@@ -538,14 +538,12 @@ class TFrontendServiceSuite extends KyuubiFunSuite {
       eventually(timeout(Span(60, Seconds)), interval(Span(1, Seconds))) {
         assert(lastAccessTime <= session.lastIdleTime)
       }
-
       info("operation is terminated")
-      assert(lastAccessTime === session.lastAccessTime)
-      assert(sessionManager.getOpenSessionCount === 1)
 
       eventually(timeout(Span(60, Seconds)), interval(Span(1, Seconds))) {
         assert(session.lastAccessTime > lastAccessTime)
       }
+      info("operation is terminated")
       assert(sessionManager.getOpenSessionCount === 0)
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

The assertions are fragile because the session only has 5s as the idle timeout.
```
assert(lastAccessTime === session.lastAccessTime)
assert(sessionManager.getOpenSessionCount === 1)
```

https://github.com/apache/kyuubi/actions/runs/5312620487/jobs/9617377736?pr=4980

```
- close expired operations *** FAILED ***
  0 did not equal 1 (TFrontendServiceSuite.scala:544)
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request
