### PR TITLE
Support to refresh kubernetes configs dynamically

### DIFF
--- a/docs/client/rest/rest_api.md
+++ b/docs/client/rest/rest_api.md
@@ -455,6 +455,8 @@ Refresh the [user defaults configs](../../deployment/settings.html#user-defaults
 
 Refresh the kubernetes configs with key prefixed with `kyuubi.kubernetes` from default property file.
 
+It is helpful if you need to support multiple kubernetes contexts and namespaces, see [KYUUBI #4843].
+
 ### DELETE /admin/engine
 
 Delete the specified engine.

--- a/docs/client/rest/rest_api.md
+++ b/docs/client/rest/rest_api.md
@@ -451,6 +451,10 @@ Refresh the Hadoop configurations of the Kyuubi server.
 
 Refresh the [user defaults configs](../../deployment/settings.html#user-defaults) with key in format in the form of `___{username}___.{config key}` from default property file.
 
+### POST /admin/refresh/kubernetes_conf
+
+Refresh the kubernetes configs with key prefixed with `kyuubi.kubernetes` from default property file.
+
 ### DELETE /admin/engine
 
 Delete the specified engine.

--- a/docs/client/rest/rest_api.md
+++ b/docs/client/rest/rest_api.md
@@ -455,7 +455,7 @@ Refresh the [user defaults configs](../../deployment/settings.html#user-defaults
 
 Refresh the kubernetes configs with key prefixed with `kyuubi.kubernetes` from default property file.
 
-It is helpful if you need to support multiple kubernetes contexts and namespaces, see [KYUUBI #4843].
+It is helpful if you need to support multiple kubernetes contexts and namespaces, see [KYUUBI #4843](https://github.com/apache/kyuubi/issues/4843).
 
 ### DELETE /admin/engine
 

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/refresh/RefreshConfigCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/refresh/RefreshConfigCommand.scala
@@ -21,7 +21,7 @@ import org.apache.kyuubi.KyuubiException
 import org.apache.kyuubi.client.AdminRestApi
 import org.apache.kyuubi.ctl.RestClientFactory.withKyuubiRestClient
 import org.apache.kyuubi.ctl.cmd.AdminCtlCommand
-import org.apache.kyuubi.ctl.cmd.refresh.RefreshConfigCommandConfigType.{HADOOP_CONF, UNLIMITED_USERS, USER_DEFAULTS_CONF}
+import org.apache.kyuubi.ctl.cmd.refresh.RefreshConfigCommandConfigType.{HADOOP_CONF, KUBERNETES_CONF, UNLIMITED_USERS, USER_DEFAULTS_CONF}
 import org.apache.kyuubi.ctl.opt.CliConfig
 import org.apache.kyuubi.ctl.util.{Tabulator, Validator}
 
@@ -36,6 +36,7 @@ class RefreshConfigCommand(cliConfig: CliConfig) extends AdminCtlCommand[String]
       normalizedCliConfig.adminConfigOpts.configType match {
         case HADOOP_CONF => adminRestApi.refreshHadoopConf()
         case USER_DEFAULTS_CONF => adminRestApi.refreshUserDefaultsConf()
+        case KUBERNETES_CONF => adminRestApi.refreshKubernetesConf()
         case UNLIMITED_USERS => adminRestApi.refreshUnlimitedUsers()
         case configType => throw new KyuubiException(s"Invalid config type:$configType")
       }
@@ -49,5 +50,6 @@ class RefreshConfigCommand(cliConfig: CliConfig) extends AdminCtlCommand[String]
 object RefreshConfigCommandConfigType {
   final val HADOOP_CONF = "hadoopConf"
   final val USER_DEFAULTS_CONF = "userDefaultsConf"
+  final val KUBERNETES_CONF = "kubernetesConf"
   final val UNLIMITED_USERS = "unlimitedUsers"
 }

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/opt/AdminCommandLine.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/opt/AdminCommandLine.scala
@@ -108,6 +108,6 @@ object AdminCommandLine extends CommonCommandLine {
           .optional()
           .action((v, c) => c.copy(adminConfigOpts = c.adminConfigOpts.copy(configType = v)))
           .text("The valid config type can be one of the following: " +
-            s"$HADOOP_CONF, $USER_DEFAULTS_CONF, $UNLIMITED_USERS."))
+            s"$HADOOP_CONF, $USER_DEFAULTS_CONF, $KUBERNETES_CONF, $UNLIMITED_USERS."))
   }
 }

--- a/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/AdminControlCliArgumentsSuite.scala
+++ b/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/AdminControlCliArgumentsSuite.scala
@@ -86,6 +86,15 @@ class AdminControlCliArgumentsSuite extends KyuubiFunSuite with TestPrematureExi
     args = Array(
       "refresh",
       "config",
+      "kubernetesConf")
+    val opArgs4 = new AdminControlCliArguments(args)
+    assert(opArgs4.cliConfig.action === ControlAction.REFRESH)
+    assert(opArgs4.cliConfig.resource === ControlObject.CONFIG)
+    assert(opArgs4.cliConfig.adminConfigOpts.configType === KUBERNETES_CONF)
+
+    args = Array(
+      "refresh",
+      "config",
       "--hostUrl",
       "https://kyuubi.test.com",
       "otherConf")
@@ -165,7 +174,7 @@ class AdminControlCliArgumentsSuite extends KyuubiFunSuite with TestPrematureExi
          |	Refresh the resource.
          |Command: refresh config [<configType>]
          |	Refresh the config with specified type.
-         |  <configType>             The valid config type can be one of the following: $HADOOP_CONF, $USER_DEFAULTS_CONF, $UNLIMITED_USERS.
+         |  <configType>             The valid config type can be one of the following: $HADOOP_CONF, $USER_DEFAULTS_CONF, $KUBERNETES_CONF, $UNLIMITED_USERS.
          |
          |  -h, --help               Show help message and exit.""".stripMargin
     // scalastyle:on

--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/AdminRestApi.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/AdminRestApi.java
@@ -52,7 +52,6 @@ public class AdminRestApi {
     return this.getClient().post(path, null, client.getAuthHeader());
   }
 
-
   public String refreshUnlimitedUsers() {
     String path = String.format("%s/%s", API_BASE_PATH, "refresh/unlimited_users");
     return this.getClient().post(path, null, client.getAuthHeader());

--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/AdminRestApi.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/AdminRestApi.java
@@ -47,6 +47,12 @@ public class AdminRestApi {
     return this.getClient().post(path, null, client.getAuthHeader());
   }
 
+  public String refreshKubernetesConf() {
+    String path = String.format("%s/%s", API_BASE_PATH, "refresh/kubernetes_conf");
+    return this.getClient().post(path, null, client.getAuthHeader());
+  }
+
+
   public String refreshUnlimitedUsers() {
     String path = String.format("%s/%s", API_BASE_PATH, "refresh/unlimited_users");
     return this.getClient().post(path, null, client.getAuthHeader());

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
@@ -40,11 +40,13 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
   private val enginePodInformers: ConcurrentHashMap[KubernetesInfo, SharedIndexInformer[Pod]] =
     new ConcurrentHashMap[KubernetesInfo, SharedIndexInformer[Pod]]
 
-  private var allowedContexts: Seq[String] = Seq.empty
-  private var allowedNamespaces: Seq[String] = Seq.empty
-
   private var submitTimeout: Long = _
   private var kyuubiConf: KyuubiConf = _
+
+  private def allowedContexts: Seq[String] =
+    kyuubiConf.get(KyuubiConf.KUBERNETES_CONTEXT_ALLOW_LIST)
+  private def allowedNamespaces: Seq[String] =
+    kyuubiConf.get(KyuubiConf.KUBERNETES_NAMESPACE_ALLOW_LIST)
 
   // key is kyuubi_unique_key
   private val appInfoStore: ConcurrentHashMap[String, ApplicationInfo] =
@@ -90,8 +92,6 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
     kyuubiConf = conf
     info("Start initializing Kubernetes application operation.")
     submitTimeout = conf.get(KyuubiConf.ENGINE_KUBERNETES_SUBMIT_TIMEOUT)
-    allowedContexts = conf.get(KyuubiConf.KUBERNETES_CONTEXT_ALLOW_LIST)
-    allowedNamespaces = conf.get(KyuubiConf.KUBERNETES_NAMESPACE_ALLOW_LIST)
     // Defer cleaning terminated application information
     val retainPeriod = conf.get(KyuubiConf.KUBERNETES_TERMINATED_APPLICATION_RETAIN_PERIOD)
     cleanupTerminatedAppInfoTrigger = CacheBuilder.newBuilder()

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/AdminResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/AdminResource.scala
@@ -90,6 +90,25 @@ private[v1] class AdminResource extends ApiRequestContext with Logging {
   @ApiResponse(
     responseCode = "200",
     content = Array(new Content(mediaType = MediaType.APPLICATION_JSON)),
+    description = "refresh the kubernetes configs")
+  @POST
+  @Path("refresh/kubernetes_conf")
+  def refreshKubernetesConf(): Response = {
+    val userName = fe.getSessionUser(Map.empty[String, String])
+    val ipAddress = fe.getIpAddress
+    info(s"Receive refresh kubernetes conf request from $userName/$ipAddress")
+    if (!isAdministrator(userName)) {
+      throw new NotAllowedException(
+        s"$userName is not allowed to refresh the kubernetes conf")
+    }
+    info(s"Reloading kubernetes conf")
+    KyuubiServer.refreshKubernetesConf()
+    Response.ok(s"Refresh the kubernetes conf successfully.").build()
+  }
+
+  @ApiResponse(
+    responseCode = "200",
+    content = Array(new Content(mediaType = MediaType.APPLICATION_JSON)),
     description = "refresh the unlimited users")
   @POST
   @Path("refresh/unlimited_users")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This is a followup of #4843 

To support load kubernetes conf during runtime, so that we can support more kuberntes contexts without restarting the kyuubi server.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request
