### PR TITLE
Fix typo for kubernetes allowed context and namespace check

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
@@ -58,12 +58,12 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
     val context = kubernetesInfo.context
     val namespace = kubernetesInfo.namespace
 
-    if (allowedContexts.nonEmpty && !allowedContexts.contains(context)) {
+    if (allowedContexts.nonEmpty && context.exists(!allowedContexts.contains(_))) {
       throw new KyuubiException(
         s"Kubernetes context $context is not in the allowed list[$allowedContexts]")
     }
 
-    if (allowedNamespaces.nonEmpty && !allowedNamespaces.contains(namespace)) {
+    if (allowedNamespaces.nonEmpty && namespace.exists(!allowedNamespaces.contains(_))) {
       throw new KyuubiException(
         s"Kubernetes namespace $namespace is not in the allowed list[$allowedNamespaces]")
     }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
@@ -59,6 +59,7 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
     kubernetesClients.computeIfAbsent(kubernetesInfo, kInfo => buildKubernetesClient(kInfo))
   }
 
+  // Visible for testing
   private[engine] def checkKubernetesInfo(kubernetesInfo: KubernetesInfo): Unit = {
     val context = kubernetesInfo.context
     val namespace = kubernetesInfo.namespace

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
@@ -55,6 +55,11 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
   private var cleanupTerminatedAppInfoTrigger: Cache[String, ApplicationState] = _
 
   private def getOrCreateKubernetesClient(kubernetesInfo: KubernetesInfo): KubernetesClient = {
+    checkKubernetesInfo(kubernetesInfo)
+    kubernetesClients.computeIfAbsent(kubernetesInfo, kInfo => buildKubernetesClient(kInfo))
+  }
+
+  private[engine] def checkKubernetesInfo(kubernetesInfo: KubernetesInfo): Unit = {
     val context = kubernetesInfo.context
     val namespace = kubernetesInfo.namespace
 
@@ -67,8 +72,6 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
       throw new KyuubiException(
         s"Kubernetes namespace $namespace is not in the allowed list[$allowedNamespaces]")
     }
-
-    kubernetesClients.computeIfAbsent(kubernetesInfo, kInfo => buildKubernetesClient(kInfo))
   }
 
   private def buildKubernetesClient(kubernetesInfo: KubernetesInfo): KubernetesClient = {

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/KubernetesApplicationOperationSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/KubernetesApplicationOperationSuite.scala
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.engine
+
+import org.apache.kyuubi.{KyuubiException, KyuubiFunSuite}
+import org.apache.kyuubi.config.KyuubiConf
+
+class KubernetesApplicationOperationSuite extends KyuubiFunSuite {
+
+  test("test check kubernetes info") {
+    val kyuubiConf = KyuubiConf()
+    kyuubiConf.set(KyuubiConf.KUBERNETES_CONTEXT_ALLOW_LIST.key, "1,2")
+    kyuubiConf.set(KyuubiConf.KUBERNETES_NAMESPACE_ALLOW_LIST.key, "ns1,ns2")
+
+    val operation = new KubernetesApplicationOperation()
+    operation.initialize(kyuubiConf)
+
+    operation.checkKubernetesInfo(KubernetesInfo(None, None))
+    operation.checkKubernetesInfo(KubernetesInfo(Some("1"), None))
+    operation.checkKubernetesInfo(KubernetesInfo(Some("2"), None))
+    operation.checkKubernetesInfo(KubernetesInfo(Some("1"), Some("ns1")))
+    operation.checkKubernetesInfo(KubernetesInfo(Some("1"), Some("ns2")))
+    operation.checkKubernetesInfo(KubernetesInfo(Some("2"), Some("ns1")))
+    operation.checkKubernetesInfo(KubernetesInfo(Some("2"), Some("ns2")))
+
+    intercept[KyuubiException] {
+      operation.checkKubernetesInfo(KubernetesInfo(Some("3"), Some("ns1")))
+    }
+    intercept[KyuubiException] {
+      operation.checkKubernetesInfo(KubernetesInfo(Some("1"), Some("ns3")))
+    }
+    intercept[KyuubiException] {
+      operation.checkKubernetesInfo(KubernetesInfo(Some("3"), None))
+    }
+    intercept[KyuubiException] {
+      operation.checkKubernetesInfo(KubernetesInfo(None, Some("ns3")))
+    }
+
+    kyuubiConf.unset(KyuubiConf.KUBERNETES_CONTEXT_ALLOW_LIST.key)
+    operation.checkKubernetesInfo(KubernetesInfo(Some("3"), None))
+    kyuubiConf.unset(KyuubiConf.KUBERNETES_NAMESPACE_ALLOW_LIST.key)
+    operation.checkKubernetesInfo(KubernetesInfo(None, Some("ns3")))
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

I met below exception.
```
2023-06-29 00:10:43.174 ERROR org.apache.kyuubi.engine.KubernetesApplicationOperation: Failed to get application with 3c036904-ffef-480b-89e9-2bc6439a6d04, due to Kubernetes context Some(97) is not in the allowed list[ArrayBuffer(97, 116)]
```

The context and namespace are type of `Option[String]` and the allowed lists are type of `Seq[String]`.


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request
