### PR TITLE
[KSHC] CreateTable should use the correct provider

### DIFF
--- a/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/HiveCatalogSuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/HiveCatalogSuite.scala
@@ -219,6 +219,7 @@ class HiveCatalogSuite extends KyuubiHiveTest {
 
   test("createTable: location") {
     val properties = new util.HashMap[String, String]()
+    properties.put(TableCatalog.PROP_PROVIDER, "parquet")
     assert(!catalog.tableExists(testIdent))
 
     // default location

--- a/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/KyuubiHiveTest.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/KyuubiHiveTest.scala
@@ -35,7 +35,8 @@ abstract class KyuubiHiveTest extends QueryTest with Logging {
       TableCatalog.PROP_PROVIDER,
       TableCatalog.PROP_OWNER,
       TableCatalog.PROP_EXTERNAL,
-      TableCatalog.PROP_IS_MANAGED_LOCATION)
+      TableCatalog.PROP_IS_MANAGED_LOCATION,
+      "transient_lastDdlTime")
 
   protected val NAMESPACE_RESERVED_PROPERTIES =
     Seq(

--- a/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/command/CreateTableSuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/command/CreateTableSuite.scala
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kyuubi.spark.connector.hive.command
+
+import org.apache.spark.sql.connector.catalog.Identifier
+
+import org.apache.kyuubi.spark.connector.hive.{HiveTable, HiveTableCatalog}
+import org.apache.kyuubi.spark.connector.hive.command.DDLCommandTestUtils.V2_COMMAND_VERSION
+
+class CreateTableSuite extends DDLCommandTestUtils {
+
+  override protected def command: String = "CREATE TABLE"
+
+  override protected def catalogVersion: String = "Hive V2"
+
+  override protected def commandVersion: String = V2_COMMAND_VERSION
+
+  test("Create datasource table") {
+    val hiveCatalog = spark.sessionState.catalogManager
+      .catalog(catalogName).asInstanceOf[HiveTableCatalog]
+    val table = "hive.default.employee"
+    Seq("parquet", "orc").foreach { provider =>
+      withTable(table) {
+        sql(
+          s"""
+             | CREATE TABLE IF NOT EXISTS
+             | $table (id String, year String, month string)
+             | USING $provider
+             | PARTITIONED BY (year, month)
+             |""".stripMargin).collect()
+        val employee = Identifier.of(Array("default"), "employee")
+        val loadTable = hiveCatalog.loadTable(employee)
+        assert(loadTable.isInstanceOf[HiveTable])
+        val catalogTable = loadTable.asInstanceOf[HiveTable].catalogTable
+        assert(catalogTable.provider.isDefined)
+        assert(catalogTable.provider.get.equalsIgnoreCase(provider))
+      }
+    }
+  }
+
+  test("Create hive table") {
+    val hiveCatalog = spark.sessionState.catalogManager
+      .catalog(catalogName).asInstanceOf[HiveTableCatalog]
+    val table = "hive.default.employee"
+    Seq("parquet", "orc").foreach { provider =>
+      withTable(table) {
+        sql(
+          s"""
+             | CREATE TABLE IF NOT EXISTS
+             | $table (id String, year String, month string)
+             | STORED AS $provider
+             | PARTITIONED BY (year, month)
+             |""".stripMargin).collect()
+        val employee = Identifier.of(Array("default"), "employee")
+        val loadTable = hiveCatalog.loadTable(employee)
+        assert(loadTable.isInstanceOf[HiveTable])
+        val catalogTable = loadTable.asInstanceOf[HiveTable].catalogTable
+        assert(catalogTable.provider.isDefined)
+        assert(catalogTable.provider.get.equalsIgnoreCase("hive"))
+        assert(catalogTable.storage.serde.getOrElse("Unknown").contains(provider))
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This PR aims to fix a bug, In KSHC, `catalog.createTable` should use the correct provider.

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request
