### PR TITLE
[KSHC] TableIdentify don't attach catalog

### DIFF
--- a/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/HiveCatalogSuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/HiveCatalogSuite.scala
@@ -164,7 +164,7 @@ class HiveCatalogSuite extends KyuubiHiveTest {
       catalog.createTable(testIdent, schema, Array.empty[Transform], emptyProps)
 
     val parsed = CatalystSqlParser.parseMultipartIdentifier(table.name)
-    assert(parsed == Seq("db", "test_table") || parsed == Seq("spark_catalog", "db", "test_table"))
+    assert(parsed == Seq("db", "test_table"))
     assert(table.schema == schema)
     assert(filterV2TableProperties(table.properties) == Map())
 
@@ -181,7 +181,7 @@ class HiveCatalogSuite extends KyuubiHiveTest {
     val table = catalog.createTable(testIdent, schema, Array.empty[Transform], properties)
 
     val parsed = CatalystSqlParser.parseMultipartIdentifier(table.name)
-    assert(parsed == Seq("db", "test_table") || parsed == Seq("spark_catalog", "db", "test_table"))
+    assert(parsed == Seq("db", "test_table"))
     assert(table.schema == schema)
     assert(filterV2TableProperties(table.properties).asJava == properties)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
As title, In KSHC, HiveTable's identify does not attach the catalog to prevent an incorrect catalogName. default catalog is "spark_catalog"

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request
