### PR TITLE
Use formatDuration instead of formatDurationVerbose in SparkUI's engine tab

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EnginePage.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EnginePage.scala
@@ -292,7 +292,7 @@ case class EnginePage(parent: EngineTab) extends WebUIPage("") {
         <td> {session.name} </td>
         <td> {formatDate(session.startTime)} </td>
         <td> {if (session.endTime > 0) formatDate(session.endTime)} </td>
-        <td> {formatDurationVerbose(session.duration)} </td>
+        <td> {formatDuration(session.duration)} </td>
         <td> {session.totalOperations} </td>
       </tr>
     }
@@ -386,7 +386,7 @@ private class StatementStatsPagedTable(
         {if (event.completeTime > 0) formatDate(event.completeTime)}
       </td>
       <td >
-        {formatDurationVerbose(event.duration)}
+        {formatDuration(event.duration)}
       </td>
       <td>
         <span class="description-input">


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- previously used `formatDurationVerbose` generates duration with dedicated unit parts
- Spark UI itself also uses `formatDuration` in its Job/Stage pages for displaying duration
   - `JobDataUtil.getFormattedDuration` in AllJobsPage, and `formatDuration` used in `getFormattedDuration` , https://github.com/apache/spark/blob/v3.3.2/core/src/main/scala/org/apache/spark/ui/jobs/JobDataUtil.scala#L32

Before:
![image](https://github.com/apache/kyuubi/assets/1935105/e7fce841-5519-4bf9-bc04-701ea2a90dae)

After:
![image](https://github.com/apache/kyuubi/assets/1935105/b2805183-b7ea-4d4a-af9e-d532019dae31)


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request
