### PR TITLE
[KYUUBI #5035] Spark engine session page display session end time and duration

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EngineSessionPage.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EngineSessionPage.scala
@@ -81,7 +81,7 @@ case class EngineSessionPage(parent: EngineTab)
           Server {sessionStat.serverIp},
           Session created at {formatDate(sessionStat.startTime)},
           {
-          if (sessionStat.endTime == -1L) {
+          if (sessionStat.endTime < 0) {
             ""
           } else {
             s"""

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EngineSessionPage.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EngineSessionPage.scala
@@ -78,15 +78,15 @@ case class EngineSessionPage(parent: EngineTab)
         <h4>
           User {sessionStat.username},
           IP {sessionStat.ip},
-          Server {sessionStat.serverIp},
+          Server {sessionStat.serverIp}
+        </h4> ++
+        <h4>
           Session created at {formatDate(sessionStat.startTime)},
           {
-          if (sessionStat.endTime < 0) {
-            ""
-          } else {
+          if (sessionStat.endTime > 0) {
             s"""
-               |Session end at ${formatDate(sessionStat.endTime)},
-               |Session duration ${formatDuration(sessionStat.duration)},
+               | ended at ${formatDate(sessionStat.endTime)},
+               | after ${formatDuration(sessionStat.duration)}.
                |""".stripMargin
           }
         }

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EngineSessionPage.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EngineSessionPage.scala
@@ -80,6 +80,16 @@ case class EngineSessionPage(parent: EngineTab)
           IP {sessionStat.ip},
           Server {sessionStat.serverIp},
           Session created at {formatDate(sessionStat.startTime)},
+          {
+          if (sessionStat.endTime == -1L) {
+            ""
+          } else {
+            s"""
+               |Session end at ${formatDate(sessionStat.endTime)},
+               |Session duration ${formatDuration(sessionStat.duration)},
+               |""".stripMargin
+          }
+        }
           Total run {sessionStat.totalOperations} SQL
         </h4> ++
         sessionPropertiesTable ++


### PR DESCRIPTION
### _Why are the changes needed?_
close #5035 

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate
![image](https://github.com/apache/kyuubi/assets/18713676/502b489f-6cbd-4510-a89c-b7816b3e15bf)
- [x] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request
