### PR TITLE
[KYUUBI #5036] Fix Operation.close not update complete timestamp

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/AbstractOperation.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/AbstractOperation.scala
@@ -115,7 +115,7 @@ abstract class AbstractOperation(session: Session) extends Operation with Loggin
         info(s"Processing ${session.user}'s query[$statementId]: " +
           s"${state.name} -> ${newState.name}, statement:\n$redactedStatement")
         startTime = System.currentTimeMillis()
-      case ERROR | FINISHED | CANCELED | TIMEOUT =>
+      case ERROR | FINISHED | CANCELED | TIMEOUT | CLOSED =>
         completedTime = System.currentTimeMillis()
         val timeCost = s", time taken: ${(completedTime - startTime) / 1000.0} seconds"
         info(s"Processing ${session.user}'s query[$statementId]: " +


### PR DESCRIPTION
### _Why are the changes needed?_
To fix #5036, Operation.close() (maybe caused by query timeout) does not update operation complete time.

User may find it confusing and think the query is still running because each refresh on UI will show a different timestamp


### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request
