### PR TITLE
[KYUUBI #5043] Destroy the build process when waitCompletion is false and the engine is running in cluster mode

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
@@ -267,9 +267,15 @@ private[kyuubi] class EngineRef(
       }
       engineRef.get
     } finally {
+      val waitCompletion = conf.get(KyuubiConf.SESSION_ENGINE_STARTUP_WAIT_COMPLETION)
+      val destroyProcess = !waitCompletion && builder.isClusterMode()
+      if (destroyProcess) {
+        info("Destroy the builder process because waitCompletion is false" +
+          " and the engine is running in cluster mode.")
+      }
       // we must close the process builder whether session open is success or failure since
       // we have a log capture thread in process builder.
-      builder.close()
+      builder.close(destroyProcess)
     }
   }
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ProcBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ProcBuilder.scala
@@ -155,7 +155,7 @@ trait ProcBuilder {
   @volatile private var error: Throwable = UNCAUGHT_ERROR
 
   private val engineLogMaxLines = conf.get(KyuubiConf.SESSION_ENGINE_STARTUP_MAX_LOG_LINES)
-  private val waitCompletion = conf.get(KyuubiConf.SESSION_ENGINE_STARTUP_WAIT_COMPLETION)
+
   protected val lastRowsOfLog: EvictingQueue[String] = EvictingQueue.create(engineLogMaxLines)
   // Visible for test
   @volatile private[kyuubi] var logCaptureThreadReleased: Boolean = true
@@ -249,13 +249,14 @@ trait ProcBuilder {
     process
   }
 
-  def close(destroyProcess: Boolean = !waitCompletion): Unit = synchronized {
+  def isClusterMode(): Boolean = false
+
+  def close(destroyProcess: Boolean): Unit = synchronized {
     if (logCaptureThread != null) {
       logCaptureThread.interrupt()
       logCaptureThread = null
     }
     if (destroyProcess && process != null) {
-      info("Destroy the process, since waitCompletion is false.")
       process.destroyForcibly()
       process = null
     }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
@@ -19,6 +19,7 @@ package org.apache.kyuubi.engine.spark
 
 import java.io.{File, IOException}
 import java.nio.file.Paths
+import java.util.Locale
 
 import scala.collection.mutable.ArrayBuffer
 
@@ -210,6 +211,18 @@ class SparkProcessBuilder(
     conf.getOption(MASTER_KEY).orElse(defaultsConf.get(MASTER_KEY))
   }
 
+  def deployMode(): Option[String] = {
+    conf.getOption(DEPLOY_MODE_KEY).orElse(defaultsConf.get(DEPLOY_MODE_KEY))
+  }
+
+  override def isClusterMode(): Boolean = {
+    clusterManager().map(_.toLowerCase(Locale.ROOT)) match {
+      case Some(m) if m.startsWith("yarn") || m.startsWith("k8s") =>
+        deployMode().exists(_.toLowerCase(Locale.ROOT) == "cluster")
+      case _ => false
+    }
+  }
+
   def kubernetesContext(): Option[String] = {
     conf.getOption(KUBERNETES_CONTEXT_KEY).orElse(defaultsConf.get(KUBERNETES_CONTEXT_KEY))
   }
@@ -237,6 +250,7 @@ object SparkProcessBuilder {
   final val APP_KEY = "spark.app.name"
   final val TAG_KEY = "spark.yarn.tags"
   final val MASTER_KEY = "spark.master"
+  final val DEPLOY_MODE_KEY = "spark.submit.deployMode"
   final val KUBERNETES_CONTEXT_KEY = "spark.kubernetes.context"
   final val KUBERNETES_NAMESPACE_KEY = "spark.kubernetes.namespace"
   final val INTERNAL_RESOURCE = "spark-internal"

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilderSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilderSuite.scala
@@ -141,7 +141,7 @@ class SparkProcessBuilderSuite extends KerberizedTestHelper with MockitoSugar {
       assert(!process.logCaptureThreadReleased)
       subProcess.waitFor(3, TimeUnit.SECONDS)
     } finally {
-      process.close()
+      process.close(true)
     }
     eventually(timeout(3.seconds), interval(100.milliseconds)) {
       assert(process.logCaptureThreadReleased)
@@ -173,7 +173,7 @@ class SparkProcessBuilderSuite extends KerberizedTestHelper with MockitoSugar {
               val p = pb.start
               p.waitFor()
             } finally {
-              pb.close()
+              pb.close(true)
             }
           })
         }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/rest/client/BatchCliSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/rest/client/BatchCliSuite.scala
@@ -75,23 +75,24 @@ class BatchCliSuite extends RestClientTestHelper with TestPrematureExit with Bat
     Files.write(Paths.get(batchFile), batch_basic.getBytes(StandardCharsets.UTF_8))
 
     val long_time_batch_basic = s"""apiVersion: v1
-                         |username: ${ldapUser}
-                         |request:
-                         |  batchType: Spark
-                         |  name: LongTimeBatch
-                         |  resource: ${sparkBatchTestResource.get}
-                         |  className: org.apache.spark.examples.DriverSubmissionTest
-                         |  args:
-                         |   - 10
-                         |  configs:
-                         |    spark.master: local
-                         |    wait.completion: true
-                         |    k1: v1
-                         |    1: test_integer_key
-                         |    key:
-                         |options:
-                         |  verbose: true""".stripMargin
-    Files.write(Paths.get(longTimeBatchFile),
+                                   |username: ${ldapUser}
+                                   |request:
+                                   |  batchType: Spark
+                                   |  name: LongTimeBatch
+                                   |  resource: ${sparkBatchTestResource.get}
+                                   |  className: org.apache.spark.examples.DriverSubmissionTest
+                                   |  args:
+                                   |   - 10
+                                   |  configs:
+                                   |    spark.master: local
+                                   |    wait.completion: true
+                                   |    k1: v1
+                                   |    1: test_integer_key
+                                   |    key:
+                                   |options:
+                                   |  verbose: true""".stripMargin
+    Files.write(
+      Paths.get(longTimeBatchFile),
       long_time_batch_basic.getBytes(StandardCharsets.UTF_8))
   }
 

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/rest/client/BatchCliSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/rest/client/BatchCliSuite.scala
@@ -40,6 +40,7 @@ class BatchCliSuite extends RestClientTestHelper with TestPrematureExit with Bat
 
   val basePath: String = Utils.getCodeSourceLocation(getClass)
   val batchFile: String = s"${basePath}/batch.yaml"
+  val longTimeBatchFile: String = s"${basePath}/batch_long_time.yaml"
 
   override protected val otherConfigs: Map[String, String] = {
     Map(KyuubiConf.BATCH_APPLICATION_CHECK_INTERVAL.key -> "100")
@@ -72,6 +73,26 @@ class BatchCliSuite extends RestClientTestHelper with TestPrematureExit with Bat
                          |options:
                          |  verbose: true""".stripMargin
     Files.write(Paths.get(batchFile), batch_basic.getBytes(StandardCharsets.UTF_8))
+
+    val long_time_batch_basic = s"""apiVersion: v1
+                         |username: ${ldapUser}
+                         |request:
+                         |  batchType: Spark
+                         |  name: LongTimeBatch
+                         |  resource: ${sparkBatchTestResource.get}
+                         |  className: org.apache.spark.examples.DriverSubmissionTest
+                         |  args:
+                         |   - 10
+                         |  configs:
+                         |    spark.master: local
+                         |    wait.completion: true
+                         |    k1: v1
+                         |    1: test_integer_key
+                         |    key:
+                         |options:
+                         |  verbose: true""".stripMargin
+    Files.write(Paths.get(longTimeBatchFile),
+      long_time_batch_basic.getBytes(StandardCharsets.UTF_8))
   }
 
   override def afterEach(): Unit = {
@@ -94,7 +115,7 @@ class BatchCliSuite extends RestClientTestHelper with TestPrematureExit with Bat
       "create",
       "batch",
       "-f",
-      batchFile,
+      longTimeBatchFile,
       "--password",
       ldapUserPasswd)
     var result = testPrematureExitForControlCli(createArgs, "")
@@ -110,9 +131,15 @@ class BatchCliSuite extends RestClientTestHelper with TestPrematureExit with Bat
       ldapUser,
       "--password",
       ldapUserPasswd)
-    result = testPrematureExitForControlCli(getArgs, "SPARK")
-    assert(result.contains("SPARK"))
-    assert(result.contains(s"${fe.connectionUrl}"))
+    var invalidCount = 0
+    eventually(timeout(5.seconds), interval(100.milliseconds)) {
+      invalidCount += 1
+      result = testPrematureExitForControlCli(getArgs, "SPARK")
+      assert(result.contains("RUNNING"))
+      assert(result.contains("SPARK"))
+      assert(result.contains(s"${fe.connectionUrl}"))
+      invalidCount -= 1
+    }
 
     val logArgs = Array(
       "log",
@@ -140,7 +167,7 @@ class BatchCliSuite extends RestClientTestHelper with TestPrematureExit with Bat
 
     eventually(timeout(3.seconds), interval(200.milliseconds)) {
       assert(MetricsSystem.counterValue(
-        MetricsConstants.REST_CONN_TOTAL).getOrElse(0L) - totalConnections === 5)
+        MetricsConstants.REST_CONN_TOTAL).getOrElse(0L) - totalConnections - invalidCount === 5)
       assert(MetricsSystem.counterValue(MetricsConstants.REST_CONN_OPEN).getOrElse(0L) === 0)
     }
   }
@@ -152,7 +179,7 @@ class BatchCliSuite extends RestClientTestHelper with TestPrematureExit with Bat
       "create",
       "batch",
       "-f",
-      batchFile,
+      longTimeBatchFile,
       "--authSchema",
       "SPNEGO")
     var result = testPrematureExitForControlCli(createArgs, "")
@@ -166,9 +193,12 @@ class BatchCliSuite extends RestClientTestHelper with TestPrematureExit with Bat
       batchId,
       "--authSchema",
       "spnego")
-    result = testPrematureExitForControlCli(getArgs, "SPARK")
-    assert(result.contains("SPARK"))
-    assert(result.contains(s"${fe.connectionUrl}"))
+    eventually(timeout(5.seconds), interval(100.milliseconds)) {
+      result = testPrematureExitForControlCli(getArgs, "SPARK")
+      assert(result.contains("RUNNING"))
+      assert(result.contains("SPARK"))
+      assert(result.contains(s"${fe.connectionUrl}"))
+    }
 
     val logArgs = Array(
       "log",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

When waitCompletion is false, we need to determine whether it is in cluster mode to avoid killing the engine running locally.

close #5043

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request
