### PR TITLE
[WIP] Infer constant conditions for dynamic partitions

### DIFF
--- a/extensions/spark/kyuubi-extension-spark-3-3/src/main/scala/org/apache/kyuubi/sql/InferDynamicPartitionConstantConditions.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-3/src/main/scala/org/apache/kyuubi/sql/InferDynamicPartitionConstantConditions.scala
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.sql
+
+import scala.annotation.tailrec
+
+import org.apache.spark.sql.catalyst.expressions.{Alias, And, Attribute, Cast, EqualTo, Expression, In, Literal, NamedExpression}
+import org.apache.spark.sql.catalyst.planning.ExtractEquiJoinKeys
+import org.apache.spark.sql.catalyst.plans.logical._
+
+object InferDynamicPartitionConstantConditions {
+
+  def infer(
+      dynamicPartitionColumns: Seq[Attribute],
+      query: LogicalPlan): Map[Attribute, Seq[Literal]] = {
+    extractAttributeConditions(query).flatMap {
+      case (k, v) =>
+        dynamicPartitionColumns.find(c => c.exprId == k.exprId && c.name == k.name).map(_ -> v)
+      case _ => None
+    }
+  }
+
+  private def extractAttributeConditions(
+      plan: LogicalPlan): Map[Attribute, Seq[Literal]] = {
+    plan match {
+      case p: Project =>
+        val aliasMap = getAliasMap(p.projectList)
+        extractAttributeConditions(p.child).map {
+          case (attr, literals) =>
+            aliasMap.getOrElse(attr, attr) -> literals
+        }
+      case f: Filter =>
+        val attributeConditions = getExprAttributeConditions(f.condition)
+        attributeConditions ++ extractAttributeConditions(f.child).map {
+          case (k, v) =>
+            k -> (v ++ attributeConditions.getOrElse(k, Nil))
+        }
+      case agg: Aggregate =>
+        val aliasMap = getAliasMap(agg.aggregateExpressions)
+        extractAttributeConditions(agg.child).map {
+          case (attr, literals) =>
+            aliasMap.getOrElse(attr, attr) -> literals
+        }
+      case ExtractEquiJoinKeys(_, _, _, _, _, leftChild, rightChild, _) =>
+        val leftAttributeConditions = extractAttributeConditions(leftChild)
+        val rightAttributeConditions = extractAttributeConditions(rightChild)
+        leftAttributeConditions ++ rightAttributeConditions.map {
+          case (k, v) =>
+            k -> (v ++ leftAttributeConditions.getOrElse(k, Nil))
+        }
+      case p: Union =>
+        p.children.map(child => {
+          (child.output, extractAttributeConditions(child))
+        }).reduce { (left, right) =>
+          val leftAttributeConditions = left._2
+          val rightAttributeConditions = right._2
+          val v = p.output.zip(left._1).zip(right._1).flatMap {
+            case ((o, l), r) =>
+              if (leftAttributeConditions.contains(l) && rightAttributeConditions.contains(r)) {
+                Some(o -> (leftAttributeConditions(l) ++ rightAttributeConditions(r)))
+              } else {
+                None
+              }
+          }.toMap
+          (p.output, v)
+        }._2
+
+      // TODO: support more UnaryNode
+      // case p: Expand => Map.empty
+      // case p: Generate => Map.empty
+      // case p: Window => Map.empty
+      // case p: View => Map.empty
+      case p: UnaryNode => extractAttributeConditions(p.child)
+      case _ => Map.empty
+    }
+  }
+
+  private def getAliasMap(named: Seq[NamedExpression]): Map[Attribute, Attribute] = {
+    @tailrec
+    def throughUnary(e: Expression): Option[Attribute] = e match {
+      case a: Attribute => Some(a)
+      case u: Expression if u.deterministic && u.references.size == 1 =>
+        throughUnary(u.references.head)
+      case _ => None
+    }
+
+    named.flatMap {
+      case alias @ Alias(child, _) =>
+        throughUnary(child).map(a => (a, alias.toAttribute))
+      case _ => None
+    }.toMap
+  }
+
+  private def getExprAttributeConditions(condition: Expression): Map[Attribute, Seq[Literal]] = {
+    object ExtractAttribute {
+      @scala.annotation.tailrec
+      def unapply(expr: Expression): Option[Attribute] = {
+        expr match {
+          case attr: Attribute => Some(attr)
+          case Cast(child, _, _, _) => unapply(child)
+          case _ => None
+        }
+      }
+    }
+
+    splitConjunctivePredicates(condition).flatMap {
+      case EqualTo(ExtractAttribute(attr), value: Literal) =>
+        Some((attr, Seq(value)))
+      case EqualTo(value: Literal, ExtractAttribute(attr)) =>
+        Some((attr, Seq(value)))
+      case In(ExtractAttribute(attr), values: Seq[Expression])
+          if values.forall(_.isInstanceOf[Literal]) =>
+        Some((attr, values.asInstanceOf[Seq[Literal]]))
+      case _ => None
+    }.toMap
+  }
+
+  private def splitConjunctivePredicates(condition: Expression): Seq[Expression] = {
+    condition match {
+      case And(cond1, cond2) =>
+        splitConjunctivePredicates(cond1) ++ splitConjunctivePredicates(cond2)
+      case other => other :: Nil
+    }
+  }
+}

--- a/extensions/spark/kyuubi-extension-spark-3-3/src/main/scala/org/apache/kyuubi/sql/InferDynamicPartitionConstantConditions.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-3/src/main/scala/org/apache/kyuubi/sql/InferDynamicPartitionConstantConditions.scala
@@ -80,11 +80,20 @@ object InferDynamicPartitionConstantConditions {
           (p.output, v)
         }._2
 
-      // TODO: support more UnaryNode
-      // case p: Expand => Map.empty
-      // case p: Generate => Map.empty
-      // case p: Window => Map.empty
-      // case p: View => Map.empty
+       case p: Generate =>
+         val childAttributeConditions = extractAttributeConditions(p.child)
+         if (p.generator.deterministic && p.generator.references.size == 1) {
+           val singleRef = p.generator.references.head
+           val outputs = p.generatorOutput
+           childAttributeConditions.flatMap {
+             case (k, v) if k == singleRef =>
+               outputs.map(o => o -> v)
+             case o => Some(o)
+           }
+         } else {
+           childAttributeConditions
+         }
+      // TODO: support more UnaryNode like: Expand, Window
       case p: UnaryNode => extractAttributeConditions(p.child)
       case _ => Map.empty
     }

--- a/extensions/spark/kyuubi-extension-spark-3-3/src/main/scala/org/apache/kyuubi/sql/InferDynamicPartitionConstantConditions.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-3/src/main/scala/org/apache/kyuubi/sql/InferDynamicPartitionConstantConditions.scala
@@ -80,19 +80,19 @@ object InferDynamicPartitionConstantConditions {
           (p.output, v)
         }._2
 
-       case p: Generate =>
-         val childAttributeConditions = extractAttributeConditions(p.child)
-         if (p.generator.deterministic && p.generator.references.size == 1) {
-           val singleRef = p.generator.references.head
-           val outputs = p.generatorOutput
-           childAttributeConditions.flatMap {
-             case (k, v) if k == singleRef =>
-               outputs.map(o => o -> v)
-             case o => Some(o)
-           }
-         } else {
-           childAttributeConditions
-         }
+      case p: Generate =>
+        val childAttributeConditions = extractAttributeConditions(p.child)
+        if (p.generator.deterministic && p.generator.references.size == 1) {
+          val singleRef = p.generator.references.head
+          val outputs = p.generatorOutput
+          childAttributeConditions.flatMap {
+            case (k, v) if k == singleRef =>
+              outputs.map(o => o -> v)
+            case o => Some(o)
+          }
+        } else {
+          childAttributeConditions
+        }
       // TODO: support more UnaryNode like: Expand, Window
       case p: UnaryNode => extractAttributeConditions(p.child)
       case _ => Map.empty

--- a/extensions/spark/kyuubi-extension-spark-3-3/src/main/scala/org/apache/kyuubi/sql/RebalanceBeforeWriting.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-3/src/main/scala/org/apache/kyuubi/sql/RebalanceBeforeWriting.scala
@@ -31,10 +31,10 @@ trait RepartitionBuilderWithRebalance extends RepartitionBuilder {
       val constantConditions = InferDynamicPartitionConstantConditions
         .infer(dynamicPartitionColumns, query)
 
-      val inferredConstantPartition = dynamicPartitionColumns
-        .forall(constantConditions.getOrElse(_, Nil).nonEmpty)
+      val inferredStaticPartition = dynamicPartitionColumns
+        .forall(constantConditions.getOrElse(_, Nil).size == 1)
 
-      if (inferredConstantPartition) {
+      if (inferredStaticPartition) {
         RebalancePartitions(Seq.empty, query)
       } else {
         RebalancePartitions(dynamicPartitionColumns, query)

--- a/extensions/spark/kyuubi-extension-spark-3-3/src/test/scala/org/apache/spark/sql/InferDynamicPartitionConstantConditionsSuite.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-3/src/test/scala/org/apache/spark/sql/InferDynamicPartitionConstantConditionsSuite.scala
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.spark.sql.catalyst.expressions.Literal
+
+import org.apache.kyuubi.sql.InferDynamicPartitionConstantConditions
+
+class InferDynamicPartitionConstantConditionsSuite extends KyuubiSparkSQLExtensionTest {
+
+  test("infer dynamic partition constant conditions") {
+    withTable("t1", "t2") {
+      sql("CREATE TABLE t1 (c1 INT, p1 STRING) USING parquet PARTITIONED BY (p1)")
+      sql("CREATE TABLE t2 (c2 INT, p2 STRING) USING parquet PARTITIONED BY (p2)")
+
+      def check(query: String, expect: Map[String, Seq[Any]]): Unit = {
+        val df = sql(query)
+        val parts = df.queryExecution.analyzed.output.filter(o => expect.contains(o.name))
+        val actualResult = InferDynamicPartitionConstantConditions.infer(
+          parts,
+          df.queryExecution.analyzed)
+        val expectResult = expect.map {
+          case (k, v) =>
+            val part = parts.find(_.name == k).get
+            val values = v.map(Literal(_))
+            part -> values
+        }
+        assert(actualResult == expectResult)
+      }
+
+      check("SELECT c1, p1 FROM t1 WHERE p1 = '1'", Map("p1" -> Seq("1")))
+
+      check("SELECT c1, p1 FROM t1 WHERE p1 in ('1', '2')", Map("p1" -> Seq("1", "2")))
+
+      check(
+        "SELECT c1, p1 FROM t1 join t2 on t1.c1 = t2.c2 WHERE t1.p1 = '1'",
+        Map("p1" -> Seq("1")))
+
+      check(
+        "SELECT c1, p1 FROM (select * from t1 WHERE p1 = '1') t join t2 on t.c1 = t2.c2",
+        Map("p1" -> Seq("1")))
+
+      check(
+        """
+          |SELECT c1, p1
+          |FROM (SELECT c1, nvl(p1, 2) as p1 FROM t1 WHERE p1 = '1') t
+          |JOIN t2 on t.c1 = t2.c2""".stripMargin,
+        Map("p1" -> Seq("1")))
+
+      check(
+        """
+          |SELECT c1, p1
+          |FROM (SELECT c1, p1 FROM t1 WHERE p1 = '1' UNION ALL SELECT c2, p2 FROM t2 WHERE p2 = '2') t
+          |JOIN t2 on t.c1 = t2.c2""".stripMargin,
+        Map("p1" -> Seq("1", "2")))
+
+      check(
+        """
+          |SELECT c1, p1
+          |FROM (SELECT c1, p1 FROM t1 WHERE p1 = '1' UNION ALL SELECT c2, p2 FROM t2 WHERE p2 > '2') t
+          |JOIN t2 on t.c1 = t2.c2""".stripMargin,
+        Map())
+    }
+  }
+
+}

--- a/extensions/spark/kyuubi-extension-spark-3-3/src/test/scala/org/apache/spark/sql/InferDynamicPartitionConstantConditionsSuite.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-3/src/test/scala/org/apache/spark/sql/InferDynamicPartitionConstantConditionsSuite.scala
@@ -86,6 +86,15 @@ class InferDynamicPartitionConstantConditionsSuite extends KyuubiSparkSQLExtensi
           | UNION ALL SELECT c2, p2 FROM t2 WHERE p2 > '2') t
           |JOIN t2 on t.c1 = t2.c2""".stripMargin,
         Map())
+
+      // generate from deterministic expressions
+      check(
+        """
+          |SELECT c1, p1 FROM
+          | (select c1, explode(from_json(p1, 'array<int>')) as p1 from t1 where p1 = '[1]')
+          |""".stripMargin,
+        Map("p1" -> Seq("[1]")))
+
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

When dynamic partitions write data with constant partition filter, the Rebalance inserted in the last stage will result in a large partition, which is not suitable for remote shuffle service.

For example:

```
insert overwrite t1 partition(p1) select c1, p1 from t2 where p1='1';
```

The previous behavior was to insert `rebalance_by_col(p1)`, I want to change to `rebalance_by_none` to use random shuffle to avoid large partition.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request
