### PR TITLE
Add a closing method with timeout for JDBC connection 

### DIFF
--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
@@ -17,6 +17,7 @@
 
 package org.apache.kyuubi.jdbc.hive;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.kyuubi.jdbc.hive.JdbcConnectionParams.*;
 import static org.apache.kyuubi.jdbc.hive.Utils.HIVE_SERVER2_RETRY_KEY;
 import static org.apache.kyuubi.jdbc.hive.Utils.HIVE_SERVER2_RETRY_TRUE;
@@ -992,9 +993,7 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
    * @throws SQLException
    */
   public void close(int closeTimeout) throws SQLException {
-    if (closeTimeout <= 0) {
-      throw new IllegalArgumentException("closeTimeout must be greater than 0");
-    }
+    checkArgument(closeTimeout > 0, "closeTimeout must be greater than 0");
     ExecutorService executor = Executors.newSingleThreadExecutor();
     try {
       SimpleTimeLimiter.create(executor)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- add the method in `KyuubiConnection` for forcibly closing the connection with timeout
- to get rid of the jammed situation on the client side, and making sure of destorying instance of `transport` and `client`

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request
