### PR TITLE
[KYUUBI #4686] KubernetesApplicationOperation should not support client deploy mode for spark engine

### DIFF
--- a/integration-tests/kyuubi-kubernetes-it/src/test/scala/org/apache/kyuubi/kubernetes/test/spark/SparkOnKubernetesTestsSuite.scala
+++ b/integration-tests/kyuubi-kubernetes-it/src/test/scala/org/apache/kyuubi/kubernetes/test/spark/SparkOnKubernetesTestsSuite.scala
@@ -45,7 +45,7 @@ abstract class SparkOnKubernetesSuiteBase
   }
 
   protected val appMgrInfo =
-    ApplicationManagerInfo(Some(s"k8s://$apiServerAddress"), Some("minikube"), None)
+    ApplicationManagerInfo(Some(s"k8s://$apiServerAddress"), Some("cluster") Some("minikube"), None)
 
   protected def sparkOnK8sConf: KyuubiConf = {
     // TODO Support more Spark version
@@ -140,44 +140,6 @@ class KyuubiOperationKubernetesClusterClientModeSuite
 
   private def sessionManager: KyuubiSessionManager =
     server.backendService.sessionManager.asInstanceOf[KyuubiSessionManager]
-
-  ignore("Spark Client Mode On Kubernetes Kyuubi KubernetesApplicationOperation Suite") {
-    val batchRequest = newSparkBatchRequest(conf.getAll ++ Map(
-      KYUUBI_BATCH_ID_KEY -> UUID.randomUUID().toString))
-
-    val sessionHandle = sessionManager.openBatchSession(
-      "kyuubi",
-      "passwd",
-      "localhost",
-      batchRequest.getConf.asScala.toMap,
-      batchRequest)
-
-    eventually(timeout(3.minutes), interval(50.milliseconds)) {
-      val state = k8sOperation.getApplicationInfoByTag(
-        appMgrInfo,
-        sessionHandle.identifier.toString)
-      assert(state.id != null)
-      assert(state.name != null)
-      assert(state.state == RUNNING)
-    }
-
-    val killResponse = k8sOperation.killApplicationByTag(
-      appMgrInfo,
-      sessionHandle.identifier.toString)
-    assert(killResponse._1)
-    assert(killResponse._2 startsWith "Succeeded to terminate:")
-
-    val appInfo = k8sOperation.getApplicationInfoByTag(
-      appMgrInfo,
-      sessionHandle.identifier.toString)
-    assert(appInfo == ApplicationInfo(null, null, NOT_FOUND))
-
-    val failKillResponse = k8sOperation.killApplicationByTag(
-      appMgrInfo,
-      sessionHandle.identifier.toString)
-    assert(!failKillResponse._1)
-    assert(failKillResponse._2 === ApplicationOperation.NOT_FOUND)
-  }
 }
 
 class KyuubiOperationKubernetesClusterClusterModeSuite

--- a/integration-tests/kyuubi-kubernetes-it/src/test/scala/org/apache/kyuubi/kubernetes/test/spark/SparkOnKubernetesTestsSuite.scala
+++ b/integration-tests/kyuubi-kubernetes-it/src/test/scala/org/apache/kyuubi/kubernetes/test/spark/SparkOnKubernetesTestsSuite.scala
@@ -29,8 +29,7 @@ import org.apache.kyuubi._
 import org.apache.kyuubi.client.util.BatchUtils._
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.FRONTEND_THRIFT_BINARY_BIND_HOST
-import org.apache.kyuubi.engine.{ApplicationInfo, ApplicationManagerInfo, ApplicationOperation,
-  KubernetesApplicationOperation}
+import org.apache.kyuubi.engine.{ApplicationManagerInfo, KubernetesApplicationOperation}
 import org.apache.kyuubi.engine.ApplicationState.{FAILED, NOT_FOUND, RUNNING}
 import org.apache.kyuubi.engine.spark.SparkProcessBuilder
 import org.apache.kyuubi.kubernetes.test.MiniKube

--- a/integration-tests/kyuubi-kubernetes-it/src/test/scala/org/apache/kyuubi/kubernetes/test/spark/SparkOnKubernetesTestsSuite.scala
+++ b/integration-tests/kyuubi-kubernetes-it/src/test/scala/org/apache/kyuubi/kubernetes/test/spark/SparkOnKubernetesTestsSuite.scala
@@ -45,7 +45,10 @@ abstract class SparkOnKubernetesSuiteBase
   }
 
   protected val appMgrInfo =
-    ApplicationManagerInfo(Some(s"k8s://$apiServerAddress"), Some("cluster") Some("minikube"), None)
+    ApplicationManagerInfo(
+      Some(s"k8s://$apiServerAddress"),
+      Some("cluster") Some ("minikube"),
+      None)
 
   protected def sparkOnK8sConf: KyuubiConf = {
     // TODO Support more Spark version

--- a/integration-tests/kyuubi-kubernetes-it/src/test/scala/org/apache/kyuubi/kubernetes/test/spark/SparkOnKubernetesTestsSuite.scala
+++ b/integration-tests/kyuubi-kubernetes-it/src/test/scala/org/apache/kyuubi/kubernetes/test/spark/SparkOnKubernetesTestsSuite.scala
@@ -29,7 +29,8 @@ import org.apache.kyuubi._
 import org.apache.kyuubi.client.util.BatchUtils._
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.FRONTEND_THRIFT_BINARY_BIND_HOST
-import org.apache.kyuubi.engine.{ApplicationInfo, ApplicationManagerInfo, ApplicationOperation, KubernetesApplicationOperation}
+import org.apache.kyuubi.engine.{ApplicationInfo, ApplicationManagerInfo, ApplicationOperation,
+  KubernetesApplicationOperation}
 import org.apache.kyuubi.engine.ApplicationState.{FAILED, NOT_FOUND, RUNNING}
 import org.apache.kyuubi.engine.spark.SparkProcessBuilder
 import org.apache.kyuubi.kubernetes.test.MiniKube
@@ -47,7 +48,8 @@ abstract class SparkOnKubernetesSuiteBase
   protected val appMgrInfo =
     ApplicationManagerInfo(
       Some(s"k8s://$apiServerAddress"),
-      Some("cluster") Some ("minikube"),
+      Some("cluster"),
+      Some("minikube"),
       None)
 
   protected def sparkOnK8sConf: KyuubiConf = {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ApplicationOperation.scala
@@ -118,17 +118,21 @@ case class KubernetesInfo(context: Option[String] = None, namespace: Option[Stri
 
 case class ApplicationManagerInfo(
     resourceManager: Option[String],
+    deployMode: Option[String] = None,
     kubernetesInfo: KubernetesInfo = KubernetesInfo())
 
 object ApplicationManagerInfo {
   final val DEFAULT_KUBERNETES_NAMESPACE = "default"
+  final val SPARK_DEPLOY_MODE_KEY = "spark.submit.deployMode"
 
   def apply(
       resourceManager: Option[String],
+      deployMode: Option[String],
       kubernetesContext: Option[String],
       kubernetesNamespace: Option[String]): ApplicationManagerInfo = {
     new ApplicationManagerInfo(
       resourceManager,
+      deployMode,
       KubernetesInfo(kubernetesContext, kubernetesNamespace))
   }
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
@@ -110,9 +110,9 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
   }
 
   override def isSupported(appMgrInfo: ApplicationManagerInfo): Boolean = {
-    // TODO add deploy mode to check whether is supported
     kyuubiConf != null &&
-    appMgrInfo.resourceManager.exists(_.toLowerCase(Locale.ROOT).startsWith("k8s"))
+    appMgrInfo.resourceManager.exists(_.toLowerCase(Locale.ROOT).startsWith("k8s")) &&
+    appMgrInfo.deployMode.exists(_.toLowerCase(Locale.ROOT).equals("cluster"))
   }
 
   override def killApplicationByTag(

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
@@ -29,6 +29,7 @@ import org.apache.hadoop.security.UserGroupInformation
 import org.apache.kyuubi._
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.engine.{ApplicationManagerInfo, KyuubiApplicationManager, ProcBuilder}
+import org.apache.kyuubi.engine.ApplicationManagerInfo.SPARK_DEPLOY_MODE_KEY
 import org.apache.kyuubi.engine.KubernetesApplicationOperation.{KUBERNETES_SERVICE_HOST, KUBERNETES_SERVICE_PORT}
 import org.apache.kyuubi.engine.ProcBuilder.KYUUBI_ENGINE_LOG_PATH_KEY
 import org.apache.kyuubi.ha.HighAvailabilityConf
@@ -204,6 +205,7 @@ class SparkProcessBuilder(
   override def appMgrInfo(): ApplicationManagerInfo = {
     ApplicationManagerInfo(
       clusterManager(),
+      deployMode(),
       kubernetesContext(),
       kubernetesNamespace())
   }
@@ -213,7 +215,7 @@ class SparkProcessBuilder(
   }
 
   def deployMode(): Option[String] = {
-    conf.getOption(DEPLOY_MODE_KEY).orElse(defaultsConf.get(DEPLOY_MODE_KEY))
+    conf.getOption(SPARK_DEPLOY_MODE_KEY).orElse(defaultsConf.get(SPARK_DEPLOY_MODE_KEY))
   }
 
   override def isClusterMode(): Boolean = {
@@ -255,7 +257,6 @@ object SparkProcessBuilder {
   final val APP_KEY = "spark.app.name"
   final val TAG_KEY = "spark.yarn.tags"
   final val MASTER_KEY = "spark.master"
-  final val DEPLOY_MODE_KEY = "spark.submit.deployMode"
   final val KUBERNETES_CONTEXT_KEY = "spark.kubernetes.context"
   final val KUBERNETES_NAMESPACE_KEY = "spark.kubernetes.namespace"
   final val INTERNAL_RESOURCE = "spark-internal"

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/api/Metadata.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/api/Metadata.scala
@@ -79,6 +79,7 @@ case class Metadata(
   def appMgrInfo: ApplicationManagerInfo = {
     ApplicationManagerInfo(
       clusterManager,
+      requestConf.get(ApplicationManagerInfo.SPARK_DEPLOY_MODE_KEY),
       requestConf.get(KyuubiConf.KUBERNETES_CONTEXT.key),
       requestConf.get(KyuubiConf.KUBERNETES_NAMESPACE.key))
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Skip check spark client deploy-mode engine, to avoid APP_NOT_FOUND cause fail.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request
