### PR TITLE
[Minor] Exclude web-ui coverage reports in rat plugins

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -53,6 +53,7 @@ build/scala-*/**
 **/*.sqlite.sql
 **/node/**
 **/web-ui/dist/**
+**/web-ui/coverage/**
 **/pnpm-lock.yaml
 **/node_modules/**
 **/gen/*


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- To avoid the generated web-ui's coverage report files triggering Rat plugin checks on Maven
```
[WARNING] Files with unapproved licenses:
  kyuubi-server/web-ui/coverage/index.html
  kyuubi-server/web-ui/coverage/locales/en_US/index.html
  kyuubi-server/web-ui/coverage/locales/zh_CN/index.html
...
[ERROR] Failed to execute goal org.apache.rat:apache-rat-plugin:0.15:check (default) on project kyuubi-parent: Too many files with unapproved license: 21 See RAT report in: /kyuubi/target/rat.txt ->
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request
