### PR TITLE
[KYUUBI #3885][FOLLOWUP] Fix memory leak when using incremental collect mode in JDBC engine

### DIFF
--- a/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/operation/ExecuteStatement.scala
@@ -38,7 +38,6 @@ class ExecuteStatement(
   private val operationLog: OperationLog = OperationLog.createOperationLog(session, getHandle)
   override def getOperationLog: Option[OperationLog] = Option(operationLog)
 
-  val connection: Connection = session.asInstanceOf[JdbcSessionImpl].sessionConnection
   var jdbcStatement: Statement = _
 
   override protected def runInternal(): Unit = {
@@ -60,6 +59,7 @@ class ExecuteStatement(
   private def executeStatement(): Unit = {
     setState(OperationState.RUNNING)
     try {
+      val connection: Connection = session.asInstanceOf[JdbcSessionImpl].sessionConnection
       jdbcStatement = dialect.createStatement(connection)
       val hasResult = jdbcStatement.execute(statement)
       if (hasResult) {
@@ -106,9 +106,6 @@ class ExecuteStatement(
     } finally {
       if (jdbcStatement != null) {
         jdbcStatement.close()
-      }
-      if (connection != null) {
-        connection.close()
       }
     }
   }

--- a/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/operation/ExecuteStatement.scala
@@ -105,7 +105,7 @@ class ExecuteStatement(
       }
     } finally {
       if (jdbcStatement != null) {
-        jdbcStatement.close()
+        jdbcStatement.closeOnCompletion()
       }
     }
   }

--- a/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/operation/ExecuteStatement.scala
@@ -67,7 +67,9 @@ class ExecuteStatement(
         iter =
           if (incrementalCollect) {
             info("Execute in incremental collect mode")
-            new IterableFetchIterator(resultSetWrapper.toIterable)
+            new IterableFetchIterator[Row](new Iterable[Row] {
+              override def iterator: Iterator[Row] = resultSetWrapper
+            })
           } else {
             warn(s"Execute in full collect mode")
             new ArrayFetchIterator(resultSetWrapper.toArray())

--- a/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/util/ResultSetWrapper.scala
+++ b/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/util/ResultSetWrapper.scala
@@ -30,6 +30,7 @@ class ResultSetWrapper(statement: Statement)
   private lazy val metadata = currentResult.getMetaData
 
   override def hasNext: Boolean = {
+    if (currentResult.isClosed) return false
     val result = currentResult.next()
     if (!result) {
       val hasMoreResults = statement.getMoreResults(Statement.CLOSE_CURRENT_RESULT)

--- a/externals/kyuubi-jdbc-engine/src/test/scala/org/apache/kyuubi/engine/jdbc/doris/OperationWithEngineSuite.scala
+++ b/externals/kyuubi-jdbc-engine/src/test/scala/org/apache/kyuubi/engine/jdbc/doris/OperationWithEngineSuite.scala
@@ -80,7 +80,7 @@ class OperationWithEngineSuite extends DorisOperationSuite with HiveJDBCTestHelp
   }
 
   test("test fetch orientation with incremental collect mode") {
-    val sql = "select e1 from (select 1 k1) as t lateral view explode([1,2,3]) tmp1 as e1"
+    val sql = "select e1 from (select 1 k1) as t lateral view explode([0,1]) tmp1 as e1"
 
     withSessionConf(Map(KyuubiConf.OPERATION_INCREMENTAL_COLLECT.key -> "true"))()() {
       withSessionHandle { (client, handle) =>

--- a/externals/kyuubi-jdbc-engine/src/test/scala/org/apache/kyuubi/engine/jdbc/doris/OperationWithEngineSuite.scala
+++ b/externals/kyuubi-jdbc-engine/src/test/scala/org/apache/kyuubi/engine/jdbc/doris/OperationWithEngineSuite.scala
@@ -16,7 +16,9 @@
  */
 package org.apache.kyuubi.engine.jdbc.doris
 
-import org.apache.hive.service.rpc.thrift.{TExecuteStatementReq, TFetchResultsReq, TGetInfoReq, TGetInfoType, TStatusCode}
+import scala.collection.JavaConverters._
+
+import org.apache.hive.service.rpc.thrift.{TExecuteStatementReq, TFetchOrientation, TFetchResultsReq, TGetInfoReq, TGetInfoType, TStatusCode}
 
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.engine.jdbc.connection.ConnectionProvider
@@ -74,6 +76,53 @@ class OperationWithEngineSuite extends DorisOperationSuite with HiveJDBCTestHelp
 
       val tFetchResultsResp = client.FetchResults(tFetchResultsReq)
       assert(tFetchResultsResp.getStatus.getStatusCode === TStatusCode.SUCCESS_STATUS)
+    }
+  }
+
+  test("test fetch orientation with incremental collect mode") {
+    val sql = "select e1 from (select 1 k1) as t lateral view explode([1,2,3]) tmp1 as e1"
+
+    withSessionConf(Map(KyuubiConf.OPERATION_INCREMENTAL_COLLECT.key -> "true"))()() {
+      withSessionHandle { (client, handle) =>
+        val req = new TExecuteStatementReq()
+        req.setSessionHandle(handle)
+        req.setStatement(sql)
+        val tExecuteStatementResp = client.ExecuteStatement(req)
+        val opHandle = tExecuteStatementResp.getOperationHandle
+        waitForOperationToComplete(client, opHandle)
+
+        // fetch next from before first row
+        val tFetchResultsReq1 = new TFetchResultsReq(opHandle, TFetchOrientation.FETCH_NEXT, 1)
+        val tFetchResultsResp1 = client.FetchResults(tFetchResultsReq1)
+        assert(tFetchResultsResp1.getStatus.getStatusCode === TStatusCode.SUCCESS_STATUS)
+        val idSeq1 = tFetchResultsResp1.getResults.getColumns.get(0)
+          .getI64Val.getValues.asScala
+        assertResult(Seq(0L))(idSeq1)
+
+        // fetch next from first row
+        val tFetchResultsReq2 = new TFetchResultsReq(opHandle, TFetchOrientation.FETCH_NEXT, 1)
+        val tFetchResultsResp2 = client.FetchResults(tFetchResultsReq2)
+        assert(tFetchResultsResp2.getStatus.getStatusCode === TStatusCode.SUCCESS_STATUS)
+        val idSeq2 = tFetchResultsResp2.getResults.getColumns.get(0)
+          .getI64Val.getValues.asScala
+        assertResult(Seq(1L))(idSeq2)
+
+        // fetch prior from second row, expected got first row
+        val tFetchResultsReq3 = new TFetchResultsReq(opHandle, TFetchOrientation.FETCH_PRIOR, 1)
+        val tFetchResultsResp3 = client.FetchResults(tFetchResultsReq3)
+        assert(tFetchResultsResp3.getStatus.getStatusCode === TStatusCode.SUCCESS_STATUS)
+        val idSeq3 = tFetchResultsResp3.getResults.getColumns.get(0)
+          .getI64Val.getValues.asScala
+        assertResult(Seq(0L))(idSeq3)
+
+        // fetch first
+        val tFetchResultsReq4 = new TFetchResultsReq(opHandle, TFetchOrientation.FETCH_FIRST, 3)
+        val tFetchResultsResp4 = client.FetchResults(tFetchResultsReq4)
+        assert(tFetchResultsResp4.getStatus.getStatusCode === TStatusCode.SUCCESS_STATUS)
+        val idSeq4 = tFetchResultsResp4.getResults.getColumns.get(0)
+          .getI64Val.getValues.asScala
+        assertResult(Seq(0L, 1L))(idSeq4)
+      }
     }
   }
 }

--- a/externals/kyuubi-jdbc-engine/src/test/scala/org/apache/kyuubi/engine/jdbc/doris/OperationWithEngineSuite.scala
+++ b/externals/kyuubi-jdbc-engine/src/test/scala/org/apache/kyuubi/engine/jdbc/doris/OperationWithEngineSuite.scala
@@ -80,7 +80,7 @@ class OperationWithEngineSuite extends DorisOperationSuite with HiveJDBCTestHelp
   }
 
   test("test fetch orientation with incremental collect mode") {
-    val sql = "select e1 from (select 1 k1) as t lateral view explode([0,1]) tmp1 as e1"
+    val sql = "select id from (select 0 as id union select 1 as id) t;"
 
     withSessionConf(Map(KyuubiConf.OPERATION_INCREMENTAL_COLLECT.key -> "true"))()() {
       withSessionHandle { (client, handle) =>

--- a/externals/kyuubi-jdbc-engine/src/test/scala/org/apache/kyuubi/engine/jdbc/doris/OperationWithEngineSuite.scala
+++ b/externals/kyuubi-jdbc-engine/src/test/scala/org/apache/kyuubi/engine/jdbc/doris/OperationWithEngineSuite.scala
@@ -96,7 +96,7 @@ class OperationWithEngineSuite extends DorisOperationSuite with HiveJDBCTestHelp
         val tFetchResultsResp1 = client.FetchResults(tFetchResultsReq1)
         assert(tFetchResultsResp1.getStatus.getStatusCode === TStatusCode.SUCCESS_STATUS)
         val idSeq1 = tFetchResultsResp1.getResults.getColumns.get(0)
-          .getI64Val.getValues.asScala
+          .getI32Val.getValues.asScala
         assertResult(Seq(0L))(idSeq1)
 
         // fetch next from first row
@@ -104,7 +104,7 @@ class OperationWithEngineSuite extends DorisOperationSuite with HiveJDBCTestHelp
         val tFetchResultsResp2 = client.FetchResults(tFetchResultsReq2)
         assert(tFetchResultsResp2.getStatus.getStatusCode === TStatusCode.SUCCESS_STATUS)
         val idSeq2 = tFetchResultsResp2.getResults.getColumns.get(0)
-          .getI64Val.getValues.asScala
+          .getI32Val.getValues.asScala
         assertResult(Seq(1L))(idSeq2)
 
         // fetch prior from second row, expected got first row
@@ -112,7 +112,7 @@ class OperationWithEngineSuite extends DorisOperationSuite with HiveJDBCTestHelp
         val tFetchResultsResp3 = client.FetchResults(tFetchResultsReq3)
         assert(tFetchResultsResp3.getStatus.getStatusCode === TStatusCode.SUCCESS_STATUS)
         val idSeq3 = tFetchResultsResp3.getResults.getColumns.get(0)
-          .getI64Val.getValues.asScala
+          .getI32Val.getValues.asScala
         assertResult(Seq(0L))(idSeq3)
 
         // fetch first
@@ -120,7 +120,7 @@ class OperationWithEngineSuite extends DorisOperationSuite with HiveJDBCTestHelp
         val tFetchResultsResp4 = client.FetchResults(tFetchResultsReq4)
         assert(tFetchResultsResp4.getStatus.getStatusCode === TStatusCode.SUCCESS_STATUS)
         val idSeq4 = tFetchResultsResp4.getResults.getColumns.get(0)
-          .getI64Val.getValues.asScala
+          .getI32Val.getValues.asScala
         assertResult(Seq(0L, 1L))(idSeq4)
       }
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- similar situation and reason in #3885
- `toIterable` creates a stream by `Stream.cons(self.next(), self.toStream)` which holds iterated rows of resultset in JDBC engine

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request
