### PR TITLE
Explicitly close underlying httpclient when closing KyuubiConnection in HTTP transport mode

### DIFF
--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
@@ -88,6 +88,7 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
   private JdbcConnectionParams connParams;
   private TTransport transport;
   private TCLIService.Iface client;
+  private CloseableHttpClient httpClient;
   private boolean isClosed = true;
   private SQLWarning warningChain = null;
   private TSessionHandle sessHandle = null;
@@ -413,7 +414,6 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
   }
 
   private TTransport createHttpTransport() throws SQLException, TTransportException {
-    CloseableHttpClient httpClient;
     boolean useSsl = isSslConnection();
     // Create an http client from the configs
     httpClient = getHttpClient(useSsl);
@@ -977,6 +977,14 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
       if (transport != null && transport.isOpen()) {
         transport.close();
         transport = null;
+      }
+      if (httpClient != null) {
+        try {
+          httpClient.close();
+        } catch (Exception e) {
+          LOG.error("Error while closing http client", e);
+        }
+        httpClient = null;
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- Currently KyuubiConnection's`close` method closes the TTransport instance in HTTP transport mode, that only closes the InputStream of HTTP response rather than the underlying HTTP client/connection in `libthrift 0.9.3`. It may cause connection leaks.
- Explicitly close the underlying HTTP client to fix this problem. Note: close a closed HTTP client would have no side effect.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
