### PR TITLE
[DOC] Make MarkdownBuilder not extending Growable

### DIFF
--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/MarkdownUtils.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/MarkdownUtils.scala
@@ -83,7 +83,7 @@ class MarkdownBuilder {
    * @return
    */
   def ++=(multiline: String, marginChar: Char = '|'): MarkdownBuilder = {
-    multiline.stripMargin(marginChar).linesIterator.foreach(this += _)
+    buffer ++= multiline.stripMargin(marginChar).linesIterator
     this
   }
 

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/MarkdownUtils.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/MarkdownUtils.scala
@@ -21,7 +21,6 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path, StandardOpenOption}
 
 import scala.collection.JavaConverters._
-import scala.collection.generic.Growable
 import scala.collection.mutable.ListBuffer
 
 import com.vladsch.flexmark.formatter.Formatter
@@ -60,10 +59,8 @@ object MarkdownUtils {
   }
 }
 
-class MarkdownBuilder extends Growable[String] {
+class MarkdownBuilder {
   private val buffer = new ListBuffer[String]
-
-  override def clear: Unit = buffer.clear
 
   /**
    * append a single line
@@ -72,7 +69,7 @@ class MarkdownBuilder extends Growable[String] {
    * @param str single line
    * @return
    */
-  override def +=(str: String): MarkdownBuilder.this.type = {
+  def +=(str: String): MarkdownBuilder = {
     buffer += str.stripMargin.linesIterator.mkString
     this
   }
@@ -86,7 +83,8 @@ class MarkdownBuilder extends Growable[String] {
    * @return
    */
   def ++=(multiline: String, marginChar: Char = '|'): MarkdownBuilder = {
-    this ++= multiline.stripMargin(marginChar).linesIterator
+    multiline.stripMargin(marginChar).linesIterator.foreach(this += _)
+    this
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- As `scala.collection.generic.Growable` is marked as deprecated and made `+=` is marked as a final method in Scala 2.13, MarkdownBuilder which extends Growable is a blocker issue for Scala 2.13 in the future

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
