### PR TITLE
Use Iterable instead of Seq in kyuubi-ctl commands

### DIFF
--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/create/CreateServerCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/create/CreateServerCommand.scala
@@ -25,7 +25,8 @@ import org.apache.kyuubi.ha.HighAvailabilityConf._
 import org.apache.kyuubi.ha.client.{DiscoveryClient, DiscoveryPaths, ServiceNodeInfo}
 import org.apache.kyuubi.ha.client.DiscoveryClientProvider.withDiscoveryClient
 
-class CreateServerCommand(cliConfig: CliConfig) extends Command[Seq[ServiceNodeInfo]](cliConfig) {
+class CreateServerCommand(cliConfig: CliConfig)
+  extends Command[Iterable[ServiceNodeInfo]](cliConfig) {
 
   def validate(): Unit = {
     if (normalizedCliConfig.resource != ControlObject.SERVER) {
@@ -49,7 +50,7 @@ class CreateServerCommand(cliConfig: CliConfig) extends Command[Seq[ServiceNodeI
   /**
    * Expose Kyuubi server instance to another domain.
    */
-  def doRun(): Seq[ServiceNodeInfo] = {
+  override def doRun(): Iterable[ServiceNodeInfo] = {
     val kyuubiConf = conf
 
     kyuubiConf.setIfMissing(HA_ADDRESSES, normalizedCliConfig.zkOpts.zkQuorum)
@@ -89,7 +90,7 @@ class CreateServerCommand(cliConfig: CliConfig) extends Command[Seq[ServiceNodeI
     }
   }
 
-  def render(nodes: Seq[ServiceNodeInfo]): Unit = {
+  override def render(nodes: Iterable[ServiceNodeInfo]): Unit = {
     val title = "Created zookeeper service nodes"
     info(Render.renderServiceNodesInfo(title, nodes))
   }

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/delete/DeleteCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/delete/DeleteCommand.scala
@@ -22,7 +22,7 @@ import org.apache.kyuubi.ctl.util.{Render, Validator}
 import org.apache.kyuubi.ha.client.ServiceNodeInfo
 
 abstract class DeleteCommand(cliConfig: CliConfig)
-  extends Command[Seq[ServiceNodeInfo]](cliConfig) {
+  extends Command[Iterable[ServiceNodeInfo]](cliConfig) {
 
   def validate(): Unit = {
     Validator.validateZkArguments(normalizedCliConfig)
@@ -33,9 +33,9 @@ abstract class DeleteCommand(cliConfig: CliConfig)
   /**
    * Delete zookeeper service node with specified host port.
    */
-  def doRun(): Seq[ServiceNodeInfo]
+  override def doRun(): Iterable[ServiceNodeInfo]
 
-  def render(nodes: Seq[ServiceNodeInfo]): Unit = {
+  override def render(nodes: Iterable[ServiceNodeInfo]): Unit = {
     val title = "Deleted zookeeper service nodes"
     info(Render.renderServiceNodesInfo(title, nodes))
   }

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/delete/DeleteEngineCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/delete/DeleteEngineCommand.scala
@@ -34,7 +34,7 @@ class DeleteEngineCommand(cliConfig: CliConfig) extends DeleteCommand(cliConfig)
     }
   }
 
-  def doRun(): Seq[ServiceNodeInfo] = {
+  override def doRun(): Iterable[ServiceNodeInfo] = {
     withDiscoveryClient(conf) { discoveryClient =>
       val hostPortOpt =
         Some((cliConfig.zkOpts.host, cliConfig.zkOpts.port.toInt))

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/get/GetCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/get/GetCommand.scala
@@ -21,7 +21,8 @@ import org.apache.kyuubi.ctl.opt.CliConfig
 import org.apache.kyuubi.ctl.util.{Render, Validator}
 import org.apache.kyuubi.ha.client.ServiceNodeInfo
 
-abstract class GetCommand(cliConfig: CliConfig) extends Command[Seq[ServiceNodeInfo]](cliConfig) {
+abstract class GetCommand(cliConfig: CliConfig)
+  extends Command[Iterable[ServiceNodeInfo]](cliConfig) {
 
   def validate(): Unit = {
     Validator.validateZkArguments(normalizedCliConfig)
@@ -29,9 +30,9 @@ abstract class GetCommand(cliConfig: CliConfig) extends Command[Seq[ServiceNodeI
     mergeArgsIntoKyuubiConf()
   }
 
-  def doRun(): Seq[ServiceNodeInfo]
+  override def doRun(): Iterable[ServiceNodeInfo]
 
-  def render(nodes: Seq[ServiceNodeInfo]): Unit = {
+  override def render(nodes: Iterable[ServiceNodeInfo]): Unit = {
     val title = "Zookeeper service nodes"
     info(Render.renderServiceNodesInfo(title, nodes))
   }

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/get/GetEngineCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/get/GetEngineCommand.scala
@@ -31,7 +31,7 @@ class GetEngineCommand(cliConfig: CliConfig) extends GetCommand(cliConfig) {
     }
   }
 
-  override def doRun(): Seq[ServiceNodeInfo] = {
+  override def doRun(): Iterable[ServiceNodeInfo] = {
     CtlUtils.listZkEngineNodes(
       conf,
       normalizedCliConfig,

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/get/GetServerCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/get/GetServerCommand.scala
@@ -21,7 +21,7 @@ import org.apache.kyuubi.ctl.util.CtlUtils
 import org.apache.kyuubi.ha.client.ServiceNodeInfo
 
 class GetServerCommand(cliConfig: CliConfig) extends GetCommand(cliConfig) {
-  override def doRun(): Seq[ServiceNodeInfo] = {
+  override def doRun(): Iterable[ServiceNodeInfo] = {
     CtlUtils.listZkServerNodes(
       conf,
       normalizedCliConfig,

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/list/AdminListEngineCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/list/AdminListEngineCommand.scala
@@ -26,11 +26,12 @@ import org.apache.kyuubi.ctl.cmd.AdminCtlCommand
 import org.apache.kyuubi.ctl.opt.CliConfig
 import org.apache.kyuubi.ctl.util.Render
 
-class AdminListEngineCommand(cliConfig: CliConfig) extends AdminCtlCommand[Seq[Engine]](cliConfig) {
+class AdminListEngineCommand(cliConfig: CliConfig)
+  extends AdminCtlCommand[Iterable[Engine]](cliConfig) {
 
   override def validate(): Unit = {}
 
-  def doRun(): Seq[Engine] = {
+  override def doRun(): Iterable[Engine] = {
     withKyuubiRestClient(normalizedCliConfig, null, conf) { kyuubiRestClient =>
       val adminRestApi = new AdminRestApi(kyuubiRestClient)
       adminRestApi.listEngines(
@@ -41,7 +42,7 @@ class AdminListEngineCommand(cliConfig: CliConfig) extends AdminCtlCommand[Seq[E
     }
   }
 
-  def render(resp: Seq[Engine]): Unit = {
+  override def render(resp: Iterable[Engine]): Unit = {
     info(Render.renderEngineNodesInfo(resp))
   }
 }

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/list/AdminListServerCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/list/AdminListServerCommand.scala
@@ -27,18 +27,18 @@ import org.apache.kyuubi.ctl.opt.CliConfig
 import org.apache.kyuubi.ctl.util.Render
 
 class AdminListServerCommand(cliConfig: CliConfig)
-  extends AdminCtlCommand[Seq[ServerData]](cliConfig) {
+  extends AdminCtlCommand[Iterable[ServerData]](cliConfig) {
 
   override def validate(): Unit = {}
 
-  override def doRun(): Seq[ServerData] = {
+  override def doRun(): Iterable[ServerData] = {
     withKyuubiRestClient(normalizedCliConfig, null, conf) { kyuubiRestClient =>
       val adminRestApi = new AdminRestApi(kyuubiRestClient)
       adminRestApi.listServers().asScala
     }
   }
 
-  override def render(resp: Seq[ServerData]): Unit = {
+  override def render(resp: Iterable[ServerData]): Unit = {
     info(Render.renderServerNodesInfo(resp))
   }
 }

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/list/ListCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/list/ListCommand.scala
@@ -21,16 +21,17 @@ import org.apache.kyuubi.ctl.opt.CliConfig
 import org.apache.kyuubi.ctl.util.{Render, Validator}
 import org.apache.kyuubi.ha.client.ServiceNodeInfo
 
-abstract class ListCommand(cliConfig: CliConfig) extends Command[Seq[ServiceNodeInfo]](cliConfig) {
+abstract class ListCommand(cliConfig: CliConfig)
+  extends Command[Iterable[ServiceNodeInfo]](cliConfig) {
 
   def validate(): Unit = {
     Validator.validateZkArguments(normalizedCliConfig)
     mergeArgsIntoKyuubiConf()
   }
 
-  def doRun(): Seq[ServiceNodeInfo]
+  override def doRun(): Iterable[ServiceNodeInfo]
 
-  def render(nodes: Seq[ServiceNodeInfo]): Unit = {
+  override def render(nodes: Iterable[ServiceNodeInfo]): Unit = {
     val title = "Zookeeper service nodes"
     info(Render.renderServiceNodesInfo(title, nodes))
   }

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/list/ListServerCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/list/ListServerCommand.scala
@@ -21,7 +21,7 @@ import org.apache.kyuubi.ctl.util.CtlUtils
 import org.apache.kyuubi.ha.client.ServiceNodeInfo
 
 class ListServerCommand(cliConfig: CliConfig) extends ListCommand(cliConfig) {
-  override def doRun(): Seq[ServiceNodeInfo] = {
+  override def doRun(): Iterable[ServiceNodeInfo] = {
     CtlUtils.listZkServerNodes(conf, normalizedCliConfig, None)
   }
 }

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/list/ListSessionCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/list/ListSessionCommand.scala
@@ -26,18 +26,18 @@ import org.apache.kyuubi.ctl.cmd.Command
 import org.apache.kyuubi.ctl.opt.CliConfig
 import org.apache.kyuubi.ctl.util.Render
 
-class ListSessionCommand(cliConfig: CliConfig) extends Command[Seq[SessionData]](cliConfig) {
+class ListSessionCommand(cliConfig: CliConfig) extends Command[Iterable[SessionData]](cliConfig) {
 
   override def validate(): Unit = {}
 
-  def doRun(): Seq[SessionData] = {
+  override def doRun(): Iterable[SessionData] = {
     withKyuubiRestClient(normalizedCliConfig, null, conf) { kyuubiRestClient =>
       val sessionRestApi = new SessionRestApi(kyuubiRestClient)
       sessionRestApi.listSessions.asScala
     }
   }
 
-  def render(resp: Seq[SessionData]): Unit = {
+  override def render(resp: Iterable[SessionData]): Unit = {
     info(Render.renderSessionDataListInfo(resp))
   }
 }

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/util/Render.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/util/Render.scala
@@ -25,15 +25,15 @@ import org.apache.kyuubi.ha.client.ServiceNodeInfo
 
 private[ctl] object Render {
 
-  def renderServiceNodesInfo(title: String, serviceNodeInfo: Seq[ServiceNodeInfo]): String = {
+  def renderServiceNodesInfo(title: String, serviceNodeInfo: Iterable[ServiceNodeInfo]): String = {
     val header = Array("Namespace", "Host", "Port", "Version")
-    val rows = serviceNodeInfo.sortBy(_.nodeName).map { sn =>
+    val rows = serviceNodeInfo.toSeq.sortBy(_.nodeName).map { sn =>
       Array(sn.namespace, sn.host, sn.port.toString, sn.version.getOrElse(""))
     }.toArray
     Tabulator.format(title, header, rows)
   }
 
-  def renderEngineNodesInfo(engineNodesInfo: Seq[Engine]): String = {
+  def renderEngineNodesInfo(engineNodesInfo: Iterable[Engine]): String = {
     val title = s"Engine Node List (total ${engineNodesInfo.size})"
     val header = Array("Namespace", "Instance", "Attributes")
     val rows = engineNodesInfo.map { engine =>
@@ -45,7 +45,7 @@ private[ctl] object Render {
     Tabulator.format(title, header, rows)
   }
 
-  def renderServerNodesInfo(serverNodesInfo: Seq[ServerData]): String = {
+  def renderServerNodesInfo(serverNodesInfo: Iterable[ServerData]): String = {
     val title = s"Server Node List (total ${serverNodesInfo.size})"
     val header = Array("Namespace", "Instance", "Attributes", "Status")
     val rows = serverNodesInfo.map { server =>
@@ -58,7 +58,7 @@ private[ctl] object Render {
     Tabulator.format(title, header, rows)
   }
 
-  def renderSessionDataListInfo(sessions: Seq[SessionData]): String = {
+  def renderSessionDataListInfo(sessions: Iterable[SessionData]): String = {
     val title = s"Live Session List (total ${sessions.size})"
     val header = Array(
       "Identifier",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- Use `Iterable` instead of `Seq` in kyuubi-ctl commands for Scala  compatibility, as
1.  in Scala 2.13,  the `scala.Seq` is now an alias for `scala.collection.immutable.Seq`  (instead of `scala.collection.Seq`)
2. in Scala 2.13, `scala.collection.mutable.ListBuffer` (or Buffers) does not extend `scala.collection.immutable.Seq` according to [Scala collection migration guide](https://docs.scala-lang.org/overviews/core/collections-migration-213.html)
3. in both Scala 2.12 and 2.13, `ListBuffer` (or Buffers) extends `scala.collection.mutable.Iterable` 

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
