### PR TITLE
Introducing profile scala-2.13 for development use

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/KyuubiSQLException.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/KyuubiSQLException.scala
@@ -156,7 +156,7 @@ object KyuubiSQLException {
     (i1, i2, i3)
   }
 
-  def toCause(details: Seq[String]): Throwable = {
+  def toCause(details: Iterable[String]): Throwable = {
     var ex: Throwable = null
     if (details != null && details.nonEmpty) {
       val head = details.head
@@ -172,7 +172,7 @@ object KyuubiSQLException {
         val lineNum = line.substring(i3 + 1).toInt
         new StackTraceElement(clzName, methodName, fileName, lineNum)
       }
-      ex = newInstance(exClz, msg, toCause(details.slice(length + 2, details.length)))
+      ex = newInstance(exClz, msg, toCause(details.slice(length + 2, details.size)))
       ex.setStackTrace(stackTraceElements.toArray)
     }
     ex

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -42,7 +42,7 @@ case class KyuubiConf(loadSysDefault: Boolean = true) extends Logging {
   }
 
   if (loadSysDefault) {
-    val fromSysDefaults = Utils.getSystemProperties.filterKeys(_.startsWith("kyuubi."))
+    val fromSysDefaults = Utils.getSystemProperties.filterKeys(_.startsWith("kyuubi.")).toMap
     loadFromMap(fromSysDefaults)
   }
 

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/service/authentication/LdapAuthenticationProviderImplSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/service/authentication/LdapAuthenticationProviderImplSuite.scala
@@ -47,7 +47,7 @@ class LdapAuthenticationProviderImplSuite extends WithLdapServer {
   }
 
   test("authenticateGivenBlankOrNullPassword") {
-    Seq("", "\0", null).foreach { pwd =>
+    Seq("", "\u0000", null).foreach { pwd =>
       auth = new LdapAuthenticationProviderImpl(conf, new LdapSearchFactory)
       val thrown = intercept[AuthenticationException] {
         auth.authenticate("user", pwd)

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/delete/DeleteServerCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/delete/DeleteServerCommand.scala
@@ -24,7 +24,7 @@ import org.apache.kyuubi.ha.client.DiscoveryClientProvider.withDiscoveryClient
 import org.apache.kyuubi.ha.client.ServiceNodeInfo
 
 class DeleteServerCommand(cliConfig: CliConfig) extends DeleteCommand(cliConfig) {
-  override def doRun(): Seq[ServiceNodeInfo] = {
+  override def doRun(): Iterable[ServiceNodeInfo] = {
     withDiscoveryClient(conf) { discoveryClient =>
       val znodeRoot = CtlUtils.getZkServerNamespace(conf, normalizedCliConfig)
       val hostPortOpt =

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/etcd/EtcdDiscoveryClient.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/etcd/EtcdDiscoveryClient.scala
@@ -358,11 +358,11 @@ class EtcdDiscoveryClient(conf: KyuubiConf) extends DiscoveryClient {
         client.getLeaseClient.keepAlive(
           leaseId,
           new StreamObserver[LeaseKeepAliveResponse] {
-            override def onNext(v: LeaseKeepAliveResponse): Unit = Unit // do nothing
+            override def onNext(v: LeaseKeepAliveResponse): Unit = () // do nothing
 
-            override def onError(throwable: Throwable): Unit = Unit // do nothing
+            override def onError(throwable: Throwable): Unit = () // do nothing
 
-            override def onCompleted(): Unit = Unit // do nothing
+            override def onCompleted(): Unit = () // do nothing
           })
         client.getKVClient.put(
           ByteSequence.from(realPath.getBytes()),
@@ -388,7 +388,7 @@ class EtcdDiscoveryClient(conf: KyuubiConf) extends DiscoveryClient {
     override def onError(throwable: Throwable): Unit =
       throw new KyuubiException(throwable.getMessage, throwable.getCause)
 
-    override def onCompleted(): Unit = Unit
+    override def onCompleted(): Unit = ()
   }
 }
 

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/zookeeper/ZookeeperDiscoveryClient.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/zookeeper/ZookeeperDiscoveryClient.scala
@@ -26,38 +26,24 @@ import scala.collection.JavaConverters._
 
 import com.google.common.annotations.VisibleForTesting
 
-import org.apache.kyuubi.KYUUBI_VERSION
-import org.apache.kyuubi.KyuubiException
-import org.apache.kyuubi.KyuubiSQLException
-import org.apache.kyuubi.Logging
+import org.apache.kyuubi.{KYUUBI_VERSION, KyuubiException, KyuubiSQLException, Logging}
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiReservedKeys.KYUUBI_ENGINE_ID
-import org.apache.kyuubi.ha.HighAvailabilityConf.HA_ENGINE_REF_ID
-import org.apache.kyuubi.ha.HighAvailabilityConf.HA_ZK_NODE_TIMEOUT
-import org.apache.kyuubi.ha.HighAvailabilityConf.HA_ZK_PUBLISH_CONFIGS
-import org.apache.kyuubi.ha.client.DiscoveryClient
-import org.apache.kyuubi.ha.client.ServiceDiscovery
-import org.apache.kyuubi.ha.client.ServiceNodeInfo
-import org.apache.kyuubi.ha.client.zookeeper.ZookeeperClientProvider.buildZookeeperClient
-import org.apache.kyuubi.ha.client.zookeeper.ZookeeperClientProvider.getGracefulStopThreadDelay
+import org.apache.kyuubi.ha.HighAvailabilityConf.{HA_ENGINE_REF_ID, HA_ZK_NODE_TIMEOUT, HA_ZK_PUBLISH_CONFIGS}
+import org.apache.kyuubi.ha.client.{DiscoveryClient, ServiceDiscovery, ServiceNodeInfo}
+import org.apache.kyuubi.ha.client.zookeeper.ZookeeperClientProvider.{buildZookeeperClient, getGracefulStopThreadDelay}
 import org.apache.kyuubi.ha.client.zookeeper.ZookeeperDiscoveryClient.connectionChecker
 import org.apache.kyuubi.shaded.curator.framework.CuratorFramework
 import org.apache.kyuubi.shaded.curator.framework.recipes.atomic.{AtomicValue, DistributedAtomicInteger}
 import org.apache.kyuubi.shaded.curator.framework.recipes.locks.InterProcessSemaphoreMutex
 import org.apache.kyuubi.shaded.curator.framework.recipes.nodes.PersistentNode
-import org.apache.kyuubi.shaded.curator.framework.state.ConnectionState
-import org.apache.kyuubi.shaded.curator.framework.state.ConnectionState.CONNECTED
-import org.apache.kyuubi.shaded.curator.framework.state.ConnectionState.LOST
-import org.apache.kyuubi.shaded.curator.framework.state.ConnectionState.RECONNECTED
-import org.apache.kyuubi.shaded.curator.framework.state.ConnectionStateListener
+import org.apache.kyuubi.shaded.curator.framework.state.{ConnectionState, ConnectionStateListener}
+import org.apache.kyuubi.shaded.curator.framework.state.ConnectionState.{CONNECTED, LOST, RECONNECTED}
 import org.apache.kyuubi.shaded.curator.retry.RetryForever
 import org.apache.kyuubi.shaded.curator.utils.ZKPaths
-import org.apache.kyuubi.shaded.zookeeper.CreateMode
+import org.apache.kyuubi.shaded.zookeeper.{CreateMode, KeeperException, WatchedEvent, Watcher}
 import org.apache.kyuubi.shaded.zookeeper.CreateMode.PERSISTENT
-import org.apache.kyuubi.shaded.zookeeper.KeeperException
 import org.apache.kyuubi.shaded.zookeeper.KeeperException.NodeExistsException
-import org.apache.kyuubi.shaded.zookeeper.WatchedEvent
-import org.apache.kyuubi.shaded.zookeeper.Watcher
 import org.apache.kyuubi.util.ThreadUtils
 
 class ZookeeperDiscoveryClient(conf: KyuubiConf) extends DiscoveryClient {
@@ -226,7 +212,7 @@ class ZookeeperDiscoveryClient(conf: KyuubiConf) extends DiscoveryClient {
         info(s"Get service instance:$instance$engineIdStr and version:${version.getOrElse("")} " +
           s"under $namespace")
         ServiceNodeInfo(namespace, p, host, port, version, engineRefId, attributes)
-      }
+      }.toSeq
     } catch {
       case _: Exception if silent => Nil
       case e: Exception =>

--- a/pom.xml
+++ b/pom.xml
@@ -2126,7 +2126,7 @@
             </properties>
         </profile>
 
-        <!-- For development only, not generally ready for all modules -->
+        <!-- For development only, not generally applicable for all modules -->
         <profile>
             <id>scala-2.13</id>
             <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -2084,6 +2084,13 @@
 
     <profiles>
         <profile>
+            <id>scala-2.13</id>
+            <properties>
+                <scala.binary.version>2.13</scala.binary.version>
+                <scala.version>2.13.6</scala.version>
+            </properties>
+        </profile>
+        <profile>
             <id>mirror-cdn</id>
             <properties>
                 <!-- the apache cdn mirror works only for latest apache releases -->

--- a/pom.xml
+++ b/pom.xml
@@ -2129,7 +2129,7 @@
             <id>scala-2.13</id>
             <properties>
                 <scala.binary.version>2.13</scala.binary.version>
-                <scala.version>2.13.11</scala.version>
+                <scala.version>2.13.8</scala.version>
             </properties>
             <build>
                 <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -2131,7 +2131,7 @@
             <id>scala-2.13</id>
             <properties>
                 <scala.binary.version>2.13</scala.binary.version>
-                <scala.version>2.13.6</scala.version>
+                <scala.version>2.13.11</scala.version>
                 <scala.compile.option.noAdaptedArgs></scala.compile.option.noAdaptedArgs>
             </properties>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -283,8 +283,6 @@
             -Djdk.reflect.useDirectMethodHandle=false
             -Dio.netty.tryReflectionSetAccessible=true</extraJavaTestArgs>
         <debugArgLine>-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005</debugArgLine>
-
-        <scala.compile.option.noAdaptedArgs>-Yno-adapted-args</scala.compile.option.noAdaptedArgs>
     </properties>
 
     <dependencyManagement>
@@ -1635,7 +1633,7 @@
                             <arg>-deprecation</arg>
                             <arg>-feature</arg>
                             <arg>-explaintypes</arg>
-                            <arg>${scala.compile.option.noAdaptedArgs}</arg>
+                            <arg>-Yno-adapted-args</arg>
                             <arg>-P:silencer:globalFilters=.*deprecated.*</arg>
                             <arg>-P:silencer:globalFilters=.*Could not find any member to link for.*</arg>
                             <arg>-P:silencer:globalFilters=.*undefined in comment for class.*</arg>
@@ -2132,8 +2130,49 @@
             <properties>
                 <scala.binary.version>2.13</scala.binary.version>
                 <scala.version>2.13.11</scala.version>
-                <scala.compile.option.noAdaptedArgs></scala.compile.option.noAdaptedArgs>
             </properties>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>net.alchim31.maven</groupId>
+                            <artifactId>scala-maven-plugin</artifactId>
+                            <configuration>
+                                <scalaVersion>${scala.version}</scalaVersion>
+                                <recompileMode>incremental</recompileMode>
+                                <args>
+                                    <arg>-unchecked</arg>
+                                    <arg>-deprecation</arg>
+                                    <arg>-feature</arg>
+                                    <arg>-explaintypes</arg>
+                                    <arg>-P:silencer:globalFilters=.*deprecated.*</arg>
+                                    <arg>-P:silencer:globalFilters=.*Could not find any member to link for.*</arg>
+                                    <arg>-P:silencer:globalFilters=.*undefined in comment for class.*</arg>
+                                    <arg>-Xfatal-warnings</arg>
+                                    <arg>-Ywarn-unused:imports</arg>
+                                </args>
+                                <jvmArgs>
+                                    <jvmArg>-Xms1024m</jvmArg>
+                                    <jvmArg>-Xmx1024m</jvmArg>
+                                    <jvmArg>-XX:ReservedCodeCacheSize=512M</jvmArg>
+                                </jvmArgs>
+                                <javacArgs>
+                                    <javacArg>-Xlint:all,-serial,-path,-try,-processing</javacArg>
+                                </javacArgs>
+                                <compilerPlugins>
+                                    <compilerPlugin>
+                                        <groupId>com.github.ghik</groupId>
+                                        <artifactId>silencer-plugin_${scala.version}</artifactId>
+                                        <version>${maven.plugin.silencer.version}</version>
+                                    </compilerPlugin>
+                                </compilerPlugins>
+                                <!-- only skipping `scala:doc-jar` -->
+                                <skip>${maven.scaladoc.skip}</skip>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
         </profile>
 
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -283,6 +283,8 @@
             -Djdk.reflect.useDirectMethodHandle=false
             -Dio.netty.tryReflectionSetAccessible=true</extraJavaTestArgs>
         <debugArgLine>-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005</debugArgLine>
+
+        <scala-compile-no-adapted-args>-Yno-adapted-args</scala-compile-no-adapted-args>
     </properties>
 
     <dependencyManagement>
@@ -1633,7 +1635,7 @@
                             <arg>-deprecation</arg>
                             <arg>-feature</arg>
                             <arg>-explaintypes</arg>
-                            <arg>-Yno-adapted-args</arg>
+                            <arg>${scala-compile-no-adapted-args}</arg>
                             <arg>-P:silencer:globalFilters=.*deprecated.*</arg>
                             <arg>-P:silencer:globalFilters=.*Could not find any member to link for.*</arg>
                             <arg>-P:silencer:globalFilters=.*undefined in comment for class.*</arg>
@@ -2088,6 +2090,7 @@
             <properties>
                 <scala.binary.version>2.13</scala.binary.version>
                 <scala.version>2.13.6</scala.version>
+                <scala-compile-no-adapted-args></scala-compile-no-adapted-args>
             </properties>
         </profile>
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -2126,6 +2126,7 @@
             </properties>
         </profile>
 
+        <!-- For development only, not generally ready for all modules -->
         <profile>
             <id>scala-2.13</id>
             <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -284,7 +284,7 @@
             -Dio.netty.tryReflectionSetAccessible=true</extraJavaTestArgs>
         <debugArgLine>-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005</debugArgLine>
 
-        <scala-compile-no-adapted-args>-Yno-adapted-args</scala-compile-no-adapted-args>
+        <scala.compile.option.noAdaptedArgs>-Yno-adapted-args</scala.compile.option.noAdaptedArgs>
     </properties>
 
     <dependencyManagement>
@@ -1635,7 +1635,7 @@
                             <arg>-deprecation</arg>
                             <arg>-feature</arg>
                             <arg>-explaintypes</arg>
-                            <arg>${scala-compile-no-adapted-args}</arg>
+                            <arg>${scala.compile.option.noAdaptedArgs}</arg>
                             <arg>-P:silencer:globalFilters=.*deprecated.*</arg>
                             <arg>-P:silencer:globalFilters=.*Could not find any member to link for.*</arg>
                             <arg>-P:silencer:globalFilters=.*undefined in comment for class.*</arg>
@@ -2086,14 +2086,6 @@
 
     <profiles>
         <profile>
-            <id>scala-2.13</id>
-            <properties>
-                <scala.binary.version>2.13</scala.binary.version>
-                <scala.version>2.13.6</scala.version>
-                <scala-compile-no-adapted-args></scala-compile-no-adapted-args>
-            </properties>
-        </profile>
-        <profile>
             <id>mirror-cdn</id>
             <properties>
                 <!-- the apache cdn mirror works only for latest apache releases -->
@@ -2131,6 +2123,15 @@
                 <maven.compiler.target></maven.compiler.target>
                 <maven.compiler.release>${java.version}</maven.compiler.release>
                 <minimalJavaBuildVersion>${java.version}</minimalJavaBuildVersion>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>scala-2.13</id>
+            <properties>
+                <scala.binary.version>2.13</scala.binary.version>
+                <scala.version>2.13.6</scala.version>
+                <scala.compile.option.noAdaptedArgs></scala.compile.option.noAdaptedArgs>
             </properties>
         </profile>
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- introducing `scala-2.13` for development use only
- adapt the common modules compilable on Scala 2.13, including
  - kyuubi-common
  - kyuubi-ctl
  - kyuubi-ha
- use separate compile options for Scala 2.13 , skipping deprecated scala compiler option `-Yno-adapted-args`

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
