### PR TITLE
[AUTHZ] Make spark authz module compilable on Scala 2.13

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -209,7 +209,7 @@ object PrivilegesBuilder {
     }
   }
 
-  type PrivilegesAndOpType = (Seq[PrivilegeObject], Seq[PrivilegeObject], OperationType)
+  type PrivilegesAndOpType = (Iterable[PrivilegeObject], Iterable[PrivilegeObject], OperationType)
 
   /**
    * Build input  privilege objects from a Spark's LogicalPlan for hive permanent udf

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleAuthorization.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleAuthorization.scala
@@ -53,7 +53,7 @@ object RuleAuthorization {
       requests += AccessRequest(resource, ugi, opType, AccessType.USE)
     }
 
-    def addAccessRequest(objects: Seq[PrivilegeObject], isInput: Boolean): Unit = {
+    def addAccessRequest(objects: Iterable[PrivilegeObject], isInput: Boolean): Unit = {
       objects.foreach { obj =>
         val resource = AccessResource(obj, opType)
         val accessType = ranger.AccessType(obj, opType, isInput)
@@ -84,7 +84,7 @@ object RuleAuthorization {
           }
         case _ => Seq(request)
       }
-    }
+    }.toSeq
 
     if (authorizeInSingleCall) {
       verify(requestArrays.flatten, auditHandler)

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/SparkSessionProvider.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/SparkSessionProvider.scala
@@ -33,7 +33,7 @@ trait SparkSessionProvider {
   protected val catalogImpl: String
   protected def format: String = if (catalogImpl == "hive") "hive" else "parquet"
 
-  protected val extension: SparkSessionExtensions => Unit = _ => Unit
+  protected val extension: SparkSessionExtensions => Unit = _ => ()
   protected val sqlExtensions: String = ""
 
   protected val extraSparkConf: SparkConf = new SparkConf()

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/V2CommandsPrivilegesSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/V2CommandsPrivilegesSuite.scala
@@ -670,7 +670,7 @@ abstract class V2CommandsPrivilegesSuite extends PrivilegesBuilderSuite {
     val spec = DB_COMMAND_SPECS(plan1.getClass.getName)
     var db: Database = null
     spec.databaseDescs.find { d =>
-      Try(db = d.extract(plan1)).isSuccess
+      Try { db = d.extract(plan1) }.isSuccess
     }
     withClue(sql1) {
       assert(db.catalog === None)

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/V2JdbcTableCatalogPrivilegesBuilderSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/V2JdbcTableCatalogPrivilegesBuilderSuite.scala
@@ -79,7 +79,7 @@ class V2JdbcTableCatalogPrivilegesBuilderSuite extends V2CommandsPrivilegesSuite
           val spec = TABLE_COMMAND_SPECS(plan.getClass.getName)
           var table: Table = null
           spec.tableDescs.find { d =>
-            Try(table = d.extract(plan, spark).get).isSuccess
+            Try { table = d.extract(plan, spark).get }.isSuccess
           }
           withClue(str) {
             assertEqualsIgnoreCase(Some(catalogV2))(table.catalog)
@@ -104,7 +104,7 @@ class V2JdbcTableCatalogPrivilegesBuilderSuite extends V2CommandsPrivilegesSuite
         val spec = TABLE_COMMAND_SPECS(plan.getClass.getName)
         var table: Table = null
         spec.tableDescs.find { d =>
-          Try(table = d.extract(plan, spark).get).isSuccess
+          Try { table = d.extract(plan, spark).get }.isSuccess
         }
         withClue(sql1) {
           assertEqualsIgnoreCase(Some(catalogV2))(table.catalog)
@@ -127,7 +127,7 @@ class V2JdbcTableCatalogPrivilegesBuilderSuite extends V2CommandsPrivilegesSuite
         val plan = executePlan(sql1).analyzed
         val spec = TABLE_COMMAND_SPECS(plan.getClass.getName)
         var table: Table = null
-        spec.tableDescs.find { d => Try(table = d.extract(plan, spark).get).isSuccess }
+        spec.tableDescs.find { d => Try { table = d.extract(plan, spark).get }.isSuccess }
         withClue(sql1) {
           assertEqualsIgnoreCase(Some(catalogV2))(table.catalog)
           assertEqualsIgnoreCase(Some(ns1))(table.database)
@@ -146,7 +146,7 @@ class V2JdbcTableCatalogPrivilegesBuilderSuite extends V2CommandsPrivilegesSuite
       val spec = DB_COMMAND_SPECS(plan.getClass.getName)
       var db: Database = null
       spec.databaseDescs.find { d =>
-        Try(db = d.extract(plan)).isSuccess
+        Try { db = d.extract(plan) }.isSuccess
       }
       withClue(sql) {
         assertEqualsIgnoreCase(Some(catalogV2))(db.catalog)
@@ -165,7 +165,7 @@ class V2JdbcTableCatalogPrivilegesBuilderSuite extends V2CommandsPrivilegesSuite
       val spec = DB_COMMAND_SPECS(plan.getClass.getName)
       var db: Database = null
       spec.databaseDescs.find { d =>
-        Try(db = d.extract(plan)).isSuccess
+        Try { db = d.extract(plan) }.isSuccess
       }
       withClue(sql1) {
         assertEqualsIgnoreCase(Some(catalogV2))(db.catalog)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- Make spark authz module compilable on Scala 2.13

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.