### PR TITLE
[FLINK] Explicitly name Flink bootstrap SQL in application mode

### DIFF
--- a/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/FlinkSQLEngine.scala
+++ b/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/FlinkSQLEngine.scala
@@ -24,7 +24,7 @@ import java.util.concurrent.CountDownLatch
 
 import scala.collection.JavaConverters._
 
-import org.apache.flink.configuration.{Configuration, DeploymentOptions, GlobalConfiguration}
+import org.apache.flink.configuration.{Configuration, DeploymentOptions, GlobalConfiguration, PipelineOptions}
 import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.gateway.service.context.DefaultContext
 
@@ -131,11 +131,12 @@ object FlinkSQLEngine extends Logging {
   private def bootstrapFlinkApplicationExecutor() = {
     // trigger an execution to initiate EmbeddedExecutor with the default flink conf
     val flinkConf = new Configuration()
-    debug(s"Running initial Flink SQL in application mode with flink conf: $flinkConf.")
+    flinkConf.set(PipelineOptions.NAME, "kyuubi-bootstrap-sql")
+    debug(s"Running bootstrap Flink SQL in application mode with flink conf: $flinkConf.")
     val tableEnv = TableEnvironment.create(flinkConf)
     val res = tableEnv.executeSql("select 'kyuubi'")
     res.await()
-    info("Initial Flink SQL finished.")
+    info("Bootstrap Flink SQL finished.")
   }
 
   private def setDeploymentConf(executionTarget: String, flinkConf: Configuration): Unit = {


### PR DESCRIPTION
### _Why are the changes needed?_
Currently, the name of flink bootstrap SQL is auto-generated 'collect'.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.