### PR TITLE
Make Spark extension plugin compilable on Scala 2.13

### DIFF
--- a/extensions/spark/kyuubi-extension-spark-3-4/pom.xml
+++ b/extensions/spark/kyuubi-extension-spark-3-4/pom.xml
@@ -25,7 +25,7 @@
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 
-    <artifactId>kyuubi-extension-spark-3-4_2.12</artifactId>
+    <artifactId>kyuubi-extension-spark-3-4_${scala.binary.version}</artifactId>
     <packaging>jar</packaging>
     <name>Kyuubi Dev Spark Extensions (for Spark 3.4)</name>
     <url>https://kyuubi.apache.org/</url>

--- a/extensions/spark/kyuubi-extension-spark-3-4/src/main/scala/org/apache/kyuubi/sql/KyuubiSparkSQLAstBuilder.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-4/src/main/scala/org/apache/kyuubi/sql/KyuubiSparkSQLAstBuilder.scala
@@ -116,6 +116,7 @@ class KyuubiSparkSQLAstBuilder extends KyuubiSparkSQLBaseVisitor[AnyRef] with SQ
     val zorderCols = ctx.zorderClause().order.asScala
       .map(visitMultipartIdentifier)
       .map(UnresolvedAttribute(_))
+      .toSeq
 
     val orderExpr =
       if (zorderCols.length == 1) {
@@ -130,16 +131,16 @@ class KyuubiSparkSQLAstBuilder extends KyuubiSparkSQLBaseVisitor[AnyRef] with SQ
 
   override def visitMultipartIdentifier(ctx: MultipartIdentifierContext): Seq[String] =
     withOrigin(ctx) {
-      ctx.parts.asScala.map(_.getText)
+      ctx.parts.asScala.map(_.getText).toSeq
     }
 
   override def visitZorderClause(ctx: ZorderClauseContext): Seq[UnresolvedAttribute] =
     withOrigin(ctx) {
       val res = ListBuffer[UnresolvedAttribute]()
       ctx.multipartIdentifier().forEach { identifier =>
-        res += UnresolvedAttribute(identifier.parts.asScala.map(_.getText))
+        res += UnresolvedAttribute(identifier.parts.asScala.map(_.getText).toSeq)
       }
-      res
+      res.toSeq
     }
 
   private def typedVisit[T](ctx: ParseTree): T = {

--- a/extensions/spark/kyuubi-extension-spark-3-4/src/test/scala/org/apache/spark/sql/WatchDogSuiteBase.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-4/src/test/scala/org/apache/spark/sql/WatchDogSuiteBase.scala
@@ -376,7 +376,7 @@ trait WatchDogSuiteBase extends KyuubiSparkSQLExtensionTest {
                |ORDER BY a
                |DESC
                |""".stripMargin)
-            .collect().head.get(0).equals(10))
+            .collect().head.get(0) === 10)
         }
       }
     }

--- a/extensions/spark/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/KyuubiSparkSQLAstBuilder.scala
+++ b/extensions/spark/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/KyuubiSparkSQLAstBuilder.scala
@@ -116,6 +116,7 @@ class KyuubiSparkSQLAstBuilder extends KyuubiSparkSQLBaseVisitor[AnyRef] with SQ
     val zorderCols = ctx.zorderClause().order.asScala
       .map(visitMultipartIdentifier)
       .map(UnresolvedAttribute(_))
+      .toSeq
 
     val orderExpr =
       if (zorderCols.length == 1) {
@@ -130,16 +131,16 @@ class KyuubiSparkSQLAstBuilder extends KyuubiSparkSQLBaseVisitor[AnyRef] with SQ
 
   override def visitMultipartIdentifier(ctx: MultipartIdentifierContext): Seq[String] =
     withOrigin(ctx) {
-      ctx.parts.asScala.map(_.getText)
+      ctx.parts.asScala.map(_.getText).toSeq
     }
 
   override def visitZorderClause(ctx: ZorderClauseContext): Seq[UnresolvedAttribute] =
     withOrigin(ctx) {
       val res = ListBuffer[UnresolvedAttribute]()
       ctx.multipartIdentifier().forEach { identifier =>
-        res += UnresolvedAttribute(identifier.parts.asScala.map(_.getText))
+        res += UnresolvedAttribute(identifier.parts.asScala.map(_.getText).toSeq)
       }
-      res
+      res.toSeq
     }
 
   private def typedVisit[T](ctx: ParseTree): T = {

--- a/extensions/spark/kyuubi-extension-spark-common/src/test/scala/org/apache/spark/sql/WatchDogSuiteBase.scala
+++ b/extensions/spark/kyuubi-extension-spark-common/src/test/scala/org/apache/spark/sql/WatchDogSuiteBase.scala
@@ -376,7 +376,7 @@ trait WatchDogSuiteBase extends KyuubiSparkSQLExtensionTest {
                |ORDER BY a
                |DESC
                |""".stripMargin)
-            .collect().head.get(0).equals(10))
+            .collect().head.get(0) === 10)
         }
       }
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- to make Spark extension plugin compilable on Scala 2.13 with Spark 3.2/3.3/3.4 (Spark 3.1 does not support Scala 2.13)
```
mvn clean install -DskipTests -Pflink-provided,hive-provided,spark-provided -Pscala-2.13 -pl :kyuubi-extension-spark-3-2_2.13 -Pspark-3.2 -am

mvn clean install -DskipTests -Pflink-provided,hive-provided,spark-provided -Pscala-2.13 -pl :kyuubi-extension-spark-3-3_2.13 -Pspark-3.3 -am


mvn clean install -DskipTests -Pflink-provided,hive-provided,spark-provided -Pscala-2.13 -pl :kyuubi-extension-spark-3-4_2.13 -Pspark-3.4 -am
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
