### PR TITLE
Allow disabling batch impl v2 on globally

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -129,7 +129,7 @@ case class KyuubiConf(loadSysDefault: Boolean = true) extends Logging {
   def getBatchConf(batchType: String): Map[String, String] = {
     val normalizedBatchType = batchType.toLowerCase(Locale.ROOT) match {
       case "pyspark" => "spark"
-      case other => other.toLowerCase(Locale.ROOT)
+      case other => other
     }
     getAllWithPrefix(s"$KYUUBI_BATCH_CONF_PREFIX.$normalizedBatchType", "")
   }
@@ -1670,24 +1670,12 @@ object KyuubiConf {
       .booleanConf
       .createWithDefault(true)
 
-  val BATCH_IMPL_VERSION: ConfigEntry[String] =
-    buildConf("kyuubi.batch.impl.version")
-      .internal
-      .serverOnly
-      .doc("Batch API version, candidates: 1, 2. " +
-        "Note: Batch API v2 is experimental and under rapid development, this configuration " +
-        "is added to allow explorers conveniently testing the developing Batch v2 API, not " +
-        "intended exposing to end users, it may be removed in anytime.")
-      .version("1.8.0")
-      .stringConf
-      .createWithDefault("1")
-
   val BATCH_SUBMITTER_ENABLED: ConfigEntry[Boolean] =
     buildConf("kyuubi.batch.submitter.enabled")
       .internal
       .serverOnly
-      .doc("When Batch API v2 is enabled, Kyuubi server requires to pick the INITIALIZED " +
-        "batch job from metastore and submits it to Resource Manager. " +
+      .doc("In Batch API v2, it requires batch submitter to pick the INITIALIZED batch job " +
+        "from metastore and submits it to Resource Manager. " +
         "Note: Batch API v2 is experimental and under rapid development, this configuration " +
         "is added to allow explorers conveniently testing the developing Batch v2 API, not " +
         "intended exposing to end users, it may be removed in anytime.")
@@ -1704,6 +1692,19 @@ object KyuubiConf {
       .version("1.8.0")
       .intConf
       .createWithDefault(100)
+
+  val BATCH_IMPL_VERSION: ConfigEntry[String] =
+    buildConf("kyuubi.batch.impl.version")
+      .internal
+      .serverOnly
+      .doc("Batch API version, candidates: 1, 2. Only take effect when " +
+        s"${BATCH_SUBMITTER_ENABLED.key} is true, otherwise always use v1 implementation. " +
+        "Note: Batch API v2 is experimental and under rapid development, this configuration " +
+        "is added to allow explorers conveniently testing the developing Batch v2 API, not " +
+        "intended exposing to end users, it may be removed in anytime.")
+      .version("1.8.0")
+      .stringConf
+      .createWithDefault("1")
 
   val SERVER_EXEC_POOL_SIZE: ConfigEntry[Int] =
     buildConf("kyuubi.backend.server.exec.pool.size")

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -129,7 +129,7 @@ case class KyuubiConf(loadSysDefault: Boolean = true) extends Logging {
   def getBatchConf(batchType: String): Map[String, String] = {
     val normalizedBatchType = batchType.toLowerCase(Locale.ROOT) match {
       case "pyspark" => "spark"
-      case other => other
+      case other => other.toLowerCase(Locale.ROOT)
     }
     getAllWithPrefix(s"$KYUUBI_BATCH_CONF_PREFIX.$normalizedBatchType", "")
   }

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -1674,7 +1674,7 @@ object KyuubiConf {
     buildConf("kyuubi.batch.submitter.enabled")
       .internal
       .serverOnly
-      .doc("In Batch API v2, it requires batch submitter to pick the INITIALIZED batch job " +
+      .doc("Batch API v2 requires batch submitter to pick the INITIALIZED batch job " +
         "from metastore and submits it to Resource Manager. " +
         "Note: Batch API v2 is experimental and under rapid development, this configuration " +
         "is added to allow explorers conveniently testing the developing Batch v2 API, not " +

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
@@ -42,6 +42,7 @@ import org.apache.kyuubi.config.KyuubiConf._
 import org.apache.kyuubi.config.KyuubiReservedKeys._
 import org.apache.kyuubi.engine.{ApplicationInfo, ApplicationManagerInfo, KillResponse, KyuubiApplicationManager}
 import org.apache.kyuubi.operation.{BatchJobSubmission, FetchOrientation, OperationState}
+import org.apache.kyuubi.server.KyuubiServer
 import org.apache.kyuubi.server.api.ApiRequestContext
 import org.apache.kyuubi.server.api.v1.BatchesResource._
 import org.apache.kyuubi.server.metadata.MetadataManager
@@ -59,6 +60,7 @@ private[v1] class BatchesResource extends ApiRequestContext with Logging {
     fe.getConf.get(BATCH_INTERNAL_REST_CLIENT_CONNECT_TIMEOUT).toInt
 
   private def batchV2Enabled(reqConf: Map[String, String]): Boolean = {
+    KyuubiServer.kyuubiServer.getConf.get(BATCH_SUBMITTER_ENABLED) &&
     reqConf.getOrElse(BATCH_IMPL_VERSION.key, fe.getConf.get(BATCH_IMPL_VERSION)) == "2"
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
It makes no sense to enable batch impl v2 when `kyuubi.batch.submitter.enabled` is disabled, to avoid misuse, globally disable batch impl v2 in such case.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.