### PR TITLE
Thrift HTTP FE checks req conf nullable before evaluating proxy user

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiTHttpFrontendService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiTHttpFrontendService.scala
@@ -278,7 +278,11 @@ final class KyuubiTHttpFrontendService(
     val realUser = getShortName(Option(SessionManager.getUserName).getOrElse(req.getUsername))
     // using the remote ip address instead of that in proxy http header for authentication
     val ipAddress: String = SessionManager.getIpAddress
-    val sessionUser: String = getProxyUser(req.getConfiguration, ipAddress, realUser)
+    val sessionUser: String = if (req.getConfiguration == null) {
+      realUser
+    } else {
+      getProxyUser(req.getConfiguration, ipAddress, realUser)
+    }
     debug(s"Client's real user: $realUser, session user: $sessionUser")
     realUser -> sessionUser
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This PR fixes a NPE when client opens session with null configuration using Thrift HTTP protocol

```
2023-08-28 02:03:56.512 ERROR org.apache.kyuubi.server.KyuubiTHttpFrontendService: Error opening session:
java.lang.NullPointerException: null
        at org.apache.kyuubi.service.TFrontendService.getProxyUser(TFrontendService.scala:130) ~[kyuubi-common_2.12-1.8.0-SNAPSHOT.jar:1.8.0-SNAPSHOT]
        at org.apache.kyuubi.server.KyuubiTHttpFrontendService.getRealUserAndSessionUser(KyuubiTHttpFrontendService.scala:281) ~[kyuubi-server_2.12-1.8.0-SNAPSHOT.jar:1.8.0-SNAPSHOT]
        at org.apache.kyuubi.service.TFrontendService.getSessionHandle(TFrontendService.scala:168) ~[kyuubi-common_2.12-1.8.0-SNAPSHOT.jar:1.8.0-SNAPSHOT]
        at org.apache.kyuubi.service.TFrontendService.OpenSession(TFrontendService.scala:190) ~[kyuubi-common_2.12-1.8.0-SNAPSHOT.jar:1.8.0-SNAPSHOT]
        at org.apache.hive.service.rpc.thrift.TCLIService$Processor$OpenSession.getResult(TCLIService.java:1497) ~[hive-service-rpc-3.1.3.jar:3.1.3]
        at org.apache.hive.service.rpc.thrift.TCLIService$Processor$OpenSession.getResult(TCLIService.java:1482) ~[hive-service-rpc-3.1.3.jar:3.1.3]
        at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:39) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:39) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.server.TServlet.doPost(TServlet.java:83) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.kyuubi.server.http.ThriftHttpServlet.doPost(ThriftHttpServlet.scala:146) ~[kyuubi-server_2.12-1.8.0-SNAPSHOT.jar:1.8.0-SNAPSHOT]
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:517) ~[jakarta.servlet-api-4.0.4.jar:4.0.4]
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No