### PR TITLE
Try to kill pod with label if no ApplicationInfo found to prevent pod leak

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
@@ -140,7 +140,7 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
                   s" application[appId: ${info.id} ,tag: $tag] is completed")
           }
         case None =>
-          debug(s"No application info found for tag[$tag]," +
+          warn(s"No application info found for tag[$tag]," +
             s" trying to delete pod with label [$LABEL_KYUUBI_UNIQUE_KEY -> $tag]")
           (
             !kubernetesClient.pods.withLabel(LABEL_KYUUBI_UNIQUE_KEY, tag).delete().isEmpty,

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
@@ -125,18 +125,27 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
     val kubernetesClient = getOrCreateKubernetesClient(kubernetesInfo)
     debug(s"[$kubernetesInfo] Deleting application info from Kubernetes cluster by $tag tag")
     try {
-      val info = appInfoStore.getOrDefault(tag, ApplicationInfo.NOT_FOUND)
-      debug(s"Application info[tag: $tag] is in ${info.state}")
-      info.state match {
-        case NOT_FOUND | FAILED | UNKNOWN =>
+      Option(appInfoStore.get(tag)) match {
+        case Some(info) =>
+          debug(s"Application info[tag: $tag] is in ${info.state}")
+          info.state match {
+            case NOT_FOUND | FAILED | UNKNOWN =>
+              (
+                false,
+                s"[$kubernetesInfo] Target application[tag: $tag] is in ${info.state} status")
+            case _ =>
+              (
+                !kubernetesClient.pods.withName(info.name).delete().isEmpty,
+                s"[$kubernetesInfo] Operation of deleted" +
+                  s" application[appId: ${info.id} ,tag: $tag] is completed")
+          }
+        case None =>
+          debug(s"No application info found for tag[$tag]," +
+            s" trying to delete pod with label [$LABEL_KYUUBI_UNIQUE_KEY -> $tag]")
           (
-            false,
-            s"[$kubernetesInfo] Target application[tag: $tag] is in ${info.state} status")
-        case _ =>
-          (
-            !kubernetesClient.pods.withName(info.name).delete().isEmpty,
+            !kubernetesClient.pods.withLabel(LABEL_KYUUBI_UNIQUE_KEY, tag).delete().isEmpty,
             s"[$kubernetesInfo] Operation of deleted" +
-              s" application[appId: ${info.id} ,tag: $tag] is completed")
+              s" pod with label [$LABEL_KYUUBI_UNIQUE_KEY -> $tag] is completed")
       }
     } catch {
       case e: Exception =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Now for `KubernetesApplicationOperation`, it rely on the appInfoStore.

For batch rest api, if the closeBatch request can not be send to the kyuubiInstance that created the batch, the current kyuubiInstance will try to kill the batch.

I wonder that, in this case, the applicationInfo might can not be found in the appInfoStore.

It is better to try the best to kill the pod with  `kyuubi-unique-tag` label to prevent pod leak.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
