### PR TITLE
Batch submitter should only block submitting stage

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -1691,7 +1691,7 @@ object KyuubiConf {
         s"when ${BATCH_SUBMITTER_ENABLED.key} is enabled")
       .version("1.8.0")
       .intConf
-      .createWithDefault(100)
+      .createWithDefault(16)
 
   val BATCH_IMPL_VERSION: ConfigEntry[String] =
     buildConf("kyuubi.batch.impl.version")

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiBatchService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiBatchService.scala
@@ -103,11 +103,12 @@ class KyuubiBatchService(
               }
               // should we always treat metastore as the single of truth?
               //
-              // terminated = metadataManager.getBatchSessionMetadata(batchId) match {
+              // submitted = metadataManager.getBatchSessionMetadata(batchId) match {
               //   case Some(metadata) =>
-              //     OperationState.isTerminal(OperationState.withName(metadata.state))
+              //     val batchState = OperationState.withName(metadata.state)
+              //     batchState == OperationState.RUNNING || OperationState.isTerminal(batchState)
               //   case None =>
-              //     error(s"$batchId is not existed in metastore, assume it is finished")
+              //     error(s"$batchId does not existed in metastore, assume it is finished")
               //     true
               // }
               if (!submitted) Thread.sleep(1000)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiBatchService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiBatchService.scala
@@ -92,11 +92,11 @@ class KyuubiBatchService(
               clusterManager = batchSession.batchJobSubmissionOp.builder.clusterManager())
             metadataManager.updateMetadata(metadataForUpdate, asyncRetryOnError = false)
             val sessionHandle = sessionManager.openBatchSession(batchSession)
-            var terminated = false
-            while (!terminated) { // block until batch job finished
-              terminated = sessionManager.getBatchSession(sessionHandle).map { batchSession =>
-                val batchOp = batchSession.batchJobSubmissionOp
-                OperationState.isTerminal(batchOp.getStatus.state)
+            var submitted = false
+            while (!submitted) { // block until batch job finished
+              submitted = sessionManager.getBatchSession(sessionHandle).map { batchSession =>
+                val batchState = batchSession.batchJobSubmissionOp.getStatus.state
+                batchState == OperationState.RUNNING || OperationState.isTerminal(batchState)
               }.getOrElse {
                 error(s"Batch Session $batchId is not existed, marked as finished")
                 true
@@ -110,9 +110,9 @@ class KyuubiBatchService(
               //     error(s"$batchId is not existed in metastore, assume it is finished")
               //     true
               // }
-              if (!terminated) Thread.sleep(1000)
+              if (!submitted) Thread.sleep(1000)
             }
-            info(s"$batchId is finished.")
+            info(s"$batchId is submitted.")
         }
       }
     }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiBatchService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiBatchService.scala
@@ -93,7 +93,7 @@ class KyuubiBatchService(
             metadataManager.updateMetadata(metadataForUpdate, asyncRetryOnError = false)
             val sessionHandle = sessionManager.openBatchSession(batchSession)
             var submitted = false
-            while (!submitted) { // block until batch job finished
+            while (!submitted) { // block until batch job submitted
               submitted = sessionManager.getBatchSession(sessionHandle).map { batchSession =>
                 val batchState = batchSession.batchJobSubmissionOp.getStatus.state
                 batchState == OperationState.RUNNING || OperationState.isTerminal(batchState)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This PR changes the block phase of the batch submitter

- before: from PENDING until TERMINATED 
- after: from PENDING until RUNNING or TERMINATED

Usually, we submit Spark batch applications in cluster mode with waitAppCompletion disabled, after a Spark application goes into the RUNNING or TERMINATED stage, the `spark-submit` process exits and the batch session does not occupy too many resources. Thus, limiting the concurrency on the submitting phase instead of the whole lifecycle of the Spark app makes more sense. 

In practice, we use 16 threads for Kyuubi instance with 8C32G. A larger concurrency may result in CPU resources being exhausted and `spark-submit` process hanging. 

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.