### PR TITLE
[DO-NOT-MERGE] Flink sql engine compilation on Scala 2.13

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -189,8 +189,7 @@ jobs:
         uses: ./.github/actions/setup-maven
       - name: Build on Scala ${{ matrix.scala }}
         run: |
-          MODULES='!externals/kyuubi-flink-sql-engine'
-          ./build/mvn clean install -pl ${MODULES} -am \
+          ./build/mvn clean install -am \
           -DskipTests -Pflink-provided,hive-provided,spark-provided \
           -Pjava-${{ matrix.java }} \
           -Pscala-${{ matrix.scala }} \

--- a/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/FlinkSQLEngine.scala
+++ b/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/FlinkSQLEngine.scala
@@ -90,6 +90,7 @@ object FlinkSQLEngine extends Logging {
       val flinkConfFromArgs =
         kyuubiConf.getAll.filterKeys(_.startsWith("flink."))
           .map { case (k, v) => (k.stripPrefix("flink."), v) }
+          .toMap
       flinkConf.addAll(Configuration.fromMap(flinkConfFromArgs.asJava))
 
       val executionTarget = flinkConf.getString(DeploymentOptions.TARGET)

--- a/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/util/StringUtils.scala
+++ b/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/util/StringUtils.scala
@@ -19,6 +19,8 @@ package org.apache.kyuubi.engine.flink.util
 
 import java.util.regex.PatternSyntaxException
 
+import scala.collection.mutable
+
 object StringUtils {
 
   /**
@@ -30,8 +32,8 @@ object StringUtils {
    *                on both ends will be ignored
    * @return the filtered names list in order
    */
-  def filterPattern(names: Seq[String], pattern: String): Seq[String] = {
-    val funcNames = scala.collection.mutable.SortedSet.empty[String]
+  def filterPattern(names: Iterable[String], pattern: String): Seq[String] = {
+    val funcNames = mutable.SortedSet[String]()
     pattern.trim().split("\\|").foreach { subPattern =>
       try {
         val regex = ("(?i)" + subPattern.replaceAll("\\*", ".*")).r


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- make Flink SQL Engine module compilable on Scala 2.13
- However, as Flink only provides and is embedded with Scala 2.12 runtime, there's no possible way or gain to use Flink SQL Engine on Scala 2.13.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
