### PR TITLE
[KSHC] Unify the exception handling of v1 and v2 during dropDatabase

### DIFF
--- a/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveTableCatalog.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveTableCatalog.scala
@@ -382,9 +382,6 @@ class HiveTableCatalog(sparkSession: SparkSession)
     withSQLConf(LEGACY_NON_IDENTIFIER_OUTPUT_CATALOG_NAME -> "true") {
       namespace match {
         case Array(db) if catalog.databaseExists(db) =>
-          if (catalog.listTables(db).nonEmpty && !cascade) {
-            throw new IllegalStateException(s"Namespace ${namespace.quoted} is not empty")
-          }
           catalog.dropDatabase(db, ignoreIfNotExists = false, cascade)
           true
 

--- a/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/KyuubiHiveTest.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/KyuubiHiveTest.scala
@@ -44,7 +44,7 @@ abstract class KyuubiHiveTest extends QueryTest with Logging {
       SupportsNamespaces.PROP_LOCATION,
       SupportsNamespaces.PROP_OWNER)
 
-  protected def catalogName: String = "hive"
+  protected val catalogName: String = "hive"
 
   override def beforeEach(): Unit = {
     super.beforeAll()

--- a/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/command/CreateNamespaceSuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/command/CreateNamespaceSuite.scala
@@ -133,8 +133,6 @@ trait CreateNamespaceSuiteBase extends DDLCommandTestUtils {
 
 class CreateNamespaceV2Suite extends CreateNamespaceSuiteBase {
 
-  override protected def catalogName: String = super.catalogName
-
   override protected def catalogVersion: String = "Hive V2"
 
   override protected def commandVersion: String = V2_COMMAND_VERSION
@@ -144,7 +142,7 @@ class CreateNamespaceV1Suite extends CreateNamespaceSuiteBase {
 
   val SESSION_CATALOG_NAME: String = "spark_catalog"
 
-  override protected def catalogName: String = SESSION_CATALOG_NAME
+  override protected val catalogName: String = SESSION_CATALOG_NAME
 
   override protected def catalogVersion: String = "V1"
 

--- a/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/command/DropNamespaceSuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/command/DropNamespaceSuite.scala
@@ -20,7 +20,9 @@ package org.apache.kyuubi.spark.connector.hive.command
 import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.types.{StringType, StructType}
 
+import org.apache.kyuubi.spark.connector.common.SparkUtils.SPARK_RUNTIME_VERSION
 import org.apache.kyuubi.spark.connector.hive.command.DDLCommandTestUtils.{V1_COMMAND_VERSION, V2_COMMAND_VERSION}
+import org.apache.kyuubi.util.AssertionUtils.interceptContains
 
 trait DropNamespaceSuiteBase extends DDLCommandTestUtils {
   override protected def command: String = "DROP NAMESPACE"
@@ -70,10 +72,14 @@ trait DropNamespaceSuiteBase extends DDLCommandTestUtils {
     checkNamespace(Seq(namespace) ++ builtinNamespace)
 
     // $catalog.ns.table is present, thus $catalog.ns cannot be dropped.
-    val e = intercept[IllegalStateException] {
+    interceptContains[AnalysisException] {
       sql(s"DROP NAMESPACE $catalogName.$namespace")
-    }
-    assert(e.getMessage.contains(s"Namespace $namespace is not empty"))
+    }(if (SPARK_RUNTIME_VERSION >= "3.4") {
+      s"[SCHEMA_NOT_EMPTY] Cannot drop a schema `$namespace` because it contains objects"
+    } else {
+      "Use CASCADE option to drop a non-empty database"
+    })
+
     sql(s"DROP TABLE $catalogName.$namespace.table")
 
     // Now that $catalog.ns is empty, it can be dropped.
@@ -100,8 +106,6 @@ trait DropNamespaceSuiteBase extends DDLCommandTestUtils {
 
 class DropNamespaceV2Suite extends DropNamespaceSuiteBase {
 
-  override protected def catalogName: String = super.catalogName
-
   override protected def catalogVersion: String = "Hive V2"
 
   override protected def commandVersion: String = V2_COMMAND_VERSION
@@ -111,7 +115,7 @@ class DropNamespaceV1Suite extends DropNamespaceSuiteBase {
 
   val SESSION_CATALOG_NAME: String = "spark_catalog"
 
-  override protected def catalogName: String = SESSION_CATALOG_NAME
+  override protected val catalogName: String = SESSION_CATALOG_NAME
 
   override protected def catalogVersion: String = "V1"
 

--- a/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/command/ShowTablesSuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/command/ShowTablesSuite.scala
@@ -96,8 +96,6 @@ trait ShowTablesSuiteBase extends DDLCommandTestUtils {
 
 class ShowTablesV2Suite extends ShowTablesSuiteBase {
 
-  override protected def catalogName: String = super.catalogName
-
   override protected def catalogVersion: String = "Hive V2"
 
   override protected def commandVersion: String = V2_COMMAND_VERSION
@@ -107,7 +105,7 @@ class ShowTablesV1Suite extends ShowTablesSuiteBase {
 
   val SESSION_CATALOG_NAME: String = "spark_catalog"
 
-  override protected def catalogName: String = SESSION_CATALOG_NAME
+  override protected val catalogName: String = SESSION_CATALOG_NAME
 
   override protected def catalogVersion: String = "V1"
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->
### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This PR aims to unify the exception handling of v1 and v2 during dropDatabase



### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
