### PR TITLE
[LINEAGE] Adapt `CreateTableAsSelect` plan to Spark 3.5 changes

### DIFF
--- a/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/helper/SparkSQLLineageParseHelper.scala
+++ b/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/helper/SparkSQLLineageParseHelper.scala
@@ -251,7 +251,7 @@ trait LineageParser {
               invokeAs[Identifier](plan, "tableName").name(),
               invokeAs[Identifier](plan, "tableName").namespace().mkString("."),
               getField[CatalogPlugin](
-                invokeAs[LogicalPlan](plan, "left"),
+                invokeAs[LogicalPlan](plan, "name"),
                 "catalog").name())
           }
         extractColumnsLineage(getQuery(plan), parentColumnsLineage).map { case (k, v) =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

to fix
```
- columns lineage extract - CreateTableAsSelect *** FAILED ***
  java.util.NoSuchElementException: None.get
  at scala.None$.get(Option.scala:529)
  at scala.None$.get(Option.scala:527)
  at org.apache.kyuubi.plugin.lineage.helper.SparkSQLLineageParserHelperSuite.extractLineage(SparkSQLLineageParserHelperSuite.scala:1452)
  at org.apache.kyuubi.plugin.lineage.helper.SparkSQLLineageParserHelperSuite.$anonfun$new$24(SparkSQLLineageParserHelperSuite.scala:354)
  at org.apache.kyuubi.plugin.lineage.helper.SparkSQLLineageParserHelperSuite.$anonfun$new$24$adapted(SparkSQLLineageParserHelperSuite.scala:353)
  at org.apache.spark.sql.SparkListenerExtensionTest.withTable(SparkListenerExtensionTest.scala:48)
  at org.apache.spark.sql.SparkListenerExtensionTest.withTable$(SparkListenerExtensionTest.scala:46)
  at org.apache.kyuubi.plugin.lineage.helper.SparkSQLLineageParserHelperSuite.withTable(SparkSQLLineageParserHelperSuite.scala:34)
  at org.apache.kyuubi.plugin.lineage.helper.SparkSQLLineageParserHelperSuite.$anonfun$new$23(SparkSQLLineageParserHelperSuite.scala:353)
  at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
  ...
```

the method `CreateTableAsSelect#left` was removed since Spark 3.5, for more details, see https://github.com/apache/spark/pull/40734 


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No