### PR TITLE
[FLINK] Force disable Flink's session timeout

### DIFF
--- a/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/FlinkSQLEngine.scala
+++ b/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/FlinkSQLEngine.scala
@@ -19,12 +19,14 @@ package org.apache.kyuubi.engine.flink
 
 import java.io.File
 import java.nio.file.Paths
+import java.time.Duration
 import java.util.concurrent.CountDownLatch
 
 import scala.collection.JavaConverters._
 
 import org.apache.flink.configuration.{Configuration, DeploymentOptions, GlobalConfiguration, PipelineOptions}
 import org.apache.flink.table.api.TableEnvironment
+import org.apache.flink.table.gateway.api.config.SqlGatewayServiceConfigOptions
 import org.apache.flink.table.gateway.service.context.DefaultContext
 
 import org.apache.kyuubi.{Logging, Utils}
@@ -145,6 +147,11 @@ object FlinkSQLEngine extends Logging {
 
     kyuubiConf.getOption(KYUUBI_SESSION_USER_KEY)
       .foreach(flinkConf.setString(KYUUBI_SESSION_USER_KEY, _))
+
+    // force disable Flink's session timeout
+    flinkConf.set(
+      SqlGatewayServiceConfigOptions.SQL_GATEWAY_SESSION_IDLE_TIMEOUT,
+      Duration.ofMillis(0))
 
     executionTarget match {
       case "yarn-per-job" | "yarn-application" =>


### PR DESCRIPTION
### _Why are the changes needed?_
Flink sessions are now managed by Kyuubi, hence disable session timeout from Flink itself.


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
No.
