### PR TITLE
[CLIENT] New RetryableClient  get http://null server uri from metadata.kyuubiInstance

### DIFF
--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/RestClientFactory.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/RestClientFactory.scala
@@ -47,7 +47,8 @@ object RestClientFactory {
       kyuubiRestClient: KyuubiRestClient,
       kyuubiInstance: String)(f: KyuubiRestClient => Unit): Unit = {
     val kyuubiInstanceRestClient = kyuubiRestClient.clone()
-    val hostUrls = Seq(s"http://$kyuubiInstance") ++ kyuubiRestClient.getHostUrls.asScala
+    val hostUrls = Option(kyuubiInstance).map(instance => s"http://$instance").toSeq ++
+      kyuubiRestClient.getHostUrls.asScala
     kyuubiInstanceRestClient.setHostUrls(hostUrls.asJava)
     try {
       f(kyuubiInstanceRestClient)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Due to #5078, we marked kyuubi_instance in metadata can be null.

We should append kyuubi_instance after we check it's non-null.

Otherwise we may face the following error when we use v2 submit job
```
2023-09-14 19:05:43 [INFO] [main] org.apache.kyuubi.client.RetryableRestClient#74 - Current connect server uri http://null/api/v1
2023-09-14 19:05:43 [ERROR] [main] org.apache.kyuubi.client.RestClient#189 - Error:
java.net.UnknownHostException: null: Name or service not known
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No