### PR TITLE
Return dummy log when batch job before being added to session manager

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
@@ -416,11 +416,8 @@ private[v1] class BatchesResource extends ApiRequestContext with Logging {
           val internalRestClient = getInternalRestClient(metadata.kyuubiInstance)
           internalRestClient.getBatchLocalLog(userName, batchId, from, size)
         } else if (batchV2Enabled(metadata.requestConf) &&
-          // Aims to cover the case that batch job been picked by current instance
-          // but the batch id not been handled by this SessionManager.
-          // Ref to we open session first then hand the session
-          // and mark operation RUNNING also has code gap with handler session,
-          // we consider RUNNING state too
+          // in batch v2 impl, the operation state is changed from PENDING to RUNNING
+          // before being added to SessionManager.
           (metadata.state == "PENDING" || metadata.state == "RUNNING")) {
           info(s"Batch $batchId is waiting for submitting")
           val dummyLogs = List(s"Batch $batchId is waiting for submitting").asJava


### PR DESCRIPTION
…sion manager

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
As title

Current we open session first then hand this session with batch by SessionManager:
https://github.com/apache/kyuubi/blob/413683507079f8f97217e8099177f0b16bc9192d/kyuubi-common/src/main/scala/org/apache/kyuubi/session/SessionManager.scala#L97-L121

We may face `No local log `exception, when kyuubi server picked this batch job to open session but not handled by SessionManager, due to time gap and code gap.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [X] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No