### PR TITLE
[BATCH] Batch session recovery should start after HTTP server getting started

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiRestFrontendService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiRestFrontendService.scala
@@ -189,7 +189,7 @@ class KyuubiRestFrontendService(override val serverable: Serverable)
         // block until the HTTP server is started, otherwise, we may get
         // the wrong HTTP server port -1
         while (server.getState != "STARTED") {
-          debug(s"Wait for $getName server start")
+          info(s"Waiting for $getName's HTTP server getting started")
           Thread.sleep(1000)
         }
         recoverBatchSessions()

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiRestFrontendService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiRestFrontendService.scala
@@ -55,8 +55,6 @@ class KyuubiRestFrontendService(override val serverable: Serverable)
   private[kyuubi] def sessionManager = be.sessionManager.asInstanceOf[KyuubiSessionManager]
 
   private val batchChecker = ThreadUtils.newDaemonSingleThreadScheduledExecutor("batch-checker")
-  private val batchRecoveryPicker =
-    ThreadUtils.newDaemonSingleThreadScheduledExecutor("batch-recovery-picker")
 
   lazy val host: String = conf.get(FRONTEND_REST_BIND_HOST)
     .getOrElse {
@@ -205,7 +203,6 @@ class KyuubiRestFrontendService(override val serverable: Serverable)
 
   override def stop(): Unit = synchronized {
     ThreadUtils.shutdown(batchChecker)
-    ThreadUtils.shutdown(batchRecoveryPicker)
     if (isStarted.getAndSet(false)) {
       server.stop()
     }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiRestFrontendService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiRestFrontendService.scala
@@ -186,8 +186,8 @@ class KyuubiRestFrontendService(override val serverable: Serverable)
         isStarted.set(true)
         startBatchChecker()
         startInternal()
-        // if the server is not started, we should wait for it to start
-        // otherwise, we may get wrong server port with default -1
+        // block until the HTTP server is started, otherwise, we may get
+        // the wrong HTTP server port -1
         while (server.getState != "STARTED") {
           debug(s"Wait for $getName server start")
           Thread.sleep(1000)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/ui/JettyServer.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/ui/JettyServer.scala
@@ -67,6 +67,8 @@ private[kyuubi] case class JettyServer(
       dest: String): Unit = {
     addHandler(JettyUtils.createRedirectHandler(src, dest))
   }
+
+  def getState: String = server.getState
 }
 
 object JettyServer {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
In rare cases, when JettyServer is not fully started, we start the recovery task, will get the wrong port.

As a result, we cannot get the task that is not properly submitted by the current kyuubi server instance correctly.

Like :
```
mysql> select identifier, kyuubi_instance  from metadata where kyuubi_instance like '%:-1';
+--------------------------------------+----------------------+
| identifier                           | kyuubi_instance      |
+--------------------------------------+----------------------+
| b6e88262-fddb-3ccd-abdf-95ef206e612b | XXXX:-1              |
| 6a02b526-ed10-3b76-ba36-d61fbaf6b28d | XXXX:-1              |
| 70a0446e-d3d0-3b13-9d34-4cc90369c2d9 | XXXX:-1              |
| d290ee2e-b8cd-3bc4-b6c6-72f5b5dfcb9b | XXXX:-1              |
| 9bb10f4-24b4-3eec-b13b-7932b310cb5cd | XXXX:-1              |
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request

In local env, start kyuubi server with this PR, kyuubi server start as excpeted.

And i remove start server and runInternal, kyuubi server will wait here.

### _Was this patch authored or co-authored using generative AI tooling?_
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
