### PR TITLE
[BATCH][V2] Marked V2 Metadata as Init instead of open session

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiRestFrontendService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiRestFrontendService.scala
@@ -170,7 +170,7 @@ class KyuubiRestFrontendService(override val serverable: Serverable)
       v2Metadata.foreach { m =>
         sessionManager.updateMetadata(Metadata(
           identifier = m.identifier,
-          state = OperationState.INITIALIZED.name()))
+          state = OperationState.INITIALIZED.toString))
       }
 
       val batchSessionsToRecover =

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiRestFrontendService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiRestFrontendService.scala
@@ -23,10 +23,13 @@ import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 import javax.servlet.DispatcherType
 import javax.ws.rs.WebApplicationException
 import javax.ws.rs.core.Response.Status
+
 import scala.collection.mutable.ListBuffer
+
 import com.google.common.annotations.VisibleForTesting
 import org.apache.hadoop.conf.Configuration
 import org.eclipse.jetty.servlet.{ErrorPageErrorHandler, FilterHolder}
+
 import org.apache.kyuubi.{KyuubiException, Utils}
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf._

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
@@ -42,7 +42,6 @@ import org.apache.kyuubi.config.KyuubiConf._
 import org.apache.kyuubi.config.KyuubiReservedKeys._
 import org.apache.kyuubi.engine.{ApplicationInfo, ApplicationManagerInfo, KillResponse, KyuubiApplicationManager}
 import org.apache.kyuubi.operation.{BatchJobSubmission, FetchOrientation, OperationState}
-import org.apache.kyuubi.server.KyuubiServer
 import org.apache.kyuubi.server.api.ApiRequestContext
 import org.apache.kyuubi.server.api.v1.BatchesResource._
 import org.apache.kyuubi.server.metadata.MetadataManager

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
@@ -48,7 +48,7 @@ import org.apache.kyuubi.server.api.v1.BatchesResource._
 import org.apache.kyuubi.server.metadata.MetadataManager
 import org.apache.kyuubi.server.metadata.api.{Metadata, MetadataFilter}
 import org.apache.kyuubi.session.{KyuubiBatchSession, KyuubiSessionManager, SessionHandle, SessionType}
-import org.apache.kyuubi.util.JdbcUtils
+import org.apache.kyuubi.util.{JdbcUtils, KyuubiUtils}
 
 @Tag(name = "Batch")
 @Produces(Array(MediaType.APPLICATION_JSON))
@@ -58,11 +58,6 @@ private[v1] class BatchesResource extends ApiRequestContext with Logging {
     fe.getConf.get(BATCH_INTERNAL_REST_CLIENT_SOCKET_TIMEOUT).toInt
   private lazy val internalConnectTimeout =
     fe.getConf.get(BATCH_INTERNAL_REST_CLIENT_CONNECT_TIMEOUT).toInt
-
-  private def batchV2Enabled(reqConf: Map[String, String]): Boolean = {
-    KyuubiServer.kyuubiServer.getConf.get(BATCH_SUBMITTER_ENABLED) &&
-    reqConf.getOrElse(BATCH_IMPL_VERSION.key, fe.getConf.get(BATCH_IMPL_VERSION)) == "2"
-  }
 
   private def getInternalRestClient(kyuubiInstance: String): InternalRestClient = {
     internalRestClients.computeIfAbsent(
@@ -239,7 +234,7 @@ private[v1] class BatchesResource extends ApiRequestContext with Logging {
             KYUUBI_SESSION_CONNECTION_URL_KEY -> fe.connectionUrl,
             KYUUBI_SESSION_REAL_USER_KEY -> fe.getRealUser())).asJava)
 
-        if (batchV2Enabled(request.getConf.asScala.toMap)) {
+        if (KyuubiUtils.batchV2Enabled(request.getConf.asScala.toMap)) {
           logger.info(s"Submit batch job $batchId using Batch API v2")
           return Try {
             sessionManager.initializeBatchState(
@@ -309,7 +304,7 @@ private[v1] class BatchesResource extends ApiRequestContext with Logging {
       buildBatch(batchSession)
     }.getOrElse {
       sessionManager.getBatchMetadata(batchId).map { metadata =>
-        if (batchV2Enabled(metadata.requestConf) ||
+        if (KyuubiUtils.batchV2Enabled(metadata.requestConf) ||
           OperationState.isTerminal(OperationState.withName(metadata.state)) ||
           metadata.kyuubiInstance == fe.connectionUrl) {
           MetadataManager.buildBatch(metadata)
@@ -409,14 +404,14 @@ private[v1] class BatchesResource extends ApiRequestContext with Logging {
       }
     }.getOrElse {
       sessionManager.getBatchMetadata(batchId).map { metadata =>
-        if (batchV2Enabled(metadata.requestConf) && metadata.state == "INITIALIZED") {
+        if (KyuubiUtils.batchV2Enabled(metadata.requestConf) && metadata.state == "INITIALIZED") {
           info(s"Batch $batchId is waiting for scheduling")
           val dummyLogs = List(s"Batch $batchId is waiting for scheduling").asJava
           new OperationLog(dummyLogs, dummyLogs.size)
         } else if (fe.connectionUrl != metadata.kyuubiInstance) {
           val internalRestClient = getInternalRestClient(metadata.kyuubiInstance)
           internalRestClient.getBatchLocalLog(userName, batchId, from, size)
-        } else if (batchV2Enabled(metadata.requestConf) &&
+        } else if (KyuubiUtils.batchV2Enabled(metadata.requestConf) &&
           // in batch v2 impl, the operation state is changed from PENDING to RUNNING
           // before being added to SessionManager.
           (metadata.state == "PENDING" || metadata.state == "RUNNING")) {
@@ -477,7 +472,8 @@ private[v1] class BatchesResource extends ApiRequestContext with Logging {
         checkPermission(userName, metadata.username)
         if (OperationState.isTerminal(OperationState.withName(metadata.state))) {
           new CloseBatchResponse(false, s"The batch[$metadata] has been terminated.")
-        } else if (batchV2Enabled(metadata.requestConf) && metadata.state == "INITIALIZED") {
+        } else if (KyuubiUtils.batchV2Enabled(
+            metadata.requestConf) && metadata.state == "INITIALIZED") {
           if (batchService.get.cancelUnscheduledBatch(batchId)) {
             new CloseBatchResponse(true, s"Unscheduled batch $batchId is canceled.")
           } else if (OperationState.isTerminal(OperationState.withName(metadata.state))) {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionManager.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionManager.scala
@@ -256,10 +256,6 @@ class KyuubiSessionManager private (name: String) extends SessionManager(name) {
     metadataManager.foreach(_.updateMetadata(metadata))
   }
 
-  def markMetadataInitialized(identifier: String): Unit = {
-    metadataManager.foreach(_.markMetadataInitialized(identifier))
-  }
-
   def getMetadataRequestsRetryRef(identifier: String): Option[MetadataRequestsRetryRef] = {
     metadataManager.flatMap(mm => Option(mm.getMetadataRequestsRetryRef(identifier)))
   }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/util/KyuubiUtils.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/util/KyuubiUtils.scala
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.util
+
+import org.apache.kyuubi.config.KyuubiConf.{BATCH_IMPL_VERSION, BATCH_SUBMITTER_ENABLED}
+import org.apache.kyuubi.server.KyuubiServer
+
+object KyuubiUtils {
+
+  /**
+   * Check whether the batch v2 is enabled
+   * 1. Kyuubi Server should enable the batch submitter
+   * 2. Request conf contains enable V2 or Kyuubi Server enabled V2
+   * @param reqConf request conf from rest job
+   * @return true if v2 can be enabled
+   */
+  def batchV2Enabled(reqConf: Map[String, String]): Boolean = {
+    KyuubiServer.kyuubiServer.getConf.get(BATCH_SUBMITTER_ENABLED) &&
+    reqConf.getOrElse(
+      BATCH_IMPL_VERSION.key,
+      KyuubiServer.kyuubiServer.getConf.get(BATCH_IMPL_VERSION)) == "2"
+  }
+}

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
@@ -598,7 +598,8 @@ abstract class BatchesResourceSuiteBase extends KyuubiFunSuite
         }
       case "2" =>
         eventually(timeout(20.seconds)) {
-          Seq(batchId1, batchId2).foreach { batchId =>
+          Seq(batchMetadata, batchMetadata2).foreach { originMetadata =>
+            val batchId = originMetadata.identifier
             val metadata = sessionManager.getBatchMetadata(batchId).getOrElse(fail(
               s"Can't find metadata for recovery batch: $batchId"))
             assert(
@@ -606,6 +607,7 @@ abstract class BatchesResourceSuiteBase extends KyuubiFunSuite
                 metadata.state === OperationState.RUNNING.toString ||
                 metadata.state === OperationState.FINISHED.toString)
             assert(metadata.kyuubiInstance === fe.connectionUrl)
+            assert(metadata.createTime !== originMetadata.createTime)
           }
         }
       case "_" =>

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
@@ -597,20 +597,16 @@ abstract class BatchesResourceSuiteBase extends KyuubiFunSuite
           assert(!session2.batchJobSubmissionOp.builder.processLaunched)
         }
       case "2" =>
-        assert(sessionManager.getBatchMetadata(batchId1).nonEmpty)
-        assert(sessionManager.getBatchMetadata(batchId1).nonEmpty)
-
         eventually(timeout(20.seconds)) {
-          assert(sessionManager.getBatchMetadata(batchId1).exists(m =>
-            m.state === OperationState.INITIALIZED.toString ||
-              m.state === OperationState.PENDING.toString ||
-              m.state === OperationState.RUNNING.toString ||
-              m.state === OperationState.FINISHED.toString))
-          assert(sessionManager.getBatchMetadata(batchId2).exists(m =>
-            m.state === OperationState.INITIALIZED.toString ||
-              m.state === OperationState.PENDING.toString ||
-              m.state === OperationState.RUNNING.toString ||
-              m.state === OperationState.FINISHED.toString))
+          Seq(batchId1, batchId2).foreach { batchId =>
+            val metadata = sessionManager.getBatchMetadata(batchId).getOrElse(fail(
+              s"Can't find metadata for recovery batch: $batchId"))
+            assert(
+                metadata.state === OperationState.PENDING.toString ||
+                metadata.state === OperationState.RUNNING.toString ||
+                metadata.state === OperationState.FINISHED.toString)
+            assert(metadata.kyuubiInstance === fe.connectionUrl)
+          }
         }
       case "_" =>
         fail(s"unexpected batch version: $batchVersion")

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
@@ -602,7 +602,7 @@ abstract class BatchesResourceSuiteBase extends KyuubiFunSuite
             val metadata = sessionManager.getBatchMetadata(batchId).getOrElse(fail(
               s"Can't find metadata for recovery batch: $batchId"))
             assert(
-                metadata.state === OperationState.PENDING.toString ||
+              metadata.state === OperationState.PENDING.toString ||
                 metadata.state === OperationState.RUNNING.toString ||
                 metadata.state === OperationState.FINISHED.toString)
             assert(metadata.kyuubiInstance === fe.connectionUrl)


### PR DESCRIPTION
### _Why are the changes needed?_

When we try to recover all running tasks before the restart on a specified Kyuubi service, we encounter that the kyuubi server is booted in  Start -> OOM  -> Start vicious cycle when there are too many tasks.

Here we set all need recover task as `INITIALIZED`, let every kyuubi service have chance to pick and run those job, to avoid the problem of excessive single point of load

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
No