### PR TITLE
[WIP][EXTENSION] Inject Rule to fast fail gluten app if there are too much un-support operator

### DIFF
--- a/extensions/spark/kyuubi-extension-spark-3-3/src/main/scala/org/apache/kyuubi/sql/GlutenPlanManager.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-3/src/main/scala/org/apache/kyuubi/sql/GlutenPlanManager.scala
@@ -23,7 +23,6 @@ import org.apache.spark.sql.catalyst.expressions.UserDefinedExpression
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.aggregate.{ObjectHashAggregateExec, SortAggregateExec}
-import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
 import org.apache.spark.sql.execution.joins.{BroadcastNestedLoopJoinExec, CartesianProductExec}
@@ -52,51 +51,38 @@ case class GlutenPlanManager(session: SparkSession) extends ColumnarRule {
 object GlutenPlanAnalysis extends Rule[SparkPlan] {
 
   override def apply(plan: SparkPlan): SparkPlan = {
-    var count = 0
-
-    plan foreach { p =>
-      if (containsUnsupportedOperator(p)) {
-        count += 1
-      }
-    }
+    val count = plan.collect {
+      case p: FileSourceScanExec
+          if !p.relation.fileFormat.isInstanceOf[ParquetFileFormat] =>
+        p
+      case p: RowDataSourceScanExec =>
+        p
+      case p: UserDefinedExpression =>
+        p
+      case p: CartesianProductExec =>
+        p
+      case p: ShuffleExchangeExec =>
+        p
+      case p: CollectLimitExec =>
+        p
+      case p: ObjectHashAggregateExec =>
+        p
+      case p: SortAggregateExec =>
+        p
+      case p: CoalesceExec =>
+        p
+      case p: GenerateExec =>
+        p
+      case p: RangeExec =>
+        p
+      case p: SampleExec =>
+        p
+      case p: BroadcastNestedLoopJoinExec =>
+        p
+      // TODO check whether the plan contains unsupported expressions
+    }.size
     check(count)
     plan
-  }
-
-  private def containsUnsupportedOperator(plan: SparkPlan): Boolean = {
-    plan match {
-      case FileSourceScanExec(relation, _, _, _, _, _, _, _, _) =>
-        !relation.fileFormat.isInstanceOf[ParquetFileFormat]
-      case _: RowDataSourceScanExec =>
-        true
-      case _: UserDefinedExpression =>
-        true
-      case _: CartesianProductExec =>
-        true
-      case _: ShuffleExchangeExec =>
-        true
-      case _: CollectLimitExec =>
-        true
-      case _: ObjectHashAggregateExec =>
-        true
-      case _: SortAggregateExec =>
-        true
-      case _: CoalesceExec =>
-        true
-      case _: GenerateExec =>
-        true
-      case _: RangeExec =>
-        true
-      case _: SampleExec =>
-        true
-      case _: InMemoryTableScanExec =>
-        true
-      case _: BroadcastNestedLoopJoinExec =>
-        true
-      case _: SparkPlan =>
-        // TODO check whether the plan contains unsupported expressions
-        false
-    }
   }
 
   /**

--- a/extensions/spark/kyuubi-extension-spark-3-3/src/main/scala/org/apache/kyuubi/sql/GlutenPlanManager.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-3/src/main/scala/org/apache/kyuubi/sql/GlutenPlanManager.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
 import org.apache.spark.sql.execution.joins.{BroadcastNestedLoopJoinExec, CartesianProductExec}
 
 /**
- * Kyuubi extension for gluten enabled case.
+ * [Experimental]Kyuubi extension for gluten enabled case.
  * 1. check whether the plan contains too much unsupported operator
  */
 case class GlutenPlanManager(session: SparkSession) extends ColumnarRule {

--- a/extensions/spark/kyuubi-extension-spark-3-3/src/main/scala/org/apache/kyuubi/sql/GlutenPlanManager.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-3/src/main/scala/org/apache/kyuubi/sql/GlutenPlanManager.scala
@@ -59,7 +59,6 @@ object GlutenPlanAnalysis extends Rule[SparkPlan] {
           _: UserDefinedExpression |
           _: CartesianProductExec |
           _: ShuffleExchangeExec |
-          _: CollectLimitExec |
           _: ObjectHashAggregateExec |
           _: SortAggregateExec |
           _: CoalesceExec |

--- a/extensions/spark/kyuubi-extension-spark-3-3/src/main/scala/org/apache/kyuubi/sql/GlutenPlanManager.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-3/src/main/scala/org/apache/kyuubi/sql/GlutenPlanManager.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
 import org.apache.spark.sql.execution.joins.{BroadcastNestedLoopJoinExec, CartesianProductExec}
 
-import org.apache.kyuubi.sql.KyuubiSQLConf.GLUTEN_NON_SUPPORT_OPERATOR_LIST
+import org.apache.kyuubi.sql.KyuubiSQLConf.GLUTEN_FALLBACK_OPERATORS
 
 /**
  * [Experimental]Kyuubi extension for gluten enabled case.
@@ -55,7 +55,7 @@ object GlutenPlanAnalysis extends Rule[SparkPlan] {
 
   override def apply(plan: SparkPlan): SparkPlan = {
     val nonSupportedOperatorList =
-      conf.getConf(GLUTEN_NON_SUPPORT_OPERATOR_LIST).getOrElse(Seq.empty)
+      conf.getConf(GLUTEN_FALLBACK_OPERATORS).getOrElse(Seq.empty)
     val count = plan.collect {
       case p: FileSourceScanExec
           if !p.relation.fileFormat.isInstanceOf[ParquetFileFormat] &&
@@ -80,7 +80,6 @@ object GlutenPlanAnalysis extends Rule[SparkPlan] {
             case _ => false
           }) =>
         true
-      // TODO check whether the plan contains unsupported expressions
     }.size
     check(count)
     plan

--- a/extensions/spark/kyuubi-extension-spark-3-3/src/main/scala/org/apache/kyuubi/sql/GlutenPlanManager.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-3/src/main/scala/org/apache/kyuubi/sql/GlutenPlanManager.scala
@@ -54,31 +54,20 @@ object GlutenPlanAnalysis extends Rule[SparkPlan] {
     val count = plan.collect {
       case p: FileSourceScanExec
           if !p.relation.fileFormat.isInstanceOf[ParquetFileFormat] =>
-        p
-      case p: RowDataSourceScanExec =>
-        p
-      case p: UserDefinedExpression =>
-        p
-      case p: CartesianProductExec =>
-        p
-      case p: ShuffleExchangeExec =>
-        p
-      case p: CollectLimitExec =>
-        p
-      case p: ObjectHashAggregateExec =>
-        p
-      case p: SortAggregateExec =>
-        p
-      case p: CoalesceExec =>
-        p
-      case p: GenerateExec =>
-        p
-      case p: RangeExec =>
-        p
-      case p: SampleExec =>
-        p
-      case p: BroadcastNestedLoopJoinExec =>
-        p
+        true
+      case _: RowDataSourceScanExec |
+          _: UserDefinedExpression |
+          _: CartesianProductExec |
+          _: ShuffleExchangeExec |
+          _: CollectLimitExec |
+          _: ObjectHashAggregateExec |
+          _: SortAggregateExec |
+          _: CoalesceExec |
+          _: GenerateExec |
+          _: RangeExec |
+          _: SampleExec |
+          _: BroadcastNestedLoopJoinExec =>
+        true
       // TODO check whether the plan contains unsupported expressions
     }.size
     check(count)

--- a/extensions/spark/kyuubi-extension-spark-3-3/src/main/scala/org/apache/kyuubi/sql/GlutenPlanManager.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-3/src/main/scala/org/apache/kyuubi/sql/GlutenPlanManager.scala
@@ -52,9 +52,10 @@ case class GlutenPlanManager(session: SparkSession) extends ColumnarRule {
 }
 
 object GlutenPlanAnalysis extends Rule[SparkPlan] {
-  private val nonSupportedOperatorList = conf.getConf(GLUTEN_NON_SUPPORT_OPERATOR_LIST)
 
   override def apply(plan: SparkPlan): SparkPlan = {
+    val nonSupportedOperatorList =
+      conf.getConf(GLUTEN_NON_SUPPORT_OPERATOR_LIST).getOrElse(Seq.empty)
     val count = plan.collect {
       case p: FileSourceScanExec
           if !p.relation.fileFormat.isInstanceOf[ParquetFileFormat] &&

--- a/extensions/spark/kyuubi-extension-spark-3-3/src/main/scala/org/apache/kyuubi/sql/KyuubiSparkSQLExtension.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-3/src/main/scala/org/apache/kyuubi/sql/KyuubiSparkSQLExtension.scala
@@ -40,7 +40,7 @@ class KyuubiSparkSQLExtension extends (SparkSessionExtensions => Unit) {
     extensions.injectOptimizerRule(ForcedMaxOutputRowsRule)
     extensions.injectPlannerStrategy(MaxScanStrategy)
 
-    extensions.injectColumnar(GlutenPlanManager(_))
+    extensions.injectColumnar(GlutenPlanManager)
 
     extensions.injectQueryStagePrepRule(FinalStageResourceManager(_))
     extensions.injectQueryStagePrepRule(InjectCustomResourceProfile)

--- a/extensions/spark/kyuubi-extension-spark-3-3/src/main/scala/org/apache/kyuubi/sql/KyuubiSparkSQLExtension.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-3/src/main/scala/org/apache/kyuubi/sql/KyuubiSparkSQLExtension.scala
@@ -40,6 +40,8 @@ class KyuubiSparkSQLExtension extends (SparkSessionExtensions => Unit) {
     extensions.injectOptimizerRule(ForcedMaxOutputRowsRule)
     extensions.injectPlannerStrategy(MaxScanStrategy)
 
+    extensions.injectColumnar(GlutenPlanManager(_))
+
     extensions.injectQueryStagePrepRule(FinalStageResourceManager(_))
     extensions.injectQueryStagePrepRule(InjectCustomResourceProfile)
   }

--- a/extensions/spark/kyuubi-extension-spark-3-3/src/test/scala/org/apache/kyuubi/sql/GlutenPlanManagerSuite.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-3/src/test/scala/org/apache/kyuubi/sql/GlutenPlanManagerSuite.scala
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.sql
+
+import org.apache.spark.sql.KyuubiSparkSQLExtensionTest
+
+class GlutenPlanManagerSuite extends KyuubiSparkSQLExtensionTest {
+
+  test("Kyuubi Extension fast fail if over un-supported operator threshold") {
+    withSQLConf(
+      KyuubiSQLConf.GLUTEN_FALLBACK_OPERATOR_THRESHOLD.key -> "1") {
+      withTable("gluten_tmp_1") {
+        sql("CREATE TABLE gluten_tmp_1 (c1 int) PARTITIONED BY (c2 string)")
+        sql("INSERT INTO TABLE gluten_tmp_1 PARTITION (c2='1') SELECT 1")
+        assertThrows[TooMuchGlutenUnsupportedOperationException] {
+          sql("SELECT * FROM gluten_tmp_1 LIMIT 1").collect()
+        }
+        sql("SELECT * FROM gluten_tmp_1").collect()
+      }
+    }
+  }
+}

--- a/extensions/spark/kyuubi-extension-spark-3-3/src/test/scala/org/apache/kyuubi/sql/GlutenPlanManagerSuite.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-3/src/test/scala/org/apache/kyuubi/sql/GlutenPlanManagerSuite.scala
@@ -25,12 +25,14 @@ class GlutenPlanManagerSuite extends KyuubiSparkSQLExtensionTest {
     withSQLConf(
       KyuubiSQLConf.GLUTEN_FALLBACK_OPERATOR_THRESHOLD.key -> "1") {
       withTable("gluten_tmp_1") {
-        sql("CREATE TABLE gluten_tmp_1 (c1 int) PARTITIONED BY (c2 string)")
-        sql("INSERT INTO TABLE gluten_tmp_1 PARTITION (c2='1') SELECT 1")
+        sql("CREATE TABLE gluten_tmp_1 (c1 int) USING JSON PARTITIONED BY (c2 string)")
         assertThrows[TooMuchGlutenUnsupportedOperationException] {
-          sql("SELECT * FROM gluten_tmp_1 LIMIT 1").collect()
+          sql("SELECT * FROM gluten_tmp_1").collect()
         }
-        sql("SELECT * FROM gluten_tmp_1").collect()
+      }
+      withTable("gluten_tmp_2") {
+        sql("CREATE TABLE gluten_tmp_2 (c1 int) USING PARQUET PARTITIONED BY (c2 string)")
+        sql("SELECT * FROM gluten_tmp_2").collect()
       }
     }
   }

--- a/extensions/spark/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/GlutenPlanManager.scala
+++ b/extensions/spark/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/GlutenPlanManager.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.sql
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.{ColumnarRule, SparkPlan}
+
+/**
+ */
+case class GlutenPlanManager(session: SparkSession) extends ColumnarRule {
+  private val GLUTEN_DRIVER_PLUGIN_CLASS = "io.glutenproject.GlutenDriverPlugin"
+
+  val unSupportOperators = Option(System.getProperty("gluten.version")) match {
+    case Some(version) if version == "1.1.0" =>
+      Seq("")
+    case None =>
+      Seq("")
+  }
+
+  override def preColumnarTransitions: Rule[SparkPlan] =
+    if (session.sparkContext.getConf.get("spark.plugins", "")
+        .contains(GLUTEN_DRIVER_PLUGIN_CLASS)) {
+      GlutenPlanAnalysis(unSupportOperators)
+    } else {
+      (plan: SparkPlan) => plan
+    }
+}
+
+case class GlutenPlanAnalysis(unSupportOperators: Seq[String]) extends Rule[SparkPlan] {
+  private var count = 0
+  override def apply(plan: SparkPlan): SparkPlan = {
+    // count un-supported plan
+    if (unSupportOperators.contains(plan.getClass.getSimpleName)) {
+      count += 1
+    }
+
+    // fallback to non-gluten mode
+    if (count >= conf.getConf(KyuubiSQLConf.GLUTEN_FALLBACK_OPERATOR_THRESHOLD)) {
+      throw TooMuchGlutenUnsupportedOperationException("")
+    }
+    plan
+  }
+}
+
+final case class TooMuchGlutenUnsupportedOperationException(
+    private val reason: String = "",
+    private val cause: Throwable = None.orNull)
+  extends KyuubiSQLExtensionException(reason, cause)

--- a/extensions/spark/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/KyuubiSQLConf.scala
+++ b/extensions/spark/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/KyuubiSQLConf.scala
@@ -273,4 +273,12 @@ object KyuubiSQLConf {
       .version("1.8.0")
       .stringConf
       .createOptional
+
+  val GLUTEN_FALLBACK_OPERATOR_THRESHOLD =
+    buildConf("spark.sql.gluten.fallbackOperatorThreshold")
+      .doc("The threshold of fallback operator. If the number of fallback operator is " +
+        "bigger than this threshold, we will fallback to original plan.")
+      .version("1.8.0")
+      .intConf
+      .createWithDefault(3)
 }

--- a/extensions/spark/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/KyuubiSQLConf.scala
+++ b/extensions/spark/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/KyuubiSQLConf.scala
@@ -295,23 +295,5 @@ object KyuubiSQLConf {
       .version("1.8.0")
       .stringConf
       .toSequence
-      .createWithDefault(Seq(
-        "SplitPart",
-        "Factorial",
-        "ConcatWs",
-        "Rand",
-        "LengthOfJsonArray",
-        "FromUnixTime",
-        "StringRepeat",
-        "StringTranslate",
-        "AddMonths",
-        "DateFormatClass",
-        "TruncDate",
-        "TruncTimestamp",
-        "Sequence",
-        "PosExplode",
-        "ArraysOverlap",
-        "ArrayMin",
-        "ArrayMax",
-        "ApproximatePercentile"))
+      .createOptional
 }

--- a/extensions/spark/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/KyuubiSQLConf.scala
+++ b/extensions/spark/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/KyuubiSQLConf.scala
@@ -277,7 +277,10 @@ object KyuubiSQLConf {
   val GLUTEN_FALLBACK_OPERATOR_THRESHOLD =
     buildConf("spark.sql.gluten.fallbackOperatorThreshold")
       .doc("The threshold of fallback operator. If the number of fallback operator is " +
-        "bigger than this threshold, we will fallback to original plan.")
+        "bigger than this threshold, we will fallback to original plan." +
+        "Note: Gluten-Related extension is experimental and under rapid development," +
+        "this configuration is added to allow user to control extension, not " +
+        "intended exposing to end users, it may be removed in anytime.")
       .version("1.8.0")
       .intConf
       .createWithDefault(5)

--- a/extensions/spark/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/KyuubiSQLConf.scala
+++ b/extensions/spark/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/KyuubiSQLConf.scala
@@ -285,8 +285,8 @@ object KyuubiSQLConf {
       .intConf
       .createWithDefault(Int.MaxValue)
 
-  val GLUTEN_NON_SUPPORT_OPERATOR_LIST =
-    buildConf("spark.sql.gluten.nonSupportOperatorList")
+  val GLUTEN_FALLBACK_OPERATORS =
+    buildConf("spark.sql.gluten.fallbackOperators")
       .doc("The list of non-support operator. If the plan contains these operators, " +
         "we will fallback to original plan." +
         "Note: Gluten-Related extension is experimental and under rapid development," +

--- a/extensions/spark/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/KyuubiSQLConf.scala
+++ b/extensions/spark/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/KyuubiSQLConf.scala
@@ -283,5 +283,5 @@ object KyuubiSQLConf {
         "intended exposing to end users, it may be removed in anytime.")
       .version("1.8.0")
       .intConf
-      .createWithDefault(5)
+      .createWithDefault(Int.MaxValue)
 }

--- a/extensions/spark/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/KyuubiSQLConf.scala
+++ b/extensions/spark/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/KyuubiSQLConf.scala
@@ -280,5 +280,5 @@ object KyuubiSQLConf {
         "bigger than this threshold, we will fallback to original plan.")
       .version("1.8.0")
       .intConf
-      .createWithDefault(3)
+      .createWithDefault(5)
 }

--- a/extensions/spark/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/KyuubiSQLConf.scala
+++ b/extensions/spark/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/KyuubiSQLConf.scala
@@ -284,4 +284,34 @@ object KyuubiSQLConf {
       .version("1.8.0")
       .intConf
       .createWithDefault(Int.MaxValue)
+
+  val GLUTEN_NON_SUPPORT_OPERATOR_LIST =
+    buildConf("spark.sql.gluten.nonSupportOperatorList")
+      .doc("The list of non-support operator. If the plan contains these operators, " +
+        "we will fallback to original plan." +
+        "Note: Gluten-Related extension is experimental and under rapid development," +
+        "this configuration is added to allow user to control extension, not " +
+        "intended exposing to end users, it may be removed in anytime.")
+      .version("1.8.0")
+      .stringConf
+      .toSequence
+      .createWithDefault(Seq(
+        "SplitPart",
+        "Factorial",
+        "ConcatWs",
+        "Rand",
+        "LengthOfJsonArray",
+        "FromUnixTime",
+        "StringRepeat",
+        "StringTranslate",
+        "AddMonths",
+        "DateFormatClass",
+        "TruncDate",
+        "TruncTimestamp",
+        "Sequence",
+        "PosExplode",
+        "ArraysOverlap",
+        "ArrayMin",
+        "ArrayMax",
+        "ApproximatePercentile"))
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fast fail if there are too much un-support operators in spark plan when enabled gluten.

Too much un-support operators when enabled gluten may significantly reduce the performance, so we want to notify user by fast fail this application.

If the user can tolerate this kind of performance penalty, you can increase the value of the `spark.sql.gluten.fallbackOperatorThreshold`.

See more gluten un-support operators in [Velox Backend Support Progress](https://github.com/oap-project/gluten/blob/main/docs/velox-backend-support-progress.md)

Note:
> Gluten-Related extension is experimental and under rapid development, this configuration is added to allow user to control extension, not intended exposing to end users, it may be removed in anytime.

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No