### PR TITLE
[MINOR] Avoid using `kyuubi.session.engine.initialize.timeout` string

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
@@ -376,7 +376,7 @@ object SparkSQLEngine extends Logging {
         case i: InterruptedException if !sparkSessionCreated.get =>
           error(
             s"The Engine main thread was interrupted, possibly due to `createSpark` timeout." +
-              s" The `kyuubi.session.engine.initialize.timeout` is ($initTimeout ms) " +
+              s" The `${ENGINE_INIT_TIMEOUT.key}` is ($initTimeout ms) " +
               s" and submitted at $submitTime.",
             i)
         case t: Throwable => error(s"Failed to instantiate SparkSession: ${t.getMessage}", t)

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/IndividualSparkSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/IndividualSparkSuite.scala
@@ -114,7 +114,7 @@ class SparkEngineSuites extends KyuubiFunSuite {
       }
       assert(SparkSQLEngine.currentEngine.isEmpty)
       val errorMsg = s"The Engine main thread was interrupted, possibly due to `createSpark`" +
-        s" timeout. The `kyuubi.session.engine.initialize.timeout` is ($timeout ms) " +
+        s" timeout. The `${ENGINE_INIT_TIMEOUT.key}` is ($timeout ms) " +
         s" and submitted at $submitTime."
       assert(logAppender.loggingEvents.exists(
         _.getMessage.getFormattedMessage.equals(errorMsg)))

--- a/integration-tests/kyuubi-kubernetes-it/src/test/scala/org/apache/kyuubi/kubernetes/test/spark/SparkOnKubernetesTestsSuite.scala
+++ b/integration-tests/kyuubi-kubernetes-it/src/test/scala/org/apache/kyuubi/kubernetes/test/spark/SparkOnKubernetesTestsSuite.scala
@@ -27,7 +27,7 @@ import org.apache.hadoop.net.NetUtils
 import org.apache.kyuubi._
 import org.apache.kyuubi.client.util.BatchUtils._
 import org.apache.kyuubi.config.KyuubiConf
-import org.apache.kyuubi.config.KyuubiConf.FRONTEND_THRIFT_BINARY_BIND_HOST
+import org.apache.kyuubi.config.KyuubiConf._
 import org.apache.kyuubi.engine.{ApplicationInfo, ApplicationManagerInfo, ApplicationOperation, KubernetesApplicationOperation}
 import org.apache.kyuubi.engine.ApplicationState.{FAILED, NOT_FOUND, RUNNING}
 import org.apache.kyuubi.engine.spark.SparkProcessBuilder
@@ -57,9 +57,9 @@ abstract class SparkOnKubernetesSuiteBase
       .set("spark.driver.memory", "512M")
       .set("spark.kubernetes.driver.request.cores", "250m")
       .set("spark.kubernetes.executor.request.cores", "250m")
-      .set("kyuubi.kubernetes.context", "minikube")
-      .set("kyuubi.frontend.protocols", "THRIFT_BINARY,REST")
-      .set("kyuubi.session.engine.initialize.timeout", "PT10M")
+      .set(KUBERNETES_CONTEXT.key, "minikube")
+      .set(FRONTEND_PROTOCOLS.key, "THRIFT_BINARY,REST")
+      .set(ENGINE_INIT_TIMEOUT.key, "PT10M")
   }
 }
 

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/WithKyuubiServerOnYarn.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/WithKyuubiServerOnYarn.scala
@@ -198,7 +198,7 @@ class KyuubiOperationYarnClusterSuite extends WithKyuubiServerOnYarn with HiveJD
       "spark.submit.deployMode" -> "cluster",
       "spark.sql.defaultCatalog=spark_catalog" -> "spark_catalog",
       "spark.sql.catalog.spark_catalog.type" -> "invalid_type",
-      "kyuubi.session.engine.initialize.timeout" -> "PT10M",
+      ENGINE_INIT_TIMEOUT.key -> "PT10M",
       KYUUBI_BATCH_ID_KEY -> UUID.randomUUID().toString))(Map.empty) {
       val startTime = System.currentTimeMillis()
       val exception = intercept[Exception] {


### PR DESCRIPTION
### _Why are the changes needed?_

Replace string literal with constant variable

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
No
