### PR TITLE
[DOCS] Fix non-kerberized code description in quick_start_with_jdbc

### DIFF
--- a/docs/quick_start/quick_start_with_jdbc.md
+++ b/docs/quick_start/quick_start_with_jdbc.md
@@ -35,7 +35,7 @@ The driver is available from Maven Central:
 
 ## Connect to non-kerberized Kyuubi Server
 
-The below java code is using a keytab file to login and connect to Kyuubi server by JDBC.
+The following java code connects directly to the Kyuubi Server by JDBC without using kerberos authentication.
 
 ```java
 package org.apache.kyuubi.examples;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
In the `Getting Started with Hive JDBC`documentation, section`Connect to non-kerberized Kyuubi Server`, the code description is incorrect:
```
The below java code is using a keytab file to login and connect to Kyuubi server by JDBC.
```
Obviously, the sections and code here are describing how to connect to a kyuubi service without kerberos authentication.


### _How was this patch tested?_
Just fix code description, no test need.


