### PR TITLE
[KYUUBI #5362] Remove Spark 3.0 support for Authz

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -127,8 +127,8 @@ jobs:
             **/kyuubi-spark-sql-engine.log*
             **/kyuubi-spark-batch-submit.log*
 
-  scala213:
-    name: Scala Compilation Test
+  scala-test:
+    name: Scala Test
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -126,49 +126,6 @@ jobs:
             **/kyuubi-spark-sql-engine.log*
             **/kyuubi-spark-batch-submit.log*
 
-  authz:
-    name: Kyuubi-AuthZ and Spark Test
-    runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        java:
-          - 8
-          - 11
-        spark:
-          - '3.0.3'
-        comment: ["normal"]
-    env:
-      SPARK_LOCAL_IP: localhost
-    steps:
-      - uses: actions/checkout@v3
-      - name: Tune Runner VM
-        uses: ./.github/actions/tune-runner-vm
-      - name: Setup JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: ${{ matrix.java }}
-          cache: 'maven'
-          check-latest: false
-      - name: Setup Maven
-        uses: ./.github/actions/setup-maven
-      - name: Cache Engine Archives
-        uses: ./.github/actions/cache-engine-archives
-      - name: Build and test Kyuubi AuthZ with supported Spark versions
-        run: |
-          TEST_MODULES="extensions/spark/kyuubi-spark-authz"
-          ./build/mvn clean test ${MVN_OPT} -pl ${TEST_MODULES} -am \
-          -Dspark.version=${{ matrix.spark }}
-      - name: Upload test logs
-        if: failure()
-        uses: actions/upload-artifact@v3
-        with:
-          name: unit-tests-log-java-${{ matrix.java }}-spark-${{ matrix.spark }}-${{ matrix.comment }}
-          path: |
-            **/target/unit-tests.log
-            **/kyuubi-spark-sql-engine.log*
-
   scala213:
     name: Scala Compilation Test
     runs-on: ubuntu-22.04

--- a/docs/security/authorization/spark/build.md
+++ b/docs/security/authorization/spark/build.md
@@ -45,14 +45,14 @@ build/mvn clean package -pl :kyuubi-spark-authz_2.12 -DskipTests -Dspark.version
 
 The available `spark.version`s are shown in the following table.
 
-|   Spark Version   | Supported |                                                         Remark                                                          |
-|:-----------------:|:---------:|:-----------------------------------------------------------------------------------------------------------------------:|
-|      master       |     √     |                                                            -                                                            |
-|       3.3.x       |     √     |                                                            -                                                            |
-|       3.2.x       |     √     |                                                            -                                                            |
-|       3.1.x       |     √     |                                                            -                                                            |
-|       3.0.x       |     x     | [PR 5363](https://github.com/apache/kyuubi/pull/5363) is used to track how we work with older releases with spark 3.0.x |
-| 2.4.x and earlier |     ×     | [PR 2367](https://github.com/apache/kyuubi/pull/2367) is used to track how we work with older releases with scala 2.11  |
+|   Spark Version   | Supported |                                                         Remark                                                         |
+|:-----------------:|:---------:|:----------------------------------------------------------------------------------------------------------------------:|
+|      master       |     √     |                                                           -                                                            |
+|       3.3.x       |     √     |                                                           -                                                            |
+|       3.2.x       |     √     |                                                           -                                                            |
+|       3.1.x       |     √     |                                                           -                                                            |
+|       3.0.x       |     x     |                                                   EOL since v1.9.0                                                     |
+| 2.4.x and earlier |     ×     | [PR 2367](https://github.com/apache/kyuubi/pull/2367) is used to track how we work with older releases with scala 2.11 |
 
 Currently, Spark released with Scala 2.12 are supported.
 

--- a/docs/security/authorization/spark/build.md
+++ b/docs/security/authorization/spark/build.md
@@ -45,14 +45,14 @@ build/mvn clean package -pl :kyuubi-spark-authz_2.12 -DskipTests -Dspark.version
 
 The available `spark.version`s are shown in the following table.
 
-|   Spark Version   | Supported |                                                         Remark                                                         |
-|:-----------------:|:---------:|:----------------------------------------------------------------------------------------------------------------------:|
-|      master       |     √     |                                                           -                                                            |
-|       3.3.x       |     √     |                                                           -                                                            |
-|       3.2.x       |     √     |                                                           -                                                            |
-|       3.1.x       |     √     |                                                           -                                                            |
-|       3.0.x       |     √     |                                                           -                                                            |
-| 2.4.x and earlier |     ×     | [PR 2367](https://github.com/apache/kyuubi/pull/2367) is used to track how we work with older releases with scala 2.11 |
+|   Spark Version   | Supported |                                                         Remark                                                          |
+|:-----------------:|:---------:|:-----------------------------------------------------------------------------------------------------------------------:|
+|      master       |     √     |                                                            -                                                            |
+|       3.3.x       |     √     |                                                            -                                                            |
+|       3.2.x       |     √     |                                                            -                                                            |
+|       3.1.x       |     √     |                                                            -                                                            |
+|       3.0.x       |     x     | [PR 5363](https://github.com/apache/kyuubi/pull/5363) is used to track how we work with older releases with spark 3.0.x |
+| 2.4.x and earlier |     ×     | [PR 2367](https://github.com/apache/kyuubi/pull/2367) is used to track how we work with older releases with scala 2.11  |
 
 Currently, Spark released with Scala 2.12 are supported.
 

--- a/docs/security/authorization/spark/build.md
+++ b/docs/security/authorization/spark/build.md
@@ -51,7 +51,7 @@ The available `spark.version`s are shown in the following table.
 |       3.3.x       |     √     |                                                           -                                                            |
 |       3.2.x       |     √     |                                                           -                                                            |
 |       3.1.x       |     √     |                                                           -                                                            |
-|       3.0.x       |     x     |                                                   EOL since v1.9.0                                                     |
+|       3.0.x       |     x     |                                                    EOL since v1.9.0                                                    |
 | 2.4.x and earlier |     ×     | [PR 2367](https://github.com/apache/kyuubi/pull/2367) is used to track how we work with older releases with scala 2.11 |
 
 Currently, Spark released with Scala 2.12 are supported.

--- a/extensions/spark/kyuubi-spark-authz/README.md
+++ b/extensions/spark/kyuubi-spark-authz/README.md
@@ -38,7 +38,7 @@ build/mvn clean package -DskipTests -pl :kyuubi-spark-authz_2.12 -am -Dspark.ver
 - [x] 3.3.x
 - [x] 3.2.x
 - [x] 3.1.x
-- [x] 3.0.x
+- [ ] 3.0.x
 - [ ] 2.4.x and earlier
 
 ### Supported Apache Ranger Versions

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/IcebergCatalogPrivilegesBuilderSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/IcebergCatalogPrivilegesBuilderSuite.scala
@@ -30,9 +30,7 @@ import org.apache.kyuubi.util.AssertionUtils._
 class IcebergCatalogPrivilegesBuilderSuite extends V2CommandsPrivilegesSuite {
   override protected val catalogImpl: String = "hive"
   override protected val sqlExtensions: String =
-    if (isSparkV31OrGreater) {
-      "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions"
-    } else ""
+    "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions"
   override protected def format = "iceberg"
 
   override protected val supportsUpdateTable = false
@@ -42,20 +40,17 @@ class IcebergCatalogPrivilegesBuilderSuite extends V2CommandsPrivilegesSuite {
   override protected val supportsPartitionManagement = false
 
   override def beforeAll(): Unit = {
-    if (isSparkV31OrGreater) {
-      spark.conf.set(
-        s"spark.sql.catalog.$catalogV2",
-        "org.apache.iceberg.spark.SparkCatalog")
-      spark.conf.set(s"spark.sql.catalog.$catalogV2.type", "hadoop")
-      spark.conf.set(
-        s"spark.sql.catalog.$catalogV2.warehouse",
-        Utils.createTempDir("iceberg-hadoop").toString)
-    }
+    spark.conf.set(
+      s"spark.sql.catalog.$catalogV2",
+      "org.apache.iceberg.spark.SparkCatalog")
+    spark.conf.set(s"spark.sql.catalog.$catalogV2.type", "hadoop")
+    spark.conf.set(
+      s"spark.sql.catalog.$catalogV2.warehouse",
+      Utils.createTempDir("iceberg-hadoop").toString)
     super.beforeAll()
   }
 
   override def withFixture(test: NoArgTest): Outcome = {
-    assume(isSparkV31OrGreater)
     test()
   }
 

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/IcebergCatalogPrivilegesBuilderSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/IcebergCatalogPrivilegesBuilderSuite.scala
@@ -22,7 +22,6 @@ import org.scalatest.Outcome
 import org.apache.kyuubi.Utils
 import org.apache.kyuubi.plugin.spark.authz.OperationType._
 import org.apache.kyuubi.plugin.spark.authz.ranger.AccessType
-import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
 import org.apache.kyuubi.tags.IcebergTest
 import org.apache.kyuubi.util.AssertionUtils._
 

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilderSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilderSuite.scala
@@ -662,7 +662,6 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
   }
 
   test("RefreshFunctionCommand") {
-    assume(isSparkV31OrGreater)
     sql(s"CREATE FUNCTION RefreshFunctionCommand AS '${getClass.getCanonicalName}'")
     val plan = sql("REFRESH FUNCTION RefreshFunctionCommand")
       .queryExecution.analyzed

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/V2JdbcTableCatalogPrivilegesBuilderSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/V2JdbcTableCatalogPrivilegesBuilderSuite.scala
@@ -23,7 +23,6 @@ import scala.util.Try
 import org.scalatest.Outcome
 
 import org.apache.kyuubi.plugin.spark.authz.serde._
-import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
 import org.apache.kyuubi.util.AssertionUtils._
 
 class V2JdbcTableCatalogPrivilegesBuilderSuite extends V2CommandsPrivilegesSuite {

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/V2JdbcTableCatalogPrivilegesBuilderSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/V2JdbcTableCatalogPrivilegesBuilderSuite.scala
@@ -39,15 +39,13 @@ class V2JdbcTableCatalogPrivilegesBuilderSuite extends V2CommandsPrivilegesSuite
   val jdbcUrl: String = s"$dbUrl;create=true"
 
   override def beforeAll(): Unit = {
-    if (isSparkV31OrGreater) {
-      spark.conf.set(
-        s"spark.sql.catalog.$catalogV2",
-        "org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog")
-      spark.conf.set(s"spark.sql.catalog.$catalogV2.url", jdbcUrl)
-      spark.conf.set(
-        s"spark.sql.catalog.$catalogV2.driver",
-        "org.apache.derby.jdbc.AutoloadedDriver")
-    }
+    spark.conf.set(
+      s"spark.sql.catalog.$catalogV2",
+      "org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog")
+    spark.conf.set(s"spark.sql.catalog.$catalogV2.url", jdbcUrl)
+    spark.conf.set(
+      s"spark.sql.catalog.$catalogV2.driver",
+      "org.apache.derby.jdbc.AutoloadedDriver")
     super.beforeAll()
   }
 
@@ -61,7 +59,6 @@ class V2JdbcTableCatalogPrivilegesBuilderSuite extends V2CommandsPrivilegesSuite
   }
 
   override def withFixture(test: NoArgTest): Outcome = {
-    assume(isSparkV31OrGreater)
     test()
   }
 

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/IcebergCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/IcebergCatalogRangerSparkExtensionSuite.scala
@@ -37,9 +37,7 @@ import org.apache.kyuubi.util.AssertionUtils._
 class IcebergCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
   override protected val catalogImpl: String = "hive"
   override protected val sqlExtensions: String =
-    if (isSparkV31OrGreater)
-      "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions"
-    else ""
+    "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions"
 
   val catalogV2 = "local"
   val namespace1 = icebergNamespace
@@ -47,37 +45,34 @@ class IcebergCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite 
   val outputTable1 = "outputTable1"
 
   override def withFixture(test: NoArgTest): Outcome = {
-    assume(isSparkV31OrGreater)
     test()
   }
 
   override def beforeAll(): Unit = {
-    if (isSparkV31OrGreater) {
-      spark.conf.set(
-        s"spark.sql.catalog.$catalogV2",
-        "org.apache.iceberg.spark.SparkCatalog")
-      spark.conf.set(s"spark.sql.catalog.$catalogV2.type", "hadoop")
-      spark.conf.set(
-        s"spark.sql.catalog.$catalogV2.warehouse",
-        Utils.createTempDir("iceberg-hadoop").toString)
+    spark.conf.set(
+      s"spark.sql.catalog.$catalogV2",
+      "org.apache.iceberg.spark.SparkCatalog")
+    spark.conf.set(s"spark.sql.catalog.$catalogV2.type", "hadoop")
+    spark.conf.set(
+      s"spark.sql.catalog.$catalogV2.warehouse",
+      Utils.createTempDir("iceberg-hadoop").toString)
 
-      super.beforeAll()
+    super.beforeAll()
 
-      doAs(admin, sql(s"CREATE DATABASE IF NOT EXISTS $catalogV2.$namespace1"))
-      doAs(
-        admin,
-        sql(s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table1" +
-          " (id int, name string, city string) USING iceberg"))
+    doAs(admin, sql(s"CREATE DATABASE IF NOT EXISTS $catalogV2.$namespace1"))
+    doAs(
+      admin,
+      sql(s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table1" +
+        " (id int, name string, city string) USING iceberg"))
 
-      doAs(
-        admin,
-        sql(s"INSERT INTO $catalogV2.$namespace1.$table1" +
-          " (id , name , city ) VALUES (1, 'liangbowen','Guangzhou')"))
-      doAs(
-        admin,
-        sql(s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$outputTable1" +
-          " (id int, name string, city string) USING iceberg"))
-    }
+    doAs(
+      admin,
+      sql(s"INSERT INTO $catalogV2.$namespace1.$table1" +
+        " (id , name , city ) VALUES (1, 'liangbowen','Guangzhou')"))
+    doAs(
+      admin,
+      sql(s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$outputTable1" +
+        " (id int, name string, city string) USING iceberg"))
   }
 
   override def afterAll(): Unit = {

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
@@ -567,11 +567,7 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
           someone, {
             sql(s"select * from $db1.$permView").collect()
           }))
-      if (isSparkV31OrGreater) {
-        assert(e1.getMessage.contains(s"does not have [select] privilege on [$db1/$permView/id]"))
-      } else {
-        assert(e1.getMessage.contains(s"does not have [select] privilege on [$db1/$table/id]"))
-      }
+      assert(e1.getMessage.contains(s"does not have [select] privilege on [$db1/$permView/id]"))
     }
   }
 
@@ -590,22 +586,12 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
       // query all columns of the permanent view
       // with access privileges to the permanent view but no privilege to the source table
       val sql1 = s"SELECT * FROM $db1.$permView"
-      if (isSparkV31OrGreater) {
-        doAs(userPermViewOnly, { sql(sql1).collect() })
-      } else {
-        val e1 = intercept[AccessControlException](doAs(userPermViewOnly, { sql(sql1).collect() }))
-        assert(e1.getMessage.contains(s"does not have [select] privilege on [$db1/$table/id]"))
-      }
+      doAs(userPermViewOnly, { sql(sql1).collect() })
 
       // query the second column of permanent view with multiple columns
       // with access privileges to the permanent view but no privilege to the source table
       val sql2 = s"SELECT name FROM $db1.$permView"
-      if (isSparkV31OrGreater) {
-        doAs(userPermViewOnly, { sql(sql2).collect() })
-      } else {
-        val e2 = intercept[AccessControlException](doAs(userPermViewOnly, { sql(sql2).collect() }))
-        assert(e2.getMessage.contains(s"does not have [select] privilege on [$db1/$table/name]"))
-      }
+      doAs(userPermViewOnly, { sql(sql2).collect() })
     }
   }
 

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
@@ -44,27 +44,25 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
   val jdbcUrl: String = s"$dbUrl;create=true"
 
   override def beforeAll(): Unit = {
-    if (isSparkV31OrGreater) {
-      spark.conf.set(
-        s"spark.sql.catalog.$catalogV2",
-        "org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog")
-      spark.conf.set(s"spark.sql.catalog.$catalogV2.url", jdbcUrl)
-      spark.conf.set(
-        s"spark.sql.catalog.$catalogV2.driver",
-        "org.apache.derby.jdbc.AutoloadedDriver")
+    spark.conf.set(
+      s"spark.sql.catalog.$catalogV2",
+      "org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog")
+    spark.conf.set(s"spark.sql.catalog.$catalogV2.url", jdbcUrl)
+    spark.conf.set(
+      s"spark.sql.catalog.$catalogV2.driver",
+      "org.apache.derby.jdbc.AutoloadedDriver")
 
-      super.beforeAll()
+    super.beforeAll()
 
-      doAs(admin, sql(s"CREATE DATABASE IF NOT EXISTS $catalogV2.$namespace1"))
-      doAs(
-        admin,
-        sql(s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table1" +
-          " (id int, name string, city string)"))
-      doAs(
-        admin,
-        sql(s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$outputTable1" +
-          " (id int, name string, city string)"))
-    }
+    doAs(admin, sql(s"CREATE DATABASE IF NOT EXISTS $catalogV2.$namespace1"))
+    doAs(
+      admin,
+      sql(s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table1" +
+        " (id int, name string, city string)"))
+    doAs(
+      admin,
+      sql(s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$outputTable1" +
+        " (id int, name string, city string)"))
   }
 
   override def afterAll(): Unit = {
@@ -79,8 +77,6 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
   }
 
   test("[KYUUBI #3424] CREATE DATABASE") {
-    assume(isSparkV31OrGreater)
-
     // create database
     val e1 = intercept[AccessControlException](
       doAs(someone, sql(s"CREATE DATABASE IF NOT EXISTS $catalogV2.$namespace2").explain()))
@@ -89,8 +85,6 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
   }
 
   test("[KYUUBI #3424] DROP DATABASE") {
-    assume(isSparkV31OrGreater)
-
     // create database
     val e1 = intercept[AccessControlException](
       doAs(someone, sql(s"DROP DATABASE IF EXISTS $catalogV2.$namespace2").explain()))
@@ -99,8 +93,6 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
   }
 
   test("[KYUUBI #3424] SELECT TABLE") {
-    assume(isSparkV31OrGreater)
-
     // select
     val e1 = intercept[AccessControlException](
       doAs(someone, sql(s"select city, id from $catalogV2.$namespace1.$table1").explain()))
@@ -109,7 +101,6 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
   }
 
   test("[KYUUBI #4255] DESCRIBE TABLE") {
-    assume(isSparkV31OrGreater)
     val e1 = intercept[AccessControlException](
       doAs(someone, sql(s"DESCRIBE TABLE $catalogV2.$namespace1.$table1").explain()))
     assert(e1.getMessage.contains(s"does not have [select] privilege" +
@@ -117,8 +108,6 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
   }
 
   test("[KYUUBI #3424] CREATE TABLE") {
-    assume(isSparkV31OrGreater)
-
     // CreateTable
     val e2 = intercept[AccessControlException](
       doAs(someone, sql(s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table2")))
@@ -136,8 +125,6 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
   }
 
   test("[KYUUBI #3424] DROP TABLE") {
-    assume(isSparkV31OrGreater)
-
     // DropTable
     val e3 = intercept[AccessControlException](
       doAs(someone, sql(s"DROP TABLE $catalogV2.$namespace1.$table1")))
@@ -146,8 +133,6 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
   }
 
   test("[KYUUBI #3424] INSERT TABLE") {
-    assume(isSparkV31OrGreater)
-
     // AppendData: Insert Using a VALUES Clause
     val e4 = intercept[AccessControlException](
       doAs(
@@ -186,8 +171,6 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
   }
 
   test("[KYUUBI #3424] MERGE INTO") {
-    assume(isSparkV31OrGreater)
-
     val mergeIntoSql =
       s"""
          |MERGE INTO $catalogV2.$namespace1.$outputTable1 AS target
@@ -218,8 +201,6 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
   }
 
   test("[KYUUBI #3424] UPDATE TABLE") {
-    assume(isSparkV31OrGreater)
-
     // UpdateTable
     val e5 = intercept[AccessControlException](
       doAs(
@@ -231,8 +212,6 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
   }
 
   test("[KYUUBI #3424] DELETE FROM TABLE") {
-    assume(isSparkV31OrGreater)
-
     // DeleteFromTable
     val e6 = intercept[AccessControlException](
       doAs(someone, sql(s"DELETE FROM $catalogV2.$namespace1.$table1 WHERE id=1")))
@@ -241,8 +220,6 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
   }
 
   test("[KYUUBI #3424] CACHE TABLE") {
-    assume(isSparkV31OrGreater)
-
     // CacheTable
     val e7 = intercept[AccessControlException](
       doAs(
@@ -281,8 +258,6 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
   }
 
   test("[KYUUBI #3424] ALTER TABLE") {
-    assume(isSparkV31OrGreater)
-
     // AddColumns
     val e61 = intercept[AccessControlException](
       doAs(
@@ -318,8 +293,6 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
   }
 
   test("[KYUUBI #3424] COMMENT ON") {
-    assume(isSparkV31OrGreater)
-
     // CommentOnNamespace
     val e1 = intercept[AccessControlException](
       doAs(

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingForIcebergSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingForIcebergSuite.scala
@@ -25,21 +25,15 @@ import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
 
 class DataMaskingForIcebergSuite extends DataMaskingTestBase {
   override protected val extraSparkConf: SparkConf = {
-    val conf = new SparkConf()
-
-    if (isSparkV31OrGreater) {
-      conf
-        .set("spark.sql.defaultCatalog", "testcat")
-        .set(
-          "spark.sql.catalog.testcat",
-          "org.apache.iceberg.spark.SparkCatalog")
-        .set(s"spark.sql.catalog.testcat.type", "hadoop")
-        .set(
-          "spark.sql.catalog.testcat.warehouse",
-          Utils.createTempDir("iceberg-hadoop").toString)
-    }
-    conf
-
+    new SparkConf()
+      .set("spark.sql.defaultCatalog", "testcat")
+      .set(
+        "spark.sql.catalog.testcat",
+        "org.apache.iceberg.spark.SparkCatalog")
+      .set(s"spark.sql.catalog.testcat.type", "hadoop")
+      .set(
+        "spark.sql.catalog.testcat.warehouse",
+        Utils.createTempDir("iceberg-hadoop").toString)
   }
 
   override protected val catalogImpl: String = "in-memory"
@@ -47,19 +41,14 @@ class DataMaskingForIcebergSuite extends DataMaskingTestBase {
   override protected def format: String = "USING iceberg"
 
   override def beforeAll(): Unit = {
-    if (isSparkV31OrGreater) {
-      super.beforeAll()
-    }
+    super.beforeAll()
   }
 
   override def afterAll(): Unit = {
-    if (isSparkV31OrGreater) {
-      super.afterAll()
-    }
+    super.afterAll()
   }
 
   override def withFixture(test: NoArgTest): Outcome = {
-    assume(isSparkV31OrGreater)
     test()
   }
 }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingForIcebergSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingForIcebergSuite.scala
@@ -21,7 +21,6 @@ import org.apache.spark.SparkConf
 import org.scalatest.Outcome
 
 import org.apache.kyuubi.Utils
-import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
 
 class DataMaskingForIcebergSuite extends DataMaskingTestBase {
   override protected val extraSparkConf: SparkConf = {

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingForJDBCV2Suite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingForJDBCV2Suite.scala
@@ -23,7 +23,6 @@ import scala.util.Try
 import org.apache.spark.SparkConf
 import org.scalatest.Outcome
 
-
 class DataMaskingForJDBCV2Suite extends DataMaskingTestBase {
   override protected val extraSparkConf: SparkConf = {
     new SparkConf()

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingForJDBCV2Suite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingForJDBCV2Suite.scala
@@ -27,19 +27,15 @@ import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
 
 class DataMaskingForJDBCV2Suite extends DataMaskingTestBase {
   override protected val extraSparkConf: SparkConf = {
-    val conf = new SparkConf()
-    if (isSparkV31OrGreater) {
-      conf
-        .set("spark.sql.defaultCatalog", "testcat")
-        .set(
-          "spark.sql.catalog.testcat",
-          "org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog")
-        .set(s"spark.sql.catalog.testcat.url", "jdbc:derby:memory:testcat;create=true")
-        .set(
-          s"spark.sql.catalog.testcat.driver",
-          "org.apache.derby.jdbc.AutoloadedDriver")
-    }
-    conf
+    new SparkConf()
+      .set("spark.sql.defaultCatalog", "testcat")
+      .set(
+        "spark.sql.catalog.testcat",
+        "org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog")
+      .set(s"spark.sql.catalog.testcat.url", "jdbc:derby:memory:testcat;create=true")
+      .set(
+        s"spark.sql.catalog.testcat.driver",
+        "org.apache.derby.jdbc.AutoloadedDriver")
   }
 
   override protected val catalogImpl: String = "in-memory"
@@ -47,21 +43,18 @@ class DataMaskingForJDBCV2Suite extends DataMaskingTestBase {
   override protected def format: String = ""
 
   override def beforeAll(): Unit = {
-    if (isSparkV31OrGreater) super.beforeAll()
+    super.beforeAll()
   }
 
   override def afterAll(): Unit = {
-    if (isSparkV31OrGreater) {
-      super.afterAll()
-      // cleanup db
-      Try {
-        DriverManager.getConnection(s"jdbc:derby:memory:testcat;shutdown=true")
-      }
+    super.afterAll()
+    // cleanup db
+    Try {
+      DriverManager.getConnection(s"jdbc:derby:memory:testcat;shutdown=true")
     }
   }
 
   override def withFixture(test: NoArgTest): Outcome = {
-    assume(isSparkV31OrGreater)
     test()
   }
 }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingForJDBCV2Suite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingForJDBCV2Suite.scala
@@ -23,7 +23,6 @@ import scala.util.Try
 import org.apache.spark.SparkConf
 import org.scalatest.Outcome
 
-import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
 
 class DataMaskingForJDBCV2Suite extends DataMaskingTestBase {
   override protected val extraSparkConf: SparkConf = {

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingTestBase.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingTestBase.scala
@@ -30,7 +30,6 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.apache.kyuubi.plugin.spark.authz.RangerTestUsers._
 import org.apache.kyuubi.plugin.spark.authz.SparkSessionProvider
 import org.apache.kyuubi.plugin.spark.authz.ranger.RangerSparkExtension
-import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
 
 /**
  * Base trait for data masking tests, derivative classes shall name themselves following:

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingTestBase.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingTestBase.scala
@@ -279,7 +279,6 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
   }
 
   test("KYUUBI #3581: permanent view should lookup rule on itself not the raw table") {
-    assume(isSparkV31OrGreater)
     val supported = doAs(
       permViewUser,
       Try(sql("CREATE OR REPLACE VIEW default.perm_view AS SELECT * FROM default.src")).isSuccess)

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/rowfiltering/RowFilteringForIcebergSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/rowfiltering/RowFilteringForIcebergSuite.scala
@@ -21,7 +21,6 @@ import org.apache.spark.SparkConf
 import org.scalatest.Outcome
 
 import org.apache.kyuubi.Utils
-import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
 
 class RowFilteringForIcebergSuite extends RowFilteringTestBase {
   override protected val extraSparkConf: SparkConf = {

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/rowfiltering/RowFilteringForIcebergSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/rowfiltering/RowFilteringForIcebergSuite.scala
@@ -25,21 +25,15 @@ import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
 
 class RowFilteringForIcebergSuite extends RowFilteringTestBase {
   override protected val extraSparkConf: SparkConf = {
-    val conf = new SparkConf()
-
-    if (isSparkV31OrGreater) {
-      conf
-        .set("spark.sql.defaultCatalog", "testcat")
-        .set(
-          "spark.sql.catalog.testcat",
-          "org.apache.iceberg.spark.SparkCatalog")
-        .set(s"spark.sql.catalog.testcat.type", "hadoop")
-        .set(
-          "spark.sql.catalog.testcat.warehouse",
-          Utils.createTempDir("iceberg-hadoop").toString)
-    }
-    conf
-
+    new SparkConf()
+      .set("spark.sql.defaultCatalog", "testcat")
+      .set(
+        "spark.sql.catalog.testcat",
+        "org.apache.iceberg.spark.SparkCatalog")
+      .set(s"spark.sql.catalog.testcat.type", "hadoop")
+      .set(
+        "spark.sql.catalog.testcat.warehouse",
+        Utils.createTempDir("iceberg-hadoop").toString)
   }
 
   override protected val catalogImpl: String = "in-memory"
@@ -47,19 +41,14 @@ class RowFilteringForIcebergSuite extends RowFilteringTestBase {
   override protected def format: String = "USING iceberg"
 
   override def beforeAll(): Unit = {
-    if (isSparkV31OrGreater) {
-      super.beforeAll()
-    }
+    super.beforeAll()
   }
 
   override def afterAll(): Unit = {
-    if (isSparkV31OrGreater) {
-      super.afterAll()
-    }
+    super.afterAll()
   }
 
   override def withFixture(test: NoArgTest): Outcome = {
-    assume(isSparkV31OrGreater)
     test()
   }
 }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/rowfiltering/RowFilteringForJDBCV2Suite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/rowfiltering/RowFilteringForJDBCV2Suite.scala
@@ -24,8 +24,6 @@ import scala.util.Try
 import org.apache.spark.SparkConf
 import org.scalatest.Outcome
 
-import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
-
 class RowFilteringForJDBCV2Suite extends RowFilteringTestBase {
   override protected val extraSparkConf: SparkConf = {
     new SparkConf()

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/rowfiltering/RowFilteringForJDBCV2Suite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/rowfiltering/RowFilteringForJDBCV2Suite.scala
@@ -28,19 +28,15 @@ import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
 
 class RowFilteringForJDBCV2Suite extends RowFilteringTestBase {
   override protected val extraSparkConf: SparkConf = {
-    val conf = new SparkConf()
-    if (isSparkV31OrGreater) {
-      conf
-        .set("spark.sql.defaultCatalog", "testcat")
-        .set(
-          "spark.sql.catalog.testcat",
-          "org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog")
-        .set(s"spark.sql.catalog.testcat.url", "jdbc:derby:memory:testcat;create=true")
-        .set(
-          s"spark.sql.catalog.testcat.driver",
-          "org.apache.derby.jdbc.AutoloadedDriver")
-    }
-    conf
+    new SparkConf()
+      .set("spark.sql.defaultCatalog", "testcat")
+      .set(
+        "spark.sql.catalog.testcat",
+        "org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog")
+      .set(s"spark.sql.catalog.testcat.url", "jdbc:derby:memory:testcat;create=true")
+      .set(
+        s"spark.sql.catalog.testcat.driver",
+        "org.apache.derby.jdbc.AutoloadedDriver")
   }
 
   override protected val catalogImpl: String = "in-memory"
@@ -48,21 +44,18 @@ class RowFilteringForJDBCV2Suite extends RowFilteringTestBase {
   override protected def format: String = ""
 
   override def beforeAll(): Unit = {
-    if (isSparkV31OrGreater) super.beforeAll()
+    super.beforeAll()
   }
 
   override def afterAll(): Unit = {
-    if (isSparkV31OrGreater) {
-      super.afterAll()
-      // cleanup db
-      Try {
-        DriverManager.getConnection(s"jdbc:derby:memory:testcat;shutdown=true")
-      }
+    super.afterAll()
+    // cleanup db
+    Try {
+      DriverManager.getConnection(s"jdbc:derby:memory:testcat;shutdown=true")
     }
   }
 
   override def withFixture(test: NoArgTest): Outcome = {
-    assume(isSparkV31OrGreater)
     test()
   }
 }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/rowfiltering/RowFilteringTestBase.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/rowfiltering/RowFilteringTestBase.scala
@@ -27,7 +27,6 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.apache.kyuubi.plugin.spark.authz.RangerTestUsers._
 import org.apache.kyuubi.plugin.spark.authz.SparkSessionProvider
 import org.apache.kyuubi.plugin.spark.authz.ranger.RangerSparkExtension
-import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
 
 /**
  * Base trait for row filtering tests, derivative classes shall name themselves following:

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/rowfiltering/RowFilteringTestBase.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/rowfiltering/RowFilteringTestBase.scala
@@ -98,7 +98,6 @@ trait RowFilteringTestBase extends AnyFunSuite with SparkSessionProvider with Be
   }
 
   test("[KYUUBI #3581]: row level filter on permanent view") {
-    assume(isSparkV31OrGreater)
     val supported = doAs(
       permViewUser,
       Try(sql("CREATE OR REPLACE VIEW default.perm_view AS SELECT * FROM default.src")).isSuccess)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
To close #5362 .

Considering the maintenance burden of the Kyuubi community and easy cross-support for data lake projects.
Drop support EOLs of Spark 3 for the coming Spark 4.x era in kyuubi v1.9.
We will still do bugfix release for these spark3.0.x users.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
No
