### PR TITLE
[KYUUBI #5365] Don't use Log4j2's extended throwable conversion pattern in default logging configurations

### DIFF
--- a/conf/log4j2.xml.template
+++ b/conf/log4j2.xml.template
@@ -30,14 +30,14 @@
     </Properties>
     <Appenders>
         <Console name="stdout" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %p %c: %m%n"/>
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %p %c: %m%n%ex"/>
             <Filters>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>
         </Console>
         <RollingFile name="restAudit" fileName="${sys:restAuditLogPath}"
                      filePattern="${sys:restAuditLogFilePattern}">
-            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %p %c{1}: %m%n"/>
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %p %c{1}: %m%n%ex"/>
             <Policies>
                 <SizeBasedTriggeringPolicy size="51200KB" />
             </Policies>
@@ -45,7 +45,7 @@
         </RollingFile>
         <RollingFile name="k8sAudit" fileName="${sys:k8sAuditLogPath}"
                      filePattern="${sys:k8sAuditLogFilePattern}">
-            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %p %c{1}: %m%n"/>
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %p %c{1}: %m%n%ex"/>
             <Policies>
                 <SizeBasedTriggeringPolicy size="51200KB" />
             </Policies>

--- a/docker/playground/conf/kyuubi-log4j2.xml
+++ b/docker/playground/conf/kyuubi-log4j2.xml
@@ -22,7 +22,7 @@
 <Configuration status="INFO">
     <Appenders>
         <Console name="stdout" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %p %c: %m%n"/>
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %p %c: %m%n%ex"/>
             <Filters>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>

--- a/docs/monitor/logging.md
+++ b/docs/monitor/logging.md
@@ -114,7 +114,7 @@ For example, we can disable the console appender and enable the file appender li
 <Configuration status="INFO">
   <Appenders>
     <File name="fa" fileName="log/dummy.log">
-      <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %p %c: %m%n"/>
+      <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %p %c: %m%n%ex"/>
       <Filters>
         <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
       </Filters>

--- a/extensions/spark/kyuubi-extension-spark-3-3/src/test/resources/log4j2-test.xml
+++ b/extensions/spark/kyuubi-extension-spark-3-3/src/test/resources/log4j2-test.xml
@@ -21,14 +21,14 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="stdout" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n%ex"/>
             <Filters>
                 <ThresholdFilter level="FATAL"/>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex"/>
             <Filters>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>

--- a/extensions/spark/kyuubi-extension-spark-3-4/src/test/resources/log4j2-test.xml
+++ b/extensions/spark/kyuubi-extension-spark-3-4/src/test/resources/log4j2-test.xml
@@ -21,14 +21,14 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="stdout" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n%ex"/>
             <Filters>
                 <ThresholdFilter level="FATAL"/>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex"/>
             <Filters>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>

--- a/extensions/spark/kyuubi-extension-spark-3-5/src/test/resources/log4j2-test.xml
+++ b/extensions/spark/kyuubi-extension-spark-3-5/src/test/resources/log4j2-test.xml
@@ -21,14 +21,14 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="stdout" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n%ex"/>
             <Filters>
                 <ThresholdFilter level="FATAL"/>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex"/>
             <Filters>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>

--- a/extensions/spark/kyuubi-extension-spark-common/src/test/resources/log4j2-test.xml
+++ b/extensions/spark/kyuubi-extension-spark-common/src/test/resources/log4j2-test.xml
@@ -21,14 +21,14 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="stdout" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n%ex"/>
             <Filters>
                 <ThresholdFilter level="FATAL"/>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex"/>
             <Filters>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>

--- a/extensions/spark/kyuubi-extension-spark-jdbc-dialect/src/test/scala/resources/log4j2-test.xml
+++ b/extensions/spark/kyuubi-extension-spark-jdbc-dialect/src/test/scala/resources/log4j2-test.xml
@@ -21,14 +21,14 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="stdout" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n%ex"/>
             <Filters>
                 <ThresholdFilter level="FATAL"/>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex"/>
             <Filters>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>

--- a/extensions/spark/kyuubi-spark-authz/src/test/resources/log4j2-test.xml
+++ b/extensions/spark/kyuubi-spark-authz/src/test/resources/log4j2-test.xml
@@ -21,14 +21,14 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="stdout" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n%ex"/>
             <Filters>
                 <ThresholdFilter level="FATAL"/>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex"/>
             <Filters>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>

--- a/extensions/spark/kyuubi-spark-connector-common/src/test/resources/log4j2-test.xml
+++ b/extensions/spark/kyuubi-spark-connector-common/src/test/resources/log4j2-test.xml
@@ -21,14 +21,14 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="stdout" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n%ex"/>
             <Filters>
                 <ThresholdFilter level="FATAL"/>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex"/>
             <Filters>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>

--- a/extensions/spark/kyuubi-spark-connector-hive/src/test/resources/log4j2-test.xml
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/test/resources/log4j2-test.xml
@@ -21,14 +21,14 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="stdout" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n%ex"/>
             <Filters>
                 <ThresholdFilter level="FATAL"/>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex"/>
             <Filters>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>

--- a/extensions/spark/kyuubi-spark-connector-tpcds/src/test/resources/log4j2-test.xml
+++ b/extensions/spark/kyuubi-spark-connector-tpcds/src/test/resources/log4j2-test.xml
@@ -21,14 +21,14 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="stdout" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n%ex"/>
             <Filters>
                 <ThresholdFilter level="FATAL"/>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex"/>
             <Filters>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>

--- a/extensions/spark/kyuubi-spark-connector-tpch/src/test/resources/log4j2-test.xml
+++ b/extensions/spark/kyuubi-spark-connector-tpch/src/test/resources/log4j2-test.xml
@@ -21,14 +21,14 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="stdout" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n%ex"/>
             <Filters>
                 <ThresholdFilter level="FATAL"/>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex"/>
             <Filters>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>

--- a/extensions/spark/kyuubi-spark-lineage/src/test/resources/log4j2-test.xml
+++ b/extensions/spark/kyuubi-spark-lineage/src/test/resources/log4j2-test.xml
@@ -21,14 +21,14 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="stdout" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n%ex"/>
             <Filters>
                 <ThresholdFilter level="FATAL"/>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex"/>
             <Filters>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>

--- a/externals/kyuubi-chat-engine/src/test/resources/log4j2-test.xml
+++ b/externals/kyuubi-chat-engine/src/test/resources/log4j2-test.xml
@@ -21,14 +21,14 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="stdout" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n%ex"/>
             <Filters>
                 <ThresholdFilter level="FATAL"/>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex"/>
             <Filters>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>

--- a/externals/kyuubi-flink-sql-engine/src/test/resources/log4j2-test.xml
+++ b/externals/kyuubi-flink-sql-engine/src/test/resources/log4j2-test.xml
@@ -21,14 +21,14 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="stdout" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n%ex"/>
             <Filters>
                 <ThresholdFilter level="FATAL"/>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex"/>
             <Filters>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>

--- a/externals/kyuubi-hive-sql-engine/src/test/resources/log4j2-test.xml
+++ b/externals/kyuubi-hive-sql-engine/src/test/resources/log4j2-test.xml
@@ -21,14 +21,14 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="stdout" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n%ex"/>
             <Filters>
                 <ThresholdFilter level="FATAL"/>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex"/>
             <Filters>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>

--- a/externals/kyuubi-jdbc-engine/src/test/resources/log4j2-test.xml
+++ b/externals/kyuubi-jdbc-engine/src/test/resources/log4j2-test.xml
@@ -21,14 +21,14 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="stdout" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n%ex"/>
             <Filters>
                 <ThresholdFilter level="FATAL"/>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex"/>
             <Filters>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>

--- a/externals/kyuubi-spark-sql-engine/src/test/resources/log4j2-test.xml
+++ b/externals/kyuubi-spark-sql-engine/src/test/resources/log4j2-test.xml
@@ -21,14 +21,14 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="stdout" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n%ex"/>
             <Filters>
                 <ThresholdFilter level="FATAL"/>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex"/>
             <Filters>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>

--- a/externals/kyuubi-trino-engine/src/test/resources/log4j2-test.xml
+++ b/externals/kyuubi-trino-engine/src/test/resources/log4j2-test.xml
@@ -21,14 +21,14 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="stdout" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n%ex"/>
             <Filters>
                 <ThresholdFilter level="FATAL"/>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex"/>
             <Filters>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>

--- a/integration-tests/kyuubi-flink-it/src/test/resources/log4j2-test.xml
+++ b/integration-tests/kyuubi-flink-it/src/test/resources/log4j2-test.xml
@@ -21,14 +21,14 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="stdout" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n%ex"/>
             <Filters>
                 <ThresholdFilter level="FATAL"/>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex"/>
             <Filters>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>

--- a/integration-tests/kyuubi-hive-it/src/test/resources/log4j2-test.xml
+++ b/integration-tests/kyuubi-hive-it/src/test/resources/log4j2-test.xml
@@ -21,14 +21,14 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="stdout" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n%ex"/>
             <Filters>
                 <ThresholdFilter level="FATAL"/>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex"/>
             <Filters>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>

--- a/integration-tests/kyuubi-jdbc-it/src/test/resources/log4j2-test.xml
+++ b/integration-tests/kyuubi-jdbc-it/src/test/resources/log4j2-test.xml
@@ -21,14 +21,14 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="stdout" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n%ex"/>
             <Filters>
                 <ThresholdFilter level="FATAL"/>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex"/>
             <Filters>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>

--- a/integration-tests/kyuubi-kubernetes-it/src/test/resources/log4j2-test.xml
+++ b/integration-tests/kyuubi-kubernetes-it/src/test/resources/log4j2-test.xml
@@ -21,14 +21,14 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="stdout" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n%ex"/>
             <Filters>
                 <ThresholdFilter level="FATAL"/>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex"/>
             <Filters>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>

--- a/integration-tests/kyuubi-trino-it/src/test/resources/log4j2-test.xml
+++ b/integration-tests/kyuubi-trino-it/src/test/resources/log4j2-test.xml
@@ -21,14 +21,14 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="stdout" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n%ex"/>
             <Filters>
                 <ThresholdFilter level="FATAL"/>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex"/>
             <Filters>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>

--- a/integration-tests/kyuubi-zookeeper-it/src/test/resources/log4j2-test.xml
+++ b/integration-tests/kyuubi-zookeeper-it/src/test/resources/log4j2-test.xml
@@ -21,14 +21,14 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="stdout" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n%ex"/>
             <Filters>
                 <ThresholdFilter level="FATAL"/>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex"/>
             <Filters>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>

--- a/kyuubi-common/src/main/resources/log4j2-defaults.xml
+++ b/kyuubi-common/src/main/resources/log4j2-defaults.xml
@@ -21,7 +21,7 @@
 <Configuration status="INFO">
     <Appenders>
         <Console name="stdout" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %p %c: %m%n"/>
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %p %c: %m%n%ex"/>
             <Filters>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/log/Log4j2DivertAppender.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/log/Log4j2DivertAppender.scala
@@ -93,7 +93,7 @@ object Log4j2DivertAppender {
           ap.getLayout.isInstanceOf[StringLayout])
       .map(_.getLayout.asInstanceOf[StringLayout])
       .getOrElse(PatternLayout.newBuilder().withPattern(
-        "%d{yy/MM/dd HH:mm:ss} %p %c{2}: %m%n").build())
+        "%d{yy/MM/dd HH:mm:ss} %p %c{2}: %m%n%ex").build())
   }
 
   def initialize(): Unit = {

--- a/kyuubi-common/src/test/resources/log4j2-test.xml
+++ b/kyuubi-common/src/test/resources/log4j2-test.xml
@@ -21,14 +21,14 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="stdout" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n%ex"/>
             <Filters>
                 <ThresholdFilter level="FATAL"/>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex"/>
             <Filters>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>

--- a/kyuubi-ctl/src/test/resources/log4j2-test.xml
+++ b/kyuubi-ctl/src/test/resources/log4j2-test.xml
@@ -21,14 +21,14 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="stdout" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n%ex"/>
             <Filters>
                 <ThresholdFilter level="FATAL"/>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex"/>
             <Filters>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>

--- a/kyuubi-events/src/test/resources/log4j2-test.xml
+++ b/kyuubi-events/src/test/resources/log4j2-test.xml
@@ -21,14 +21,14 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="stdout" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n%ex"/>
             <Filters>
                 <ThresholdFilter level="FATAL"/>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex"/>
             <Filters>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>

--- a/kyuubi-ha/src/test/resources/log4j2-test.xml
+++ b/kyuubi-ha/src/test/resources/log4j2-test.xml
@@ -21,14 +21,14 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="stdout" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n%ex"/>
             <Filters>
                 <ThresholdFilter level="FATAL"/>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex"/>
             <Filters>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>

--- a/kyuubi-hive-jdbc/src/test/resources/log4j2-test.xml
+++ b/kyuubi-hive-jdbc/src/test/resources/log4j2-test.xml
@@ -21,14 +21,14 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="stdout" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n%ex"/>
             <Filters>
                 <ThresholdFilter level="FATAL"/>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex"/>
             <Filters>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>

--- a/kyuubi-metrics/src/test/resources/log4j2-test.xml
+++ b/kyuubi-metrics/src/test/resources/log4j2-test.xml
@@ -21,14 +21,14 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="stdout" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n%ex"/>
             <Filters>
                 <ThresholdFilter level="FATAL"/>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex"/>
             <Filters>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>

--- a/kyuubi-rest-client/src/test/resources/log4j2-test.xml
+++ b/kyuubi-rest-client/src/test/resources/log4j2-test.xml
@@ -21,13 +21,13 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="stdout" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n%ex"/>
             <Filters>
                 <ThresholdFilter level="FATAL"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex"/>
         </File>
     </Appenders>
     <Loggers>

--- a/kyuubi-server/src/test/resources/log4j2-test.xml
+++ b/kyuubi-server/src/test/resources/log4j2-test.xml
@@ -24,20 +24,20 @@
     </Properties>
     <Appenders>
         <Console name="stdout" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n%ex"/>
             <Filters>
                 <ThresholdFilter level="FATAL"/>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex"/>
             <Filters>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>
         </File>
         <File name="restAudit" fileName="${sys:restAuditLogPath}">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c{1}: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c{1}: %m%n%ex"/>
         </File>
     </Appenders>
     <Loggers>

--- a/kyuubi-zookeeper/src/test/resources/log4j2-test.xml
+++ b/kyuubi-zookeeper/src/test/resources/log4j2-test.xml
@@ -21,14 +21,14 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="stdout" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n%ex"/>
             <Filters>
                 <ThresholdFilter level="FATAL"/>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex"/>
             <Filters>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_

The Apache Spark Community found a performance regression with log4j2. See https://github.com/apache/spark/pull/36747. 

This PR to fix the performance issue on our side.



### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
No.