### PR TITLE
[KYUUBI #5359] [AUTHZ] Support Create Table Commands for Hudi

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/resources/table_command_spec.json
+++ b/extensions/spark/kyuubi-spark-authz/src/main/resources/table_command_spec.json
@@ -1493,6 +1493,60 @@
   "opType" : "ALTERTABLE_PROPERTIES",
   "queryDescs" : [ ]
 }, {
+  "classname" : "org.apache.spark.sql.hudi.command.CreateHoodieTableAsSelectCommand",
+  "tableDescs" : [ {
+    "fieldName" : "table",
+    "fieldExtractor" : "CatalogTableTableExtractor",
+    "columnDesc" : null,
+    "actionTypeDesc" : null,
+    "tableTypeDesc" : null,
+    "catalogDesc" : null,
+    "isInput" : false,
+    "setCurrentDatabaseIfMissing" : false
+  } ],
+  "opType" : "CREATETABLE_AS_SELECT",
+  "queryDescs" : [ {
+    "fieldName" : "query",
+    "fieldExtractor" : "LogicalPlanQueryExtractor"
+  } ]
+}, {
+  "classname" : "org.apache.spark.sql.hudi.command.CreateHoodieTableCommand",
+  "tableDescs" : [ {
+    "fieldName" : "table",
+    "fieldExtractor" : "CatalogTableTableExtractor",
+    "columnDesc" : null,
+    "actionTypeDesc" : null,
+    "tableTypeDesc" : null,
+    "catalogDesc" : null,
+    "isInput" : false,
+    "setCurrentDatabaseIfMissing" : false
+  } ],
+  "opType" : "CREATETABLE",
+  "queryDescs" : [ ]
+}, {
+  "classname" : "org.apache.spark.sql.hudi.command.CreateHoodieTableLikeCommand",
+  "tableDescs" : [ {
+    "fieldName" : "targetTable",
+    "fieldExtractor" : "TableIdentifierTableExtractor",
+    "columnDesc" : null,
+    "actionTypeDesc" : null,
+    "tableTypeDesc" : null,
+    "catalogDesc" : null,
+    "isInput" : false,
+    "setCurrentDatabaseIfMissing" : true
+  }, {
+    "fieldName" : "sourceTable",
+    "fieldExtractor" : "TableIdentifierTableExtractor",
+    "columnDesc" : null,
+    "actionTypeDesc" : null,
+    "tableTypeDesc" : null,
+    "catalogDesc" : null,
+    "isInput" : true,
+    "setCurrentDatabaseIfMissing" : true
+  } ],
+  "opType" : "CREATETABLE",
+  "queryDescs" : [ ]
+}, {
   "classname" : "org.apache.spark.sql.hudi.command.Spark31AlterTableCommand",
   "tableDescs" : [ {
     "fieldName" : "table",

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/HudiCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/HudiCommands.scala
@@ -72,11 +72,42 @@ object HudiCommands {
     TableCommandSpec(cmd, Seq(tableDesc), ALTERTABLE_PROPERTIES)
   }
 
+  val CreateHoodieTableCommand = {
+    val cmd = "org.apache.spark.sql.hudi.command.CreateHoodieTableCommand"
+    val tableDesc = TableDesc("table", classOf[CatalogTableTableExtractor])
+    TableCommandSpec(cmd, Seq(tableDesc), CREATETABLE)
+  }
+
+  val CreateHoodieTableAsSelectCommand = {
+    val cmd = "org.apache.spark.sql.hudi.command.CreateHoodieTableAsSelectCommand"
+    CreateHoodieTableCommand.copy(
+      classname = cmd,
+      opType = CREATETABLE_AS_SELECT,
+      queryDescs = Seq(QueryDesc("query")))
+  }
+
+  val CreateHoodieTableLikeCommand = {
+    val cmd = "org.apache.spark.sql.hudi.command.CreateHoodieTableLikeCommand"
+    val tableDesc1 = TableDesc(
+      "targetTable",
+      classOf[TableIdentifierTableExtractor],
+      setCurrentDatabaseIfMissing = true)
+    val tableDesc2 = TableDesc(
+      "sourceTable",
+      classOf[TableIdentifierTableExtractor],
+      isInput = true,
+      setCurrentDatabaseIfMissing = true)
+    TableCommandSpec(cmd, Seq(tableDesc1, tableDesc2), CREATETABLE)
+  }
+
   val data: Array[TableCommandSpec] = Array(
     AlterHoodieTableAddColumnsCommand,
     AlterHoodieTableChangeColumnCommand,
     AlterHoodieTableDropPartitionCommand,
     AlterHoodieTableRenameCommand,
     AlterTableCommand,
-    Spark31AlterTableCommand)
+    Spark31AlterTableCommand,
+    CreateHoodieTableCommand,
+    CreateHoodieTableAsSelectCommand,
+    CreateHoodieTableLikeCommand)
 }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/HudiCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/HudiCatalogRangerSparkExtensionSuite.scala
@@ -38,8 +38,6 @@ class HudiCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
   //  should change after Apache Hudi support Spark 3.5 and Scala 2.13.
   private def isSupportedVersion = !isSparkV35OrGreater && !isScalaV213
 
-  override def format: String = "HUDI"
-
   override protected val sqlExtensions: String =
     if (isSupportedVersion) {
       "org.apache.spark.sql.hudi.HoodieSparkSessionExtension"
@@ -141,7 +139,7 @@ class HudiCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
           sql(
             s"""
                |CREATE TABLE IF NOT EXISTS $namespace1.$table1(id int, name string, city string)
-               |USING $format
+               |USING HUDI
                |OPTIONS (
                | type = 'cow',
                | primaryKey = 'id',
@@ -160,7 +158,7 @@ class HudiCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
         sql(
           s"""
              |CREATE TABLE IF NOT EXISTS $namespace1.$table1(id int, name string, city string)
-             |USING $format
+             |USING HUDI
              |OPTIONS (
              | type = 'cow',
              | primaryKey = 'id',
@@ -174,10 +172,10 @@ class HudiCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
           sql(
             s"""
                |CREATE TABLE IF NOT EXISTS $namespace1.$table2
-               |USING $format
+               |USING HUDI
                |AS
-               |SELECT * FROM $namespace1.$table1
-               |""".stripMargin)))(s"does not have [select] privilege on [$namespace1/$table1]")
+               |SELECT id FROM $namespace1.$table1
+               |""".stripMargin)))(s"does not have [select] privilege on [$namespace1/$table1/id]")
     }
   }
 
@@ -189,7 +187,7 @@ class HudiCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
         sql(
           s"""
              |CREATE TABLE IF NOT EXISTS $namespace1.$table1(id int, name string, city string)
-             |USING $format
+             |USING HUDI
              |OPTIONS (
              | type = 'cow',
              | primaryKey = 'id',
@@ -204,7 +202,7 @@ class HudiCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
             s"""
                |CREATE TABLE IF NOT EXISTS $namespace1.$table2
                |LIKE  $namespace1.$table1
-               |USING $format
+               |USING HUDI
                |""".stripMargin)))(s"does not have [select] privilege on [$namespace1/$table1]")
     }
   }


### PR DESCRIPTION
### _Why are the changes needed?_
To close #5359. Kyuubi authz support hudi create table commands

- [CreateHoodieTableCommand](https://github.com/apache/hudi/blob/master/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableCommand.scala): https://hudi.apache.org/docs/sql_ddl#create-table
- [CreateHoodieTableAsSelectCommand](https://github.com/apache/hudi/blob/master/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableCommand.scala): https://hudi.apache.org/docs/sql_ddl#create-table-as-select-ctas
- [CreateHoodieTableLikeCommand](https://github.com/apache/hudi/blob/master/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableLikeCommand.scala): https://github.com/apache/hudi/blob/master/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableLikeCommand.scala

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
No