### PR TITLE
[CI] Check style with profiles of Spark 3.4 and 3.5

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         profiles:
-          - '-Pflink-provided,hive-provided,spark-provided,spark-block-cleaner,spark-3.1,spark-3.2,spark-3.3,spark-3.4,spark-3.5,tpcds,kubernetes-it'
+          - '-Pflink-provided,hive-provided,spark-provided,spark-block-cleaner,spark-3.2,spark-3.3,spark-3.4,spark-3.5,tpcds,kubernetes-it'
 
     steps:
       - uses: actions/checkout@v3
@@ -73,7 +73,10 @@ jobs:
 
       - name: Scalastyle with maven
         id: scalastyle-check
-        run: build/mvn scalastyle:check ${{ matrix.profiles }}
+        # Check with Spark 3.1 profile separately as it use Iceberg 1.3.1 which is not compatible with Spark 3.5+
+        run: |
+          build/mvn scalastyle:check ${{ matrix.profiles }}        
+          build/mvn scalastyle:check -Pflink-provided,hive-provided,spark-provided -Pspark-3.1
       - name: Print scalastyle error report
         if: failure() && steps.scalastyle-check.outcome != 'success'
         run: >-

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         profiles:
-          - '-Pflink-provided,hive-provided,spark-provided,spark-block-cleaner,spark-3.5,spark-3.4,spark-3.3,spark-3.2,spark-3.1,tpcds,kubernetes-it'
+          - '-Pflink-provided,hive-provided,spark-provided,spark-block-cleaner,spark-3.1,spark-3.2,spark-3.3,spark-3.4,spark-3.5,tpcds,kubernetes-it'
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         profiles:
-          - '-Pflink-provided,hive-provided,spark-provided,spark-block-cleaner,spark-3.2,spark-3.3,spark-3.4,spark-3.5,tpcds,kubernetes-it'
+          - '-Pflink-provided,hive-provided,spark-provided,spark-block-cleaner,spark-3.5,spark-3.4,spark-3.3,spark-3.2,tpcds,kubernetes-it'
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -76,7 +76,7 @@ jobs:
         # Check with Spark 3.1 profile separately as it use Iceberg 1.3.1 which is not compatible with Spark 3.5+
         run: |
           build/mvn scalastyle:check ${{ matrix.profiles }}        
-          build/mvn scalastyle:check -Pflink-provided,hive-provided,spark-provided -Pspark-3.1
+          build/mvn scalastyle:check -Pflink-provided,hive-provided,spark-provided,spark-3.1
       - name: Print scalastyle error report
         if: failure() && steps.scalastyle-check.outcome != 'success'
         run: >-

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -90,7 +90,7 @@ jobs:
         run: |
           SPOTLESS_BLACK_VERSION=$(build/mvn help:evaluate -Dexpression=spotless.python.black.version -q -DforceStdout)
           pip install black==$SPOTLESS_BLACK_VERSION
-          build/mvn spotless:check ${{ matrix.profiles }} -Pspotless-python
+          build/mvn spotless:check ${{ matrix.profiles }} -Pspotless-python,spark-3.1
       - name: setup npm
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         profiles:
-          - '-Pflink-provided,hive-provided,spark-provided,spark-block-cleaner,spark-3.3,spark-3.2,spark-3.1,tpcds,kubernetes-it'
+          - '-Pflink-provided,hive-provided,spark-provided,spark-block-cleaner,spark-3.5,spark-3.4,spark-3.3,spark-3.2,spark-3.1,tpcds,kubernetes-it'
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- Check style with profile of Spark 3.4 and 3.5 in the style workflow
- Isolated scalastyle check for Spark 3.1 profile, as Iceberg 1.3.1 does not support Spark 3.5

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.