### PR TITLE
[KYUUBI #5451] Ignore NoSuchFileException during OperationLog.close()

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/log/OperationLog.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/log/OperationLog.scala
@@ -20,7 +20,7 @@ package org.apache.kyuubi.operation.log
 import java.io.{BufferedReader, IOException}
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
-import java.nio.file.{Files, Path, Paths}
+import java.nio.file.{Files, NoSuchFileException, Path, Paths}
 import java.util.{ArrayList => JArrayList, List => JList}
 
 import scala.collection.JavaConverters._
@@ -262,6 +262,7 @@ class OperationLog(path: Path) {
     try {
       f
     } catch {
+      case _: NoSuchFileException =>
       case e: IOException =>
         // Printing log here may cause a deadlock. The lock order of OperationLog.write
         // is RootLogger -> LogDivertAppender -> OperationLog. If printing log here, the


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
OperationLog.close() try to close BufferedReader, but it says file is missing(NoSuchFileException). This happens a lot after restarting kyuubi-server and PV is not set for `kyuubi.operation.log.dir.root`.

Logs are like this:
```
2023-10-18 04:16:34.296 ERROR KyuubiTBinaryFrontendHandler-Pool: Thread-113 org.apache.kyuubi.operation.LaunchEngine: Failed to remove corresponding log file of operation: /opt/kyuubi/work/server_operation_logs/26434238-5615-456a-aa7b-fad4dde8da27/43a9bfd4-6795-422c-8031-5409d7fe3732
java.io.IOException: Failed to remove corresponding log file of operation: /opt/kyuubi/work/server_operation_logs/26434238-5615-456a-aa7b-fad4dde8da27/43a9bfd4-6795-422c-8031-5409d7fe3732
	at org.apache.kyuubi.operation.log.OperationLog.trySafely(OperationLog.scala:230) ~[kyuubi-common_2.12-1.6.1-incubating.jar:1.6.1-incubating]
	at org.apache.kyuubi.operation.log.OperationLog.close(OperationLog.scala:201) ~[kyuubi-common_2.12-1.6.1-incubating.jar:1.6.1-incubating]
	at org.apache.kyuubi.operation.KyuubiOperation.$anonfun$close$2(KyuubiOperation.scala:119) ~[kyuubi-server_2.12-1.6.1-incubating.jar:1.6.1-incubating]
	at org.apache.kyuubi.operation.KyuubiOperation.$anonfun$close$2$adapted(KyuubiOperation.scala:119) ~[kyuubi-server_2.12-1.6.1-incubating.jar:1.6.1-incubating]
	at scala.Option.foreach(Option.scala:407) ~[scala-library-2.12.15.jar:?]
	at org.apache.kyuubi.operation.KyuubiOperation.liftedTree2$1(KyuubiOperation.scala:119) ~[kyuubi-server_2.12-1.6.1-incubating.jar:1.6.1-incubating]
	at org.apache.kyuubi.operation.KyuubiOperation.close(KyuubiOperation.scala:116) ~[kyuubi-server_2.12-1.6.1-incubating.jar:1.6.1-incubating]
	at org.apache.kyuubi.operation.OperationManager.closeOperation(OperationManager.scala:126) ~[kyuubi-common_2.12-1.6.1-incubating.jar:1.6.1-incubating]
	at org.apache.kyuubi.session.AbstractSession.$anonfun$close$2(AbstractSession.scala:89) ~[kyuubi-common_2.12-1.6.1-incubating.jar:1.6.1-incubating]
	at java.lang.Iterable.forEach(Iterable.java:75) ~[?:1.8.0_342]
...
Caused by: java.nio.file.NoSuchFileException: /opt/kyuubi/work/server_operation_logs/26434238-5615-456a-aa7b-fad4dde8da27/43a9bfd4-6795-422c-8031-5409d7fe3732
	at sun.nio.fs.UnixException.translateToIOException(UnixException.java:86) ~[?:1.8.0_342]
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102) ~[?:1.8.0_342]
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107) ~[?:1.8.0_342]
	at sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:214) ~[?:1.8.0_342]
	at java.nio.file.Files.newByteChannel(Files.java:361) ~[?:1.8.0_342]
	at java.nio.file.Files.newByteChannel(Files.java:407) ~[?:1.8.0_342]
	at java.nio.file.spi.FileSystemProvider.newInputStream(FileSystemProvider.java:384) ~[?:1.8.0_342]
	at java.nio.file.Files.newInputStream(Files.java:152) ~[?:1.8.0_342]
	at java.nio.file.Files.newBufferedReader(Files.java:2784) ~[?:1.8.0_342]
	at org.apache.kyuubi.operation.log.OperationLog.reader$lzycompute(OperationLog.scala:89) ~[kyuubi-common_2.12-1.6.1-incubating.jar:1.6.1-incubating]
	at org.apache.kyuubi.operation.log.OperationLog.reader(OperationLog.scala:89) ~[kyuubi-common_2.12-1.6.1-incubating.jar:1.6.1-incubating]
	at org.apache.kyuubi.operation.log.OperationLog.$anonfun$close$1(OperationLog.scala:201) ~[kyuubi-common_2.12-1.6.1-incubating.jar:1.6.1-incubating]
	at org.apache.kyuubi.operation.log.OperationLog.trySafely(OperationLog.scala:221) ~[kyuubi-common_2.12-1.6.1-incubating.jar:1.6.1-incubating]
	... 34 more
```

`OperationLog.trySafely()`is called by `OperationLog.close()` only, so we can ignore this exception.

This closes #5451 

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [X] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
