### PR TITLE
[KYUUBI #5452][AUTHZ] Support Compaction table commands for Hudi

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/resources/table_command_spec.json
+++ b/extensions/spark/kyuubi-spark-authz/src/main/resources/table_command_spec.json
@@ -1514,11 +1514,6 @@
   "opType" : "ALTERTABLE_PROPERTIES",
   "queryDescs" : [ ]
 }, {
-  "classname" : "org.apache.spark.sql.hudi.command.CompactionHoodiePathCommand",
-  "tableDescs" : [ ],
-  "opType" : "CREATETABLE",
-  "queryDescs" : [ ]
-}, {
   "classname" : "org.apache.spark.sql.hudi.command.CompactionHoodieTableCommand",
   "tableDescs" : [ {
     "fieldName" : "table",
@@ -1540,11 +1535,6 @@
     "setCurrentDatabaseIfMissing" : false
   } ],
   "opType" : "CREATETABLE",
-  "queryDescs" : [ ]
-}, {
-  "classname" : "org.apache.spark.sql.hudi.command.CompactionShowHoodiePathCommand",
-  "tableDescs" : [ ],
-  "opType" : "SHOW_TBLPROPERTIES",
   "queryDescs" : [ ]
 }, {
   "classname" : "org.apache.spark.sql.hudi.command.CompactionShowHoodieTableCommand",

--- a/extensions/spark/kyuubi-spark-authz/src/main/resources/table_command_spec.json
+++ b/extensions/spark/kyuubi-spark-authz/src/main/resources/table_command_spec.json
@@ -1514,6 +1514,53 @@
   "opType" : "ALTERTABLE_PROPERTIES",
   "queryDescs" : [ ]
 }, {
+  "classname" : "org.apache.spark.sql.hudi.command.CompactionHoodiePathCommand",
+  "tableDescs" : [ ],
+  "opType" : "CREATETABLE",
+  "queryDescs" : [ ]
+}, {
+  "classname" : "org.apache.spark.sql.hudi.command.CompactionHoodieTableCommand",
+  "tableDescs" : [ {
+    "fieldName" : "table",
+    "fieldExtractor" : "CatalogTableTableExtractor",
+    "columnDesc" : null,
+    "actionTypeDesc" : null,
+    "tableTypeDesc" : null,
+    "catalogDesc" : null,
+    "isInput" : false,
+    "setCurrentDatabaseIfMissing" : false
+  }, {
+    "fieldName" : "table",
+    "fieldExtractor" : "CatalogTableTableExtractor",
+    "columnDesc" : null,
+    "actionTypeDesc" : null,
+    "tableTypeDesc" : null,
+    "catalogDesc" : null,
+    "isInput" : true,
+    "setCurrentDatabaseIfMissing" : false
+  } ],
+  "opType" : "CREATETABLE",
+  "queryDescs" : [ ]
+}, {
+  "classname" : "org.apache.spark.sql.hudi.command.CompactionShowHoodiePathCommand",
+  "tableDescs" : [ ],
+  "opType" : "SHOW_TBLPROPERTIES",
+  "queryDescs" : [ ]
+}, {
+  "classname" : "org.apache.spark.sql.hudi.command.CompactionShowHoodieTableCommand",
+  "tableDescs" : [ {
+    "fieldName" : "table",
+    "fieldExtractor" : "CatalogTableTableExtractor",
+    "columnDesc" : null,
+    "actionTypeDesc" : null,
+    "tableTypeDesc" : null,
+    "catalogDesc" : null,
+    "isInput" : true,
+    "setCurrentDatabaseIfMissing" : false
+  } ],
+  "opType" : "SHOW_TBLPROPERTIES",
+  "queryDescs" : [ ]
+}, {
   "classname" : "org.apache.spark.sql.hudi.command.CreateHoodieTableAsSelectCommand",
   "tableDescs" : [ {
     "fieldName" : "table",

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/HudiCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/HudiCommands.scala
@@ -145,12 +145,12 @@ object HudiCommands {
     AlterHoodieTableDropPartitionCommand,
     AlterHoodieTableRenameCommand,
     AlterTableCommand,
-    Spark31AlterTableCommand,
-    CreateHoodieTableCommand,
     CreateHoodieTableAsSelectCommand,
+    CreateHoodieTableCommand,
     CreateHoodieTableLikeCommand,
+    CompactionHoodieTableCommand,
+    CompactionShowHoodieTableCommand,
     DropHoodieTableCommand,
     TruncateHoodieTableCommand,
-    CompactionHoodieTableCommand,
-    CompactionShowHoodieTableCommand)
+    Spark31AlterTableCommand)
 }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/HudiCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/HudiCommands.scala
@@ -133,20 +133,10 @@ object HudiCommands {
     TableCommandSpec(cmd, Seq(tableDesc, tableDesc.copy(isInput = true)), CREATETABLE)
   }
 
-  val CompactionHoodiePathCommand = {
-    val cmd = "org.apache.spark.sql.hudi.command.CompactionHoodiePathCommand"
-    TableCommandSpec(cmd, Seq.empty, CREATETABLE)
-  }
-
   val CompactionShowHoodieTableCommand = {
     val cmd = "org.apache.spark.sql.hudi.command.CompactionShowHoodieTableCommand"
     val tableDesc = TableDesc("table", classOf[CatalogTableTableExtractor], isInput = true)
     TableCommandSpec(cmd, Seq(tableDesc), SHOW_TBLPROPERTIES)
-  }
-
-  val CompactionShowHoodiePathCommand = {
-    val cmd = "org.apache.spark.sql.hudi.command.CompactionShowHoodiePathCommand"
-    TableCommandSpec(cmd, Seq.empty, SHOW_TBLPROPERTIES)
   }
 
   val data: Array[TableCommandSpec] = Array(
@@ -162,7 +152,5 @@ object HudiCommands {
     DropHoodieTableCommand,
     TruncateHoodieTableCommand,
     CompactionHoodieTableCommand,
-    CompactionHoodiePathCommand,
-    CompactionShowHoodieTableCommand,
-    CompactionShowHoodiePathCommand)
+    CompactionShowHoodieTableCommand)
 }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/HudiCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/HudiCommands.scala
@@ -127,6 +127,28 @@ object HudiCommands {
     TableCommandSpec(cmd, Seq(tableDesc), TRUNCATETABLE)
   }
 
+  val CompactionHoodieTableCommand = {
+    val cmd = "org.apache.spark.sql.hudi.command.CompactionHoodieTableCommand"
+    val tableDesc = TableDesc("table", classOf[CatalogTableTableExtractor])
+    TableCommandSpec(cmd, Seq(tableDesc, tableDesc.copy(isInput = true)), CREATETABLE)
+  }
+
+  val CompactionHoodiePathCommand = {
+    val cmd = "org.apache.spark.sql.hudi.command.CompactionHoodiePathCommand"
+    TableCommandSpec(cmd, Seq.empty, CREATETABLE)
+  }
+
+  val CompactionShowHoodieTableCommand = {
+    val cmd = "org.apache.spark.sql.hudi.command.CompactionShowHoodieTableCommand"
+    val tableDesc = TableDesc("table", classOf[CatalogTableTableExtractor], isInput = true)
+    TableCommandSpec(cmd, Seq(tableDesc), SHOW_TBLPROPERTIES)
+  }
+
+  val CompactionShowHoodiePathCommand = {
+    val cmd = "org.apache.spark.sql.hudi.command.CompactionShowHoodiePathCommand"
+    TableCommandSpec(cmd, Seq.empty, SHOW_TBLPROPERTIES)
+  }
+
   val data: Array[TableCommandSpec] = Array(
     AlterHoodieTableAddColumnsCommand,
     AlterHoodieTableChangeColumnCommand,
@@ -138,5 +160,9 @@ object HudiCommands {
     CreateHoodieTableAsSelectCommand,
     CreateHoodieTableLikeCommand,
     DropHoodieTableCommand,
-    TruncateHoodieTableCommand)
+    TruncateHoodieTableCommand,
+    CompactionHoodieTableCommand,
+    CompactionHoodiePathCommand,
+    CompactionShowHoodieTableCommand,
+    CompactionShowHoodiePathCommand)
 }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/HudiCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/HudiCatalogRangerSparkExtensionSuite.scala
@@ -265,7 +265,7 @@ class HudiCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
     }
   }
 
-  test("CompactionHoodieTable/CompactionShowHoodieTable Command") {
+  test("CompactionHoodieTableCommand / CompactionShowHoodieTableCommand") {
     withCleanTmpResources(Seq((s"$namespace1.$table1", "table"), (namespace1, "database"))) {
       doAs(admin, sql(s"CREATE DATABASE IF NOT EXISTS $namespace1"))
       doAs(

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/HudiCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/HudiCatalogRangerSparkExtensionSuite.scala
@@ -264,4 +264,35 @@ class HudiCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
       doAs(admin, sql(truncateTableSql))
     }
   }
+
+  test("Compaction Table/Path") {
+    withCleanTmpResources(Seq((s"$namespace1.$table1", "table"), (namespace1, "database"))) {
+      doAs(admin, sql(s"CREATE DATABASE IF NOT EXISTS $namespace1"))
+      doAs(
+        admin,
+        sql(
+          s"""
+             |CREATE TABLE IF NOT EXISTS $namespace1.$table1(id int, name string, city string)
+             |USING HUDI
+             |OPTIONS (
+             | type = 'mor',
+             | primaryKey = 'id',
+             | 'hoodie.datasource.hive_sync.enable' = 'false'
+             |)
+             |PARTITIONED BY(city)
+             |""".stripMargin))
+
+      val compactionTable = s"RUN COMPACTION ON $namespace1.$table1"
+      interceptContains[AccessControlException] {
+        doAs(someone, sql(compactionTable))
+      }(s"does not have [select] privilege on [$namespace1/$table1]")
+      doAs(admin, sql(compactionTable))
+
+      val showCompactionTable = s"SHOW COMPACTION ON  $namespace1.$table1"
+      interceptContains[AccessControlException] {
+        doAs(someone, sql(showCompactionTable))
+      }(s"does not have [select] privilege on [$namespace1/$table1]")
+      doAs(admin, sql(showCompactionTable))
+    }
+  }
 }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/HudiCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/HudiCatalogRangerSparkExtensionSuite.scala
@@ -265,7 +265,7 @@ class HudiCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
     }
   }
 
-  test("Compaction Table/Path") {
+  test("CompactionTable/CompactionShowTable command") {
     withCleanTmpResources(Seq((s"$namespace1.$table1", "table"), (namespace1, "database"))) {
       doAs(admin, sql(s"CREATE DATABASE IF NOT EXISTS $namespace1"))
       doAs(

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/HudiCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/HudiCatalogRangerSparkExtensionSuite.scala
@@ -265,7 +265,7 @@ class HudiCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
     }
   }
 
-  test("CompactionTable/CompactionShowTable command") {
+  test("CompactionHoodieTable/CompactionShowHoodieTable Command") {
     withCleanTmpResources(Seq((s"$namespace1.$table1", "table"), (namespace1, "database"))) {
       doAs(admin, sql(s"CREATE DATABASE IF NOT EXISTS $namespace1"))
       doAs(


### PR DESCRIPTION
### _Why are the changes needed?_
To close #5452 
Support Compaction table/path related command. The SQL grammar is https://github.com/apache/hudi/blob/release-0.14.0/hudi-spark-datasource/hudi-spark/src/main/antlr4/org/apache/hudi/spark/sql/parser/HoodieSqlCommon.g4

- CompactionHoodieTableCommand :https://github.com/apache/hudi/blob/master/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/CompactionHoodieTableCommand.scala
- CompactionShowHoodiePathCommand: https://github.com/apache/hudi/blob/master/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/CompactionShowHoodiePathCommand.scala
- CompactionShowHoodieTableCommand: https://github.com/apache/hudi/blob/master/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/CompactionShowHoodieTableCommand.scala

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
No
