### PR TITLE
[KYUUBI #5457] [AUTHZ] Support RepairTable Commands for Hudi

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/resources/table_command_spec.json
+++ b/extensions/spark/kyuubi-spark-authz/src/main/resources/table_command_spec.json
@@ -1586,6 +1586,20 @@
   "opType" : "DROPTABLE",
   "queryDescs" : [ ]
 }, {
+  "classname" : "org.apache.spark.sql.hudi.command.RepairHoodieTableCommand",
+  "tableDescs" : [ {
+    "fieldName" : "tableName",
+    "fieldExtractor" : "TableIdentifierTableExtractor",
+    "columnDesc" : null,
+    "actionTypeDesc" : null,
+    "tableTypeDesc" : null,
+    "catalogDesc" : null,
+    "isInput" : false,
+    "setCurrentDatabaseIfMissing" : false
+  } ],
+  "opType" : "MSCK",
+  "queryDescs" : [ ]
+}, {
   "classname" : "org.apache.spark.sql.hudi.command.Spark31AlterTableCommand",
   "tableDescs" : [ {
     "fieldName" : "table",

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/HudiCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/HudiCommands.scala
@@ -116,6 +116,11 @@ object HudiCommands {
       DROPTABLE)
   }
 
+  val RepairHoodieTableCommand = {
+    val cmd = "org.apache.spark.sql.hudi.command.RepairHoodieTableCommand"
+    TableCommandSpec(cmd, Seq(TableDesc("tableName", classOf[TableIdentifierTableExtractor])), MSCK)
+  }
+
   val TruncateHoodieTableCommand = {
     val cmd = "org.apache.spark.sql.hudi.command.TruncateHoodieTableCommand"
     val columnDesc = ColumnDesc("partitionSpec", classOf[PartitionOptionColumnExtractor])
@@ -138,5 +143,6 @@ object HudiCommands {
     CreateHoodieTableAsSelectCommand,
     CreateHoodieTableLikeCommand,
     DropHoodieTableCommand,
+    RepairHoodieTableCommand,
     TruncateHoodieTableCommand)
 }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/HudiCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/HudiCatalogRangerSparkExtensionSuite.scala
@@ -123,11 +123,14 @@ class HudiCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
           s" on [$namespace1/$table1]")
 
       // AlterTableCommand && Spark31AlterTableCommand
-      sql("set hoodie.schema.on.read.enable=true")
-      interceptContains[AccessControlException](
-        doAs(someone, sql(s"ALTER TABLE $namespace1.$table1 ADD COLUMNS(age int)")))(
-        s"does not have [alter] privilege on [$namespace1/$table1]")
-      sql("set hoodie.schema.on.read.enable=false")
+      try {
+        sql("set hoodie.schema.on.read.enable=true")
+        interceptContains[AccessControlException](
+          doAs(someone, sql(s"ALTER TABLE $namespace1.$table1 ADD COLUMNS(age int)")))(
+          s"does not have [alter] privilege on [$namespace1/$table1]")
+      } finally {
+        sql("set hoodie.schema.on.read.enable=false")
+      }
     }
   }
 

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/HudiCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/HudiCatalogRangerSparkExtensionSuite.scala
@@ -127,6 +127,7 @@ class HudiCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
       interceptContains[AccessControlException](
         doAs(someone, sql(s"ALTER TABLE $namespace1.$table1 ADD COLUMNS(age int)")))(
         s"does not have [alter] privilege on [$namespace1/$table1]")
+      sql("set hoodie.schema.on.read.enable=false")
     }
   }
 
@@ -237,6 +238,31 @@ class HudiCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
         doAs(someone, sql(dropTableSql))
       }(s"does not have [drop] privilege on [$namespace1/$table1]")
       doAs(admin, sql(dropTableSql))
+    }
+  }
+
+  test("RepairHoodieTableCommand") {
+    withCleanTmpResources(Seq((s"$namespace1.$table1", "table"), (namespace1, "database"))) {
+      doAs(admin, sql(s"CREATE DATABASE IF NOT EXISTS $namespace1"))
+      doAs(
+        admin,
+        sql(
+          s"""
+             |CREATE TABLE IF NOT EXISTS $namespace1.$table1(id int, name string, city string)
+             |USING HUDI
+             |OPTIONS (
+             | type = 'cow',
+             | primaryKey = 'id',
+             | 'hoodie.datasource.hive_sync.enable' = 'false'
+             |)
+             |PARTITIONED BY(city)
+             |""".stripMargin))
+
+      val repairTableSql = s"MSCK REPAIR TABLE $namespace1.$table1"
+      interceptContains[AccessControlException] {
+        doAs(someone, sql(repairTableSql))
+      }(s"does not have [alter] privilege on [$namespace1/$table1]")
+      doAs(admin, sql(repairTableSql))
     }
   }
 


### PR DESCRIPTION
### _Why are the changes needed?_
To close #5457. Kyuubi authz support hudi repair table commands

- RepairHoodieTableCommand: https://github.com/apache/hudi/blob/master/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/RepairHoodieTableCommand.scala

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
No