### PR TITLE
[AUTHZ] Support create table command for Paimon

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -75,7 +75,7 @@ jobs:
           - java: 8
             spark: '3.4'
             spark-archive: '-Dspark.archive.mirror=https://archive.apache.org/dist/spark/spark-3.5.0 -Dspark.archive.name=spark-3.5.0-bin-hadoop3.tgz -Pzookeeper-3.6'
-            exclude-tags: '-Dmaven.plugin.scalatest.exclude.tags=org.scalatest.tags.Slow,org.apache.kyuubi.tags.DeltaTest,org.apache.kyuubi.tags.IcebergTest,org.apache.kyuubi.tags.SparkLocalClusterTest'
+            exclude-tags: '-Dmaven.plugin.scalatest.exclude.tags=org.scalatest.tags.Slow,org.apache.kyuubi.tags.DeltaTest,org.apache.kyuubi.tags.IcebergTest,org.apache.kyuubi.tags.PaimonTest,org.apache.kyuubi.tags.SparkLocalClusterTest'
             comment: 'verify-on-spark-3.5-binary'
         exclude:
           # SPARK-33772: Spark supports JDK 17 since 3.3.0

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -80,15 +80,12 @@ jobs:
           - java: 8
             spark: '3.5'
             deactivate-profiles: '-P !spark-authz-paimon-test'
-            comment: 'deactivate-profiles-spark-3.5'
           - java: 11
             spark: '3.5'
             deactivate-profiles: '-P !spark-authz-paimon-test'
-            comment: 'deactivate-profiles-spark-3.5'
           - java: 17
             spark: '3.5'
             deactivate-profiles: '-P !spark-authz-paimon-test'
-            comment: 'deactivate-profiles-spark-3.5'
         exclude:
           - java: 8
             spark: '3.5'

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -77,9 +77,18 @@ jobs:
             spark-archive: '-Dspark.archive.mirror=https://archive.apache.org/dist/spark/spark-3.5.0 -Dspark.archive.name=spark-3.5.0-bin-hadoop3.tgz -Pzookeeper-3.6'
             exclude-tags: '-Dmaven.plugin.scalatest.exclude.tags=org.scalatest.tags.Slow,org.apache.kyuubi.tags.DeltaTest,org.apache.kyuubi.tags.IcebergTest,org.apache.kyuubi.tags.PaimonTest,org.apache.kyuubi.tags.SparkLocalClusterTest'
             comment: 'verify-on-spark-3.5-binary'
-          - spark: '3.5'
+          - java: 8
+            spark: '3.5'
             deactivate-profiles: '-P !spark-authz-paimon-test'
-            comment: 'skip-unsupported-spark-3.5'
+            comment: 'deactivate-profiles-spark-3.5'
+          - java: 11
+            spark: '3.5'
+            deactivate-profiles: '-P !spark-authz-paimon-test'
+            comment: 'deactivate-profiles-spark-3.5'
+          - java: 17
+            spark: '3.5'
+            deactivate-profiles: '-P !spark-authz-paimon-test'
+            comment: 'deactivate-profiles-spark-3.5'
         exclude:
           # SPARK-33772: Spark supports JDK 17 since 3.3.0
           - java: 17

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -90,6 +90,12 @@ jobs:
             deactivate-profiles: '-P !spark-authz-paimon-test'
             comment: 'deactivate-profiles-spark-3.5'
         exclude:
+          - java: 8
+            spark: '3.5'
+          - java: 11
+            spark: '3.5'
+          - java: 17
+            spark: '3.5'
           # SPARK-33772: Spark supports JDK 17 since 3.3.0
           - java: 17
             spark: '3.1'

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -77,22 +77,7 @@ jobs:
             spark-archive: '-Dspark.archive.mirror=https://archive.apache.org/dist/spark/spark-3.5.0 -Dspark.archive.name=spark-3.5.0-bin-hadoop3.tgz -Pzookeeper-3.6'
             exclude-tags: '-Dmaven.plugin.scalatest.exclude.tags=org.scalatest.tags.Slow,org.apache.kyuubi.tags.DeltaTest,org.apache.kyuubi.tags.IcebergTest,org.apache.kyuubi.tags.PaimonTest,org.apache.kyuubi.tags.SparkLocalClusterTest'
             comment: 'verify-on-spark-3.5-binary'
-          - java: 8
-            spark: '3.5'
-            deactivate-profiles: '-P !spark-authz-paimon-test'
-          - java: 11
-            spark: '3.5'
-            deactivate-profiles: '-P !spark-authz-paimon-test'
-          - java: 17
-            spark: '3.5'
-            deactivate-profiles: '-P !spark-authz-paimon-test'
         exclude:
-          - java: 8
-            spark: '3.5'
-          - java: 11
-            spark: '3.5'
-          - java: 17
-            spark: '3.5'
           # SPARK-33772: Spark supports JDK 17 since 3.3.0
           - java: 17
             spark: '3.1'
@@ -123,10 +108,7 @@ jobs:
         run: |
           TEST_MODULES="dev/kyuubi-codecov"
           ./build/mvn clean install ${MVN_OPT} -pl ${TEST_MODULES} -am \
-          -Pspark-${{ matrix.spark }} \
-          -Pspark-authz-hudi-test -Pspark-authz-paimon-test \
-          ${{ matrix.deactivate-profiles }} \
-          ${{ matrix.spark-archive }} ${{ matrix.exclude-tags }}
+          -Pspark-${{ matrix.spark }} -Pspark-authz-hudi-test ${{ matrix.spark-archive }} ${{ matrix.exclude-tags }}
       - name: Code coverage
         if: |
           matrix.java == 8 &&

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -77,6 +77,9 @@ jobs:
             spark-archive: '-Dspark.archive.mirror=https://archive.apache.org/dist/spark/spark-3.5.0 -Dspark.archive.name=spark-3.5.0-bin-hadoop3.tgz -Pzookeeper-3.6'
             exclude-tags: '-Dmaven.plugin.scalatest.exclude.tags=org.scalatest.tags.Slow,org.apache.kyuubi.tags.DeltaTest,org.apache.kyuubi.tags.IcebergTest,org.apache.kyuubi.tags.PaimonTest,org.apache.kyuubi.tags.SparkLocalClusterTest'
             comment: 'verify-on-spark-3.5-binary'
+          - spark: '3.5'
+            deactivate-profiles: '-P !spark-authz-paimon-test'
+            comment: 'skip-unsupported-spark-3.5'
         exclude:
           # SPARK-33772: Spark supports JDK 17 since 3.3.0
           - java: 17
@@ -108,7 +111,10 @@ jobs:
         run: |
           TEST_MODULES="dev/kyuubi-codecov"
           ./build/mvn clean install ${MVN_OPT} -pl ${TEST_MODULES} -am \
-          -Pspark-${{ matrix.spark }} -Pspark-authz-hudi-test ${{ matrix.spark-archive }} ${{ matrix.exclude-tags }}
+          -Pspark-${{ matrix.spark }} \
+          -Pspark-authz-hudi-test -Pspark-authz-paimon-test \
+          ${{ matrix.deactivate-profiles }} \
+          ${{ matrix.spark-archive }} ${{ matrix.exclude-tags }}
       - name: Code coverage
         if: |
           matrix.java == 8 &&

--- a/extensions/spark/kyuubi-spark-authz/pom.xml
+++ b/extensions/spark/kyuubi-spark-authz/pom.xml
@@ -354,9 +354,8 @@
         </profile>
 
         <!--
-          Add spark-authz-paimon-test profile here to avoid import Apache Hudi when enable spark-3.5.
-          Can remove this profile after Apache Paimon support Spark 3.5
-          https://issues.apache.org/jira/browse/HUDI-6296
+          Add spark-authz-paimon-test profile here to avoid import Apache Paimon when enable spark-3.5.
+          Can remove this profile when Apache Paimon supports Spark 3.5
           -->
         <profile>
             <id>spark-authz-paimon-test</id>

--- a/extensions/spark/kyuubi-spark-authz/pom.xml
+++ b/extensions/spark/kyuubi-spark-authz/pom.xml
@@ -323,6 +323,12 @@
             <artifactId>scala-collection-compat_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-spark-${spark.binary.version}</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/spark/kyuubi-spark-authz/pom.xml
+++ b/extensions/spark/kyuubi-spark-authz/pom.xml
@@ -323,6 +323,12 @@
             <artifactId>scala-collection-compat_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-spark-${paimon.spark.binary.version}</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -348,21 +354,6 @@
                     <groupId>org.apache.hudi</groupId>
                     <artifactId>hudi-spark${hudi.spark.binary.version}-bundle_${scala.binary.version}</artifactId>
                     <version>${hudi.version}</version>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
-        </profile>
-
-        <!--
-          Add spark-authz-paimon-test profile here to avoid import Apache Paimon when enable spark-3.5.
-          Can remove this profile when Apache Paimon supports Spark 3.5
-          -->
-        <profile>
-            <id>spark-authz-paimon-test</id>
-            <dependencies>
-                <dependency>
-                    <groupId>org.apache.paimon</groupId>
-                    <artifactId>paimon-spark-${spark.binary.version}</artifactId>
                     <scope>test</scope>
                 </dependency>
             </dependencies>

--- a/extensions/spark/kyuubi-spark-authz/pom.xml
+++ b/extensions/spark/kyuubi-spark-authz/pom.xml
@@ -323,12 +323,6 @@
             <artifactId>scala-collection-compat_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.apache.paimon</groupId>
-            <artifactId>paimon-spark-${spark.binary.version}</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>
@@ -354,6 +348,22 @@
                     <groupId>org.apache.hudi</groupId>
                     <artifactId>hudi-spark${hudi.spark.binary.version}-bundle_${scala.binary.version}</artifactId>
                     <version>${hudi.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <!--
+          Add spark-authz-paimon-test profile here to avoid import Apache Hudi when enable spark-3.5.
+          Can remove this profile after Apache Paimon support Spark 3.5
+          https://issues.apache.org/jira/browse/HUDI-6296
+          -->
+        <profile>
+            <id>spark-authz-paimon-test</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.paimon</groupId>
+                    <artifactId>paimon-spark-${spark.binary.version}</artifactId>
                     <scope>test</scope>
                 </dependency>
             </dependencies>

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/PaimonCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/PaimonCatalogRangerSparkExtensionSuite.scala
@@ -56,12 +56,12 @@ class PaimonCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
 
   override def afterAll(): Unit = {
     if (isSupportedVersion) {
+      doAs(admin, sql(s"DROP DATABASE IF NOT EXISTS $catalogV2.$namespace1"))
+
       super.afterAll()
       spark.sessionState.catalog.reset()
       spark.sessionState.conf.clear()
     }
-
-    doAs(admin, sql(s"DROP DATABASE IF NOT EXISTS $catalogV2.$namespace1"))
   }
 
   test("CreateTable") {

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/PaimonCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/PaimonCatalogRangerSparkExtensionSuite.scala
@@ -56,7 +56,7 @@ class PaimonCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
 
   override def afterAll(): Unit = {
     if (isSupportedVersion) {
-      doAs(admin, sql(s"DROP DATABASE IF NOT EXISTS $catalogV2.$namespace1"))
+      doAs(admin, sql(s"DROP DATABASE IF EXISTS $catalogV2.$namespace1"))
 
       super.afterAll()
       spark.sessionState.catalog.reset()
@@ -65,7 +65,7 @@ class PaimonCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
   }
 
   test("CreateTable") {
-    withCleanTmpResources(Seq((s"$catalogV2.$namespace1.$table1", "table"))) {
+    withCleanTmpResources(Seq((s  "$catalogV2.$namespace1.$table1", "table"))) {
       val createTable =
         s"""
            |CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table1

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/PaimonCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/PaimonCatalogRangerSparkExtensionSuite.scala
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kyuubi.plugin.spark.authz.ranger
+
+import org.scalatest.Outcome
+
+import org.apache.kyuubi.Utils
+import org.apache.kyuubi.plugin.spark.authz.AccessControlException
+import org.apache.kyuubi.plugin.spark.authz.RangerTestUsers._
+import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
+import org.apache.kyuubi.tags.PaimonTest
+import org.apache.kyuubi.util.AssertionUtils._
+
+/**
+ * Tests for RangerSparkExtensionSuite on Paimon
+ */
+@PaimonTest
+class PaimonCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
+  override protected val catalogImpl: String = "hive"
+  private def isSupportedVersion = !isSparkV35OrGreater
+
+  val catalogV2 = "paimon_catalog"
+  val namespace1 = "paimon_ns"
+  val table1 = "table1"
+
+  override def withFixture(test: NoArgTest): Outcome = {
+    assume(isSupportedVersion)
+    test()
+  }
+
+  override def beforeAll(): Unit = {
+    if (isSupportedVersion) {
+      spark.conf.set(s"spark.sql.catalog.$catalogV2", "org.apache.paimon.spark.SparkCatalog")
+      spark.conf.set(
+        s"spark.sql.catalog.$catalogV2.warehouse",
+        Utils.createTempDir("iceberg-hadoop").toString)
+      super.beforeAll()
+    }
+
+    doAs(admin, sql(s"CREATE DATABASE IF NOT EXISTS $catalogV2.$namespace1"))
+  }
+
+  override def afterAll(): Unit = {
+    if (isSupportedVersion) {
+      super.afterAll()
+      spark.sessionState.catalog.reset()
+      spark.sessionState.conf.clear()
+    }
+  }
+
+  test("CreateTable") {
+    withCleanTmpResources(Seq((s"$catalogV2.$namespace1.$table1", "table"))) {
+      val createTable =
+        s"""
+           |CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table1
+           |(id int, name string, city string)
+           |USING paimon
+           |OPTIONS (
+           | primaryKey = 'id'
+           |)
+           |""".stripMargin
+
+      interceptContains[AccessControlException] {
+        doAs(someone, sql(createTable))
+      }(s"does not have [create] privilege on [$namespace1/$table1]")
+      doAs(admin, createTable)
+    }
+  }
+}

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/PaimonCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/PaimonCatalogRangerSparkExtensionSuite.scala
@@ -60,6 +60,8 @@ class PaimonCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
       spark.sessionState.catalog.reset()
       spark.sessionState.conf.clear()
     }
+
+    doAs(admin, sql(s"DROP DATABASE IF NOT EXISTS $catalogV2.$namespace1"))
   }
 
   test("CreateTable") {

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/PaimonCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/PaimonCatalogRangerSparkExtensionSuite.scala
@@ -65,7 +65,7 @@ class PaimonCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
   }
 
   test("CreateTable") {
-    withCleanTmpResources(Seq((s  "$catalogV2.$namespace1.$table1", "table"))) {
+    withCleanTmpResources(Seq((s"$catalogV2.$namespace1.$table1", "table"))) {
       val createTable =
         s"""
            |CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table1

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/PaimonCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/PaimonCatalogRangerSparkExtensionSuite.scala
@@ -47,7 +47,7 @@ class PaimonCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
       spark.conf.set(s"spark.sql.catalog.$catalogV2", "org.apache.paimon.spark.SparkCatalog")
       spark.conf.set(
         s"spark.sql.catalog.$catalogV2.warehouse",
-        Utils.createTempDir("iceberg-hadoop").toString)
+        Utils.createTempDir(catalogV2).toString)
       super.beforeAll()
     }
 

--- a/kyuubi-util-scala/src/test/java/org/apache/kyuubi/tags/PaimonTest.java
+++ b/kyuubi-util-scala/src/test/java/org/apache/kyuubi/tags/PaimonTest.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.tags;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.scalatest.TagAnnotation;
+
+@TagAnnotation
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface PaimonTest {}

--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,7 @@
           -->
         <netty.version>4.1.93.Final</netty.version>
         <openai.java.version>0.12.0</openai.java.version>
+        <paimon.version>0.5.0-incubating</paimon.version>
         <parquet.version>1.10.1</parquet.version>
         <phoenix.version>6.0.0</phoenix.version>
         <prometheus.version>0.16.0</prometheus.version>
@@ -1483,6 +1484,12 @@
                 <groupId>org.apache.hudi</groupId>
                 <artifactId>hudi-spark${hudi.spark.binary.version}-bundle_${scala.binary.version}</artifactId>
                 <version>${hudi.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.paimon</groupId>
+                <artifactId>paimon-spark-${spark.binary.version}</artifactId>
+                <version>${paimon.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -2275,7 +2275,7 @@
                 <hudi.spark.binary.version>3.4</hudi.spark.binary.version>
                 <spark.version>3.5.0</spark.version>
                 <spark.binary.version>3.5</spark.binary.version>
-                <maven.plugin.scalatest.exclude.tags>org.scalatest.tags.Slow,org.apache.kyuubi.tags.DeltaTest,org.apache.kyuubi.tags.PySparkTest</maven.plugin.scalatest.exclude.tags>
+                <maven.plugin.scalatest.exclude.tags>org.scalatest.tags.Slow,org.apache.kyuubi.tags.DeltaTest,org.apache.kyuubi.tags.PySparkTest,org.apache.kyuubi.tags.PaimonTest</maven.plugin.scalatest.exclude.tags>
             </properties>
         </profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -185,6 +185,7 @@
         <netty.version>4.1.93.Final</netty.version>
         <openai.java.version>0.12.0</openai.java.version>
         <paimon.version>0.5.0-incubating</paimon.version>
+        <paimon.spark.binary.version>${spark.binary.version}</paimon.spark.binary.version>
         <parquet.version>1.10.1</parquet.version>
         <phoenix.version>6.0.0</phoenix.version>
         <prometheus.version>0.16.0</prometheus.version>
@@ -1488,7 +1489,7 @@
 
             <dependency>
                 <groupId>org.apache.paimon</groupId>
-                <artifactId>paimon-spark-${spark.binary.version}</artifactId>
+                <artifactId>paimon-spark-${paimon.spark.binary.version}</artifactId>
                 <version>${paimon.version}</version>
             </dependency>
         </dependencies>
@@ -2273,6 +2274,8 @@
                 <delta.version>3.0.0</delta.version>
                 <!-- Remove this when Hudi supports Spark 3.5 -->
                 <hudi.spark.binary.version>3.4</hudi.spark.binary.version>
+                <!-- Remove this when Paimon supports Spark 3.5 -->
+                <paimon.spark.binary.version>3.4</paimon.spark.binary.version>
                 <spark.version>3.5.0</spark.version>
                 <spark.binary.version>3.5</spark.binary.version>
                 <maven.plugin.scalatest.exclude.tags>org.scalatest.tags.Slow,org.apache.kyuubi.tags.DeltaTest,org.apache.kyuubi.tags.PySparkTest,org.apache.kyuubi.tags.PaimonTest</maven.plugin.scalatest.exclude.tags>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Apache Paimon is an incubating Apache project of data lake platform for high-speed data ingestion, changelog tracking and efficient real-time analytics.

- Initial support for Paimon tables in Authz plugin
  - Create Table Command: https://paimon.apache.org/docs/master/engines/spark3/#create-table
- Paimon `0.5.0-incubating` supports Spark 3.1/3.2/3.3/3.4.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
