### PR TITLE
Support setting kyuubi hive jdbc client protocol version

### DIFF
--- a/docs/client/jdbc/kyuubi_jdbc.rst
+++ b/docs/client/jdbc/kyuubi_jdbc.rst
@@ -147,6 +147,28 @@ Connection URL over Service Discovery
 - zookeeper quorum is the corresponding zookeeper cluster configured by `kyuubi.ha.addresses` at the server side.
 - zooKeeperNamespace is  the corresponding namespace configured by `kyuubi.ha.namespace` at the server side.
 
+HiveServer2 Compatibility
+*************************
+
+.. versionadded:: 1.9.0
+
+JDBC Drivers need to negotiate a protocol version with Kyuubi Server/HiveServer2 when connecting.
+
+In order to support most HiveServer2 versions (since Hive 0.13.0),
+Kyuubi Hive JDBC Driver offers protocol version v6 to server by default.
+
+If you need to connect to HiveServer2 before 0.13.0,
+please set client property `clientProtocolVersion` to a lower number.
+
+.. code-block:: jdbc
+
+   jdbc:subprotocol://host:port[/catalog]/[schema];clientProtocolVersion=5;
+
+
+.. tip::
+    All supported protocol versions and corresponding Hive versions can be found in `TProtocolVersion.java`_
+    and its GitHub history.
+
 Kerberos Authentication
 -----------------------
 Since 1.6.0, Kyuubi JDBC driver implements the Kerberos authentication based on JAAS framework instead of `Hadoop UserGroupInformation`_,
@@ -219,3 +241,4 @@ Authentication by Subject (programing only)
 .. _java.sql.DriverManager: https://docs.oracle.com/javase/8/docs/api/java/sql/DriverManager.html
 .. _Hadoop UserGroupInformation: https://hadoop.apache.org/docs/stable/api/org/apache/hadoop/security/UserGroupInformation.html
 .. _krb5.conf instruction: https://docs.oracle.com/javase/8/docs/technotes/guides/security/jgss/tutorials/KerberosReq.html
+.. _TProtocolVersion.java: https://github.com/apache/hive/blob/master/service-rpc/src/gen/thrift/gen-javabean/org/apache/hive/service/rpc/thrift/TProtocolVersion.java

--- a/docs/client/jdbc/kyuubi_jdbc.rst
+++ b/docs/client/jdbc/kyuubi_jdbc.rst
@@ -155,7 +155,7 @@ HiveServer2 Compatibility
 JDBC Drivers need to negotiate a protocol version with Kyuubi Server/HiveServer2 when connecting.
 
 In order to support most HiveServer2 versions (since Hive 0.13.0),
-Kyuubi Hive JDBC Driver offers protocol version v6 to server by default.
+Kyuubi Hive JDBC Driver offers protocol version v6 (`clientProtocolVersion=5`) to server by default.
 
 If you need to connect to HiveServer2 before 0.13.0,
 please set client property `clientProtocolVersion` to a lower number.
@@ -167,7 +167,7 @@ please set client property `clientProtocolVersion` to a lower number.
 
 .. tip::
     All supported protocol versions and corresponding Hive versions can be found in `TProtocolVersion.java`_
-    and its GitHub history.
+    and its git commits.
 
 Kerberos Authentication
 -----------------------

--- a/docs/client/jdbc/kyuubi_jdbc.rst
+++ b/docs/client/jdbc/kyuubi_jdbc.rst
@@ -150,7 +150,7 @@ Connection URL over Service Discovery
 HiveServer2 Compatibility
 *************************
 
-.. versionadded:: 1.9.0
+.. versionadded:: 1.8.0
 
 JDBC Drivers need to negotiate a protocol version with Kyuubi Server/HiveServer2 when connecting.
 

--- a/docs/client/jdbc/kyuubi_jdbc.rst
+++ b/docs/client/jdbc/kyuubi_jdbc.rst
@@ -154,15 +154,15 @@ HiveServer2 Compatibility
 
 JDBC Drivers need to negotiate a protocol version with Kyuubi Server/HiveServer2 when connecting.
 
-In order to support most HiveServer2 versions (since Hive 0.13.0),
-Kyuubi Hive JDBC Driver offers protocol version v6 (`clientProtocolVersion=5`) to server by default.
+Kyuubi Hive JDBC Driver offers protocol version v10 (`clientProtocolVersion=9`, supported since Hive 2.3.0)
+to server by default.
 
-If you need to connect to HiveServer2 before 0.13.0,
+If you need to connect to HiveServer2 before 2.3.0,
 please set client property `clientProtocolVersion` to a lower number.
 
 .. code-block:: jdbc
 
-   jdbc:subprotocol://host:port[/catalog]/[schema];clientProtocolVersion=5;
+   jdbc:subprotocol://host:port[/catalog]/[schema];clientProtocolVersion=9;
 
 
 .. tip::

--- a/docs/deployment/migration-guide.md
+++ b/docs/deployment/migration-guide.md
@@ -29,7 +29,7 @@
 
 * Since Kyuubi 1.8, Kyuubi Hive JDBC Driver offers protocol version v6 to server by default.
   To restore previous behavior, add `clientProtocolVersion=9;` to JDBC URL client properties section:
-  `jdbc:subprotocol://host:port[/catalog]/[schema];clientProtocolVersion=9;`
+  `jdbc:kyuubi://<host>:<port>[/catalog]/[schema];clientProtocolVersion=9;`
 
 ## Upgrading from Kyuubi 1.7.1 to 1.7.2
 

--- a/docs/deployment/migration-guide.md
+++ b/docs/deployment/migration-guide.md
@@ -27,6 +27,10 @@
 * Since Kyuubi 1.8, PROMETHEUS is changed as the default metrics reporter. To restore previous behavior,
   set `kyuubi.metrics.reporters=JSON`.
 
+* Since Kyuubi 1.8, Kyuubi Hive JDBC Driver offers protocol version v6 to server by default.
+  To restore previous behavior, add `clientProtocolVersion=9;` to JDBC URL client properties section:
+  `jdbc:subprotocol://host:port[/catalog]/[schema];clientProtocolVersion=9;`
+
 ## Upgrading from Kyuubi 1.7.1 to 1.7.2
 
 * Since Kyuubi 1.7.2, for Kyuubi BeeLine, please use `--python-mode` option to run python code or script.

--- a/docs/deployment/migration-guide.md
+++ b/docs/deployment/migration-guide.md
@@ -27,10 +27,6 @@
 * Since Kyuubi 1.8, PROMETHEUS is changed as the default metrics reporter. To restore previous behavior,
   set `kyuubi.metrics.reporters=JSON`.
 
-* Since Kyuubi 1.8, Kyuubi Hive JDBC Driver offers protocol version v6 to server by default.
-  To restore previous behavior, add `clientProtocolVersion=9;` to JDBC URL client properties section:
-  `jdbc:kyuubi://<host>:<port>[/catalog]/[schema];clientProtocolVersion=9;`
-
 ## Upgrading from Kyuubi 1.7.1 to 1.7.2
 
 * Since Kyuubi 1.7.2, for Kyuubi BeeLine, please use `--python-mode` option to run python code or script.

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/JdbcConnectionParams.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/JdbcConnectionParams.java
@@ -33,6 +33,7 @@ public class JdbcConnectionParams {
 
   // Client param names:
 
+  static final String CLIENT_PROTOCOL_VERSION = "clientProtocolVersion";
   // Retry setting
   static final String RETRIES = "retries";
 

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
@@ -740,7 +740,9 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
         TProtocolVersion.findByValue(Integer.parseInt(clientProtocolStr));
     if (clientProtocol == null) {
       throw new IllegalArgumentException(
-          "Unsupported Hive2 protocol specified by session conf key " + CLIENT_PROTOCOL_VERSION);
+          String.format(
+              "Unsupported Hive2 protocol version %s specified by session conf key %s",
+              clientProtocolStr, CLIENT_PROTOCOL_VERSION));
     }
     openReq.setClient_protocol(clientProtocol);
     try {

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
@@ -733,6 +733,16 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
     if (sessVars.containsKey(HS2_PROXY_USER)) {
       openConf.put(HS2_PROXY_USER, sessVars.get(HS2_PROXY_USER));
     }
+    String clientProtocolStr =
+        sessVars.getOrDefault(
+            CLIENT_PROTOCOL_VERSION, openReq.getClient_protocol().getValue() + "");
+    TProtocolVersion clientProtocol =
+        TProtocolVersion.findByValue(Integer.parseInt(clientProtocolStr));
+    if (clientProtocol == null) {
+      throw new IllegalArgumentException(
+          "Unsupported Hive2 protocol specified by session conf key " + CLIENT_PROTOCOL_VERSION);
+    }
+    openReq.setClient_protocol(clientProtocol);
     try {
       openConf.put("kyuubi.client.ipAddress", InetAddress.getLocalHost().getHostAddress());
     } catch (UnknownHostException e) {

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
@@ -700,7 +700,9 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
   }
 
   private void openSession() throws SQLException {
-    TOpenSessionReq openReq = new TOpenSessionReq();
+    // Server responses are the same if TProtocolVersion >= HIVE_CLI_SERVICE_PROTOCOL_V6
+    // So we set it to HIVE_CLI_SERVICE_PROTOCOL_V6 to support HiveServer2 early versions.
+    TOpenSessionReq openReq = new TOpenSessionReq(TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V6);
 
     Map<String, String> openConf = new HashMap<>();
     // for remote JDBC client, try to set the conf var using 'set foo=bar'

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
@@ -700,9 +700,7 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
   }
 
   private void openSession() throws SQLException {
-    // Server responses are the same if TProtocolVersion >= HIVE_CLI_SERVICE_PROTOCOL_V6
-    // So we set it to HIVE_CLI_SERVICE_PROTOCOL_V6 to support HiveServer2 early versions.
-    TOpenSessionReq openReq = new TOpenSessionReq(TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V6);
+    TOpenSessionReq openReq = new TOpenSessionReq();
 
     Map<String, String> openConf = new HashMap<>();
     // for remote JDBC client, try to set the conf var using 'set foo=bar'

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/Utils.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/Utils.java
@@ -292,6 +292,13 @@ public class Utils {
         }
       }
     }
+    if (!connParams.getSessionVars().containsKey(CLIENT_PROTOCOL_VERSION)) {
+      if (info.containsKey(CLIENT_PROTOCOL_VERSION)) {
+        connParams
+            .getSessionVars()
+            .put(CLIENT_PROTOCOL_VERSION, info.getProperty(CLIENT_PROTOCOL_VERSION));
+      }
+    }
     // Extract user/password from JDBC connection properties if its not supplied
     // in the connection URL
     if (!connParams.getSessionVars().containsKey(AUTH_USER)) {


### PR DESCRIPTION
### _Why are the changes needed?_
When using Kyuubi Hive JDBC to Hive Server2, TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V10 is used and can not be changed.

When we connected to Hive Server2 with version lower than 2.2.0, we got the following error:
```
org.apache.kyuubi.shade.org.apache.thrift.TApplicationException: 
Required field 'client_protocol' is unset! 
Struct:TOpenSessionReq(client_protocol:null, configuration:{kyuubi.client.version=1.7.3, set:hiveconf:hive.server2.thrift.resultset.default.fetch.size=1000, kyuubi.client.ipAddress=172.16.19.113, use:database=default})
```

In this PR, we introduced a session conf `clientProtocolVersion`. 
By adding `clientProtocolVersion=8` to jdbc url, the error got fixed.

Changes of `kyuubi_jdbc.rst`

<img width="867" alt="image" src="https://github.com/apache/kyuubi/assets/88070094/8f98edf9-15c4-4d1b-9299-83b24136352b">

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Manual tests against Hive Server2 version 2.1.1-cdh6.3.0

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
No.
