### PR TITLE
[KYUUBI #5478][AUTHZ] Support Hudi ShowHoodieTablePartitionsCommand

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/resources/table_command_spec.json
+++ b/extensions/spark/kyuubi-spark-authz/src/main/resources/table_command_spec.json
@@ -1658,6 +1658,23 @@
   "opType" : "MSCK",
   "queryDescs" : [ ]
 }, {
+  "classname" : "org.apache.spark.sql.hudi.command.ShowHoodieTablePartitionsCommand",
+  "tableDescs" : [ {
+    "fieldName" : "tableIdentifier",
+    "fieldExtractor" : "TableIdentifierTableExtractor",
+    "columnDesc" : {
+      "fieldName" : "specOpt",
+      "fieldExtractor" : "PartitionOptionColumnExtractor"
+    },
+    "actionTypeDesc" : null,
+    "tableTypeDesc" : null,
+    "catalogDesc" : null,
+    "isInput" : true,
+    "setCurrentDatabaseIfMissing" : false
+  } ],
+  "opType" : "SHOWPARTITIONS",
+  "queryDescs" : [ ]
+}, {
   "classname" : "org.apache.spark.sql.hudi.command.Spark31AlterTableCommand",
   "tableDescs" : [ {
     "fieldName" : "table",

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/HudiCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/HudiCommands.scala
@@ -154,6 +154,17 @@ object HudiCommands {
     TableCommandSpec(cmd, Seq(tableDesc), queryDescs = Seq(QueryDesc("query")))
   }
 
+  val ShowHoodieTablePartitionsCommand = {
+    val cmd = "org.apache.spark.sql.hudi.command.ShowHoodieTablePartitionsCommand"
+    val columnDesc = ColumnDesc("specOpt", classOf[PartitionOptionColumnExtractor])
+    val tableDesc = TableDesc(
+      "tableIdentifier",
+      classOf[TableIdentifierTableExtractor],
+      isInput = true,
+      columnDesc = Some(columnDesc))
+    TableCommandSpec(cmd, Seq(tableDesc), SHOWPARTITIONS)
+  }
+
   val data: Array[TableCommandSpec] = Array(
     AlterHoodieTableAddColumnsCommand,
     AlterHoodieTableChangeColumnCommand,
@@ -169,5 +180,6 @@ object HudiCommands {
     InsertIntoHoodieTableCommand,
     RepairHoodieTableCommand,
     TruncateHoodieTableCommand,
+    ShowHoodieTablePartitionsCommand,
     Spark31AlterTableCommand)
 }


### PR DESCRIPTION
### _Why are the changes needed?_
To close #5478. Kyuubi authz support hudi ShowHoodieTablePartitionsCommand

- ShowHoodieTablePartitionsCommand: https://github.com/apache/hudi/blob/master/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/ShowHoodieTablePartitionsCommand.scala

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
No