### PR TITLE
[KYUUBI #5489] Adjust shuffle partitions dynamically

### DIFF
--- a/extensions/spark/kyuubi-extension-spark-3-5/src/main/scala/org/apache/kyuubi/sql/DynamicShufflePartitions.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-5/src/main/scala/org/apache/kyuubi/sql/DynamicShufflePartitions.scala
@@ -54,12 +54,12 @@ case class DynamicShufflePartitions(spark: SparkSession) extends Rule[SparkPlan]
       }
 
       val targetSize = conf.getConf(ADVISORY_PARTITION_SIZE_IN_BYTES)
-      val maxScanSizes = collectScanSizes(plan) match {
-        case sizes if sizes.nonEmpty => sizes.max
+      val sumScanSizes = collectScanSizes(plan) match {
+        case sizes if sizes.nonEmpty => sizes.sum
         case _ => targetSize
       }
       val targetShufflePartitions = Math.min(
-        Math.max(maxScanSizes / targetSize + 1, conf.numShufflePartitions).toInt,
+        Math.max(sumScanSizes / targetSize + 1, conf.numShufflePartitions).toInt,
         maxDynamicShufflePartitions)
 
       val newPlan = plan transformUp {

--- a/extensions/spark/kyuubi-extension-spark-3-5/src/main/scala/org/apache/kyuubi/sql/DynamicShufflePartitions.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-5/src/main/scala/org/apache/kyuubi/sql/DynamicShufflePartitions.scala
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kyuubi.sql
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, RangePartitioning, RoundRobinPartitioning}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
+import org.apache.spark.sql.execution.adaptive.ShuffleQueryStageExec
+import org.apache.spark.sql.execution.exchange.{REPARTITION_BY_NUM, ShuffleExchangeExec}
+import org.apache.spark.sql.hive.HiveSparkPlanHelper.HiveTableScanExec
+import org.apache.spark.sql.internal.SQLConf._
+
+/**
+ * Dynamically adjust the number of shuffle partitions according to the input data size
+ */
+case class DynamicShufflePartitions(spark: SparkSession) extends Rule[SparkPlan] {
+
+  override def apply(plan: SparkPlan): SparkPlan = {
+
+    def collectScanSizes(plan: SparkPlan): Seq[Long] = plan match {
+      case FileSourceScanExec(relation, _, _, _, _, _, _, _, _) =>
+        Seq(relation.location.sizeInBytes)
+      case t: HiveTableScanExec =>
+        Seq(t.relation.computeStats().sizeInBytes.toLong)
+          .filter(_ != conf.defaultSizeInBytes)
+      case stage: ShuffleQueryStageExec if stage.isMaterialized =>
+        Seq(stage.mapStats.map(_.bytesByPartitionId.sum).getOrElse(0L))
+      case p =>
+        p.children.flatMap(collectScanSizes)
+    }
+
+    val targetSize = conf.getConf(ADVISORY_PARTITION_SIZE_IN_BYTES)
+    val maxScanSizes = collectScanSizes(plan) match {
+      case Nil => targetSize
+      case sizes => sizes.max
+    }
+    val targetShufflePartitions =
+      Math.max(maxScanSizes / targetSize + 1, conf.numShufflePartitions).toInt
+
+    plan transformUp {
+      case exchange @ ShuffleExchangeExec(outputPartitioning, _, shuffleOrigin, _)
+          if shuffleOrigin != REPARTITION_BY_NUM =>
+        val newOutPartitioning = outputPartitioning match {
+          case RoundRobinPartitioning(numPartitions) if targetShufflePartitions != numPartitions =>
+            Some(RoundRobinPartitioning(targetShufflePartitions))
+          case HashPartitioning(expressions, numPartitions)
+              if targetShufflePartitions != numPartitions =>
+            Some(HashPartitioning(expressions, targetShufflePartitions))
+          case RangePartitioning(ordering, numPartitions)
+              if targetShufflePartitions != numPartitions =>
+            Some(RangePartitioning(ordering, targetShufflePartitions))
+          case _ => None
+        }
+        if (newOutPartitioning.isDefined) {
+          exchange.copy(outputPartitioning = newOutPartitioning.get)
+        } else {
+          exchange
+        }
+    }
+  }
+
+}

--- a/extensions/spark/kyuubi-extension-spark-3-5/src/main/scala/org/apache/kyuubi/sql/DynamicShufflePartitions.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-5/src/main/scala/org/apache/kyuubi/sql/DynamicShufflePartitions.scala
@@ -31,7 +31,6 @@ import org.apache.spark.sql.internal.SQLConf._
 case class DynamicShufflePartitions(spark: SparkSession) extends Rule[SparkPlan] {
 
   override def apply(plan: SparkPlan): SparkPlan = {
-
     def collectScanSizes(plan: SparkPlan): Seq[Long] = plan match {
       case FileSourceScanExec(relation, _, _, _, _, _, _, _, _) =>
         Seq(relation.location.sizeInBytes)
@@ -49,8 +48,8 @@ case class DynamicShufflePartitions(spark: SparkSession) extends Rule[SparkPlan]
 
     val targetSize = conf.getConf(ADVISORY_PARTITION_SIZE_IN_BYTES)
     val maxScanSizes = collectScanSizes(plan) match {
-      case Nil => targetSize
-      case sizes => sizes.max
+      case sizes if sizes.nonEmpty => sizes.max
+      case _ => targetSize
     }
     val targetShufflePartitions =
       Math.max(maxScanSizes / targetSize + 1, conf.numShufflePartitions).toInt

--- a/extensions/spark/kyuubi-extension-spark-3-5/src/main/scala/org/apache/kyuubi/sql/DynamicShufflePartitions.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-5/src/main/scala/org/apache/kyuubi/sql/DynamicShufflePartitions.scala
@@ -33,7 +33,7 @@ import org.apache.kyuubi.sql.KyuubiSQLConf.{DYNAMIC_SHUFFLE_PARTITIONS, DYNAMIC_
 case class DynamicShufflePartitions(spark: SparkSession) extends Rule[SparkPlan] {
 
   override def apply(plan: SparkPlan): SparkPlan = {
-    if (!conf.getConf(DYNAMIC_SHUFFLE_PARTITIONS)) {
+    if (!conf.getConf(DYNAMIC_SHUFFLE_PARTITIONS) || !conf.getConf(ADAPTIVE_EXECUTION_ENABLED)) {
       plan
     } else {
       val maxDynamicShufflePartitions = conf.getConf(DYNAMIC_SHUFFLE_PARTITIONS_MAX_NUM)

--- a/extensions/spark/kyuubi-extension-spark-3-5/src/main/scala/org/apache/kyuubi/sql/KyuubiSQLConf.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-5/src/main/scala/org/apache/kyuubi/sql/KyuubiSQLConf.scala
@@ -273,4 +273,20 @@ object KyuubiSQLConf {
       .version("1.8.0")
       .stringConf
       .createOptional
+
+  val DYNAMIC_SHUFFLE_PARTITIONS =
+    buildConf("spark.sql.optimizer.dynamicShufflePartitions")
+      .doc("If true, adjust the number of shuffle partitions dynamically based on the job" +
+        " input size. The new number of partitions is the maximum input size" +
+        " divided by `spark.sql.adaptive.advisoryPartitionSizeInBytes`.")
+      .version("1.9.0")
+      .booleanConf
+      .createWithDefault(false)
+
+  val DYNAMIC_SHUFFLE_PARTITIONS_MAX_NUM =
+    buildConf("spark.sql.optimizer.dynamicShufflePartitions.maxNum")
+      .doc("The maximum partition number of DynamicShufflePartitions.")
+      .version("1.9.0")
+      .intConf
+      .createWithDefault(2000)
 }

--- a/extensions/spark/kyuubi-extension-spark-3-5/src/main/scala/org/apache/kyuubi/sql/KyuubiSparkSQLCommonExtension.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-5/src/main/scala/org/apache/kyuubi/sql/KyuubiSparkSQLCommonExtension.scala
@@ -42,6 +42,7 @@ object KyuubiSparkSQLCommonExtension {
     extensions.injectPostHocResolutionRule(InsertZorderBeforeWritingHive33)
     extensions.injectPostHocResolutionRule(FinalStageConfigIsolationCleanRule)
 
+    extensions.injectQueryStagePrepRule(DynamicShufflePartitions)
     extensions.injectQueryStagePrepRule(_ => InsertShuffleNodeBeforeJoin)
 
     extensions.injectQueryStagePrepRule(FinalStageConfigIsolation(_))

--- a/extensions/spark/kyuubi-extension-spark-3-5/src/main/scala/org/apache/kyuubi/sql/KyuubiSparkSQLCommonExtension.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-5/src/main/scala/org/apache/kyuubi/sql/KyuubiSparkSQLCommonExtension.scala
@@ -42,8 +42,8 @@ object KyuubiSparkSQLCommonExtension {
     extensions.injectPostHocResolutionRule(InsertZorderBeforeWritingHive33)
     extensions.injectPostHocResolutionRule(FinalStageConfigIsolationCleanRule)
 
-    extensions.injectQueryStagePrepRule(DynamicShufflePartitions)
     extensions.injectQueryStagePrepRule(_ => InsertShuffleNodeBeforeJoin)
+    extensions.injectQueryStagePrepRule(DynamicShufflePartitions)
 
     extensions.injectQueryStagePrepRule(FinalStageConfigIsolation(_))
   }

--- a/extensions/spark/kyuubi-extension-spark-3-5/src/main/scala/org/apache/spark/sql/hive/HiveSparkPlanHelper.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-5/src/main/scala/org/apache/spark/sql/hive/HiveSparkPlanHelper.scala
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.hive
+
+object HiveSparkPlanHelper {
+  type HiveTableScanExec = org.apache.spark.sql.hive.execution.HiveTableScanExec
+}

--- a/extensions/spark/kyuubi-extension-spark-3-5/src/test/scala/org/apache/spark/sql/DynamicShufflePartitionsSuite.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-5/src/test/scala/org/apache/spark/sql/DynamicShufflePartitionsSuite.scala
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql
+
+import org.apache.spark.sql.execution.{CommandResultExec, SparkPlan}
+import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, ShuffleQueryStageExec}
+import org.apache.spark.sql.execution.exchange.{ENSURE_REQUIREMENTS, ShuffleExchangeExec}
+import org.apache.spark.sql.hive.HiveUtils.CONVERT_METASTORE_PARQUET
+import org.apache.spark.sql.internal.SQLConf._
+
+class DynamicShufflePartitionsSuite extends KyuubiSparkSQLExtensionTest {
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    setupData()
+  }
+
+  test("test dynamic shuffle partitions") {
+    def collectExchanges(plan: SparkPlan): Seq[ShuffleExchangeExec] = {
+      plan match {
+        case p: CommandResultExec => collectExchanges(p.commandPhysicalPlan)
+        case p: AdaptiveSparkPlanExec => collectExchanges(p.finalPhysicalPlan)
+        case p: ShuffleQueryStageExec => collectExchanges(p.plan)
+        case p: ShuffleExchangeExec => p +: collectExchanges(p.child)
+        case p => p.children.flatMap(collectExchanges)
+      }
+    }
+
+    // datasource scan
+    withTable("table1", "table2", "table3") {
+      sql("create table table1 stored as parquet as select c1, c2 from t1")
+      sql("create table table2 stored as parquet as select c1, c2 from t2")
+      sql("create table table3 (c1 int, c2 string) stored as parquet")
+
+      withSQLConf(
+        AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
+        COALESCE_PARTITIONS_INITIAL_PARTITION_NUM.key -> "2",
+        ADVISORY_PARTITION_SIZE_IN_BYTES.key -> "500") {
+        val df = sql("insert overwrite table3 " +
+          " select a.c1 as c1, b.c2 as c2 from table1 a join table2 b on a.c1 = b.c1")
+
+        val exchanges = collectExchanges(df.queryExecution.executedPlan)
+        val (joinExchanges, rebalanceExchanges) = exchanges
+          .partition(_.shuffleOrigin == ENSURE_REQUIREMENTS)
+        // table scan size: 7369 3287
+        assert(joinExchanges.size == 2)
+        joinExchanges.foreach(e => assert(e.outputPartitioning.numPartitions == 15))
+        // shuffle query size: 1742 509
+        assert(rebalanceExchanges.size == 1)
+        assert(rebalanceExchanges.head.outputPartitioning.numPartitions == 4)
+      }
+
+      // hive table scan
+      sql("ANALYZE TABLE table1 COMPUTE STATISTICS")
+      sql("ANALYZE TABLE table2 COMPUTE STATISTICS")
+      withSQLConf(
+        AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
+        COALESCE_PARTITIONS_INITIAL_PARTITION_NUM.key -> "2",
+        ADVISORY_PARTITION_SIZE_IN_BYTES.key -> "500",
+        CONVERT_METASTORE_PARQUET.key -> "false") {
+        val df = sql("insert overwrite table3 " +
+          " select a.c1 as c1, b.c2 as c2 from table1 a join table2 b on a.c1 = b.c1")
+
+        val exchanges = collectExchanges(df.queryExecution.executedPlan)
+        val (joinExchanges, rebalanceExchanges) = exchanges
+          .partition(_.shuffleOrigin == ENSURE_REQUIREMENTS)
+        // table scan size: 7369 3287
+        assert(joinExchanges.size == 2)
+        joinExchanges.foreach(e => assert(e.outputPartitioning.numPartitions == 15))
+        // shuffle query size: 4820 720
+        assert(rebalanceExchanges.size == 1)
+        assert(rebalanceExchanges.head.outputPartitioning.numPartitions == 10)
+      }
+    }
+  }
+
+}

--- a/extensions/spark/kyuubi-extension-spark-3-5/src/test/scala/org/apache/spark/sql/DynamicShufflePartitionsSuite.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-5/src/test/scala/org/apache/spark/sql/DynamicShufflePartitionsSuite.scala
@@ -75,7 +75,7 @@ class DynamicShufflePartitionsSuite extends KyuubiSparkSQLExtensionTest {
             if (dynamicShufflePartitions) {
               joinExchanges.foreach(e =>
                 assert(e.outputPartitioning.numPartitions
-                  == Math.min(15, maxDynamicShufflePartitionNum)))
+                  == Math.min(22, maxDynamicShufflePartitionNum)))
             } else {
               joinExchanges.foreach(e =>
                 assert(e.outputPartitioning.numPartitions == initialPartitionNum))
@@ -83,14 +83,14 @@ class DynamicShufflePartitionsSuite extends KyuubiSparkSQLExtensionTest {
 
             assert(rebalanceExchanges.size == 1)
             if (dynamicShufflePartitions) {
-              // shuffle query size: 1742 509
               if (maxDynamicShufflePartitionNum == 8) {
-                assert(rebalanceExchanges.head.outputPartitioning.numPartitions ==
-                  Math.min(3, maxDynamicShufflePartitionNum))
-              } else {
                 // shuffle query size: 1424 451
                 assert(rebalanceExchanges.head.outputPartitioning.numPartitions ==
                   Math.min(4, maxDynamicShufflePartitionNum))
+              } else {
+                // shuffle query size: 2057 664
+                assert(rebalanceExchanges.head.outputPartitioning.numPartitions ==
+                  Math.min(6, maxDynamicShufflePartitionNum))
               }
             } else {
               assert(
@@ -117,16 +117,16 @@ class DynamicShufflePartitionsSuite extends KyuubiSparkSQLExtensionTest {
             if (dynamicShufflePartitions) {
               joinExchanges.foreach(e =>
                 assert(e.outputPartitioning.numPartitions ==
-                  Math.min(15, maxDynamicShufflePartitionNum)))
+                  Math.min(22, maxDynamicShufflePartitionNum)))
             } else {
               joinExchanges.foreach(e =>
                 assert(e.outputPartitioning.numPartitions == initialPartitionNum))
             }
-            // shuffle query size: 4820 720
+            // shuffle query size: 5154 720
             assert(rebalanceExchanges.size == 1)
             if (dynamicShufflePartitions) {
               assert(rebalanceExchanges.head.outputPartitioning.numPartitions
-                == Math.min(10, maxDynamicShufflePartitionNum))
+                == Math.min(12, maxDynamicShufflePartitionNum))
             } else {
               assert(rebalanceExchanges.head.outputPartitioning.numPartitions ==
                 initialPartitionNum)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Usually, we can use `spark.sql.shuffle.partitions` to configure the number of shuffle partitions (or `spark.sql.adaptive.coalescePartitions.initialPartitionNum` for AQE). However, it seems difficult to find a universal value for all SQL jobs.

Although Spark AQE can dynamically merge and split partitions based on partition size, inappropriate shuffle partitions may still cause some problems:

+ When there are too few shuffle partitions, the join skew optimization threshold is large and the skew partitions will not be split.
+ When using RemoteShuffleService, an inappropriate number of shuffle partitions may result in too large partitions or too many partitions, which will lead to high pressure on the shuffle server.

So I want to provide an optimization rule to dynamically adjust the number of partitions based on the size of the input data.

Calculate the number of partitions based on input data size:

```
targetShufflePartitions = sum(scanSize|shuffleReadSize) / advisoryPartitionSizeInBytes
```

then replace the number of partitions for all `ShuffleExchangeExec` nodes.

### _How was this patch tested?_
- [X] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
