### PR TITLE
[KYUUBI #5492][AUTHZ] saveAsTable create DataSource table miss db info

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/resources/table_command_spec.json
+++ b/extensions/spark/kyuubi-spark-authz/src/main/resources/table_command_spec.json
@@ -988,7 +988,7 @@
     "tableTypeDesc" : null,
     "catalogDesc" : null,
     "isInput" : false,
-    "setCurrentDatabaseIfMissing" : false
+    "setCurrentDatabaseIfMissing" : true
   } ],
   "opType" : "CREATETABLE_AS_SELECT",
   "queryDescs" : [ {
@@ -1005,7 +1005,7 @@
     "tableTypeDesc" : null,
     "catalogDesc" : null,
     "isInput" : false,
-    "setCurrentDatabaseIfMissing" : false
+    "setCurrentDatabaseIfMissing" : true
   } ],
   "opType" : "CREATETABLE",
   "queryDescs" : [ ]
@@ -1019,7 +1019,7 @@
     "tableTypeDesc" : null,
     "catalogDesc" : null,
     "isInput" : false,
-    "setCurrentDatabaseIfMissing" : false
+    "setCurrentDatabaseIfMissing" : true
   } ],
   "opType" : "CREATETABLE",
   "queryDescs" : [ ]

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/serde/tableExtractors.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/serde/tableExtractors.scala
@@ -96,8 +96,10 @@ class CatalogTableTableExtractor extends TableExtractor {
     } else {
       val catalogTable = v1.asInstanceOf[CatalogTable]
       val identifier = catalogTable.identifier
+      val db = identifier.database.getOrElse(spark.sessionState.catalog.getCurrentDatabase)
+      val tableIdentWithDB = identifier.copy(database = Some(db))
       val owner = Option(catalogTable.owner).filter(_.nonEmpty)
-      Some(Table(None, identifier.database, identifier.table, owner))
+      Some(Table(None, tableIdentWithDB.database, tableIdentWithDB.table, owner))
     }
   }
 }

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/serde/tableExtractors.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/serde/tableExtractors.scala
@@ -96,10 +96,8 @@ class CatalogTableTableExtractor extends TableExtractor {
     } else {
       val catalogTable = v1.asInstanceOf[CatalogTable]
       val identifier = catalogTable.identifier
-      val db = identifier.database.getOrElse(spark.sessionState.catalog.getCurrentDatabase)
-      val tableIdentWithDB = identifier.copy(database = Some(db))
       val owner = Option(catalogTable.owner).filter(_.nonEmpty)
-      Some(Table(None, tableIdentWithDB.database, tableIdentWithDB.table, owner))
+      Some(Table(None, identifier.database, identifier.table, owner))
     }
   }
 }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/TableCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/TableCommands.scala
@@ -377,7 +377,8 @@ object TableCommands {
 
   val CreateDataSourceTable = {
     val cmd = "org.apache.spark.sql.execution.command.CreateDataSourceTableCommand"
-    val tableDesc = TableDesc("table", classOf[CatalogTableTableExtractor])
+    val tableDesc =
+      TableDesc("table", classOf[CatalogTableTableExtractor], setCurrentDatabaseIfMissing = true)
     TableCommandSpec(cmd, Seq(tableDesc), CREATETABLE)
   }
 

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
@@ -35,6 +35,7 @@ import org.apache.kyuubi.plugin.spark.authz.RangerTestNamespace._
 import org.apache.kyuubi.plugin.spark.authz.RangerTestUsers._
 import org.apache.kyuubi.plugin.spark.authz.ranger.RuleAuthorization.KYUUBI_AUTHZ_TAG
 import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
+import org.apache.kyuubi.util.AssertionUtils._
 import org.apache.kyuubi.util.reflect.ReflectUtils._
 abstract class RangerSparkExtensionSuite extends AnyFunSuite
   with SparkSessionProvider with BeforeAndAfterAll {
@@ -843,10 +844,9 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
         val df = doAs(
           admin,
           sql(s"SELECT * FROM VALUES(1, 100),(2, 200),(3, 300) AS t(id, scope)")).persist()
-        val e = intercept[AccessControlException] {
-          doAs(someone, df.write.mode("overwrite").saveAsTable(table1))
-        }
-        assert(e.getMessage.contains(s"does not have [create] privilege on [$defaultDb/$table1]"))
+        interceptContains[AccessControlException](
+          doAs(someone, df.write.mode("overwrite").saveAsTable(table1)))(
+          s"does not have [create] privilege on [$defaultDb/$table1]")
       }
     }
   }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
@@ -835,4 +835,19 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
       assert(e2.getMessage.contains(s"does not have [select] privilege on [$db1/$view1/new_id]"))
     }
   }
+
+  test("[KYUUBI #5492] saveAsTable create DataSource table miss db info") {
+    val table1 = "table1"
+    withSingleCallEnabled {
+      withCleanTmpResources(Seq.empty) {
+        val df = doAs(
+          admin,
+          sql(s"SELECT * FROM VALUES(1, 100),(2, 200),(3, 300) AS t(id, scope)")).persist()
+        val e = intercept[AccessControlException] {
+          doAs(someone, df.write.mode("overwrite").saveAsTable(table1))
+        }
+        assert(e.getMessage.contains(s"does not have [create] privilege on [$defaultDb/$table1]"))
+      }
+    }
+  }
 }


### PR DESCRIPTION
### _Why are the changes needed?_
To fix #5492 
When we use saveAsTable and write as a DataSource table, since CreateTableAsDataSource command's catalogTable was directly constructed by identifier and only will check when executing, so here authz will miss db information as below case
![image](https://github.com/apache/kyuubi/assets/46485123/f6135598-489a-47db-89eb-0dba3843b90d)

This fixes this issue by following the Spark's code
<img width="1256" alt="截屏2023-10-21 下午3 37 37" src="https://github.com/apache/kyuubi/assets/46485123/d7c66db4-400b-4637-b75a-973a8a8a9968">



### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
No
