### PR TITLE
[AuthZ] Simplify debug message for missing field/method in ReflectUtils

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/test/resources/log4j2-test.xml
+++ b/extensions/spark/kyuubi-spark-authz/src/test/resources/log4j2-test.xml
@@ -35,7 +35,7 @@
         </File>
     </Appenders>
     <Loggers>
-        <Root level="INFO">
+        <Root level="DEBUG">
             <AppenderRef ref="stdout"/>
             <AppenderRef ref="file"/>
         </Root>

--- a/kyuubi-util-scala/src/main/scala/org/apache/kyuubi/util/reflect/ReflectUtils.scala
+++ b/kyuubi-util-scala/src/main/scala/org/apache/kyuubi/util/reflect/ReflectUtils.scala
@@ -60,11 +60,7 @@ object ReflectUtils {
       }
     } catch {
       case e: Exception =>
-        val candidates =
-          (clz.getDeclaredFields ++ clz.getFields).map(_.getName).distinct.sorted
-        throw new RuntimeException(
-          s"Field $fieldName not in $clz [${candidates.mkString(",")}]",
-          e)
+        throw new RuntimeException(s"$clz does not have $fieldName field", e)
     }
   }
 
@@ -92,15 +88,8 @@ object ReflectUtils {
       }
     } catch {
       case e: Exception =>
-        val candidates =
-          (clz.getDeclaredMethods ++ clz.getMethods)
-            .map(m => s"${m.getName}(${m.getParameterTypes.map(_.getName).mkString(", ")})")
-            .distinct.sorted
-        val argClassesNames = argClasses.map(_.getName)
         throw new RuntimeException(
-          s"Method $methodName(${argClassesNames.mkString(", ")})" +
-            s" not found in $clz [${candidates.mkString(", ")}]",
-          e)
+          s"$clz does not have $methodName method or incorrect arguments", e)
     }
   }
 

--- a/kyuubi-util-scala/src/main/scala/org/apache/kyuubi/util/reflect/ReflectUtils.scala
+++ b/kyuubi-util-scala/src/main/scala/org/apache/kyuubi/util/reflect/ReflectUtils.scala
@@ -89,7 +89,7 @@ object ReflectUtils {
     } catch {
       case e: Exception =>
         throw new RuntimeException(
-          s"$clz does not have $methodName method or incorrect arguments",
+          s"$clz does not have $methodName${argClasses.map(_.getName).mkString("(", ", ", ")")}",
           e)
     }
   }

--- a/kyuubi-util-scala/src/main/scala/org/apache/kyuubi/util/reflect/ReflectUtils.scala
+++ b/kyuubi-util-scala/src/main/scala/org/apache/kyuubi/util/reflect/ReflectUtils.scala
@@ -89,7 +89,8 @@ object ReflectUtils {
     } catch {
       case e: Exception =>
         throw new RuntimeException(
-          s"$clz does not have $methodName method or incorrect arguments", e)
+          s"$clz does not have $methodName method or incorrect arguments",
+          e)
     }
   }
 

--- a/kyuubi-util-scala/src/test/scala/org/apache/kyuubi/util/reflect/ReflectUtilsSuite.scala
+++ b/kyuubi-util-scala/src/test/scala/org/apache/kyuubi/util/reflect/ReflectUtilsSuite.scala
@@ -75,8 +75,8 @@ class ReflectUtilsSuite extends AnyFunSuite {
         "methodNotExists",
         (classOf[String], "arg1"),
         (classOf[String], "arg2"))
-    }("class org.apache.kyuubi.util.reflect.ObjectA$ does not have methodNotExists method or" +
-      " incorrect arguments")
+    }("class org.apache.kyuubi.util.reflect.ObjectA$ does not have methodNotExists(" +
+      "java.lang.String, java.lang.String)")
   }
 }
 

--- a/kyuubi-util-scala/src/test/scala/org/apache/kyuubi/util/reflect/ReflectUtilsSuite.scala
+++ b/kyuubi-util-scala/src/test/scala/org/apache/kyuubi/util/reflect/ReflectUtilsSuite.scala
@@ -69,13 +69,13 @@ class ReflectUtilsSuite extends AnyFunSuite {
   }
 
   test("test invokeAs method not found exception") {
-    interceptEquals[RuntimeException] {
+    interceptEquals[NoSuchMethodException] {
       invokeAs[String](
         ObjectA,
         "methodNotExists",
         (classOf[String], "arg1"),
         (classOf[String], "arg2"))
-    }("org.apache.kyuubi.util.reflect.ObjectA$ does not have methodNotExists method or" +
+    }("class org.apache.kyuubi.util.reflect.ObjectA$ does not have methodNotExists method or" +
       " incorrect arguments")
   }
 }

--- a/kyuubi-util-scala/src/test/scala/org/apache/kyuubi/util/reflect/ReflectUtilsSuite.scala
+++ b/kyuubi-util-scala/src/test/scala/org/apache/kyuubi/util/reflect/ReflectUtilsSuite.scala
@@ -75,10 +75,8 @@ class ReflectUtilsSuite extends AnyFunSuite {
         "methodNotExists",
         (classOf[String], "arg1"),
         (classOf[String], "arg2"))
-    }("Method methodNotExists(java.lang.String, java.lang.String) not found " +
-      "in class org.apache.kyuubi.util.reflect.ObjectA$ " +
-      "[equals(java.lang.Object), field5(), field6(), getClass(), hashCode(), method5(), " +
-      "method6(), notify(), notifyAll(), toString(), wait(), wait(long), wait(long, int)]")
+    }("org.apache.kyuubi.util.reflect.ObjectA$ does not have methodNotExists method or" +
+      " incorrect arguments")
   }
 }
 

--- a/kyuubi-util-scala/src/test/scala/org/apache/kyuubi/util/reflect/ReflectUtilsSuite.scala
+++ b/kyuubi-util-scala/src/test/scala/org/apache/kyuubi/util/reflect/ReflectUtilsSuite.scala
@@ -69,7 +69,7 @@ class ReflectUtilsSuite extends AnyFunSuite {
   }
 
   test("test invokeAs method not found exception") {
-    interceptEquals[NoSuchMethodException] {
+    interceptEquals[RuntimeException] {
       invokeAs[String](
         ObjectA,
         "methodNotExists",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

It's easy for developers to check a member or method from a Java class using a code viewer or online Java doc.

The current debug msg is kinda noisy for them to locate the key information they want, which is 
Java class and field name. It makes our debug log unreadable.




### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
