### PR TITLE
[AUTHZ][MINOR] Reuse loaded table extractor in Hudi table extractors

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/serde/tableExtractors.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/serde/tableExtractors.scala
@@ -246,10 +246,10 @@ class HudiDataSourceV2RelationTableExtractor extends TableExtractor {
     invokeAs[LogicalPlan](v1, "table") match {
       // Match multipartIdentifier with tableAlias
       case SubqueryAlias(_, SubqueryAlias(identifier, _)) =>
-        new StringTableExtractor().apply(spark, identifier.toString())
+        lookupExtractor[StringTableExtractor].apply(spark, identifier.toString())
       // Match multipartIdentifier without tableAlias
       case SubqueryAlias(identifier, _) =>
-        new StringTableExtractor().apply(spark, identifier.toString())
+        lookupExtractor[StringTableExtractor].apply(spark, identifier.toString())
     }
   }
 }
@@ -259,10 +259,10 @@ class HudiMergeIntoTargetTableExtractor extends TableExtractor {
     invokeAs[LogicalPlan](v1, "targetTable") match {
       // Match multipartIdentifier with tableAlias
       case SubqueryAlias(_, SubqueryAlias(identifier, relation)) =>
-        new StringTableExtractor().apply(spark, identifier.toString())
+        lookupExtractor[StringTableExtractor].apply(spark, identifier.toString())
       // Match multipartIdentifier without tableAlias
       case SubqueryAlias(identifier, _) =>
-        new StringTableExtractor().apply(spark, identifier.toString())
+        lookupExtractor[StringTableExtractor].apply(spark, identifier.toString())
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- Reuse loaded table extractor by using `lookupExtractor` in Hudi table extractors

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.