### PR TITLE
[AUTHZ] Generalize command specs and check duplicated class names of command spec

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/serde/CommandSpec.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/serde/CommandSpec.scala
@@ -43,6 +43,10 @@ trait CommandSpec extends {
   final def operationType: OperationType = OperationType.withName(opType)
 }
 
+trait CommandSpecs[T <: CommandSpec] {
+  def specs: Seq[T]
+}
+
 /**
  * A specification describe a database command
  *

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/DatabaseCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/DatabaseCommands.scala
@@ -20,7 +20,7 @@ package org.apache.kyuubi.plugin.spark.authz.gen
 import org.apache.kyuubi.plugin.spark.authz.OperationType._
 import org.apache.kyuubi.plugin.spark.authz.serde._
 
-object DatabaseCommands {
+object DatabaseCommands extends CommandSpecs[DatabaseCommandSpec] {
 
   val AlterDatabaseProperties = {
     DatabaseCommandSpec(
@@ -141,7 +141,7 @@ object DatabaseCommands {
     DatabaseCommandSpec(cmd, Seq(databaseDesc), DESCDATABASE)
   }
 
-  val data: Array[DatabaseCommandSpec] = Array(
+  override def specs: Seq[DatabaseCommandSpec] = Seq(
     AlterDatabaseProperties,
     AlterDatabaseProperties.copy(
       classname = "org.apache.spark.sql.execution.command.AlterDatabaseSetLocationCommand",

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/FunctionCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/FunctionCommands.scala
@@ -21,7 +21,7 @@ import org.apache.kyuubi.plugin.spark.authz.OperationType._
 import org.apache.kyuubi.plugin.spark.authz.serde._
 import org.apache.kyuubi.plugin.spark.authz.serde.FunctionType.{SYSTEM, TEMP}
 
-object FunctionCommands {
+object FunctionCommands extends CommandSpecs[FunctionCommandSpec] {
 
   val CreateFunction = {
     val cmd = "org.apache.spark.sql.execution.command.CreateFunctionCommand"
@@ -83,9 +83,9 @@ object FunctionCommands {
     FunctionCommandSpec(cmd, Seq(functionDesc), RELOADFUNCTION)
   }
 
-  val data: Array[FunctionCommandSpec] = Array(
+  override def specs: Seq[FunctionCommandSpec] = Seq(
     CreateFunction,
     DropFunction,
     DescribeFunction,
-    RefreshFunction).sortBy(_.classname)
+    RefreshFunction)
 }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/HudiCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/HudiCommands.scala
@@ -22,7 +22,7 @@ import org.apache.kyuubi.plugin.spark.authz.PrivilegeObjectActionType._
 import org.apache.kyuubi.plugin.spark.authz.serde._
 import org.apache.kyuubi.plugin.spark.authz.serde.TableType._
 
-object HudiCommands {
+object HudiCommands extends CommandSpecs[TableCommandSpec] {
   val AlterHoodieTableAddColumnsCommand = {
     val cmd = "org.apache.spark.sql.hudi.command.AlterHoodieTableAddColumnsCommand"
     val columnDesc = ColumnDesc("colsToAdd", classOf[StructFieldSeqColumnExtractor])
@@ -242,7 +242,7 @@ object HudiCommands {
           setCurrentDatabaseIfMissing = true)))
   }
 
-  val data: Array[TableCommandSpec] = Array(
+  override def specs: Seq[TableCommandSpec] = Seq(
     AlterHoodieTableAddColumnsCommand,
     AlterHoodieTableChangeColumnCommand,
     AlterHoodieTableDropPartitionCommand,

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/IcebergCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/IcebergCommands.scala
@@ -21,7 +21,7 @@ import org.apache.kyuubi.plugin.spark.authz.OperationType
 import org.apache.kyuubi.plugin.spark.authz.PrivilegeObjectActionType._
 import org.apache.kyuubi.plugin.spark.authz.serde._
 
-object IcebergCommands {
+object IcebergCommands extends CommandSpecs[TableCommandSpec] {
 
   val DeleteFromIcebergTable = {
     val cmd = "org.apache.spark.sql.catalyst.plans.logical.DeleteFromIcebergTable"
@@ -56,7 +56,7 @@ object IcebergCommands {
     TableCommandSpec(cmd, Seq(td), opType = OperationType.ALTERTABLE_PROPERTIES)
   }
 
-  val data: Array[TableCommandSpec] = Array(
+  override def specs: Seq[TableCommandSpec] = Seq(
     CallProcedure,
     DeleteFromIcebergTable,
     UpdateIcebergTable,

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/JsonSpecFileGenerator.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/JsonSpecFileGenerator.scala
@@ -24,6 +24,7 @@ import java.nio.file.{Files, Paths, StandardOpenOption}
 import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.kyuubi.plugin.spark.authz.serde.{mapper, CommandSpec}
+import org.apache.kyuubi.plugin.spark.authz.serde.CommandSpecs
 import org.apache.kyuubi.util.AssertionUtils._
 
 /**
@@ -42,26 +43,30 @@ import org.apache.kyuubi.util.AssertionUtils._
 class JsonSpecFileGenerator extends AnyFunSuite {
   // scalastyle:on
   test("check spec json files") {
-    writeCommandSpecJson("database", Seq(DatabaseCommands.data))
-    writeCommandSpecJson("table", Seq(TableCommands.data, IcebergCommands.data, HudiCommands.data))
-    writeCommandSpecJson("function", Seq(FunctionCommands.data))
-    writeCommandSpecJson("scan", Seq(Scans.data))
+    writeCommandSpecJson("database", Seq(DatabaseCommands))
+    writeCommandSpecJson("table", Seq(TableCommands, IcebergCommands, HudiCommands))
+    writeCommandSpecJson("function", Seq(FunctionCommands))
+    writeCommandSpecJson("scan", Seq(Scans))
   }
 
   def writeCommandSpecJson[T <: CommandSpec](
       commandType: String,
-      specArr: Seq[Array[T]]): Unit = {
+      specArr: Seq[CommandSpecs[T]]): Unit = {
     val pluginHome = getClass.getProtectionDomain.getCodeSource.getLocation.getPath
       .split("target").head
     val filename = s"${commandType}_command_spec.json"
     val filePath = Paths.get(pluginHome, "src", "main", "resources", filename)
 
-    val generatedStr = mapper.writerWithDefaultPrettyPrinter()
-      .writeValueAsString(specArr.flatMap(_.sortBy(_.classname)))
+    val allSpecs = specArr.flatMap(_.specs.sortBy(_.classname))
+    val duplicatedClassnames = allSpecs.groupBy(_.classname).values
+      .filter(_.size > 1).flatMap(specs => specs.map(_.classname)).toSet
+    withClue(s"Unexpected duplicated classnames: $duplicatedClassnames")(
+      assertResult(0)(duplicatedClassnames.size))
+    val generatedStr = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(allSpecs)
 
     if (sys.env.get("KYUUBI_UPDATE").contains("1")) {
       // scalastyle:off println
-      println(s"writing ${specArr.length} specs to $filename")
+      println(s"writing ${allSpecs.length} specs to $filename")
       // scalastyle:on println
       Files.write(
         filePath,

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/JsonSpecFileGenerator.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/JsonSpecFileGenerator.scala
@@ -51,13 +51,13 @@ class JsonSpecFileGenerator extends AnyFunSuite {
 
   def writeCommandSpecJson[T <: CommandSpec](
       commandType: String,
-      specArr: Seq[CommandSpecs[T]]): Unit = {
+      specsArr: Seq[CommandSpecs[T]]): Unit = {
     val pluginHome = getClass.getProtectionDomain.getCodeSource.getLocation.getPath
       .split("target").head
     val filename = s"${commandType}_command_spec.json"
     val filePath = Paths.get(pluginHome, "src", "main", "resources", filename)
 
-    val allSpecs = specArr.flatMap(_.specs.sortBy(_.classname))
+    val allSpecs = specsArr.flatMap(_.specs.sortBy(_.classname))
     val duplicatedClassnames = allSpecs.groupBy(_.classname).values
       .filter(_.size > 1).flatMap(specs => specs.map(_.classname)).toSet
     withClue(s"Unexpected duplicated classnames: $duplicatedClassnames")(

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/Scans.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/Scans.scala
@@ -20,7 +20,7 @@ package org.apache.kyuubi.plugin.spark.authz.gen
 import org.apache.kyuubi.plugin.spark.authz.serde._
 import org.apache.kyuubi.plugin.spark.authz.serde.FunctionType._
 
-object Scans {
+object Scans extends CommandSpecs[ScanSpec] {
 
   val HiveTableRelation = {
     val r = "org.apache.spark.sql.catalyst.catalog.HiveTableRelation"
@@ -79,7 +79,7 @@ object Scans {
 
   val HiveGenericUDTF = HiveSimpleUDF.copy(classname = "org.apache.spark.sql.hive.HiveGenericUDTF")
 
-  val data: Array[ScanSpec] = Array(
+  override def specs: Seq[ScanSpec] = Seq(
     HiveTableRelation,
     LogicalRelation,
     DataSourceV2Relation,

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/TableCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/TableCommands.scala
@@ -22,7 +22,7 @@ import org.apache.kyuubi.plugin.spark.authz.PrivilegeObjectActionType._
 import org.apache.kyuubi.plugin.spark.authz.serde._
 import org.apache.kyuubi.plugin.spark.authz.serde.TableType._
 
-object TableCommands {
+object TableCommands extends CommandSpecs[TableCommandSpec] {
   // table extractors
   val tite = classOf[TableIdentifierTableExtractor]
   val tableNameDesc = TableDesc("tableName", tite)
@@ -594,7 +594,7 @@ object TableCommands {
     TableCommandSpec(cmd, Seq(tableIdentDesc.copy(isInput = true)))
   }
 
-  val data: Array[TableCommandSpec] = Array(
+  override def specs: Seq[TableCommandSpec] = Seq(
     AddPartitions,
     DropPartitions,
     RenamePartitions,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- Generalizing command specs for the commands of tables (including lakehouse tables), functions, db, scans
- Checking duplicated class names of command spes, to prevent breaking the serde design
- Fix the output message for spec count written to file

Error message when there are duplicated class names in command specs:
<img width="651" alt="image" src="https://github.com/apache/kyuubi/assets/1935105/315aed81-066e-4cfb-a110-89504e0eac0f">


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.