### PR TITLE
[KYUUBI #5556][AUTHZ] Support Alter table commands of set table properties

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/resources/table_command_spec.json
+++ b/extensions/spark/kyuubi-spark-authz/src/main/resources/table_command_spec.json
@@ -533,6 +533,21 @@
   } ],
   "uriDescs" : [ ]
 }, {
+  "classname" : "org.apache.spark.sql.catalyst.plans.logical.SetTableProperties",
+  "tableDescs" : [ {
+    "fieldName" : "table",
+    "fieldExtractor" : "ResolvedTableTableExtractor",
+    "columnDesc" : null,
+    "actionTypeDesc" : null,
+    "tableTypeDesc" : null,
+    "catalogDesc" : null,
+    "isInput" : false,
+    "setCurrentDatabaseIfMissing" : false
+  } ],
+  "opType" : "ALTERTABLE_PROPERTIES",
+  "queryDescs" : [ ],
+  "uriDescs" : [ ]
+}, {
   "classname" : "org.apache.spark.sql.catalyst.plans.logical.ShowCreateTable",
   "tableDescs" : [ {
     "fieldName" : "child",

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/TableCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/TableCommands.scala
@@ -594,6 +594,12 @@ object TableCommands extends CommandSpecs[TableCommandSpec] {
     TableCommandSpec(cmd, Seq(tableIdentDesc.copy(isInput = true)))
   }
 
+  val SetTableProperties = {
+    val cmd = "org.apache.spark.sql.catalyst.plans.logical.SetTableProperties"
+    val tableDesc = TableDesc("table", classOf[ResolvedTableTableExtractor])
+    TableCommandSpec(cmd, Seq(tableDesc), ALTERTABLE_PROPERTIES)
+  }
+
   override def specs: Seq[TableCommandSpec] = Seq(
     AddPartitions,
     DropPartitions,
@@ -668,6 +674,7 @@ object TableCommands extends CommandSpecs[TableCommandSpec] {
     RefreshTableV2,
     RefreshTable3d0,
     ReplaceData,
+    SetTableProperties,
     ShowColumns,
     ShowCreateTable,
     ShowCreateTable.copy(classname =

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/DeltaCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/DeltaCatalogRangerSparkExtensionSuite.scala
@@ -178,6 +178,14 @@ class DeltaCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
       interceptContains[AccessControlException](
         doAs(someone, sql(s"ALTER TABLE $namespace1.$table1 DROP COLUMN birthDate")))(
         s"does not have [alter] privilege on [$namespace1/$table1]")
+
+      // set properties
+      interceptContains[AccessControlException](
+        doAs(
+          someone,
+          sql(s"ALTER TABLE $namespace1.$table1" +
+            s" SET TBLPROPERTIES ('delta.appendOnly' = 'true')")))(
+        s"does not have [alter] privilege on [$namespace1/$table1]")
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
To close #5556.
Support Alter table commands of set table properties for Delta Lake in Authz.
https://docs.delta.io/latest/delta-batch.html#table-properties


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
No.
