### PR TITLE
[KYUUBI #5565][AUTHZ] Support Delete/Insert/Update table command for Delta Lake

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/resources/META-INF/services/org.apache.kyuubi.plugin.spark.authz.serde.TableExtractor
+++ b/extensions/spark/kyuubi-spark-authz/src/main/resources/META-INF/services/org.apache.kyuubi.plugin.spark.authz.serde.TableExtractor
@@ -29,5 +29,6 @@ org.apache.kyuubi.plugin.spark.authz.serde.ResolvedDbObjectNameTableExtractor
 org.apache.kyuubi.plugin.spark.authz.serde.ResolvedIdentifierTableExtractor
 org.apache.kyuubi.plugin.spark.authz.serde.ResolvedTableTableExtractor
 org.apache.kyuubi.plugin.spark.authz.serde.StringTableExtractor
+org.apache.kyuubi.plugin.spark.authz.serde.SubqueryAliasTableExtractor
 org.apache.kyuubi.plugin.spark.authz.serde.TableIdentifierTableExtractor
 org.apache.kyuubi.plugin.spark.authz.serde.TableTableExtractor

--- a/extensions/spark/kyuubi-spark-authz/src/main/resources/table_command_spec.json
+++ b/extensions/spark/kyuubi-spark-authz/src/main/resources/table_command_spec.json
@@ -1969,18 +1969,67 @@
   "queryDescs" : [ ],
   "uriDescs" : [ ]
 }, {
-  "classname" : "org.apache.spark.sql.delta.commands.CreateDeltaTableCommand",
+  "classname" : "org.apache.spark.sql.delta.commands.DeleteCommand",
   "tableDescs" : [ {
-    "fieldName" : "table",
-    "fieldExtractor" : "CatalogTableTableExtractor",
+    "fieldName" : "catalogTable",
+    "fieldExtractor" : "CatalogTableOptionTableExtractor",
     "columnDesc" : null,
-    "actionTypeDesc" : null,
+    "actionTypeDesc" : {
+      "fieldName" : null,
+      "fieldExtractor" : null,
+      "actionType" : "UPDATE"
+    },
+    "tableTypeDesc" : null,
+    "catalogDesc" : null,
+    "isInput" : false,
+    "setCurrentDatabaseIfMissing" : false
+  }, {
+    "fieldName" : "target",
+    "fieldExtractor" : "SubqueryAliasTableExtractor",
+    "columnDesc" : null,
+    "actionTypeDesc" : {
+      "fieldName" : null,
+      "fieldExtractor" : null,
+      "actionType" : "UPDATE"
+    },
     "tableTypeDesc" : null,
     "catalogDesc" : null,
     "isInput" : false,
     "setCurrentDatabaseIfMissing" : false
   } ],
-  "opType" : "CREATETABLE",
+  "opType" : "QUERY",
+  "queryDescs" : [ ],
+  "uriDescs" : [ ]
+}, {
+  "classname" : "org.apache.spark.sql.delta.commands.UpdateCommand",
+  "tableDescs" : [ {
+    "fieldName" : "catalogTable",
+    "fieldExtractor" : "CatalogTableOptionTableExtractor",
+    "columnDesc" : null,
+    "actionTypeDesc" : {
+      "fieldName" : null,
+      "fieldExtractor" : null,
+      "actionType" : "UPDATE"
+    },
+    "tableTypeDesc" : null,
+    "catalogDesc" : null,
+    "isInput" : false,
+    "setCurrentDatabaseIfMissing" : false
+  }, {
+    "fieldName" : "target",
+    "fieldExtractor" : "SubqueryAliasTableExtractor",
+    "columnDesc" : null,
+    "actionTypeDesc" : {
+      "fieldName" : null,
+      "fieldExtractor" : null,
+      "actionType" : "UPDATE"
+    },
+    "tableTypeDesc" : null,
+    "catalogDesc" : null,
+    "isInput" : false,
+    "setCurrentDatabaseIfMissing" : false
+  } ],
+  "opType" : "QUERY",
   "queryDescs" : [ ],
   "uriDescs" : [ ]
 } ]

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/serde/tableExtractors.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/serde/tableExtractors.scala
@@ -27,6 +27,7 @@ import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, SubqueryAlias}
+import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.types.DataType
 import org.apache.spark.unsafe.types.UTF8String
 
@@ -241,6 +242,19 @@ class TableTableExtractor extends TableExtractor {
   override def apply(spark: SparkSession, v1: AnyRef): Option[Table] = {
     val tableName = invokeAs[String](v1, "name")
     lookupExtractor[StringTableExtractor].apply(spark, tableName)
+  }
+}
+
+/**
+ * org.apache.spark.sql.catalyst.plans.logical.SubqueryAlias
+ */
+class SubqueryAliasTableExtractor extends TableExtractor {
+  override def apply(spark: SparkSession, v1: AnyRef): Option[Table] = {
+    invokeAs[AnyRef](v1, "child") match {
+      case lr: LogicalRelation =>
+        lookupExtractor[LogicalRelationTableExtractor].apply(spark, lr)
+      case _ => None
+    }
   }
 }
 

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/DeltaCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/DeltaCommands.scala
@@ -17,17 +17,32 @@
 
 package org.apache.kyuubi.plugin.spark.authz.gen
 
-import org.apache.kyuubi.plugin.spark.authz.OperationType._
+import org.apache.kyuubi.plugin.spark.authz.PrivilegeObjectActionType._
 import org.apache.kyuubi.plugin.spark.authz.serde._
 
 object DeltaCommands extends CommandSpecs[TableCommandSpec] {
 
-  val CreateDeltaTableCommand = {
-    val cmd = "org.apache.spark.sql.delta.commands.CreateDeltaTableCommand"
-    val tableDesc = TableDesc("table", classOf[CatalogTableTableExtractor])
-    TableCommandSpec(cmd, Seq(tableDesc), CREATETABLE)
+  val DeleteCommand = {
+    val cmd = "org.apache.spark.sql.delta.commands.DeleteCommand"
+    val actionTypeDesc = ActionTypeDesc(actionType = Some(UPDATE))
+    val tableDesc = TableDesc(
+      "catalogTable",
+      classOf[CatalogTableOptionTableExtractor],
+      actionTypeDesc = Some(actionTypeDesc))
+    TableCommandSpec(cmd, Seq(tableDesc))
+    val targetDesc = TableDesc(
+      "target",
+      classOf[SubqueryAliasTableExtractor],
+      actionTypeDesc = Some(actionTypeDesc))
+    TableCommandSpec(cmd, Seq(tableDesc, targetDesc))
+  }
+
+  val UpdateCommand = {
+    val cmd = "org.apache.spark.sql.delta.commands.UpdateCommand"
+    DeleteCommand.copy(classname = cmd)
   }
 
   override def specs: Seq[TableCommandSpec] = Seq(
-    CreateDeltaTableCommand)
+    DeleteCommand,
+    UpdateCommand)
 }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/DeltaCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/DeltaCatalogRangerSparkExtensionSuite.scala
@@ -38,6 +38,18 @@ class DeltaCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
   val table1 = "table1_delta"
   val table2 = "table2_delta"
 
+  def createTableSql(namespace: String, table: String): String =
+    s"""
+       |CREATE TABLE IF NOT EXISTS $namespace.$table (
+       |  id INT,
+       |  name STRING,
+       |  gender STRING,
+       |  birthDate TIMESTAMP
+       |)
+       |USING DELTA
+       |PARTITIONED BY (gender)
+       |""".stripMargin
+
   override def withFixture(test: NoArgTest): Outcome = {
     test()
   }
@@ -66,13 +78,9 @@ class DeltaCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
         s"""
            |CREATE TABLE IF NOT EXISTS $namespace1.$table1 (
            |  id INT,
-           |  firstName STRING,
-           |  middleName STRING,
-           |  lastName STRING,
+           |  name STRING,
            |  gender STRING,
-           |  birthDate TIMESTAMP,
-           |  ssn STRING,
-           |  salary INT
+           |  birthDate TIMESTAMP
            |) USING DELTA
            |""".stripMargin
       interceptContains[AccessControlException] {
@@ -80,21 +88,7 @@ class DeltaCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
       }(s"does not have [create] privilege on [$namespace1/$table1]")
       doAs(admin, createNonPartitionTableSql)
 
-      val createPartitionTableSql =
-        s"""
-           |CREATE TABLE IF NOT EXISTS $namespace1.$table2 (
-           |  id INT,
-           |  firstName STRING,
-           |  middleName STRING,
-           |  lastName STRING,
-           |  gender STRING,
-           |  birthDate TIMESTAMP,
-           |  ssn STRING,
-           |  salary INT
-           |)
-           |USING DELTA
-           |PARTITIONED BY (gender)
-           |""".stripMargin
+      val createPartitionTableSql = createTableSql(namespace1, table2)
       interceptContains[AccessControlException] {
         doAs(someone, sql(createPartitionTableSql))
       }(s"does not have [create] privilege on [$namespace1/$table2]")
@@ -108,13 +102,9 @@ class DeltaCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
         s"""
            |CREATE OR REPLACE TABLE $namespace1.$table1 (
            |  id INT,
-           |  firstName STRING,
-           |  middleName STRING,
-           |  lastName STRING,
+           |  name STRING,
            |  gender STRING,
-           |  birthDate TIMESTAMP,
-           |  ssn STRING,
-           |  salary INT
+           |  birthDate TIMESTAMP
            |) USING DELTA
            |""".stripMargin
       interceptContains[AccessControlException] {
@@ -127,23 +117,7 @@ class DeltaCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
   test("alter table") {
     withCleanTmpResources(Seq((s"$namespace1.$table1", "table"), (s"$namespace1", "database"))) {
       doAs(admin, sql(s"CREATE DATABASE IF NOT EXISTS $namespace1"))
-      doAs(
-        admin,
-        sql(
-          s"""
-             |CREATE TABLE IF NOT EXISTS $namespace1.$table1 (
-             |  id INT,
-             |  firstName STRING,
-             |  middleName STRING,
-             |  lastName STRING,
-             |  gender STRING,
-             |  birthDate TIMESTAMP,
-             |  ssn STRING,
-             |  salary INT
-             |)
-             |USING DELTA
-             |PARTITIONED BY (gender)
-             |""".stripMargin))
+      doAs(admin, sql(createTableSql(namespace1, table1)))
 
       // add columns
       interceptContains[AccessControlException](
@@ -163,7 +137,7 @@ class DeltaCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
         doAs(
           someone,
           sql(s"ALTER TABLE $namespace1.$table1" +
-            s" REPLACE COLUMNS (id INT, firstName STRING)")))(
+            s" REPLACE COLUMNS (id INT, name STRING)")))(
         s"does not have [alter] privilege on [$namespace1/$table1]")
 
       // rename column
@@ -186,6 +160,62 @@ class DeltaCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
           sql(s"ALTER TABLE $namespace1.$table1" +
             s" SET TBLPROPERTIES ('delta.appendOnly' = 'true')")))(
         s"does not have [alter] privilege on [$namespace1/$table1]")
+    }
+  }
+
+  test("delete from table") {
+    withCleanTmpResources(Seq((s"$namespace1.$table1", "table"), (s"$namespace1", "database"))) {
+      doAs(admin, sql(s"CREATE DATABASE IF NOT EXISTS $namespace1"))
+      doAs(admin, sql(createTableSql(namespace1, table1)))
+      interceptContains[AccessControlException](
+        doAs(someone, sql(s"DELETE FROM $namespace1.$table1 WHERE birthDate < '1955-01-01'")))(
+        s"does not have [update] privilege on [$namespace1/$table1]")
+    }
+  }
+
+  test("insert table") {
+    withSingleCallEnabled {
+      withCleanTmpResources(Seq(
+        (s"$namespace1.$table1", "table"),
+        (s"$namespace1.$table2", "table"),
+        (s"$namespace1", "database"))) {
+        doAs(admin, sql(s"CREATE DATABASE IF NOT EXISTS $namespace1"))
+        doAs(admin, sql(createTableSql(namespace1, table1)))
+        doAs(admin, sql(createTableSql(namespace1, table2)))
+
+        // insert into
+        interceptContains[AccessControlException](
+          doAs(
+            someone,
+            sql(s"INSERT INTO $namespace1.$table1" +
+              s" SELECT * FROM $namespace1.$table2")))(
+          s"does not have [select] privilege on [$namespace1/$table2/id,$namespace1/$table2/name," +
+            s"$namespace1/$table2/gender,$namespace1/$table2/birthDate]," +
+            s" [update] privilege on [$namespace1/$table1]")
+
+        // insert overwrite
+        interceptContains[AccessControlException](
+          doAs(
+            someone,
+            sql(s"INSERT INTO $namespace1.$table1" +
+              s" SELECT * FROM $namespace1.$table2")))(
+          s"does not have [select] privilege on [$namespace1/$table2/id,$namespace1/$table2/name," +
+            s"$namespace1/$table2/gender,$namespace1/$table2/birthDate]," +
+            s" [update] privilege on [$namespace1/$table1]")
+      }
+    }
+  }
+
+  test("update table") {
+    withCleanTmpResources(Seq((s"$namespace1.$table1", "table"), (s"$namespace1", "database"))) {
+      doAs(admin, sql(s"CREATE DATABASE IF NOT EXISTS $namespace1"))
+      doAs(admin, sql(createTableSql(namespace1, table1)))
+      interceptContains[AccessControlException](
+        doAs(
+          someone,
+          sql(s"UPDATE $namespace1.$table1" +
+            s" SET gender = 'Female' WHERE gender = 'F'")))(
+        s"does not have [update] privilege on [$namespace1/$table1]")
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
To close #5565.
- Support Delete from table command for Delta Lake in Authz.
- Support Insert table command for Delta Lake in Authz.
- Support Update table command for Delta Lake in Authz.
- Remove useless `org.apache.spark.sql.delta.commands.CreateDeltaTableCommand`. Because the logical plans for Delta Lake create table and replace table are `org.apache.spark.sql.catalyst.plans.logical.CreateTable`, `org.apache.spark.sql.catalyst.plans.logical.CreateV2Table` and `org. apache.spark.sql.catalyst.plans.logical.ReplaceTable`.
- Reduce the fields of `createTableSql`.


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
No.
