### PR TITLE
[AUTHZ] Add PaimonDataSourceV2RelationTableExtractor to fix paimon select cannot get database's problem 

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/resources/META-INF/services/org.apache.kyuubi.plugin.spark.authz.serde.TableExtractor
+++ b/extensions/spark/kyuubi-spark-authz/src/main/resources/META-INF/services/org.apache.kyuubi.plugin.spark.authz.serde.TableExtractor
@@ -18,7 +18,6 @@
 org.apache.kyuubi.plugin.spark.authz.serde.CatalogTableOptionTableExtractor
 org.apache.kyuubi.plugin.spark.authz.serde.CatalogTableTableExtractor
 org.apache.kyuubi.plugin.spark.authz.serde.DataSourceV2RelationTableExtractor
-org.apache.kyuubi.plugin.spark.authz.serde.PaimonDataSourceV2RelationTableExtractor
 org.apache.kyuubi.plugin.spark.authz.serde.ExpressionSeqTableExtractor
 org.apache.kyuubi.plugin.spark.authz.serde.HudiDataSourceV2RelationTableExtractor
 org.apache.kyuubi.plugin.spark.authz.serde.HudiMergeIntoTargetTableExtractor

--- a/extensions/spark/kyuubi-spark-authz/src/main/resources/META-INF/services/org.apache.kyuubi.plugin.spark.authz.serde.TableExtractor
+++ b/extensions/spark/kyuubi-spark-authz/src/main/resources/META-INF/services/org.apache.kyuubi.plugin.spark.authz.serde.TableExtractor
@@ -18,6 +18,7 @@
 org.apache.kyuubi.plugin.spark.authz.serde.CatalogTableOptionTableExtractor
 org.apache.kyuubi.plugin.spark.authz.serde.CatalogTableTableExtractor
 org.apache.kyuubi.plugin.spark.authz.serde.DataSourceV2RelationTableExtractor
+org.apache.kyuubi.plugin.spark.authz.serde.PaimonDataSourceV2RelationTableExtractor
 org.apache.kyuubi.plugin.spark.authz.serde.ExpressionSeqTableExtractor
 org.apache.kyuubi.plugin.spark.authz.serde.HudiDataSourceV2RelationTableExtractor
 org.apache.kyuubi.plugin.spark.authz.serde.HudiMergeIntoTargetTableExtractor

--- a/extensions/spark/kyuubi-spark-authz/src/main/resources/scan_command_spec.json
+++ b/extensions/spark/kyuubi-spark-authz/src/main/resources/scan_command_spec.json
@@ -28,6 +28,10 @@
     "fieldName" : null,
     "fieldExtractor" : "DataSourceV2RelationTableExtractor",
     "catalogDesc" : null
+  }, {
+    "fieldName" : null,
+    "fieldExtractor" : "PaimonDataSourceV2RelationTableExtractor",
+    "catalogDesc" : null
   } ],
   "functionDescs" : [ ]
 }, {

--- a/extensions/spark/kyuubi-spark-authz/src/main/resources/scan_command_spec.json
+++ b/extensions/spark/kyuubi-spark-authz/src/main/resources/scan_command_spec.json
@@ -28,10 +28,6 @@
     "fieldName" : null,
     "fieldExtractor" : "DataSourceV2RelationTableExtractor",
     "catalogDesc" : null
-  }, {
-    "fieldName" : null,
-    "fieldExtractor" : "PaimonDataSourceV2RelationTableExtractor",
-    "catalogDesc" : null
   } ],
   "functionDescs" : [ ]
 }, {

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/serde/tableExtractors.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/serde/tableExtractors.scala
@@ -191,6 +191,44 @@ class DataSourceV2RelationTableExtractor extends TableExtractor {
 }
 
 /**
+ * org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+ */
+class PaimonDataSourceV2RelationTableExtractor extends TableExtractor {
+
+  def getPaimonPath(v: AnyRef): Option[String] = {
+    val table = invokeAs[AnyRef](v, "table")
+    val properties = invokeAs[JMap[String, String]](table, "properties").asScala
+    val path = properties.get("path")
+    path match {
+      case Some(v) =>
+        val databaseLastSlash = v.substring(v.lastIndexOf("/")).lastIndexOf("/")
+        val sub = v.substring(databaseLastSlash + 1)
+        Some(sub)
+      case _ => Some("")
+    }
+  }
+
+  override def apply(spark: SparkSession, v1: AnyRef): Option[Table] = {
+    val plan = v1.asInstanceOf[LogicalPlan]
+    val maybeV2Relation = plan.find(_.getClass.getSimpleName == "DataSourceV2Relation")
+    maybeV2Relation match {
+      case None => None
+      case Some(v2Relation) =>
+        val maybeCatalogPlugin = invokeAs[Option[AnyRef]](v2Relation, "catalog")
+        val maybeCatalog = maybeCatalogPlugin.flatMap(catalogPlugin =>
+          lookupExtractor[CatalogPluginCatalogExtractor].apply(catalogPlugin))
+        lookupExtractor[TableTableExtractor].apply(spark, invokeAs[AnyRef](v2Relation, "table"))
+          .map { table =>
+            val maybeOwner = TableExtractor.getOwner(v2Relation)
+            val paimonPath = getPaimonPath(v2Relation)
+            table.copy(catalog = maybeCatalog, database = paimonPath, owner = maybeOwner)
+          }
+    }
+  }
+}
+
+
+/**
  * org.apache.spark.sql.execution.datasources.LogicalRelation
  */
 class LogicalRelationTableExtractor extends TableExtractor {

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/PaimonCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/PaimonCatalogRangerSparkExtensionSuite.scala
@@ -99,17 +99,6 @@ class PaimonCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
              |  primaryKey = 'id'
              |)
              |""".stripMargin))
-      interceptContains[AccessControlException] {
-        doAs(
-          someone,
-          sql(
-            s"""
-               |CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table2
-               |USING PAIMON
-               |AS
-               |SELECT * FROM $catalogV2.$namespace1.$table1
-               |""".stripMargin))
-      }(s"does not have [select] privilege on [$table1/id]")
       doAs(
         admin,
         sql(
@@ -120,37 +109,5 @@ class PaimonCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
              |SELECT * FROM $catalogV2.$namespace1.$table1
              |""".stripMargin))
     }
-  }
-  test("CreateTableAs1") {
-    val table2 = "table2"
-    withCleanTmpResources(Seq(
-      (s"$catalogV2.$namespace1.$table1", "table"),
-      (s"$catalogV2.$namespace1.$table2", "table"))) {
-
-      doAs(
-        admin,
-        sql(
-          s"""
-             |CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table1
-             |(id int, name string, city string)
-             |USING paimon
-             |OPTIONS (
-             |  primaryKey = 'id'
-             |)
-             |""".stripMargin))
-
-      val createTableAs =
-        s"""
-           |CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table2
-           |USING PAIMON
-           |AS
-           |SELECT * FROM $catalogV2.$namespace1.$table1
-           |""".stripMargin
-      doAs(
-        admin, {
-          val logicPlan = sql(createTableAs).queryExecution.logical
-          print(logicPlan)
-        })
     }
   }
-}

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/PaimonCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/PaimonCatalogRangerSparkExtensionSuite.scala
@@ -36,7 +36,6 @@ class PaimonCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
   val catalogV2 = "paimon_catalog"
   val namespace1 = "paimon_ns"
   val table1 = "table1"
-  val table2 = "table2"
 
   override def withFixture(test: NoArgTest): Outcome = {
     assume(isSupportedVersion)
@@ -85,7 +84,9 @@ class PaimonCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
   }
 
   test("CreateTableAs") {
-    withCleanTmpResources(Seq((s"$catalogV2.$namespace1.$table1", "table"),
+    val table2 = "table2"
+    withCleanTmpResources(Seq(
+      (s"$catalogV2.$namespace1.$table1", "table"),
       (s"$catalogV2.$namespace1.$table2", "table"))) {
       doAs(
         admin,
@@ -97,9 +98,7 @@ class PaimonCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
              |OPTIONS (
              |  primaryKey = 'id'
              |)
-             |""".stripMargin
-        )
-      )
+             |""".stripMargin))
       interceptContains[AccessControlException] {
         doAs(
           someone,
@@ -108,10 +107,8 @@ class PaimonCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
                |CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table2
                |USING PAIMON
                |AS
-               |SELECT id FROM $catalogV2.$namespace1.$table1
-               |""".stripMargin
-          )
-        )
+               |SELECT * FROM $catalogV2.$namespace1.$table1
+               |""".stripMargin))
       }(s"does not have [select] privilege on [$table1/id]")
       doAs(
         admin,
@@ -121,9 +118,39 @@ class PaimonCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
              |USING PAIMON
              |AS
              |SELECT * FROM $catalogV2.$namespace1.$table1
-             |""".stripMargin
-        )
-      )
+             |""".stripMargin))
+    }
+  }
+  test("CreateTableAs1") {
+    val table2 = "table2"
+    withCleanTmpResources(Seq(
+      (s"$catalogV2.$namespace1.$table1", "table"),
+      (s"$catalogV2.$namespace1.$table2", "table"))) {
+
+      doAs(
+        admin,
+        sql(
+          s"""
+             |CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table1
+             |(id int, name string, city string)
+             |USING paimon
+             |OPTIONS (
+             |  primaryKey = 'id'
+             |)
+             |""".stripMargin))
+
+      val createTableAs =
+        s"""
+           |CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table2
+           |USING PAIMON
+           |AS
+           |SELECT * FROM $catalogV2.$namespace1.$table1
+           |""".stripMargin
+      doAs(
+        admin, {
+          val logicPlan = sql(createTableAs).queryExecution.logical
+          print(logicPlan)
+        })
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This pr is try to fix the https://github.com/apache/kyuubi/pull/5590 's problem, but i get some problem, so need someone to help me. The problem desc:

this is the source commt https://github.com/apache/kyuubi/pull/5590
        i try to add PaimonDataSourceV2RelationTableExtractor in TableExtractor to make we can fix the question, but when i add the extractor and get table info, this is the root call extrcator code
```
case class RuleApplyRowFilter(spark: SparkSession) extends RuleHelper {
    override def apply(plan: LogicalPlan): LogicalPlan = {
        val newPlan = mapChildren(plan) {
            case p: RowFilterMarker => p
            case scan if isKnownScan(scan) && scan.resolved =>
                val tables = getScanSpec(scan).tables(scan, spark)
                tables.headOption.map(applyFilter(scan, _)).getOrElse(scan)
            case other => apply(other)
        }
        newPlan
    }

    private def applyFilter(
            plan: LogicalPlan,
            table: Table): LogicalPlan = {
        val are = AccessResource(ObjectType.TABLE, table.database.orNull, table.table, null)
        val art = AccessRequest(are, ugi, QUERY, AccessType.SELECT)
        val filterExpr = SparkRangerAdminPlugin.getFilterExpr(art).map(parse)
        val filtered = filterExpr.foldLeft(plan)((p, expr) => Filter(expr, RowFilterMarker(p)))
        filtered
    }
}
```
if we add two exector for the RelationV2 plan, we will get two tables, but the apply code only use the first table
if the tables is
```
Table(Some(paimon_catalog),None,table1,Some(admin))
Table(Some(paimon_catalog),Some(paimon_ns),table1,Some(admin))
```
the source code will only filter the first table result, is that right?


@bowenliang123 @pan3793 do you know how to solve this?


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
