### PR TITLE
[KYUUBI #5594][AUTHZ] BuildQuery should respect normal node's input

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -122,8 +122,9 @@ object PrivilegesBuilder {
         privilegeObjects += PrivilegeObject(table)
 
       case p =>
+        val newProjection = projectionList ++ p.inputSet.map(_.toAttribute)
         for (child <- p.children) {
-          buildQuery(child, privilegeObjects, projectionList, conditionList, spark)
+          buildQuery(child, privilegeObjects, newProjection, conditionList, spark)
         }
     }
   }

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -137,7 +137,8 @@ object PrivilegesBuilder {
             case _ =>
               val childCols = columnPrune(projectionList ++ conditionList, child.outputSet)
               if (childCols.isEmpty) {
-                buildQuery(child,
+                buildQuery(
+                  child,
                   privilegeObjects,
                   p.inputSet.map(_.toAttribute).toSeq,
                   conditionList,

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -305,7 +305,6 @@ object PrivilegesBuilder {
       spark: SparkSession): PrivilegesAndOpType = {
     val inputObjs = new ArrayBuffer[PrivilegeObject]
     val outputObjs = new ArrayBuffer[PrivilegeObject]
-    println(plan)
     val opType = plan match {
       // RunnableCommand
       case cmd: Command => buildCommand(cmd, inputObjs, outputObjs, spark)

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -74,18 +74,17 @@ object PrivilegesBuilder {
             privilegeObjects += PrivilegeObject(table, plan.output.map(_.name))
         }
       } else {
-        val cols = columnPrune(
-          projectionList ++ conditionList,
-          plan.outputSet)
+        val cols = columnPrune(projectionList ++ conditionList, plan.outputSet)
         privilegeObjects += PrivilegeObject(table, cols)
       }
     }
 
-    def columnPrune(
-        projectionList: Seq[NamedExpression],
-        output: AttributeSet): Seq[String] = {
-      (projectionList ++ conditionList).flatMap(collectLeaves)
-        .filter(output.contains).map(_.name).distinct
+    def columnPrune(projectionList: Seq[NamedExpression], output: AttributeSet): Seq[String] = {
+      (projectionList ++ conditionList)
+        .flatMap(collectLeaves)
+        .filter(output.contains)
+        .map(_.name)
+        .distinct
     }
 
     plan match {
@@ -136,12 +135,9 @@ object PrivilegesBuilder {
                 if pvm.isSubqueryExpressionPlaceHolder || pvm.output.isEmpty =>
               buildQuery(child, privilegeObjects, projectionList, conditionList, spark)
             case _ =>
-              val childCols = columnPrune(
-                projectionList ++ conditionList,
-                child.outputSet)
+              val childCols = columnPrune(projectionList ++ conditionList, child.outputSet)
               if (childCols.isEmpty) {
-                buildQuery(
-                  child,
+                buildQuery(child,
                   privilegeObjects,
                   p.inputSet.map(_.toAttribute).toSeq,
                   conditionList,

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -122,7 +122,11 @@ object PrivilegesBuilder {
         privilegeObjects += PrivilegeObject(table)
 
       case p =>
-        val newProjection = projectionList ++ p.inputSet.map(_.toAttribute)
+        val newProjection = if (projectionList.isEmpty) {
+          p.inputSet.map(_.toAttribute).toSeq
+        } else {
+          projectionList
+        }
         for (child <- p.children) {
           buildQuery(child, privilegeObjects, newProjection, conditionList, spark)
         }

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -133,7 +133,7 @@ object PrivilegesBuilder {
         for (child <- p.children) {
           child match {
             case pvm: PermanentViewMarker
-              if pvm.isSubqueryExpressionPlaceHolder || pvm.output.isEmpty =>
+                if pvm.isSubqueryExpressionPlaceHolder || pvm.output.isEmpty =>
               buildQuery(child, privilegeObjects, projectionList, conditionList, spark)
             case _ =>
               val childCols = columnPrune(


### PR DESCRIPTION
### _Why are the changes needed?_
To close #5594 
For case
```
def filter_func(iterator):
                for pdf in iterator:
                    yield pdf[pdf.id == 1]

df = spark.read.table("test_mapinpandas")
execute_result = df.mapInPandas(filter_func, df.schema).show()
```

The logical plan is 
```
GlobalLimit 21
+- LocalLimit 21
   +- Project [cast(id#5 as string) AS id#11, name#6]
      +- MapInPandas filter_func(id#0, name#1), [id#5, name#6]
         +- HiveTableRelation [`default`.`test_mapinpandas`, org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe, Data Cols: [id#0, name#1], Partition Cols: []]
```
When handle `MapInPandas`, we didn't match its  input with `HiveTableRelation`, cause we miss input table's  columns. This pr fix this




### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request

With this patch, it can extract the correct privilege object now
<img width="750" alt="截屏2023-11-02 上午10 25 38" src="https://github.com/apache/kyuubi/assets/46485123/82e9a91d-130c-456e-9069-5b7d5046d940">



### _Was this patch authored or co-authored using generative AI tooling?_
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
