### PR TITLE
[KYUUBI #5566][FOLLOWUP] Check InternalSecurityAccessor is initialized only when `kyuubi.engine.security.enabled` is true

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/InternalRestClient.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/InternalRestClient.scala
@@ -38,9 +38,11 @@ class InternalRestClient(
     socketTimeout: Int,
     connectTimeout: Int,
     securityEnabled: Boolean) {
-  require(
-    InternalSecurityAccessor.get() != null,
-    "Internal secure access across Kyuubi instances is not enabled")
+  if (securityEnabled) {
+    require(
+      InternalSecurityAccessor.get() != null,
+      "Internal secure access across Kyuubi instances is not enabled")
+  }
 
   private val internalBatchRestApi = new BatchRestApi(initKyuubiRestClient())
 

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
@@ -45,7 +45,7 @@ import org.apache.kyuubi.operation.OperationState.OperationState
 import org.apache.kyuubi.server.{KyuubiBatchService, KyuubiRestFrontendService}
 import org.apache.kyuubi.server.http.authentication.AuthenticationHandler.AUTHORIZATION_HEADER
 import org.apache.kyuubi.server.metadata.api.{Metadata, MetadataFilter}
-import org.apache.kyuubi.service.authentication.{InternalSecurityAccessor, KyuubiAuthenticationFactory}
+import org.apache.kyuubi.service.authentication.KyuubiAuthenticationFactory
 import org.apache.kyuubi.session.{KyuubiBatchSession, KyuubiSessionManager, SessionHandle, SessionType}
 
 class BatchesV1ResourceSuite extends BatchesResourceSuiteBase {
@@ -83,20 +83,12 @@ abstract class BatchesResourceSuiteBase extends KyuubiFunSuite
 
   override protected lazy val conf: KyuubiConf = {
     val kyuubiConf = KyuubiConf()
-      .set(KyuubiConf.ENGINE_SECURITY_ENABLED, true)
-      .set(KyuubiConf.ENGINE_SECURITY_SECRET_PROVIDER, "simple")
-      .set(KyuubiConf.SIMPLE_SECURITY_SECRET_PROVIDER_PROVIDER_SECRET, "ENGINE____SECRET")
       .set(KyuubiConf.BATCH_IMPL_VERSION, batchVersion)
       .set(
         KyuubiConf.SESSION_LOCAL_DIR_ALLOW_LIST,
         Set(Paths.get(sparkBatchTestResource.get).getParent.toString))
     customConf.foreach { case (k, v) => kyuubiConf.set(k, v) }
     kyuubiConf
-  }
-
-  override def beforeAll(): Unit = {
-    super.beforeAll()
-    InternalSecurityAccessor.initialize(conf, true)
   }
 
   override def afterEach(): Unit = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Internal REST client should work when `kyuubi.engine.security.enabled` is `true`/`false`.

The changes in https://github.com/apache/kyuubi/pull/5566 is not sufficient.

`KyuubiRestAuthenticationSuite` covers the `true` case

`BatchesV1ResourceSuite` and `BatchesV2ResourceSuite` cover the `false` case

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.