### PR TITLE
Add mock output table rule

### DIFF
--- a/extensions/spark/kyuubi-extension-spark-3-5/src/main/scala/org/apache/kyuubi/sql/KyuubiSQLConf.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-5/src/main/scala/org/apache/kyuubi/sql/KyuubiSQLConf.scala
@@ -289,4 +289,11 @@ object KyuubiSQLConf {
       .version("1.9.0")
       .intConf
       .createWithDefault(2000)
+
+  val MOCK_OUTPUT_TABLE =
+    buildConf("spark.sql.optimizer.mockOutputTable")
+      .doc("If true, replace the output table with a mock suffix table.")
+      .version("1.9.0")
+      .booleanConf
+      .createWithDefault(false)
 }

--- a/extensions/spark/kyuubi-extension-spark-3-5/src/main/scala/org/apache/kyuubi/sql/KyuubiSparkSQLCommonExtension.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-5/src/main/scala/org/apache/kyuubi/sql/KyuubiSparkSQLCommonExtension.scala
@@ -31,6 +31,7 @@ object KyuubiSparkSQLCommonExtension {
   def injectCommonExtensions(extensions: SparkSessionExtensions): Unit = {
     // inject zorder parser and related rules
     extensions.injectParser { case (_, parser) => new SparkKyuubiSparkSQLParser(parser) }
+    extensions.injectResolutionRule(MockOutputTable)
     extensions.injectResolutionRule(ResolveZorder)
 
     // Note that:

--- a/extensions/spark/kyuubi-extension-spark-3-5/src/main/scala/org/apache/kyuubi/sql/MockOutputTable.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-5/src/main/scala/org/apache/kyuubi/sql/MockOutputTable.scala
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kyuubi.sql
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType, HiveTableRelation}
+import org.apache.spark.sql.catalyst.plans.logical.{InsertIntoStatement, LogicalPlan}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.util.CharVarcharUtils
+import org.apache.spark.sql.execution.command.DDLUtils
+import org.apache.spark.sql.execution.datasources.CreateTable
+
+import org.apache.kyuubi.sql.KyuubiSQLConf.MOCK_OUTPUT_TABLE
+
+case class MockOutputTable(spark: SparkSession) extends Rule[LogicalPlan] {
+
+  override def apply(plan: LogicalPlan): LogicalPlan = {
+    if (!conf.getConf(MOCK_OUTPUT_TABLE)) {
+      plan
+    } else {
+      plan resolveOperators {
+        // InsertInto
+        case i @ InsertIntoStatement(r: HiveTableRelation, _, _, _, _, _, _)
+            if !isMockTable(r.tableMeta) =>
+          val newTable = mockTable(r.tableMeta, true)
+          i.copy(table = DDLUtils.readHiveTable(newTable))
+        // CTAS
+        case c @ CreateTable(tableDesc, _, Some(query))
+            if !isMockTable(tableDesc) && query.resolved =>
+          val newTable = mockTable(tableDesc, false)
+          c.copy(tableDesc = newTable)
+      }
+    }
+  }
+
+  private def mockTable(sourceTable: CatalogTable, needCreateTable: Boolean): CatalogTable = {
+    val newIdentifier = sourceTable.identifier
+      .copy(table = mockTableName(sourceTable.identifier.table))
+
+    val newStorage = sourceTable.storage.copy(locationUri = None)
+
+    // If the location is specified, we create an external table internally.
+    // Otherwise create a managed table.
+    val tblType = if (newStorage.locationUri.isEmpty) {
+      CatalogTableType.MANAGED
+    } else {
+      CatalogTableType.EXTERNAL
+    }
+
+    val newTableSchema = CharVarcharUtils.getRawSchema(
+      sourceTable.schema,
+      spark.sessionState.conf)
+    val newTable =
+      CatalogTable(
+        identifier = newIdentifier,
+        tableType = tblType,
+        storage = newStorage,
+        schema = newTableSchema,
+        provider = sourceTable.provider,
+        partitionColumnNames = sourceTable.partitionColumnNames,
+        bucketSpec = sourceTable.bucketSpec,
+        tracksPartitionsInCatalog = sourceTable.tracksPartitionsInCatalog)
+
+    if (needCreateTable) {
+      spark.sessionState.catalog.createTable(newTable, true)
+      spark.sessionState.catalog.getTableMetadata(newIdentifier)
+    } else {
+      newTable
+    }
+  }
+
+  private def isMockTable(table: CatalogTable): Boolean = {
+    val pattern = "(.*)_mock_\\d+$".r
+    pattern.findFirstIn(table.identifier.table).isDefined
+  }
+
+  private def mockTableName(rawName: String): String = {
+    s"${rawName}_mock_${System.currentTimeMillis()}"
+  }
+
+}

--- a/extensions/spark/kyuubi-extension-spark-3-5/src/test/scala/org/apache/spark/sql/MockOutputTableSuite.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-5/src/test/scala/org/apache/spark/sql/MockOutputTableSuite.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql
+
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.datasources.InsertIntoHadoopFsRelationCommand
+import org.apache.spark.sql.hive.execution.CreateHiveTableAsSelectCommand
+
+import org.apache.kyuubi.sql.KyuubiSQLConf.MOCK_OUTPUT_TABLE
+
+class MockOutputTableSuite extends KyuubiSparkSQLExtensionTest {
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    setupData()
+  }
+
+  test("test mock output table") {
+    withTable("table1", "table2", "table3") {
+      sql("create table table1 (c1 int, c2 string) stored as parquet")
+      sql("create table table2 (c1 int, c2 string) stored as parquet")
+      sql("create table table3 (c1 int, c2 string) stored as parquet")
+
+      def checkOutputTable(plan: LogicalPlan, table: String): Unit = {
+        val mockTablePattern = (table + "_mock_\\d+").r
+        val checkTableName = (name: String) => mockTablePattern.findFirstIn(name).isDefined
+        plan match {
+          case InsertIntoHadoopFsRelationCommand(
+                outputPath,
+                _,
+                _,
+                _,
+                _,
+                _,
+                _,
+                _,
+                _,
+                catalogTable,
+                _,
+                _) =>
+            assert(checkTableName(outputPath.toString) &&
+              checkTableName(catalogTable.get.identifier.table))
+          case CreateHiveTableAsSelectCommand(tableDesc, _, _, _) =>
+            assert(checkTableName(tableDesc.identifier.table))
+          case _ => fail("should not reach here")
+        }
+      }
+
+      withSQLConf(MOCK_OUTPUT_TABLE.key -> "true") {
+        val df1 = sql("insert overwrite table3 " +
+          " select a.c1 as c1, b.c2 as c2 from table1 a join table2 b on a.c1 = b.c1")
+        checkOutputTable(df1.queryExecution.analyzed, "table3")
+        df1.queryExecution.analyzed
+        val df2 = sql("create table table4 stored as parquet as select c1, c2 from t1")
+        checkOutputTable(df2.queryExecution.analyzed, "table4")
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
When debugging SQL tasks, we may need to replace the output table with a test table to avoid overwriting online data.
So I implemented a `MockOutputTable` rule to replace the output table with a mock table which ends with `_mock_${System.currentTimeMillis()}`.

### _How was this patch tested?_
- [X] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No