### PR TITLE
[UI] Fix sytle linting violation in web ui

### DIFF
--- a/kyuubi-server/web-ui/src/test/unit/views/layout/aside.spec.ts
+++ b/kyuubi-server/web-ui/src/test/unit/views/layout/aside.spec.ts
@@ -34,6 +34,5 @@ test('mount component', () => {
       plugins: [mockRouter, getStore()]
     }
   })
-  expect(wrapper.text())
-    .toContain(import.meta.env.VITE_APP_VERSION)
+  expect(wrapper.text()).toContain(import.meta.env.VITE_APP_VERSION)
 })


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- To fix the style violation in web UI linting
`cd ./kyuubi-server/web-ui && pnpm run lint`

```
> kyuubi-ui@1.9.0-SNAPSHOT lint /Users/bw/dev/kyuubi/kyuubi-server/web-ui
> eslint --ext .ts,vue --ignore-path .gitignore .


/Users/bw/dev/kyuubi/kyuubi-server/web-ui/src/test/unit/views/layout/aside.spec.ts
  37:25  error  Delete `⏎····`  prettier/prettier

✖ 1 problem (1 error, 0 warnings)
  1 error and 0 warnings potentially fixable with the `--fix` option.

 ELIFECYCLE  Command failed with exit code 1.

```


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.