### PR TITLE
[KYUUBI #5748][K8S][HELM] Set session affinity if needed in helm chart

### DIFF
--- a/charts/kyuubi/templates/kyuubi-service.yaml
+++ b/charts/kyuubi/templates/kyuubi-service.yaml
@@ -37,8 +37,11 @@ spec:
       {{- end }}
   selector:
     {{- include "kyuubi.selectorLabels" $ | nindent 4 }}
-  {{- with $frontend.service.sessionAffinity }}
-  {{- toYaml . | nindent 4 }}
+  {{- if ($frontend.service.sessionAffinity) }}
+  sessionAffinity: {{ $frontend.service.sessionAffinity }}
+  {{- end }}
+  {{- with $frontend.service.sessionAffinityConfig }}
+  sessionAffinityConfig: {{- toYaml . | nindent 4 }}
   {{- end }}
 ---
 {{- end }}

--- a/charts/kyuubi/templates/kyuubi-service.yaml
+++ b/charts/kyuubi/templates/kyuubi-service.yaml
@@ -38,7 +38,7 @@ spec:
   selector:
     {{- include "kyuubi.selectorLabels" $ | nindent 4 }}
   sessionAffinity: {{ .Values.service.sessionAffinity }}
-  {{- if and (eq .Values.service.sessionAffinity "ClientIP") .Values.service.sessionAffinityConfig }}
+  {{- if (eq .Values.service.sessionAffinity "ClientIP") }}
   sessionAffinityConfig:
     clientIP:
       timeoutSeconds: {{ .Values.service.sessionAffinityConfig.clientIP.timeoutSeconds }}

--- a/charts/kyuubi/templates/kyuubi-service.yaml
+++ b/charts/kyuubi/templates/kyuubi-service.yaml
@@ -37,13 +37,12 @@ spec:
       {{- end }}
   selector:
     {{- include "kyuubi.selectorLabels" $ | nindent 4 }}
-  sessionAffinity: {{ .Values.service.sessionAffinity }}
-  {{- if (eq .Values.service.sessionAffinity "ClientIP") }}
-  sessionAffinityConfig:
-    clientIP:
-      timeoutSeconds: {{ .Values.service.sessionAffinityConfig.clientIP.timeoutSeconds }}
+  {{- if $frontend.service.sessionAffinity}}
+  sessionAffinity: {{ $frontend.service.sessionAffinity}}
   {{- end }}
-
+  {{- if $frontend.service.sessionAffinityConfig.clientIP.timeoutSeconds}}
+  sessionAffinityConfig: {{- toYaml $frontend.service.sessionAffinityConfig | nindent 4 }}
+  {{- end }}
 ---
 {{- end }}
 {{- end }}

--- a/charts/kyuubi/templates/kyuubi-service.yaml
+++ b/charts/kyuubi/templates/kyuubi-service.yaml
@@ -37,11 +37,8 @@ spec:
       {{- end }}
   selector:
     {{- include "kyuubi.selectorLabels" $ | nindent 4 }}
-  {{- if $frontend.service.sessionAffinity}}
-  sessionAffinity: {{ $frontend.service.sessionAffinity}}
-  {{- end }}
-  {{- if $frontend.service.sessionAffinityConfig.clientIP.timeoutSeconds}}
-  sessionAffinityConfig: {{- toYaml $frontend.service.sessionAffinityConfig | nindent 4 }}
+  {{- with $frontend.service.sessionAffinity }}
+  {{- toYaml . | nindent 4 }}
   {{- end }}
 ---
 {{- end }}

--- a/charts/kyuubi/templates/kyuubi-service.yaml
+++ b/charts/kyuubi/templates/kyuubi-service.yaml
@@ -37,6 +37,13 @@ spec:
       {{- end }}
   selector:
     {{- include "kyuubi.selectorLabels" $ | nindent 4 }}
+  sessionAffinity: {{ .Values.service.sessionAffinity }}
+  {{- if and (eq .Values.service.sessionAffinity "ClientIP") .Values.service.sessionAffinityConfig }}
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: {{ .Values.service.sessionAffinityConfig.clientIP.timeoutSeconds }}
+  {{- end }}
+
 ---
 {{- end }}
 {{- end }}

--- a/charts/kyuubi/values.yaml
+++ b/charts/kyuubi/values.yaml
@@ -235,3 +235,9 @@ prometheusRule:
   enabled: false
   # Contents of Prometheus rules file
   groups: []
+
+service:
+  sessionAffinity: None
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: 10800

--- a/charts/kyuubi/values.yaml
+++ b/charts/kyuubi/values.yaml
@@ -85,6 +85,12 @@ server:
       port: "{{ .Values.server.thriftBinary.port }}"
       nodePort: ~
       annotations: {}
+      #candidates are ClientIP or None, ClientIP is required to set if session affinity is enabled
+      sessionAffinity: ~
+      #default is 10800s
+      sessionAffinityConfig:
+        clientIP:
+          timeoutSeconds: ~
 
   # Thrift HTTP protocol (HiveServer2 compatible)
   thriftHttp:
@@ -95,6 +101,12 @@ server:
       port: "{{ .Values.server.thriftHttp.port }}"
       nodePort: ~
       annotations: {}
+      #candidates are ClientIP or None, ClientIP is required to set if session affinity is enabled
+      sessionAffinity: ~
+      #default is 10800s
+      sessionAffinityConfig:
+        clientIP:
+          timeoutSeconds: ~
 
   # REST API protocol (experimental)
   rest:
@@ -105,6 +117,12 @@ server:
       port: "{{ .Values.server.rest.port }}"
       nodePort: ~
       annotations: {}
+      #candidates are ClientIP or None, ClientIP is required to set if session affinity is enabled
+      sessionAffinity: ~
+      #default is 10800s
+      sessionAffinityConfig:
+        clientIP:
+          timeoutSeconds: 10800s
 
   # MySQL compatible text protocol (experimental)
   mysql:
@@ -115,6 +133,12 @@ server:
       port: "{{ .Values.server.mysql.port }}"
       nodePort: ~
       annotations: {}
+      #candidates are ClientIP or None, ClientIP is required to set if session affinity is enabled
+      sessionAffinity: ~
+      #default is 10800s
+      sessionAffinityConfig:
+        clientIP:
+          timeoutSeconds: ~
 
 monitoring:
   # Exposes metrics in Prometheus format
@@ -235,9 +259,3 @@ prometheusRule:
   enabled: false
   # Contents of Prometheus rules file
   groups: []
-
-service:
-  sessionAffinity: None
-  sessionAffinityConfig:
-    clientIP:
-      timeoutSeconds: 10800

--- a/charts/kyuubi/values.yaml
+++ b/charts/kyuubi/values.yaml
@@ -85,13 +85,12 @@ server:
       port: "{{ .Values.server.thriftBinary.port }}"
       nodePort: ~
       annotations: {}
-      #candidates are ClientIP or None, ClientIP is required to set if session affinity is enabled
-      #default timeout is 10800s
-      sessionAffinity: {}
-        #sessionAffinity: ClientIP
-        #sessionAffinityConfig:
-        #  clientIP:
-        #    timeoutSeconds: 10800s
+      # candidates are ClientIP or None, ClientIP is required to set if session affinity is enabled
+      # default timeout is 10800s
+      sessionAffinity: ~
+      sessionAffinityConfig: {}
+      #  clientIP:
+      #   timeoutSeconds: 10800
 
   # Thrift HTTP protocol (HiveServer2 compatible)
   thriftHttp:
@@ -102,13 +101,12 @@ server:
       port: "{{ .Values.server.thriftHttp.port }}"
       nodePort: ~
       annotations: {}
-      #candidates are ClientIP or None, ClientIP is required to set if session affinity is enabled
-      #default timeout is 10800s
-      sessionAffinity: {}
-        #sessionAffinity: ClientIP
-        #sessionAffinityConfig:
-        #  clientIP:
-        #    timeoutSeconds: 10800s
+      # candidates are ClientIP or None, ClientIP is required to set if session affinity is enabled
+      # default timeout is 10800s
+      sessionAffinity: ~
+      sessionAffinityConfig: {}
+      #  clientIP:
+      #   timeoutSeconds: 10800
 
   # REST API protocol (experimental)
   rest:
@@ -119,13 +117,12 @@ server:
       port: "{{ .Values.server.rest.port }}"
       nodePort: ~
       annotations: {}
-      #candidates are ClientIP or None, ClientIP is required to set if session affinity is enabled
-      #default timeout is 10800s
-      sessionAffinity: {}
-        #sessionAffinity: ClientIP
-        #sessionAffinityConfig:
-        #  clientIP:
-        #    timeoutSeconds: 10800s
+      # candidates are ClientIP or None, ClientIP is required to set if session affinity is enabled
+      # default timeout is 10800s
+      sessionAffinity: ~
+      sessionAffinityConfig: {}
+      #  clientIP:
+      #   timeoutSeconds: 10800
 
   # MySQL compatible text protocol (experimental)
   mysql:
@@ -136,13 +133,12 @@ server:
       port: "{{ .Values.server.mysql.port }}"
       nodePort: ~
       annotations: {}
-      #candidates are ClientIP or None, ClientIP is required to set if session affinity is enabled
-      #default timeout is 10800s
-      sessionAffinity: {}
-        #sessionAffinity: ClientIP
-        #sessionAffinityConfig:
-        #  clientIP:
-        #    timeoutSeconds: 10800s
+      # candidates are ClientIP or None, ClientIP is required to set if session affinity is enabled
+      # default timeout is 10800s
+      sessionAffinity: ~
+      sessionAffinityConfig: {}
+      #  clientIP:
+      #   timeoutSeconds: 10800
 
 monitoring:
   # Exposes metrics in Prometheus format

--- a/charts/kyuubi/values.yaml
+++ b/charts/kyuubi/values.yaml
@@ -86,11 +86,12 @@ server:
       nodePort: ~
       annotations: {}
       #candidates are ClientIP or None, ClientIP is required to set if session affinity is enabled
-      sessionAffinity: ~
-      #default is 10800s
-      sessionAffinityConfig:
-        clientIP:
-          timeoutSeconds: ~
+      #default timeout is 10800s
+      sessionAffinity: {}
+        #sessionAffinity: ClientIP
+        #sessionAffinityConfig:
+        #  clientIP:
+        #    timeoutSeconds: 10800s
 
   # Thrift HTTP protocol (HiveServer2 compatible)
   thriftHttp:
@@ -102,11 +103,12 @@ server:
       nodePort: ~
       annotations: {}
       #candidates are ClientIP or None, ClientIP is required to set if session affinity is enabled
-      sessionAffinity: ~
-      #default is 10800s
-      sessionAffinityConfig:
-        clientIP:
-          timeoutSeconds: ~
+      #default timeout is 10800s
+      sessionAffinity: {}
+        #sessionAffinity: ClientIP
+        #sessionAffinityConfig:
+        #  clientIP:
+        #    timeoutSeconds: 10800s
 
   # REST API protocol (experimental)
   rest:
@@ -118,11 +120,12 @@ server:
       nodePort: ~
       annotations: {}
       #candidates are ClientIP or None, ClientIP is required to set if session affinity is enabled
-      sessionAffinity: ~
-      #default is 10800s
-      sessionAffinityConfig:
-        clientIP:
-          timeoutSeconds: 10800s
+      #default timeout is 10800s
+      sessionAffinity: {}
+        #sessionAffinity: ClientIP
+        #sessionAffinityConfig:
+        #  clientIP:
+        #    timeoutSeconds: 10800s
 
   # MySQL compatible text protocol (experimental)
   mysql:
@@ -134,11 +137,12 @@ server:
       nodePort: ~
       annotations: {}
       #candidates are ClientIP or None, ClientIP is required to set if session affinity is enabled
-      sessionAffinity: ~
-      #default is 10800s
-      sessionAffinityConfig:
-        clientIP:
-          timeoutSeconds: ~
+      #default timeout is 10800s
+      sessionAffinity: {}
+        #sessionAffinity: ClientIP
+        #sessionAffinityConfig:
+        #  clientIP:
+        #    timeoutSeconds: 10800s
 
 monitoring:
   # Exposes metrics in Prometheus format

--- a/charts/kyuubi/values.yaml
+++ b/charts/kyuubi/values.yaml
@@ -85,12 +85,13 @@ server:
       port: "{{ .Values.server.thriftBinary.port }}"
       nodePort: ~
       annotations: {}
-      # candidates are ClientIP or None, ClientIP is required to set if session affinity is enabled
-      # default timeout is 10800s
+      # candidates are ClientIP or None
+      # https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/
       sessionAffinity: ~
       sessionAffinityConfig: {}
-      #  clientIP:
-      #   timeoutSeconds: 10800
+      #  sessionAffinityConfig:
+      #    clientIP:
+      #      timeoutSeconds: 10800
 
   # Thrift HTTP protocol (HiveServer2 compatible)
   thriftHttp:
@@ -101,12 +102,13 @@ server:
       port: "{{ .Values.server.thriftHttp.port }}"
       nodePort: ~
       annotations: {}
-      # candidates are ClientIP or None, ClientIP is required to set if session affinity is enabled
-      # default timeout is 10800s
+      # candidates are ClientIP or None
+      # https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/
       sessionAffinity: ~
       sessionAffinityConfig: {}
-      #  clientIP:
-      #   timeoutSeconds: 10800
+      #  sessionAffinityConfig:
+      #    clientIP:
+      #      timeoutSeconds: 10800
 
   # REST API protocol (experimental)
   rest:
@@ -117,12 +119,13 @@ server:
       port: "{{ .Values.server.rest.port }}"
       nodePort: ~
       annotations: {}
-      # candidates are ClientIP or None, ClientIP is required to set if session affinity is enabled
-      # default timeout is 10800s
+      # candidates are ClientIP or None
+      # https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/
       sessionAffinity: ~
       sessionAffinityConfig: {}
-      #  clientIP:
-      #   timeoutSeconds: 10800
+      #  sessionAffinityConfig:
+      #    clientIP:
+      #      timeoutSeconds: 10800
 
   # MySQL compatible text protocol (experimental)
   mysql:
@@ -133,12 +136,13 @@ server:
       port: "{{ .Values.server.mysql.port }}"
       nodePort: ~
       annotations: {}
-      # candidates are ClientIP or None, ClientIP is required to set if session affinity is enabled
-      # default timeout is 10800s
+      # candidates are ClientIP or None
+      # https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/
       sessionAffinity: ~
       sessionAffinityConfig: {}
-      #  clientIP:
-      #   timeoutSeconds: 10800
+      #  sessionAffinityConfig:
+      #    clientIP:
+      #      timeoutSeconds: 10800
 
 monitoring:
   # Exposes metrics in Prometheus format


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

This can ensure that incoming requests from same client are forward to the same Kyuubi service instance in K8S. So this may be a workaround for users to get their session states during a period of time.

Close #5748

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.