### PR TITLE
[K8S][HELM]Save ETCD certificate in a Kubernetes Secret

### DIFF
--- a/charts/kyuubi/templates/kyuubi-configmap.yaml
+++ b/charts/kyuubi/templates/kyuubi-configmap.yaml
@@ -41,6 +41,15 @@ data:
     kyuubi.metrics.enabled={{ .Values.monitoring.prometheus.enabled }}
     kyuubi.metrics.reporters={{ .Values.metricsReporters }}
 
+    # Kyuubi ha
+    {{- if .Values.ha.etcd.ssl.enabled }}
+    kyuubi.ha.client.class=org.apache.kyuubi.ha.client.etcd.EtcdDiscoveryClient
+    kyuubi.ha.etcd.ssl.enabled=true
+    kyuubi.ha.etcd.ssl.ca.path={{ .Values.ha.etcd.ssl.ca.mountPath }}
+    kyuubi.ha.etcd.ssl.client.certificate.path={{ .Values.ha.etcd.ssl.client.certificate.mountPath }}
+    kyuubi.ha.etcd.ssl.client.key.path={{ .Values.ha.etcd.ssl.client.key.mountPath }}
+    {{- end }}
+
     ## User provided Kyuubi configurations
     {{- with .Values.kyuubiConf.kyuubiDefaults }}
       {{- tpl . $ | nindent 4 }}

--- a/charts/kyuubi/templates/kyuubi-etcd-secret.yaml
+++ b/charts/kyuubi/templates/kyuubi-etcd-secret.yaml
@@ -1,0 +1,32 @@
+{{/*
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+
+{{- if .Values.ha.etcd.ssl.enabled }}
+{{- $ca := .Files.Get .Values.ha.etcd.ssl.ca.path | b64enc | quote }}
+{{- $client_certificate := .Files.Get .Values.ha.etcd.ssl.client.certificate.path | b64enc | quote }}
+{{- $client_key := .Files.Get .Values.ha.etcd.ssl.client.key.path | b64enc | quote }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    {{- include "kyuubi.labels" . | nindent 4 }}
+data:
+  ca.crt: {{ $ca }}
+  client.crt: {{ $client_certificate }}
+  client_key.pem: {{ $client_key }}
+{{- end }}

--- a/charts/kyuubi/templates/kyuubi-statefulset.yaml
+++ b/charts/kyuubi/templates/kyuubi-statefulset.yaml
@@ -105,8 +105,10 @@ spec:
           volumeMounts:
             - name: conf
               mountPath: {{ .Values.kyuubiConfDir }}
+          {{- if .Values.ha.etcd.ssl.enabled}}
             - name: etcd-cert
               mountPath: {{ .Values.ha.etcd.ssl.mountParentPath }}
+          {{- end }}
             {{- with .Values.volumeMounts }}
               {{- tpl (toYaml .) $ | nindent 12 }}
             {{- end }}
@@ -117,9 +119,11 @@ spec:
         - name: conf
           configMap:
             name: {{ .Release.Name }}
+        {{- if .Values.ha.etcd.ssl.enabled}}
         - name: etcd-cert
           secret:
             secretName: {{ .Release.Name }}
+        {{- end }}
         {{- with .Values.volumes }}
           {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}

--- a/charts/kyuubi/templates/kyuubi-statefulset.yaml
+++ b/charts/kyuubi/templates/kyuubi-statefulset.yaml
@@ -105,6 +105,8 @@ spec:
           volumeMounts:
             - name: conf
               mountPath: {{ .Values.kyuubiConfDir }}
+            - name: etcd-cert
+              mountPath: {{ .Values.ha.etcd.ssl.mountParentPath }}
             {{- with .Values.volumeMounts }}
               {{- tpl (toYaml .) $ | nindent 12 }}
             {{- end }}
@@ -115,6 +117,9 @@ spec:
         - name: conf
           configMap:
             name: {{ .Release.Name }}
+        - name: etcd-cert
+          secret:
+            secretName: {{ .Release.Name }}
         {{- with .Values.volumes }}
           {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}

--- a/charts/kyuubi/values.yaml
+++ b/charts/kyuubi/values.yaml
@@ -235,3 +235,16 @@ prometheusRule:
   enabled: false
   # Contents of Prometheus rules file
   groups: []
+
+ha:
+  etcd:
+    ssl:
+      enabled: false
+      ca:
+        path: ~
+      client:
+        certificate:
+          path: ~
+        key:
+          path: ~
+

--- a/charts/kyuubi/values.yaml
+++ b/charts/kyuubi/values.yaml
@@ -243,12 +243,12 @@ ha:
       mountParentPath: ~
       ca:
         path: ~
-        mountPath: "{{  .Values.ha.etcd.ssl.mountParentPath }/ca.crt}}"
+        mountPath: "{{  .Values.ha.etcd.ssl.mountParentPath }}/ca.crt"
       client:
         certificate:
           path: ~
-          mountPath: "{{  .Values.ha.etcd.ssl.mountParentPath }/client.crt}}"
+          mountPath: "{{  .Values.ha.etcd.ssl.mountParentPath }}/client.crt"
         key:
           path: ~
-          mountPath: "{{  .Values.ha.etcd.ssl.mountParentPath }/client.pem}}"
+          mountPath: "{{  .Values.ha.etcd.ssl.mountParentPath }}/client.pem"
 

--- a/charts/kyuubi/values.yaml
+++ b/charts/kyuubi/values.yaml
@@ -240,11 +240,15 @@ ha:
   etcd:
     ssl:
       enabled: false
+      mountParentPath: ~
       ca:
         path: ~
+        mountPath: "{{  .Values.ha.etcd.ssl.mountParentPath }/ca.crt}}"
       client:
         certificate:
           path: ~
+          mountPath: "{{  .Values.ha.etcd.ssl.mountParentPath }/client.crt}}"
         key:
           path: ~
+          mountPath: "{{  .Values.ha.etcd.ssl.mountParentPath }/client.pem}}"
 


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
To save ETCD certificates in a Kubernetes Secret using a Helm chart,  developers can easily build the Kyuubi with ETCD  in K8S.
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
