### PR TITLE
[KYUUBI #5635] Provide TPCDSRunQueryContext/TPCDSGenerateContext to conveniently run tpcds queries and generate tpcds tables

### DIFF
--- a/extensions/spark/kyuubi-spark-connector-tpcds/src/main/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSGenerateContext.scala
+++ b/extensions/spark/kyuubi-spark-connector-tpcds/src/main/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSGenerateContext.scala
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kyuubi.spark.connector.tpcds
+
+import io.trino.tpcds.{Table, TpcdsException}
+import org.apache.spark.sql.SparkSession
+
+class TPCDSGenerateContext(spark: SparkSession, database: Option[String]) {
+
+  def persistAll(opts: TPCDSPersistOpts): Unit = {
+    persistTables(opts, TPCDSSchemaUtils.BASE_TABLES.map(_.getName()): _*)
+  }
+
+  def persistTables(opts: TPCDSPersistOpts, tables: String*): Unit = {
+    tables.foreach { table =>
+      try {
+        spark.sparkContext.setJobGroup(table, s"Generate $table", true)
+
+        val tpcdsTable = Table.getTable(table)
+        val tableName = if (database.isDefined) {
+          s"${database.get}.$table"
+        } else {
+          table
+        }
+        val sparkTable = spark.table(tableName)
+
+        val writer = sparkTable.write.format(opts.format)
+
+        if (opts.overwrite) {
+          writer.mode("overwrite")
+        }
+
+        val partitionColumns = TPCDSSchemaUtils
+          .tablePartitionColumnNames(tpcdsTable, tpcdsConf.useTableSchema_2_6)
+        if (partitionColumns.nonEmpty) {
+          writer.partitionBy(partitionColumns: _*)
+        }
+
+        writer.saveAsTable(s"${opts.targetDb}.$table")
+      } finally {
+        spark.sparkContext.clearJobGroup()
+      }
+    }
+  }
+
+  def persistTable(opts: TPCDSPersistOpts, table: String): Unit = {
+    persistTables(opts, table)
+  }
+
+  lazy val tpcdsConf: TPCDSConf = {
+    val catalog = if (database.isEmpty) {
+      spark.sessionState.catalogManager.currentCatalog
+    } else {
+      val dbParts = spark.sessionState.sqlParser.parseMultipartIdentifier(database.get)
+      if (dbParts.size == 1) {
+        spark.sessionState.catalogManager.currentCatalog
+      } else {
+        spark.sessionState.catalogManager.catalog(dbParts.head)
+      }
+    }
+    catalog match {
+      case c: TPCDSCatalog => c.tpcdsConf
+      case _ =>
+        val errorMsg = if (database.isEmpty) {
+          "Current database is not a TPCDS database, please specify a TPCDS database."
+        } else {
+          s"Database[${database.get}] is not a TPCDS database"
+        }
+        throw new TpcdsException(errorMsg)
+    }
+  }
+}
+
+object TPCDSGenerateContext {
+
+  def apply(): TPCDSGenerateContext =
+    new TPCDSGenerateContext(SparkSession.active, None)
+
+  def apply(database: String): TPCDSGenerateContext =
+    new TPCDSGenerateContext(SparkSession.active, Some(database))
+
+}
+
+case class TPCDSPersistOpts(
+    targetDb: String,
+    format: String = "parquet",
+    overwrite: Boolean = true)

--- a/extensions/spark/kyuubi-spark-connector-tpcds/src/main/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSRunQueryContext.scala
+++ b/extensions/spark/kyuubi-spark-connector-tpcds/src/main/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSRunQueryContext.scala
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kyuubi.spark.connector.tpcds
+
+import java.io.{InputStream, PrintWriter, StringWriter}
+import java.util
+import java.util.Locale
+
+import scala.io.{Codec, Source}
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
+
+import org.apache.kyuubi.spark.connector.tpcds.TPCDSRunQueryContext._
+
+class TPCDSRunQueryContext(spark: SparkSession, database: Option[String]) extends Logging {
+
+  def runAllQueries(): DataFrame = {
+    runQueries(allQueries: _*)
+  }
+
+  def runQueries(queries: String*): DataFrame = withDatabase {
+    val results = new util.ArrayList[Row]()
+    queries.foreach { query =>
+      results.add(run(query.trim.toLowerCase(Locale.ROOT)))
+    }
+
+    spark.createDataFrame(results, outputSchema)
+  }
+
+  def runQuery(name: String): DataFrame = {
+    runQueries(name)
+  }
+
+  private def run(name: String): Row = {
+    var status = "SUCCESS"
+    var duration = 0
+    var error: String = null
+    try {
+      val query = querySQLs(name)
+      spark.sparkContext.setJobGroup(name, s"$name:\n$query", true)
+      val start = System.currentTimeMillis()
+      spark.sql(query).collect()
+      duration = (System.currentTimeMillis() - start).toInt
+    } catch {
+      case e: Exception =>
+        logWarning(s"Failed to run query $name", e)
+        status = "FAILED"
+        error = TPCDSRunQueryContext.prettyPrintException(e)
+    } finally {
+      spark.sparkContext.clearJobGroup()
+    }
+
+    Row.apply(name, status, duration, error)
+  }
+
+  private def withDatabase[T](f: => T): T = {
+    if (database.isEmpty) {
+      f
+    } else {
+      val currentCatalog = spark.catalog.currentCatalog()
+      val originalDatabase = spark.catalog.currentDatabase
+      try {
+        spark.sql(s"use ${database.get}")
+        f
+      } finally {
+        spark.catalog.setCurrentCatalog(currentCatalog)
+        spark.catalog.setCurrentDatabase(originalDatabase)
+      }
+    }
+  }
+}
+
+object TPCDSRunQueryContext {
+
+  def apply(): TPCDSRunQueryContext = {
+    new TPCDSRunQueryContext(SparkSession.active, None)
+  }
+
+  def apply(database: String): TPCDSRunQueryContext = {
+    new TPCDSRunQueryContext(SparkSession.active, Some(database))
+  }
+
+  val outputSchema: StructType = StructType(
+    StructField("name", StringType) ::
+      StructField("status", StringType) ::
+      StructField("duration", IntegerType) ::
+      StructField("error", StringType) :: Nil)
+
+  val tpcdsRootDir: String = "kyuubi/tpcds_3.2"
+
+  val allQueries = Seq(
+    "q1",
+    "q2",
+    "q3",
+    "q4",
+    "q5",
+    "q6",
+    "q7",
+    "q8",
+    "q9",
+    "q10",
+    "q11",
+    "q12",
+    "q13",
+    "q14a",
+    "q14b",
+    "q15",
+    "q16",
+    "q17",
+    "q18",
+    "q19",
+    "q20",
+    "q21",
+    "q22",
+    "q23a",
+    "q23b",
+    "q24a",
+    "q24b",
+    "q25",
+    "q26",
+    "q27",
+    "q28",
+    "q29",
+    "q30",
+    "q31",
+    "q32",
+    "q33",
+    "q34",
+    "q35",
+    "q36",
+    "q37",
+    "q38",
+    "q39a",
+    "q39b",
+    "q40",
+    "q41",
+    "q42",
+    "q43",
+    "q44",
+    "q45",
+    "q46",
+    "q47",
+    "q48",
+    "q49",
+    "q50",
+    "q51",
+    "q52",
+    "q53",
+    "q54",
+    "q55",
+    "q56",
+    "q57",
+    "q58",
+    "q59",
+    "q60",
+    "q61",
+    "q62",
+    "q63",
+    "q64",
+    "q65",
+    "q66",
+    "q67",
+    "q68",
+    "q69",
+    "q70",
+    "q71",
+    "q72",
+    "q73",
+    "q74",
+    "q75",
+    "q76",
+    "q77",
+    "q78",
+    "q79",
+    "q80",
+    "q81",
+    "q82",
+    "q83",
+    "q84",
+    "q85",
+    "q86",
+    "q87",
+    "q88",
+    "q89",
+    "q90",
+    "q91",
+    "q92",
+    "q93",
+    "q94",
+    "q95",
+    "q96",
+    "q97",
+    "q98",
+    "q99")
+
+  // all queries: Map(name -> sql)
+  lazy val querySQLs: Map[String, String] = {
+    allQueries.map(name => {
+      (name, getQuerySql(s"$tpcdsRootDir/$name.sql"))
+    }).toMap
+  }
+
+  private def getQuerySql(resource: String): String = {
+    var in: InputStream = null
+    try {
+      in = getClass.getClassLoader.getResourceAsStream(resource)
+      Source.fromInputStream(in)(Codec.UTF8).getLines()
+        .filter(!_.startsWith("--"))
+        .mkString("\n")
+    } finally {
+      if (in != null) in.close()
+    }
+  }
+
+  /**
+   * Return a nice string representation of the exception. It will call "printStackTrace" to
+   * recursively generate the stack trace including the exception and its causes.
+   *
+   * Copy from `org.apache.kyuubi.Utils#prettyPrint(java.lang.Throwable)`
+   */
+  private def prettyPrintException(e: Throwable): String = {
+    if (e == null) {
+      ""
+    } else {
+      // Use e.printStackTrace here because e.getStackTrace doesn't include the cause
+      val stringWriter = new StringWriter()
+      e.printStackTrace(new PrintWriter(stringWriter))
+      stringWriter.toString
+    }
+  }
+}

--- a/extensions/spark/kyuubi-spark-connector-tpcds/src/main/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSRunQueryContext.scala
+++ b/extensions/spark/kyuubi-spark-connector-tpcds/src/main/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSRunQueryContext.scala
@@ -73,14 +73,12 @@ class TPCDSRunQueryContext(spark: SparkSession, database: Option[String]) extend
     if (database.isEmpty) {
       f
     } else {
-      val currentCatalog = spark.catalog.currentCatalog()
-      val originalDatabase = spark.catalog.currentDatabase
+      val currentNamespace = spark.sessionState.catalogManager.currentNamespace
       try {
         spark.sql(s"use ${database.get}")
         f
       } finally {
-        spark.catalog.setCurrentCatalog(currentCatalog)
-        spark.catalog.setCurrentDatabase(originalDatabase)
+        spark.sessionState.catalogManager.setCurrentNamespace(currentNamespace)
       }
     }
   }

--- a/extensions/spark/kyuubi-spark-connector-tpcds/src/test/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSGenerateContextSuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-tpcds/src/test/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSGenerateContextSuite.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kyuubi.spark.connector.tpcds
+
+import io.trino.tpcds.Table
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.TableIdentifier
+
+import org.apache.kyuubi.{KyuubiFunSuite, Utils}
+import org.apache.kyuubi.spark.connector.common.LocalSparkSession.withSparkSession
+
+class TPCDSGenerateContextSuite extends KyuubiFunSuite {
+
+  test("test TPCDSGenerateContext") {
+    val basePath = Utils.createTempDir() + "/" + getClass.getCanonicalName
+    val warehousePath = basePath + "/warehouse"
+    val sparkConf = new SparkConf().setMaster("local[*]")
+      .set("spark.ui.enabled", "false")
+      .set("spark.sql.catalogImplementation", "in-memory")
+      .set("spark.sql.warehouse.dir", warehousePath)
+      .set("spark.sql.catalog.tpcds", classOf[TPCDSCatalog].getName)
+    withSparkSession(SparkSession.builder.config(sparkConf).getOrCreate()) { spark =>
+      try {
+        val generateContext = TPCDSGenerateContext("tpcds.tiny")
+        generateContext.persistTable(TPCDSPersistOpts("default"), "catalog_sales")
+        val table = spark.sessionState.catalog
+          .getTableMetadata(TableIdentifier("catalog_sales"))
+        assert(table.partitionColumnNames === Seq("cs_sold_date_sk"))
+        val count = spark.sql("select * from catalog_sales").count()
+        assert(count == TPCDSStatisticsUtils.numRows(
+          Table.getTable("catalog_sales"),
+          TPCDSSchemaUtils.TINY_SCALE.toDouble))
+      } finally {
+        val cleanTables = Seq("catalog_sales")
+        cleanTables.foreach(t => spark.sql(s"drop table if exists $t"))
+      }
+    }
+  }
+
+}

--- a/extensions/spark/kyuubi-spark-connector-tpcds/src/test/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSRunQueryContextSuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-tpcds/src/test/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSRunQueryContextSuite.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kyuubi.spark.connector.tpcds
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.SparkSession
+
+import org.apache.kyuubi.KyuubiFunSuite
+import org.apache.kyuubi.spark.connector.common.LocalSparkSession.withSparkSession
+
+class TPCDSRunQueryContextSuite extends KyuubiFunSuite {
+
+  test("test TPCDSRunQueryContext") {
+    assert(TPCDSRunQueryContext.querySQLs.size == 103)
+
+    val sparkConf = new SparkConf().setMaster("local[*]")
+      .set("spark.ui.enabled", "false")
+      .set("spark.sql.catalogImplementation", "in-memory")
+      .set("spark.sql.catalog.tpcds", classOf[TPCDSCatalog].getName)
+    withSparkSession(SparkSession.builder.config(sparkConf).getOrCreate()) { _ =>
+      val queryContext = TPCDSRunQueryContext("tpcds.tiny")
+      val query1 = queryContext.runQuery("q1").collect()
+      assert(query1.length == 1)
+      assert(query1.head.getString(0) == "q1")
+      assert(query1.head.getString(1) == "SUCCESS")
+      assert(query1.head.getInt(2) > 0)
+      assert(query1.head.getString(3) == null)
+
+      val query2 = queryContext.runQueries("q1", "q2").collect()
+      assert(query2.length == 2)
+      assert(query2.map(_.getString(0)) === Seq("q1", "q2"))
+      query2.foreach { row =>
+        assert(row.getString(1) == "SUCCESS")
+        assert(row.getInt(2) > 0)
+        assert(row.getString(3) == null)
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Provide `TPCDSRunQueryContext` to conveniently run tpcds queries.

+ `runAllQueries()`: run all queries
+ `runQuery(query: String)`/`runQueries(queries: String*)`: run the specified query or queries

Provide `TPCDSGenerateContext` to generate tpcds tables.

+ `persistAll(opts)`:  persist all tpcds tables
+ `persistTable(opts, table)`/`persistTables(opts, tables: _*)`: persist the specified tpcds table or tables

With the kyuubi scala execution mode, we can conveniently run tpcds queries:

```
set kyuubi.operation.language=scala;

import org.apache.kyuubi.spark.connector.tpcds.TPCDSRunQueryContext;
val queryContext = TPCDSRunQueryContext("tpcds.tiny");
val result = queryContext.runAllQueries();
// queryContext.runQueries("q1", "q2", "q3", "q4").show();

result.show(200);
```

![image](https://github.com/apache/kyuubi/assets/17894939/7cf4b7b2-f157-4651-a305-9360699a6164)

persist tpcds tables:

```
import org.apache.kyuubi.spark.connector.tpcds.TPCDSGenerateContext;
import org.apache.kyuubi.spark.connector.tpcds.TPCDSPersistOpts;
val context = TPCDSGenerateContext("tpcds.tiny");
context.persistAll(TPCDSPersistOpts("default"));
// context.persistTable(TPCDSPersistOpts("default"), "CATALOG_SALES");
```

### _How was this patch tested?_
- [X] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [X] Add screenshots for manual tests if appropriate

- [X] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No