### PR TITLE
[KYUUBI #5642][FOLLOWUP] Fix unit test

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
@@ -1191,8 +1191,7 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
                 s"[write] privilege on [[$path2, $path2/]]")
             val e = intercept[UndeclaredThrowableException](
               doAs(admin, sql(s"ALTER DATABASE $db1 SET LOCATION '$path2'")))
-            assert(e.getCause.getMessage ==
-              "Hive metastore does not support altering database location.")
+            assert(e.getCause.getMessage == "does not support altering database location")
           }
         }
       }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
@@ -1191,7 +1191,7 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
                 s"[write] privilege on [[$path2, $path2/]]")
             val e = intercept[UndeclaredThrowableException](
               doAs(admin, sql(s"ALTER DATABASE $db1 SET LOCATION '$path2'")))
-            assert(e.getCause.getMessage == "does not support altering database location")
+            assert(e.getCause.getMessage.contains("does not support altering database location"))
           }
         }
       }


### PR DESCRIPTION
### _Why are the changes needed?_
To close 5642 
 Fix unit test 
Spark 3.1
```
- CreateDatabaseCommand/AlterDatabaseSetLocationCommand *** FAILED ***
  "Hive [2.3.7 does not support altering database location]" did not equal "Hive [metastore does not support altering database location.]" (RangerSparkExtensionSuite.scala:1194)
  Analysis:
  "Hive [2.3.7 does not support altering database location]" -> "Hive [metastore does not support altering database location.]"
```

Spark 3.2 & Spark 3.3
```
- CreateDatabaseCommand/AlterDatabaseSetLocationCommand *** FAILED ***
  "Hive [2.3.9 does not support altering database location]" did not equal "Hive [metastore does not support altering database location.]" (RangerSparkExtensionSuite.scala:1194)
  Analysis:
  "Hive [2.3.9 does not support altering database location]" -> "Hive [metastore does not support altering database location.]"
```


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
No