### PR TITLE
[KYUUBI #5599] Correct the parameter name of fetching op log in RESTful API

### DIFF
--- a/docs/client/rest/rest_api.md
+++ b/docs/client/rest/rest_api.md
@@ -297,7 +297,7 @@ Get a list of operation log lines of the running operation by the specified oper
 
 | Name    | Description                           | Type |
 |:--------|:--------------------------------------|:-----|
-| maxRows | The max row that are pulled each time | Int  |
+| maxrows | The max row that are pulled each time | Int  |
 
 #### Response Body
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
It corrects the fetching op log Rest API documentation to match request parameter case in code, solving issue #5599 


### _How was this patch tested?_
No tests needed.

### _Was this patch authored or co-authored using generative AI tooling?_
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No AI tool has been used for this patch. 