### PR TITLE
[KYUUBI #5600] Fix flaky test SessionsResourceSuite

### DIFF
--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/SessionsResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/SessionsResourceSuite.scala
@@ -101,13 +101,13 @@ class SessionsResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper {
     response = webTarget.path(s"api/v1/sessions/$sessionHandle").request().delete()
     assert(200 == response.getStatus)
 
+    // because delete is a asynchronous operation, we need sleep to
+    // make sure the delete operation process complete
+    Thread.sleep(3000)
     // get session list again
     response2 = webTarget.path("api/v1/sessions").request().get()
     assert(200 == response2.getStatus)
 
-    // because delete is a asynchronous operation, we need sleep to
-    // make sure the delete complete
-    Thread.sleep(3000)
     val sessions = response2.readEntity(classOf[Seq[SessionData]])
     assert(sessions.isEmpty)
   }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/SessionsResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/SessionsResourceSuite.scala
@@ -101,19 +101,15 @@ class SessionsResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper {
     response = webTarget.path(s"api/v1/sessions/$sessionHandle").request().delete()
     assert(200 == response.getStatus)
 
-    // because delete is a asynchronous operation, we need use eventually to
-    // make sure the delete complete
-    def validateSessionEmpty(): Boolean = {
-      // get session list again
-      response2 = webTarget.path("api/v1/sessions").request().get()
-      assert(200 == response2.getStatus)
-      val sessions = response.readEntity(classOf[Seq[SessionData]])
-      sessions.isEmpty
-    }
-    eventually(timeout(5.seconds)) {
-      assert(validateSessionEmpty())
-    }
+    // get session list again
+    response2 = webTarget.path("api/v1/sessions").request().get()
+    assert(200 == response2.getStatus)
 
+    // because delete is a asynchronous operation, we need sleep to
+    // make sure the delete complete
+    Thread.sleep(3000)
+    val sessions = response2.readEntity(classOf[Seq[SessionData]])
+    assert(sessions.isEmpty)
   }
 
   test("get session event") {

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/SessionsResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/SessionsResourceSuite.scala
@@ -100,7 +100,7 @@ class SessionsResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper {
     response = webTarget.path(s"api/v1/sessions/$sessionHandle").request().delete()
     assert(200 == response.getStatus)
 
-    // because delete is a asynchronous operation, we need sleep to
+    // because delete is a asynchronous operation, we need eventually to
     // make sure the delete operation process complete
     eventually(timeout(3.seconds)) {
       // get session list again

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/SessionsResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/SessionsResourceSuite.scala
@@ -17,17 +17,6 @@
 
 package org.apache.kyuubi.server.api.v1
 
-import java.nio.charset.StandardCharsets
-import java.util
-import java.util.{Base64, Collections}
-import javax.ws.rs.client.Entity
-import javax.ws.rs.core.{GenericType, MediaType, Response}
-
-import scala.collection.JavaConverters._
-
-import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
-
-import org.apache.kyuubi.{KyuubiFunSuite, RestFrontendTestHelper}
 import org.apache.kyuubi.client.api.v1.dto
 import org.apache.kyuubi.client.api.v1.dto.{SessionData, _}
 import org.apache.kyuubi.config.KyuubiConf
@@ -35,8 +24,17 @@ import org.apache.kyuubi.config.KyuubiReservedKeys.KYUUBI_SESSION_CONNECTION_URL
 import org.apache.kyuubi.engine.ShareLevel
 import org.apache.kyuubi.metrics.{MetricsConstants, MetricsSystem}
 import org.apache.kyuubi.operation.OperationHandle
-import org.apache.kyuubi.server.http.util.HttpAuthUtils.{basicAuthorizationHeader, AUTHORIZATION_HEADER}
+import org.apache.kyuubi.server.http.util.HttpAuthUtils.{AUTHORIZATION_HEADER, basicAuthorizationHeader}
 import org.apache.kyuubi.session.SessionType
+import org.apache.kyuubi.{KyuubiFunSuite, RestFrontendTestHelper}
+import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
+
+import java.nio.charset.StandardCharsets
+import java.util
+import java.util.{Base64, Collections}
+import javax.ws.rs.client.Entity
+import javax.ws.rs.core.{GenericType, MediaType, Response}
+import scala.collection.JavaConverters._
 
 class SessionsResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper {
 
@@ -101,17 +99,17 @@ class SessionsResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper {
     response = webTarget.path(s"api/v1/sessions/$sessionHandle").request().delete()
     assert(200 == response.getStatus)
 
-    // get session list again
-    response2 = webTarget.path("api/v1/sessions").request().get()
-    assert(200 == response2.getStatus)
     // because delete is a asynchronous operation, we need use eventually to
     // make sure the delete complete
-    def validateSessionEmpty(response: Response): Boolean = {
+    def validateSessionEmpty(): Boolean = {
+      // get session list again
+      response2 = webTarget.path("api/v1/sessions").request().get()
+      assert(200 == response2.getStatus)
       val sessions = response.readEntity(classOf[Seq[SessionData]])
       sessions.isEmpty
     }
     eventually(timeout(5.seconds)) {
-      assert(validateSessionEmpty(response2))
+      assert(validateSessionEmpty())
     }
 
   }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/SessionsResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/SessionsResourceSuite.scala
@@ -17,6 +17,17 @@
 
 package org.apache.kyuubi.server.api.v1
 
+import java.nio.charset.StandardCharsets
+import java.util
+import java.util.{Base64, Collections}
+import javax.ws.rs.client.Entity
+import javax.ws.rs.core.{GenericType, MediaType, Response}
+
+import scala.collection.JavaConverters._
+
+import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
+
+import org.apache.kyuubi.{KyuubiFunSuite, RestFrontendTestHelper}
 import org.apache.kyuubi.client.api.v1.dto
 import org.apache.kyuubi.client.api.v1.dto.{SessionData, _}
 import org.apache.kyuubi.config.KyuubiConf
@@ -24,17 +35,8 @@ import org.apache.kyuubi.config.KyuubiReservedKeys.KYUUBI_SESSION_CONNECTION_URL
 import org.apache.kyuubi.engine.ShareLevel
 import org.apache.kyuubi.metrics.{MetricsConstants, MetricsSystem}
 import org.apache.kyuubi.operation.OperationHandle
-import org.apache.kyuubi.server.http.util.HttpAuthUtils.{AUTHORIZATION_HEADER, basicAuthorizationHeader}
+import org.apache.kyuubi.server.http.util.HttpAuthUtils.{basicAuthorizationHeader, AUTHORIZATION_HEADER}
 import org.apache.kyuubi.session.SessionType
-import org.apache.kyuubi.{KyuubiFunSuite, RestFrontendTestHelper}
-import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
-
-import java.nio.charset.StandardCharsets
-import java.util
-import java.util.{Base64, Collections}
-import javax.ws.rs.client.Entity
-import javax.ws.rs.core.{GenericType, MediaType, Response}
-import scala.collection.JavaConverters._
 
 class SessionsResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper {
 
@@ -65,7 +67,7 @@ class SessionsResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper {
     // so we can not guarantee the poolActiveThread count must equal to 1
     assert(execPoolStatistic1.getExecPoolSize == 1 &&
       (execPoolStatistic1.getExecPoolActiveCount == 1 ||
-        execPoolStatistic1.getExecPoolActiveCount == 0) )
+        execPoolStatistic1.getExecPoolActiveCount == 0))
 
     response = webTarget.path("api/v1/sessions/count").request().get()
     val openedSessionCount = response.readEntity(classOf[SessionOpenCount])


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Because the server process is async, so when we test in ci or local, because our test operation is synchronize, but the server process is async, it will random failed, so we need to fix the problem to make sure the random test not happend.
In the SessionsResourceSuite, there may have 2 random test case failed
```
SessionsResourceSuite:
- open/close and count session *** FAILED ***
  1 equaled 1, but 0 did not equal 1 (SessionsResourceSuite.scala:65)
- getSessionList *** FAILED ***
  List(Map("duration" -> 0, "sessionType" -> "INTERACTIVE", "identifier" -> "96ca05ee-ecb1-49cd-a2e4-66cbf49ed343", "createTime" -> 1698822938391, "ipAddr" -> "127.0.0.1", "exception" -> "", "kyuubiInstance" -> "localhost:35415", "idleTime" -> 78, "engineId" -> "", "conf" -> Map("kyuubi.session.real.user" -> "anonymous", "testConfig" -> "testValue", "kyuubi.client.ipAddress" -> "127.0.0.1", "kyuubi.session.connection.url" -> "localhost:35415", "kyuubi.server.ipAddress" -> "localhost"), "user" -> "anonymous")) was not empty (SessionsResourceSuite.scala:104)
```
1. open/close session: when we open session, the server will process in async,it may complete or error quickly, so we can not make sure the active thread count must equal to 1, we need use 1 or 0 to test
2. list sessions: in the test case, we will execute delete sessions operation, then assert, but if we assert quickly and the session not delete complete, it will failed, so we need sleep 3 seconds to make the delete operation async complete

close #5600 

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No