### PR TITLE
[KYUUBI #5680] Optimize kyuubi spark engine driver&executor pod name generation

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
@@ -146,7 +146,7 @@ private[kyuubi] class EngineRef(
         s"${shareLevel}_${engineType}_${appUser}_${appKey}"
       } else {
         s"${shareLevel}_${engineType}_${appUser}"
-      }/*  */
+      }
     commonNamePrefix
   }
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
@@ -136,19 +136,19 @@ private[kyuubi] class EngineRef(
   }
 
   /**
- * Generate app key, enrich `spark.app.name` content
- * Example: connection_spark-sql_root_myappname
- */
-@VisibleForTesting
-private[kyuubi] def generateAppKey(appKey: String): String = {
-  var commonNamePrefix: String = ""
-  if (appKey != null){
-    commonNamePrefix = s"${shareLevel}_${engineType}_${appUser}_${appKey}"
-  }else {
-    commonNamePrefix = s"${shareLevel}_${engineType}_${appUser}"
+   * Generate app key, enrich `spark.app.name` content
+   * Example: connection_spark-sql_root_myappname
+   */
+  @VisibleForTesting
+  private[kyuubi] def generateAppKey(appKey: String): String = {
+    val commonNamePrefix: String =
+      if (appKey != null) {
+        s"${shareLevel}_${engineType}_${appUser}_${appKey}"
+      } else {
+        s"${shareLevel}_${engineType}_${appUser}"
+      }/*  */
+    commonNamePrefix
   }
-  commonNamePrefix
-}
 
   /**
    * The EngineSpace used to expose itself to the KyuubiServers in `serverSpace`

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
@@ -136,6 +136,21 @@ private[kyuubi] class EngineRef(
   }
 
   /**
+ * Generate app key, enrich `spark.app.name` content
+ * Example: connection_spark-sql_root_myappname
+ */
+@VisibleForTesting
+private[kyuubi] def generateAppKey(appKey: String): String = {
+  var commonNamePrefix: String = ""
+  if (appKey != null){
+    commonNamePrefix = s"${shareLevel}_${engineType}_${appUser}_${appKey}"
+  }else {
+    commonNamePrefix = s"${shareLevel}_${engineType}_${appUser}"
+  }
+  commonNamePrefix
+}
+
+  /**
    * The EngineSpace used to expose itself to the KyuubiServers in `serverSpace`
    *
    * For `CONNECTION` share level:
@@ -187,7 +202,7 @@ private[kyuubi] class EngineRef(
     conf.set(KYUUBI_ENGINE_SUBMIT_TIME_KEY, String.valueOf(started))
     builder = engineType match {
       case SPARK_SQL =>
-        conf.setIfMissing(SparkProcessBuilder.APP_KEY, defaultEngineName)
+        conf.set(SparkProcessBuilder.APP_KEY, generateAppKey(conf.getOption(SparkProcessBuilder.APP_KEY).getOrElse(null)))
         new SparkProcessBuilder(appUser, conf, engineRefId, extraEngineLog)
       case FLINK_SQL =>
         conf.setIfMissing(FlinkProcessBuilder.APP_KEY, defaultEngineName)


### PR DESCRIPTION
[KYUUBI #5680] Optimize kyuubi spark engine driver and executor pod name generation

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
**Background**:
1) In default case, when kyuubi submit spark sql engine on kubernetes, will generate spark driver pod name with "kyuubi-${app_name}-${engine_ref_id}-driver". 
2) And app_name will be "kyuubi_${shareLevel}_${engineType}_${appUser}_${engineRefId}" if not set by user. 
3) In result, we may get spark driver pod name with "kyuubi-kyuubi-${shareLevel}-${engineType}-${appUser}-${engineRefId}-${engineRefId}-driver".
4) We were hoping for a more concise and readable name, such as "kyuubi-${shareLevel}-${engineType}-${appUser}-${app_name}-${engineRefId}-driver".

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate
**1) Before modification：**
Left is unset `spark.app.name`, and right is set to “ocean”
![image](https://github.com/apache/kyuubi/assets/45907917/350aa09f-a9cb-4cc4-bdc6-71b085ba0824)

**2) Modify the code**
![image](https://github.com/apache/kyuubi/assets/45907917/f9cbef91-9e1a-482a-82bb-a78caf669438)

**3) Build module and get the jar**
![image](https://github.com/apache/kyuubi/assets/45907917/b2cf7595-dd54-46eb-bb79-354f3301499f)

**4) Build a new images**
![image](https://github.com/apache/kyuubi/assets/45907917/c0418f2d-dcde-4845-a568-84e920892359)

**5) After modification:**
![image](https://github.com/apache/kyuubi/assets/45907917/5db95d5b-2550-41b7-a11c-d8e4a6c0f09f)

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No