### PR TITLE
[REST] Return remote session id and remote operation id

### DIFF
--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/api/v1/dto/OperationData.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/api/v1/dto/OperationData.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 
 public class OperationData {
   private String identifier;
+  private String remoteId;
   private String statement;
   private String state;
   private Long createTime;
@@ -41,6 +42,7 @@ public class OperationData {
 
   public OperationData(
       String identifier,
+      String remoteId,
       String statement,
       String state,
       Long createTime,
@@ -53,6 +55,7 @@ public class OperationData {
       String kyuubiInstance,
       Map<String, String> metrics) {
     this.identifier = identifier;
+    this.remoteId = remoteId;
     this.statement = statement;
     this.state = state;
     this.createTime = createTime;
@@ -72,6 +75,14 @@ public class OperationData {
 
   public void setIdentifier(String identifier) {
     this.identifier = identifier;
+  }
+
+  public String getRemoteId() {
+    return remoteId;
+  }
+
+  public void setRemoteId(String remoteId) {
+    this.remoteId = remoteId;
   }
 
   public String getStatement() {

--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/api/v1/dto/SessionData.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/api/v1/dto/SessionData.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 
 public class SessionData {
   private String identifier;
+  private String remoteId;
   private String user;
   private String ipAddr;
   private Map<String, String> conf;
@@ -40,6 +41,7 @@ public class SessionData {
 
   public SessionData(
       String identifier,
+      String remoteId,
       String user,
       String ipAddr,
       Map<String, String> conf,
@@ -51,6 +53,7 @@ public class SessionData {
       String kyuubiInstance,
       String engineId) {
     this.identifier = identifier;
+    this.remoteId = remoteId;
     this.user = user;
     this.ipAddr = ipAddr;
     this.conf = conf;
@@ -69,6 +72,14 @@ public class SessionData {
 
   public void setIdentifier(String identifier) {
     this.identifier = identifier;
+  }
+
+  public String getRemoteId() {
+    return remoteId;
+  }
+
+  public void setRemoteId(String remoteId) {
+    this.remoteId = remoteId;
   }
 
   public String getUser() {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/ApiUtils.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/ApiUtils.scala
@@ -32,6 +32,7 @@ object ApiUtils extends Logging {
     val sessionEvent = session.getSessionEvent
     new SessionData(
       session.handle.identifier.toString,
+      sessionEvent.map(_.remoteSessionId).getOrElse(""),
       session.user,
       session.ipAddress,
       session.conf.asJava,
@@ -48,6 +49,7 @@ object ApiUtils extends Logging {
     val opEvent = KyuubiOperationEvent(operation)
     new OperationData(
       opEvent.statementId,
+      opEvent.remoteId,
       opEvent.statement,
       opEvent.state,
       opEvent.createTime,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

 Not all the engine sessionIds/operationIds are unified between kyuubi server and kyuubi engines, so we need to expose  these remote details to provide more insights.


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.
