### PR TITLE
[KYUUBI #5698][Authz] Hudi privilege object for table should ignore meta column

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegeObject.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegeObject.scala
@@ -18,8 +18,8 @@
 package org.apache.kyuubi.plugin.spark.authz
 
 import java.net.URI
-
 import javax.annotation.Nonnull
+
 import org.apache.kyuubi.plugin.spark.authz.PrivilegeObjectActionType.PrivilegeObjectActionType
 import org.apache.kyuubi.plugin.spark.authz.PrivilegeObjectType._
 import org.apache.kyuubi.plugin.spark.authz.serde.{Database, Function, Table, Uri}

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegeObject.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegeObject.scala
@@ -18,11 +18,12 @@
 package org.apache.kyuubi.plugin.spark.authz
 
 import java.net.URI
-import javax.annotation.Nonnull
 
+import javax.annotation.Nonnull
 import org.apache.kyuubi.plugin.spark.authz.PrivilegeObjectActionType.PrivilegeObjectActionType
 import org.apache.kyuubi.plugin.spark.authz.PrivilegeObjectType._
 import org.apache.kyuubi.plugin.spark.authz.serde.{Database, Function, Table, Uri}
+import org.apache.kyuubi.plugin.spark.authz.util.HudiUtils
 
 /**
  * Build a Spark logical plan to different `PrivilegeObject`s
@@ -71,7 +72,7 @@ object PrivilegeObject {
       actionType,
       table.database.orNull,
       table.table,
-      columns,
+      columns.filter(!HudiUtils.isHudiMetaField(_)),
       table.owner,
       table.catalog)
   }

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -299,6 +299,7 @@ object PrivilegesBuilder {
   def build(
       plan: LogicalPlan,
       spark: SparkSession): PrivilegesAndOpType = {
+    println(plan)
     val inputObjs = new ArrayBuffer[PrivilegeObject]
     val outputObjs = new ArrayBuffer[PrivilegeObject]
     val opType = plan match {

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -299,7 +299,6 @@ object PrivilegesBuilder {
   def build(
       plan: LogicalPlan,
       spark: SparkSession): PrivilegesAndOpType = {
-    println(plan)
     val inputObjs = new ArrayBuffer[PrivilegeObject]
     val outputObjs = new ArrayBuffer[PrivilegeObject]
     val opType = plan match {

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/util/HudiUtils.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/util/HudiUtils.scala
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.plugin.spark.authz.util
+
+object HudiUtils {
+  private val COMMIT_TIME_METADATA_FIELD = "_hoodie_commit_time"
+  private val COMMIT_SEQNO_METADATA_FIELD = "_hoodie_commit_seqno"
+  private val RECORD_KEY_METADATA_FIELD = "_hoodie_record_key"
+  private val PARTITION_PATH_METADATA_FIELD = "_hoodie_partition_path"
+  private val FILENAME_METADATA_FIELD = "_hoodie_file_name"
+
+  private val metaFields = Seq(
+    COMMIT_TIME_METADATA_FIELD,
+    COMMIT_SEQNO_METADATA_FIELD,
+    RECORD_KEY_METADATA_FIELD,
+    PARTITION_PATH_METADATA_FIELD,
+    FILENAME_METADATA_FIELD)
+
+  def isHudiMetaField(name: String): Boolean = {
+    metaFields.contains(name)
+  }
+}

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/util/HudiUtils.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/util/HudiUtils.scala
@@ -24,7 +24,7 @@ object HudiUtils {
   private val PARTITION_PATH_METADATA_FIELD = "_hoodie_partition_path"
   private val FILENAME_METADATA_FIELD = "_hoodie_file_name"
 
-  private val metaFields = Seq(
+  private val metaFields = Set(
     COMMIT_TIME_METADATA_FIELD,
     COMMIT_SEQNO_METADATA_FIELD,
     RECORD_KEY_METADATA_FIELD,

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/HudiCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/HudiCatalogRangerSparkExtensionSuite.scala
@@ -617,7 +617,7 @@ class HudiCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
     }
   }
 
-  test("[KYUUBI #5698][Authz] Hudi privilege table should ignore meta column") {
+  test("[KYUUBI #5698][Authz] Ignore meta columns for Hudi table") {
     withSingleCallEnabled {
       withCleanTmpResources(Seq((s"$namespace1.$table1", "table"), (namespace1, "database"))) {
         doAs(admin, sql(s"CREATE DATABASE IF NOT EXISTS $namespace1"))


### PR DESCRIPTION
### _Why are the changes needed?_
To close #5698 

Hudi privilege table should ignore meta column,
For simple sql 
```
SELECT * from hudi_ns.table1_hoodie
```
will throw such excepton, we should ignore meta columns

```
Permission denied: user [someone] does not have [select] privilege on [hudi_ns/table1_hoodie/_hoodie_commit_time,hudi_ns/table1_hoodie/_hoodie_commit_seqno,hudi_ns/table1_hoodie/_hoodie_record_key,hudi_ns/table1_hoodie/_hoodie_partition_path,hudi_ns/table1_hoodie/_hoodie_file_name,hudi_ns/table1_hoodie/id,hudi_ns/table1_hoodie/name,hudi_ns/table1_hoodie/city]
```

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
No
