### PR TITLE
[KYUUBI #5700][AUTHZ] DropTableCommand should check it's table or view

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilderSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilderSuite.scala
@@ -1783,6 +1783,7 @@ class HiveCatalogPrivilegeBuilderSuite extends PrivilegesBuilderSuite {
   }
 
   test("DropTableCommand") {
+    assume(!isSparkV35OrGreater)
     Seq("TABLE", "VIEW").foreach { obj =>
       withTable("DropTableCommand") { table =>
         sql(s"CREATE $obj IF NOT EXISTS $table AS SELECT 1")

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilderSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilderSuite.scala
@@ -204,6 +204,34 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
     }
   }
 
+  test("DropTableCommand") {
+    Seq("TABLE", "VIEW").foreach { obj =>
+      withTable("DropTableCommand") { table =>
+        sql(s"CREATE $obj IF NOT EXISTS $table AS SELECT 1")
+        val plan = sql(s"DROP $obj $table").queryExecution.analyzed
+        val (in, out, operationType) = PrivilegesBuilder.build(plan, spark)
+        assertResult(plan.getClass.getName)(
+          "org.apache.spark.sql.execution.command.DropTableCommand")
+        if (obj.equalsIgnoreCase("TABLE")) {
+          assert(operationType === DROPTABLE)
+        } else {
+          assert(operationType === DROPVIEW)
+        }
+        assert(in.isEmpty)
+        assert(out.size === 1)
+        val po = out.head
+        assert(po.actionType === PrivilegeObjectActionType.OTHER)
+        assert(po.privilegeObjectType === PrivilegeObjectType.TABLE_OR_VIEW)
+        assert(po.catalog.isEmpty)
+        assertEqualsIgnoreCase(defaultDb)(po.dbname)
+        assertEqualsIgnoreCase(table)(po.objectName)
+        assert(po.columns.isEmpty)
+        val accessType = ranger.AccessType(po, operationType, isInput = false)
+        assert(accessType === AccessType.DROP)
+      }
+    }
+  }
+
   test("AlterTableAddPartitionCommand") {
     val plan = sql(s"ALTER TABLE $reusedPartTable ADD IF NOT EXISTS PARTITION (pid=1)")
       .queryExecution.analyzed


### PR DESCRIPTION
### _Why are the changes needed?_
To close #5700 
Now all  DropTableCommand return DROPTABLE, but DROPVIEW also use this command, we should check it's table or view or temp view


### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
