### PR TITLE
[KYUUBI #5704] Add unit tests for `kyuubi.session.proxy.user` in RESTful API

### DIFF
--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/AdminResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/AdminResourceSuite.scala
@@ -400,7 +400,7 @@ class AdminResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper {
     // In EngineRef, when use hive.server2.proxy.user or kyuubi.session.proxy.user
     // the user is the proxyUser, and in our test it is normalUser
     val engine =
-    new EngineRef(conf.clone, user = normalUser, PluginLoader.loadGroupProvider(conf), id, null)
+      new EngineRef(conf.clone, user = normalUser, PluginLoader.loadGroupProvider(conf), id, null)
 
     // so as the firstChild in engineSpace we use normalUser
     val engineSpace = DiscoveryPaths.makePath(
@@ -414,8 +414,9 @@ class AdminResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper {
       assert(client.pathExists(engineSpace))
       assert(client.getChildren(engineSpace).size == 1)
 
-      def runDeleteEngine(kyuubiProxyUser: Option[String],
-                          hs2ProxyUser: Option[String]): Response = {
+      def runDeleteEngine(
+          kyuubiProxyUser: Option[String],
+          hs2ProxyUser: Option[String]): Response = {
         var internalWebTarget = webTarget.path("api/v1/admin/engine")
           .queryParam("sharelevel", "USER")
           .queryParam("type", "SPARK_SQL")
@@ -442,8 +443,8 @@ class AdminResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper {
       assert(deleteEngineResponse2.readEntity(classOf[String]).contains(errorMessage))
 
       // when both set, proxyUser takes precedence
-      val deleteEngineResponse3 = runDeleteEngine(Option(normalUser),
-        Option(s"${normalUser}HiveServer2"))
+      val deleteEngineResponse3 =
+        runDeleteEngine(Option(normalUser), Option(s"${normalUser}HiveServer2"))
       assert(deleteEngineResponse3.getStatus === 405)
       assert(deleteEngineResponse3.readEntity(classOf[String]).contains(errorMessage))
     }
@@ -620,7 +621,7 @@ class AdminResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper {
     // In EngineRef, when use hive.server2.proxy.user or kyuubi.session.proxy.user
     // the user is the proxyUser, and in our test it is normalUser
     val engine =
-    new EngineRef(conf.clone, user = normalUser, PluginLoader.loadGroupProvider(conf), id, null)
+      new EngineRef(conf.clone, user = normalUser, PluginLoader.loadGroupProvider(conf), id, null)
 
     // so as the firstChild in engineSpace we use normalUser
     val engineSpace = DiscoveryPaths.makePath(
@@ -663,8 +664,8 @@ class AdminResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper {
       assert(listEngineResponse2.readEntity(classOf[String]).contains(errorMessage))
 
       // when both set, proxyUser takes precedence
-      val listEngineResponse3 = runListEngine(Option(normalUser),
-        Option(s"${normalUser}HiveServer2"))
+      val listEngineResponse3 =
+        runListEngine(Option(normalUser), Option(s"${normalUser}HiveServer2"))
       assert(listEngineResponse3.getStatus === 405)
       assert(listEngineResponse3.readEntity(classOf[String]).contains(errorMessage))
     }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/AdminResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/AdminResourceSuite.scala
@@ -637,7 +637,7 @@ class AdminResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper {
       def runListEngine(kyuubiProxyUser: Option[String], hs2ProxyUser: Option[String]): Response = {
         var internalWebTarget = webTarget.path("api/v1/admin/engine")
           .queryParam("sharelevel", "USER")
-          .queryParam("type", "spark_sql")
+          .queryParam("type", "SPARK_SQL")
 
         kyuubiProxyUser.map(username =>
           internalWebTarget = internalWebTarget.queryParam("proxyUser", username))

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/AdminResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/AdminResourceSuite.scala
@@ -639,10 +639,12 @@ class AdminResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper {
           .queryParam("sharelevel", "USER")
           .queryParam("type", "SPARK_SQL")
 
-        kyuubiProxyUser.map(username =>
-          internalWebTarget = internalWebTarget.queryParam("proxyUser", username))
-        hs2ProxyUser.map(username =>
-          internalWebTarget = internalWebTarget.queryParam("hive.server2.proxy.user", username))
+        kyuubiProxyUser.map { username =>
+          internalWebTarget = internalWebTarget.queryParam("proxyUser", username)
+        }
+        hs2ProxyUser.map { username =>
+          internalWebTarget = internalWebTarget.queryParam("hive.server2.proxy.user", username)
+        }
 
         internalWebTarget.request(MediaType.APPLICATION_JSON_TYPE)
           .header(AUTHORIZATION_HEADER, HttpAuthUtils.basicAuthorizationHeader("anonymous"))

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/AdminResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/AdminResourceSuite.scala
@@ -418,7 +418,7 @@ class AdminResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper {
                           hs2ProxyUser: Option[String]): Response = {
         var internalWebTarget = webTarget.path("api/v1/admin/engine")
           .queryParam("sharelevel", "USER")
-          .queryParam("type", "spark_sql")
+          .queryParam("type", "SPARK_SQL")
 
         kyuubiProxyUser.map(username =>
           internalWebTarget = internalWebTarget.queryParam("proxyUser", username))

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/AdminResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/AdminResourceSuite.scala
@@ -401,8 +401,8 @@ class AdminResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper {
 
     // In EngineRef, when use hive.server2.proxy.user or kyuubi.session.proxy.user
     // the user is the proxyUser, and in our test it is commonUser
-    val engine = new EngineRef(conf.clone, user = commonUser, PluginLoader.loadGroupProvider(conf),
-      id, null)
+    val engine =
+      new EngineRef(conf.clone, user = commonUser, PluginLoader.loadGroupProvider(conf), id, null)
 
     // so as the firstChild in engineSpace we use commonUser
     val engineSpace = DiscoveryPaths.makePath(
@@ -629,8 +629,8 @@ class AdminResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper {
 
     // In EngineRef, when use hive.server2.proxy.user or kyuubi.session.proxy.user
     // the user is the proxyUser, and in our test it is commonUser
-    val engine = new EngineRef(conf.clone, user = commonUser, PluginLoader.loadGroupProvider(conf),
-      id, null)
+    val engine =
+      new EngineRef(conf.clone, user = commonUser, PluginLoader.loadGroupProvider(conf), id, null)
 
     // so as the firstChild in engineSpace we use commonUser
     val engineSpace = DiscoveryPaths.makePath(

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/AdminResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/AdminResourceSuite.scala
@@ -21,6 +21,7 @@ import java.time.Duration
 import java.util.UUID
 import javax.ws.rs.client.Entity
 import javax.ws.rs.core.{GenericType, MediaType, Response}
+
 import scala.collection.JavaConverters._
 
 import org.apache.hive.service.rpc.thrift.TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V2
@@ -441,7 +442,8 @@ class AdminResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper {
       assert(deleteEngineResponse2.readEntity(classOf[String]).contains(errorMessage))
 
       // when both set, proxyUser takes precedence
-      val deleteEngineResponse3 = runDeleteEngine(Option(normalUser), Option(s"${normalUser}HiveServer2"))
+      val deleteEngineResponse3 = runDeleteEngine(Option(normalUser),
+        Option(s"${normalUser}HiveServer2"))
       assert(deleteEngineResponse3.getStatus === 405)
       assert(deleteEngineResponse3.readEntity(classOf[String]).contains(errorMessage))
     }
@@ -659,7 +661,8 @@ class AdminResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper {
       assert(listEngineResponse2.readEntity(classOf[String]).contains(errorMessage))
 
       // when both set, proxyUser takes precedence
-      val listEngineResponse3 = runListEngine(Option(normalUser), Option(s"${normalUser}HiveServer2"))
+      val listEngineResponse3 = runListEngine(Option(normalUser),
+        Option(s"${normalUser}HiveServer2"))
       assert(listEngineResponse3.getStatus === 405)
       assert(listEngineResponse3.readEntity(classOf[String]).contains(errorMessage))
     }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
@@ -885,7 +885,9 @@ abstract class BatchesResourceSuiteBase extends KyuubiFunSuite
 
     // when both set, kyuubi.session.proxy.user takes precedence
     val proxyUserRequest3 = newSparkBatchRequest(
-      Map("spark.master" -> "local", PROXY_USER.key -> commonUser,
+      Map(
+        "spark.master" -> "local",
+        PROXY_USER.key -> commonUser,
         // here, we also set hive.server2.proxy.user,
         // but the different value from kyuubi.session.proxy.user
         KyuubiAuthenticationFactory.HS2_PROXY_USER -> s"${commonUser}HiveServer2"))

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
@@ -863,9 +863,12 @@ abstract class BatchesResourceSuiteBase extends KyuubiFunSuite
                              hs2ProxyUser: Option[String]): Response = {
       val conf = mutable.Map("spark.master" -> "local")
 
-      kyuubiProxyUser.map(username => conf += (PROXY_USER.key -> username))
-      hs2ProxyUser.map(username =>
-        conf += (KyuubiAuthenticationFactory.HS2_PROXY_USER -> username))
+      kyuubiProxyUser.map { username => 
+        conf += (PROXY_USER.key -> username)
+      }
+      hs2ProxyUser.map { username =>
+        conf += (KyuubiAuthenticationFactory.HS2_PROXY_USER -> username)
+      }
       val proxyUserRequest = newSparkBatchRequest(conf.toMap)
 
       webTarget.path("api/v1/batches")

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
@@ -864,7 +864,8 @@ abstract class BatchesResourceSuiteBase extends KyuubiFunSuite
       val conf = mutable.Map("spark.master" -> "local")
 
       kyuubiProxyUser.map(username => conf += (PROXY_USER.key -> username))
-      hs2ProxyUser.map(username => conf += (KyuubiAuthenticationFactory.HS2_PROXY_USER -> username))
+      hs2ProxyUser.map(username =>
+        conf += (KyuubiAuthenticationFactory.HS2_PROXY_USER -> username))
       val proxyUserRequest = newSparkBatchRequest(conf.toMap)
 
       webTarget.path("api/v1/batches")

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
@@ -69,9 +69,7 @@ class BatchesV2ResourceSuite extends BatchesResourceSuiteBase {
       .foreach { batch => batchService.cancelUnscheduledBatch(batch.getId) }
     super.afterEach()
     sessionManager.allSessions().foreach { session =>
-      Utils.tryLogNonFatalError {
-        sessionManager.closeSession(session.handle)
-      }
+      Utils.tryLogNonFatalError { sessionManager.closeSession(session.handle) }
     }
   }
 }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
@@ -857,8 +857,9 @@ abstract class BatchesResourceSuiteBase extends KyuubiFunSuite
   test("open batch session with proxyUser") {
     val normalUser = "kyuubi"
 
-    def runOpenBatchExecutor(kyuubiProxyUser: Option[String],
-                             hs2ProxyUser: Option[String]): Response = {
+    def runOpenBatchExecutor(
+        kyuubiProxyUser: Option[String],
+        hs2ProxyUser: Option[String]): Response = {
       val conf = mutable.Map("spark.master" -> "local")
 
       kyuubiProxyUser.map { username =>
@@ -887,8 +888,8 @@ abstract class BatchesResourceSuiteBase extends KyuubiFunSuite
     assert(proxyUserResponse2.readEntity(classOf[String]).contains(errorMessage))
 
     // when both set, kyuubi.session.proxy.user takes precedence
-    val proxyUserResponse3 = runOpenBatchExecutor(Option(normalUser),
-      Option(s"${normalUser}HiveServer2"))
+    val proxyUserResponse3 =
+      runOpenBatchExecutor(Option(normalUser), Option(s"${normalUser}HiveServer2"))
     assert(proxyUserResponse3.getStatus === 405)
     assert(proxyUserResponse3.readEntity(classOf[String]).contains(errorMessage))
   }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
@@ -861,7 +861,7 @@ abstract class BatchesResourceSuiteBase extends KyuubiFunSuite
                              hs2ProxyUser: Option[String]): Response = {
       val conf = mutable.Map("spark.master" -> "local")
 
-      kyuubiProxyUser.map { username => 
+      kyuubiProxyUser.map { username =>
         conf += (PROXY_USER.key -> username)
       }
       hs2ProxyUser.map { username =>
@@ -887,7 +887,8 @@ abstract class BatchesResourceSuiteBase extends KyuubiFunSuite
     assert(proxyUserResponse2.readEntity(classOf[String]).contains(errorMessage))
 
     // when both set, kyuubi.session.proxy.user takes precedence
-    val proxyUserResponse3 = runOpenBatchExecutor(Option(normalUser), Option(s"${normalUser}HiveServer2"))
+    val proxyUserResponse3 = runOpenBatchExecutor(Option(normalUser),
+      Option(s"${normalUser}HiveServer2"))
     assert(proxyUserResponse3.getStatus === 405)
     assert(proxyUserResponse3.readEntity(classOf[String]).contains(errorMessage))
   }


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

Close https://github.com/apache/kyuubi/issues/5704

## Describe Your Solution 🔧

Add unit tests for `kyuubi.session.proxy.user` in RESTful API.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklists
## 📝 Author Self Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [style guidelines](https://kyuubi.readthedocs.io/en/master/contributing/code/style.html) of this project
- [x] I have performed a self-review
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

## 📝 Committer Pre-Merge Checklist

- [x] Pull request title is okay.
- [x] No license issues.
- [x] Milestone correctly set?
- [x] Test coverage is ok
- [x] Assignees are selected.
- [x] Minimum number of approvals
- [x] No changes are requested


**Be nice. Be informative.**
