### PR TITLE
[TEST] Fix match may not be exhaustive in Scala 2.13

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/serde/tableExtractors.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/serde/tableExtractors.scala
@@ -261,6 +261,7 @@ class SubqueryAliasTableExtractor extends TableExtractor {
         lookupExtractor[StringTableExtractor].apply(spark, identifier.toString())
       case SubqueryAlias(identifier, _) if !isPathIdentifier(identifier.name, spark) =>
         lookupExtractor[StringTableExtractor].apply(spark, identifier.toString())
+      case _ => None
     }
   }
 }
@@ -284,6 +285,7 @@ class HudiDataSourceV2RelationTableExtractor extends TableExtractor {
       // Match multipartIdentifier without tableAlias
       case SubqueryAlias(identifier, _) =>
         lookupExtractor[StringTableExtractor].apply(spark, identifier.toString())
+      case _ => None
     }
   }
 }
@@ -297,6 +299,7 @@ class HudiMergeIntoTargetTableExtractor extends TableExtractor {
       // Match multipartIdentifier without tableAlias
       case SubqueryAlias(identifier, _) =>
         lookupExtractor[StringTableExtractor].apply(spark, identifier.toString())
+      case _ => None
     }
   }
 }


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗

https://github.com/apache/kyuubi/actions/runs/6885433363/job/18729567019
```
Error: ] /home/runner/work/kyuubi/kyuubi/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/serde/tableExtractors.scala:259: match may not be exhaustive.
It would fail on the following inputs: SubqueryAlias(_, (x: org.apache.spark.sql.catalyst.plans.logical.LogicalPlan forSome x not in org.apache.spark.sql.catalyst.plans.logical.SubqueryAlias)), SubqueryAlias(_, SubqueryAlias(_, _))
```


## Describe Your Solution 🔧

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklists
## 📝 Author Self Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [style guidelines](https://kyuubi.readthedocs.io/en/master/contributing/code/style.html) of this project
- [ ] I have performed a self-review
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

## 📝 Committer Pre-Merge Checklist

- [x] Pull request title is okay.
- [x] No license issues.
- [ ] Milestone correctly set?
- [ ] Test coverage is ok
- [x] Assignees are selected.
- [x] Minimum number of approvals
- [x] No changes are requested


**Be nice. Be informative.**
