### PR TITLE
Support customizing engine pool size via user defaults

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
@@ -77,7 +77,7 @@ private[kyuubi] class EngineRef(
   private val clientPoolSize: Int = shareLevel match {
     case ShareLevel.USER =>
       val serverConf = Option(KyuubiServer.kyuubiServer).map(_.getConf).getOrElse(KyuubiConf())
-      val userPoolSize = serverConf.getAllUserDefaults.get(s"___${user}___${ENGINE_POOL_SIZE.key}")
+      val userPoolSize = serverConf.getAllUserDefaults.get(s"___${user}___.${ENGINE_POOL_SIZE.key}")
       userPoolSize match {
         case Some(threshold) => threshold.toInt
         case _ => conf.get(ENGINE_POOL_SIZE)

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/EngineRefWithUserPoolSizeSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/EngineRefWithUserPoolSizeSuite.scala
@@ -51,12 +51,14 @@ class EngineRefWithUserPoolSizeSuite extends WithKyuubiServer {
     (0 until userEnginePoolSize * 2).foreach { i =>
       val poolEngineSeq = i % userEnginePoolSize
       val appName = new EngineRef(conf, user, PluginLoader.loadGroupProvider(conf), id, null)
-      assertResult(appName.engineSpace)(DiscoveryPaths.makePath(
-        s"kyuubi_${KYUUBI_VERSION}_${USER}_$SPARK_SQL",
-        user,
-        s"engine-pool-$poolEngineSeq"))
-      assertResult(appName.defaultEngineName)(
-        s"kyuubi_${USER}_${SPARK_SQL}_${user}_engine-pool-${poolEngineSeq}_$id")
+      withClue(s"index $i, expected poolEngineSeqde $poolEngineSeq") {
+        assertResult(DiscoveryPaths.makePath(
+          s"kyuubi_${KYUUBI_VERSION}_${USER}_$SPARK_SQL",
+          user,
+          s"engine-pool-$poolEngineSeq"))(appName.engineSpace)
+        assertResult(s"kyuubi_${USER}_${SPARK_SQL}_${user}_engine-pool-${poolEngineSeq}_$id")(
+          appName.defaultEngineName)
+      }
     }
 
     // other users' pool size falling back to default
@@ -64,12 +66,12 @@ class EngineRefWithUserPoolSizeSuite extends WithKyuubiServer {
     (0 until userEnginePoolSize * 2).foreach { i =>
       val poolEngineSeq = i % defaultEnginePoolSize
       val appName = new EngineRef(conf, otherUser, PluginLoader.loadGroupProvider(conf), id, null)
-      assertResult(appName.engineSpace)(DiscoveryPaths.makePath(
+      assertResult(DiscoveryPaths.makePath(
         s"kyuubi_${KYUUBI_VERSION}_${USER}_$SPARK_SQL",
         otherUser,
-        s"engine-pool-$poolEngineSeq"))
-      assertResult(appName.defaultEngineName)(
-        s"kyuubi_${USER}_${SPARK_SQL}_${otherUser}_engine-pool-${poolEngineSeq}_$id")
+        s"engine-pool-$poolEngineSeq"))(appName.engineSpace)
+      assertResult(s"kyuubi_${USER}_${SPARK_SQL}_${otherUser}_engine-pool-${poolEngineSeq}_$id")(
+        appName.defaultEngineName)
     }
   }
 
@@ -80,12 +82,12 @@ class EngineRefWithUserPoolSizeSuite extends WithKyuubiServer {
     (0 until userEnginePoolSize * 2).foreach { i =>
       val poolEngineSeq = i % defaultEnginePoolSize
       val appName = new EngineRef(conf, user, PluginLoader.loadGroupProvider(conf), id, null)
-      assertResult(appName.engineSpace)(DiscoveryPaths.makePath(
+      assertResult(DiscoveryPaths.makePath(
         s"kyuubi_${KYUUBI_VERSION}_${SERVER}_$SPARK_SQL",
         user,
-        s"engine-pool-$poolEngineSeq"))
-      assertResult(appName.defaultEngineName)(
-        s"kyuubi_${SERVER}_${SPARK_SQL}_${user}_engine-pool-${poolEngineSeq}_$id")
+        s"engine-pool-$poolEngineSeq"))(appName.engineSpace)
+      assertResult(s"kyuubi_${SERVER}_${SPARK_SQL}_${user}_engine-pool-${poolEngineSeq}_$id")(
+        appName.defaultEngineName)
     }
   }
 }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/EngineRefWithUserPoolSizeSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/EngineRefWithUserPoolSizeSuite.scala
@@ -38,7 +38,7 @@ class EngineRefWithUserPoolSizeSuite extends WithKyuubiServer {
     val kyuubiConf = KyuubiConf()
       .set(ENGINE_POOL_SELECT_POLICY, poolSelectPolicy)
       .set(ENGINE_POOL_SIZE, defaultEnginePoolSize)
-      .set(s"___${user}___${ENGINE_POOL_SIZE.key}", userEnginePoolSize.toString)
+      .set(s"___${user}___.${ENGINE_POOL_SIZE.key}", userEnginePoolSize.toString)
       .set(ENGINE_TYPE, SPARK_SQL.toString)
     kyuubiConf
   }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/EngineRefWithUserPoolSizeSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/EngineRefWithUserPoolSizeSuite.scala
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.engine
+
+import java.util.UUID
+
+import org.apache.kyuubi.{KYUUBI_VERSION, Utils, WithKyuubiServer}
+import org.apache.kyuubi.config.KyuubiConf
+import org.apache.kyuubi.config.KyuubiConf._
+import org.apache.kyuubi.engine.EngineType._
+import org.apache.kyuubi.engine.ShareLevel._
+import org.apache.kyuubi.ha.client.DiscoveryPaths
+import org.apache.kyuubi.plugin.PluginLoader
+
+class EngineRefWithUserPoolSizeSuite extends WithKyuubiServer {
+  private val user: String = Utils.currentUser
+
+  protected val poolSelectPolicy = "POLLING"
+  protected val defaultEnginePoolSize = 2
+  protected val userEnginePoolSize = 3
+
+  override protected val conf: KyuubiConf = {
+    val kyuubiConf = KyuubiConf()
+      .set(ENGINE_POOL_SELECT_POLICY, poolSelectPolicy)
+      .set(ENGINE_POOL_SIZE, defaultEnginePoolSize)
+      .set(s"___${user}___${ENGINE_POOL_SIZE.key}", userEnginePoolSize.toString)
+      .set(ENGINE_TYPE, SPARK_SQL.toString)
+    kyuubiConf
+  }
+
+  test("USER share level engine pool size") {
+    val id = UUID.randomUUID().toString
+    conf.set(KyuubiConf.ENGINE_SHARE_LEVEL, USER.toString)
+
+    // user customed pool size
+    (0 until userEnginePoolSize * 2).foreach { i =>
+      val poolEngineSeq = i % userEnginePoolSize
+      val appName = new EngineRef(conf, user, PluginLoader.loadGroupProvider(conf), id, null)
+      assertResult(appName.engineSpace)(DiscoveryPaths.makePath(
+        s"kyuubi_${KYUUBI_VERSION}_${USER}_$SPARK_SQL",
+        user,
+        s"engine-pool-$poolEngineSeq"))
+      assertResult(appName.defaultEngineName)(
+        s"kyuubi_${USER}_${SPARK_SQL}_${user}_engine-pool-${poolEngineSeq}_$id")
+    }
+
+    // other users' pool size falling back to default
+    val otherUser = "otherUser"
+    (0 until userEnginePoolSize * 2).foreach { i =>
+      val poolEngineSeq = i % defaultEnginePoolSize
+      val appName = new EngineRef(conf, otherUser, PluginLoader.loadGroupProvider(conf), id, null)
+      assertResult(appName.engineSpace)(DiscoveryPaths.makePath(
+        s"kyuubi_${KYUUBI_VERSION}_${USER}_$SPARK_SQL",
+        otherUser,
+        s"engine-pool-$poolEngineSeq"))
+      assertResult(appName.defaultEngineName)(
+        s"kyuubi_${USER}_${SPARK_SQL}_${otherUser}_engine-pool-${poolEngineSeq}_$id")
+    }
+  }
+
+  test("SERVER share level engine pool size") {
+    val id = UUID.randomUUID().toString
+    conf.set(KyuubiConf.ENGINE_SHARE_LEVEL, SERVER.toString)
+
+    (0 until userEnginePoolSize * 2).foreach { i =>
+      val poolEngineSeq = i % defaultEnginePoolSize
+      val appName = new EngineRef(conf, user, PluginLoader.loadGroupProvider(conf), id, null)
+      assertResult(appName.engineSpace)(DiscoveryPaths.makePath(
+        s"kyuubi_${KYUUBI_VERSION}_${SERVER}_$SPARK_SQL",
+        user,
+        s"engine-pool-$poolEngineSeq"))
+      assertResult(appName.defaultEngineName)(
+        s"kyuubi_${SERVER}_${SPARK_SQL}_${user}_engine-pool-${poolEngineSeq}_$id")
+    }
+  }
+}


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

As described.

## Describe Your Solution 🔧

Support customizing `kyuubi.engine.pool.size` with user defaults configs, for the parameter controlling the upper limit of the engine pool for each user.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklists
## 📝 Author Self Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [style guidelines](https://kyuubi.readthedocs.io/en/master/contributing/code/style.html) of this project
- [x] I have performed a self-review
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

## 📝 Committer Pre-Merge Checklist

- [ ] Pull request title is okay.
- [ ] No license issues.
- [ ] Milestone correctly set?
- [ ] Test coverage is ok
- [ ] Assignees are selected.
- [ ] Minimum number of approvals
- [ ] No changes are requested


**Be nice. Be informative.**
