### PR TITLE
[KYUUBI #5743][AUTHZ] Improve AccessControlException verification of RangerSparkExtensionSuite

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/HudiCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/HudiCatalogRangerSparkExtensionSuite.scala
@@ -25,7 +25,7 @@ import org.apache.kyuubi.plugin.spark.authz.RangerTestNamespace._
 import org.apache.kyuubi.plugin.spark.authz.RangerTestUsers._
 import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
 import org.apache.kyuubi.tags.HudiTest
-import org.apache.kyuubi.util.AssertionUtils.interceptContains
+import org.apache.kyuubi.util.AssertionUtils.interceptEndsWith
 
 /**
  * Tests for RangerSparkExtensionSuite on Hudi SQL.
@@ -101,24 +101,24 @@ class HudiCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
              |""".stripMargin))
 
       // AlterHoodieTableAddColumnsCommand
-      interceptContains[AccessControlException](
+      interceptEndsWith[AccessControlException](
         doAs(someone, sql(s"ALTER TABLE $namespace1.$table1 ADD COLUMNS(age int)")))(
         s"does not have [alter] privilege on [$namespace1/$table1/age]")
 
       // AlterHoodieTableChangeColumnCommand
-      interceptContains[AccessControlException](
+      interceptEndsWith[AccessControlException](
         doAs(someone, sql(s"ALTER TABLE $namespace1.$table1 CHANGE COLUMN id id bigint")))(
         s"does not have [alter] privilege" +
           s" on [$namespace1/$table1/id]")
 
       // AlterHoodieTableDropPartitionCommand
-      interceptContains[AccessControlException](
+      interceptEndsWith[AccessControlException](
         doAs(someone, sql(s"ALTER TABLE $namespace1.$table1 DROP PARTITION (city='test')")))(
         s"does not have [alter] privilege" +
           s" on [$namespace1/$table1/city]")
 
       // AlterHoodieTableRenameCommand
-      interceptContains[AccessControlException](
+      interceptEndsWith[AccessControlException](
         doAs(someone, sql(s"ALTER TABLE $namespace1.$table1 RENAME TO $namespace1.$table2")))(
         s"does not have [alter] privilege" +
           s" on [$namespace1/$table1]")
@@ -126,7 +126,7 @@ class HudiCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
       // AlterTableCommand && Spark31AlterTableCommand
       try {
         sql("set hoodie.schema.on.read.enable=true")
-        interceptContains[AccessControlException](
+        interceptEndsWith[AccessControlException](
           doAs(someone, sql(s"ALTER TABLE $namespace1.$table1 ADD COLUMNS(age int)")))(
           s"does not have [alter] privilege on [$namespace1/$table1]")
       } finally {
@@ -138,7 +138,7 @@ class HudiCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
   test("CreateHoodieTableCommand") {
     withCleanTmpResources(Seq((namespace1, "database"))) {
       doAs(admin, sql(s"CREATE DATABASE IF NOT EXISTS $namespace1"))
-      interceptContains[AccessControlException](
+      interceptEndsWith[AccessControlException](
         doAs(
           someone,
           sql(
@@ -171,7 +171,7 @@ class HudiCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
              |)
              |PARTITIONED BY(city)
              |""".stripMargin))
-      interceptContains[AccessControlException](
+      interceptEndsWith[AccessControlException](
         doAs(
           someone,
           sql(
@@ -210,7 +210,7 @@ class HudiCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
            |LIKE  $namespace1.$table1
            |USING HUDI
            |""".stripMargin
-      interceptContains[AccessControlException] {
+      interceptEndsWith[AccessControlException] {
         doAs(
           someone,
           sql(
@@ -238,7 +238,7 @@ class HudiCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
              |""".stripMargin))
 
       val dropTableSql = s"DROP TABLE IF EXISTS $namespace1.$table1"
-      interceptContains[AccessControlException] {
+      interceptEndsWith[AccessControlException] {
         doAs(someone, sql(dropTableSql))
       }(s"does not have [drop] privilege on [$namespace1/$table1]")
       doAs(admin, sql(dropTableSql))
@@ -263,7 +263,7 @@ class HudiCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
              |""".stripMargin))
 
       val repairTableSql = s"MSCK REPAIR TABLE $namespace1.$table1"
-      interceptContains[AccessControlException] {
+      interceptEndsWith[AccessControlException] {
         doAs(someone, sql(repairTableSql))
       }(s"does not have [alter] privilege on [$namespace1/$table1]")
       doAs(admin, sql(repairTableSql))
@@ -288,7 +288,7 @@ class HudiCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
              |""".stripMargin))
 
       val truncateTableSql = s"TRUNCATE TABLE $namespace1.$table1"
-      interceptContains[AccessControlException] {
+      interceptEndsWith[AccessControlException] {
         doAs(someone, sql(truncateTableSql))
       }(s"does not have [update] privilege on [$namespace1/$table1]")
       doAs(admin, sql(truncateTableSql))
@@ -313,13 +313,13 @@ class HudiCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
              |""".stripMargin))
 
       val compactionTable = s"RUN COMPACTION ON $namespace1.$table1"
-      interceptContains[AccessControlException] {
+      interceptEndsWith[AccessControlException] {
         doAs(someone, sql(compactionTable))
       }(s"does not have [create] privilege on [$namespace1/$table1]")
       doAs(admin, sql(compactionTable))
 
       val showCompactionTable = s"SHOW COMPACTION ON  $namespace1.$table1"
-      interceptContains[AccessControlException] {
+      interceptEndsWith[AccessControlException] {
         doAs(someone, sql(showCompactionTable))
       }(s"does not have [select] privilege on [$namespace1/$table1]")
       doAs(admin, sql(showCompactionTable))
@@ -331,34 +331,34 @@ class HudiCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
       withCleanTmpResources(Seq.empty) {
         val path1 = "hdfs://demo/test/hudi/path"
         val compactOnPath = s"RUN COMPACTION ON '$path1'"
-        interceptContains[AccessControlException](
+        interceptEndsWith[AccessControlException](
           doAs(someone, sql(compactOnPath)))(
           s"does not have [write] privilege on [[$path1, $path1/]]")
 
         val showCompactOnPath = s"SHOW COMPACTION ON '$path1'"
-        interceptContains[AccessControlException](
+        interceptEndsWith[AccessControlException](
           doAs(someone, sql(showCompactOnPath)))(
           s"does not have [read] privilege on [[$path1, $path1/]]")
 
         val path2 = "file:///demo/test/hudi/path"
         val compactOnPath2 = s"RUN COMPACTION ON '$path2'"
-        interceptContains[AccessControlException](
+        interceptEndsWith[AccessControlException](
           doAs(someone, sql(compactOnPath2)))(
           s"does not have [write] privilege on [[$path2, $path2/]]")
 
         val showCompactOnPath2 = s"SHOW COMPACTION ON '$path2'"
-        interceptContains[AccessControlException](
+        interceptEndsWith[AccessControlException](
           doAs(someone, sql(showCompactOnPath2)))(
           s"does not have [read] privilege on [[$path2, $path2/]]")
 
         val path3 = "hdfs://demo/test/hudi/path"
         val compactOnPath3 = s"RUN COMPACTION ON '$path3'"
-        interceptContains[AccessControlException](
+        interceptEndsWith[AccessControlException](
           doAs(someone, sql(compactOnPath3)))(
           s"does not have [write] privilege on [[$path3, $path3/]]")
 
         val showCompactOnPath3 = s"SHOW COMPACTION ON '$path3/'"
-        interceptContains[AccessControlException](
+        interceptEndsWith[AccessControlException](
           doAs(someone, sql(showCompactOnPath3)))(
           s"does not have [read] privilege on [[$path3, $path3/]]")
       }
@@ -402,7 +402,7 @@ class HudiCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
              |FROM $namespace1.$table2
              |WHERE city = 'hangzhou'
              |""".stripMargin
-        interceptContains[AccessControlException] {
+        interceptEndsWith[AccessControlException] {
           doAs(someone, sql(insertIntoHoodieTableSql))
         }(s"does not have [select] privilege on " +
           s"[$namespace1/$table2/id,$namespace1/$table2/name,hudi_ns/$table2/city], " +
@@ -433,14 +433,14 @@ class HudiCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
                |""".stripMargin))
 
         val showPartitionsSql = s"SHOW PARTITIONS $namespace1.$table1"
-        interceptContains[AccessControlException] {
+        interceptEndsWith[AccessControlException] {
           doAs(someone, sql(showPartitionsSql))
         }(s"does not have [select] privilege on [$namespace1/$table1]")
         doAs(admin, sql(showPartitionsSql))
 
         val showPartitionSpecSql =
           s"SHOW PARTITIONS $namespace1.$table1 PARTITION (city = 'hangzhou')"
-        interceptContains[AccessControlException] {
+        interceptEndsWith[AccessControlException] {
           doAs(someone, sql(showPartitionSpecSql))
         }(s"does not have [select] privilege on [$namespace1/$table1/city]")
         doAs(admin, sql(showPartitionSpecSql))
@@ -484,13 +484,13 @@ class HudiCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
                |""".stripMargin))
 
         val deleteFrom = s"DELETE FROM $namespace1.$table1 WHERE id = 10"
-        interceptContains[AccessControlException] {
+        interceptEndsWith[AccessControlException] {
           doAs(someone, sql(deleteFrom))
         }(s"does not have [update] privilege on [$namespace1/$table1]")
         doAs(admin, sql(deleteFrom))
 
         val updateSql = s"UPDATE $namespace1.$table1 SET name = 'test' WHERE id > 10"
-        interceptContains[AccessControlException] {
+        interceptEndsWith[AccessControlException] {
           doAs(someone, sql(updateSql))
         }(s"does not have [update] privilege on [$namespace1/$table1]")
         doAs(admin, sql(updateSql))
@@ -504,10 +504,11 @@ class HudiCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
              |AND target.name == 'test'
              | THEN UPDATE SET id = source.id, name = source.name, city = source.city
              |""".stripMargin
-        interceptContains[AccessControlException] {
+        interceptEndsWith[AccessControlException] {
           doAs(someone, sql(mergeIntoSQL))
         }(s"does not have [select] privilege on " +
-          s"[$namespace1/$table2/id,$namespace1/$table2/name,$namespace1/$table2/city]")
+          s"[$namespace1/$table2/id,$namespace1/$table2/name,$namespace1/$table2/city], " +
+          s"[update] privilege on [$namespace1/$table1]")
         doAs(admin, sql(mergeIntoSQL))
       }
     }
@@ -549,13 +550,14 @@ class HudiCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
 
         val copy_to_table =
           s"CALL copy_to_table(table => '$namespace1.$table1', new_table => '$namespace1.$table2')"
-        interceptContains[AccessControlException] {
+        interceptEndsWith[AccessControlException] {
           doAs(someone, sql(copy_to_table))
-        }(s"does not have [select] privilege on [$namespace1/$table1]")
+        }(s"does not have [select] privilege on [$namespace1/$table1], " +
+          s"[update] privilege on [$namespace1/$table2]")
         doAs(admin, sql(copy_to_table))
 
         val show_table_properties = s"CALL show_table_properties(table => '$namespace1.$table1')"
-        interceptContains[AccessControlException] {
+        interceptEndsWith[AccessControlException] {
           doAs(someone, sql(show_table_properties))
         }(s"does not have [select] privilege on [$namespace1/$table1]")
         doAs(admin, sql(show_table_properties))
@@ -585,7 +587,7 @@ class HudiCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
 
       // CreateIndexCommand
       val createIndex = s"CREATE INDEX $index1 ON $namespace1.$table1 USING LUCENE (id)"
-      interceptContains[AccessControlException](
+      interceptEndsWith[AccessControlException](
         doAs(
           someone,
           sql(createIndex)))(s"does not have [index] privilege on [$namespace1/$table1]")
@@ -593,7 +595,7 @@ class HudiCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
 
       // RefreshIndexCommand
       val refreshIndex = s"REFRESH INDEX $index1 ON $namespace1.$table1"
-      interceptContains[AccessControlException](
+      interceptEndsWith[AccessControlException](
         doAs(
           someone,
           sql(refreshIndex)))(s"does not have [alter] privilege on [$namespace1/$table1]")
@@ -601,7 +603,7 @@ class HudiCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
 
       // ShowIndexesCommand
       val showIndex = s"SHOW INDEXES FROM TABLE $namespace1.$table1"
-      interceptContains[AccessControlException](
+      interceptEndsWith[AccessControlException](
         doAs(
           someone,
           sql(showIndex)))(s"does not have [select] privilege on [$namespace1/$table1]")
@@ -609,7 +611,7 @@ class HudiCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
 
       // DropIndexCommand
       val dropIndex = s"DROP INDEX $index1 ON $namespace1.$table1"
-      interceptContains[AccessControlException](
+      interceptEndsWith[AccessControlException](
         doAs(
           someone,
           sql(dropIndex)))(s"does not have [drop] privilege on [$namespace1/$table1]")

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/IcebergCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/IcebergCatalogRangerSparkExtensionSuite.scala
@@ -111,7 +111,7 @@ class IcebergCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite 
       s" on [$namespace1/$table1/id]"))
 
     withSingleCallEnabled {
-      interceptContains[AccessControlException](doAs(someone, sql(mergeIntoSql)))(
+      interceptEndsWith[AccessControlException](doAs(someone, sql(mergeIntoSql)))(
         if (isSparkV35OrGreater) {
           s"does not have [select] privilege on [$namespace1/table1/id" +
             s",$namespace1/$table1/name,$namespace1/$table1/city]"
@@ -121,7 +121,7 @@ class IcebergCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite 
             s" [update] privilege on [$bobNamespace/$bobSelectTable]"
         })
 
-      interceptContains[AccessControlException] {
+      interceptEndsWith[AccessControlException] {
         doAs(bob, sql(mergeIntoSql))
       }(s"does not have [update] privilege on [$bobNamespace/$bobSelectTable]")
     }
@@ -131,7 +131,7 @@ class IcebergCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite 
 
   test("[KYUUBI #3515] UPDATE TABLE") {
     // UpdateTable
-    interceptContains[AccessControlException] {
+    interceptEndsWith[AccessControlException] {
       doAs(someone, sql(s"UPDATE $catalogV2.$namespace1.$table1 SET city='Guangzhou'  WHERE id=1"))
     }(if (isSparkV35OrGreater) {
       s"does not have [select] privilege on [$namespace1/$table1/id]"
@@ -147,7 +147,7 @@ class IcebergCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite 
 
   test("[KYUUBI #3515] DELETE FROM TABLE") {
     // DeleteFromTable
-    interceptContains[AccessControlException] {
+    interceptEndsWith[AccessControlException] {
       doAs(someone, sql(s"DELETE FROM $catalogV2.$namespace1.$table1 WHERE id=2"))
     }(if (isSparkV34OrGreater) {
       s"does not have [select] privilege on [$namespace1/$table1/id]"
@@ -155,7 +155,7 @@ class IcebergCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite 
       s"does not have [update] privilege on [$namespace1/$table1]"
     })
 
-    interceptContains[AccessControlException] {
+    interceptEndsWith[AccessControlException] {
       doAs(bob, sql(s"DELETE FROM $catalogV2.$bobNamespace.$bobSelectTable WHERE id=2"))
     }(s"does not have [update] privilege on [$bobNamespace/$bobSelectTable]")
 
@@ -264,9 +264,9 @@ class IcebergCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite 
             .foreach(i => sql(s"INSERT INTO $table VALUES ($i, 'user_$i')"))
         })
 
-      interceptContains[AccessControlException](doAs(someone, sql(rewriteDataFiles1)))(
+      interceptEndsWith[AccessControlException](doAs(someone, sql(rewriteDataFiles1)))(
         s"does not have [alter] privilege on [$namespace1/$tableName]")
-      interceptContains[AccessControlException](doAs(someone, sql(rewriteDataFiles2)))(
+      interceptEndsWith[AccessControlException](doAs(someone, sql(rewriteDataFiles2)))(
         s"does not have [alter] privilege on [$namespace1/$tableName]")
 
       /**
@@ -326,7 +326,7 @@ class IcebergCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite 
       val callRollbackToSnapshot =
         s"CALL $catalogV2.system.rollback_to_snapshot (table => '$table', snapshot_id => $targetSnapshotId)"
 
-      interceptContains[AccessControlException](doAs(someone, sql(callRollbackToSnapshot)))(
+      interceptEndsWith[AccessControlException](doAs(someone, sql(callRollbackToSnapshot)))(
         s"does not have [alter] privilege on [$namespace1/$tableName]")
       doAs(admin, sql(callRollbackToSnapshot))
     }
@@ -344,7 +344,7 @@ class IcebergCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite 
         s"CALL $catalogV2.system.rollback_to_timestamp (table => '$table', timestamp => TIMESTAMP '$targetTimestamp')"
       }
 
-      interceptContains[AccessControlException](doAs(someone, sql(callRollbackToTimestamp)))(
+      interceptEndsWith[AccessControlException](doAs(someone, sql(callRollbackToTimestamp)))(
         s"does not have [alter] privilege on [$namespace1/$tableName]")
       doAs(admin, sql(callRollbackToTimestamp))
     }
@@ -359,7 +359,7 @@ class IcebergCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite 
       val callSetCurrentSnapshot =
         s"CALL $catalogV2.system.set_current_snapshot (table => '$table', snapshot_id => $targetSnapshotId)"
 
-      interceptContains[AccessControlException](doAs(someone, sql(callSetCurrentSnapshot)))(
+      interceptEndsWith[AccessControlException](doAs(someone, sql(callSetCurrentSnapshot)))(
         s"does not have [alter] privilege on [$namespace1/$tableName]")
       doAs(admin, sql(callSetCurrentSnapshot))
     }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/PaimonCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/PaimonCatalogRangerSparkExtensionSuite.scala
@@ -76,7 +76,7 @@ class PaimonCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
            |)
            |""".stripMargin
 
-      interceptContains[AccessControlException] {
+      interceptEndsWith[AccessControlException] {
         doAs(someone, sql(createTable))
       }(s"does not have [create] privilege on [$namespace1/$table1]")
       doAs(admin, createTable)

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
@@ -1254,8 +1254,13 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
               s"""
                  |CREATE TABLE IF NOT EXISTS $db1.$table1(id int, scope int)
                  |LOCATION '$path'""".stripMargin)))(
-            s"does not have [create] privilege on [$db1/$table1], " +
-              s"[write] privilege on [[$path, $path/]]")
+            if (!isSparkV35OrGreater) {
+              s"does not have [create] privilege on [$db1/$table1], " +
+                s"[write] privilege on [[$path, $path/]]"
+            } else {
+              s"does not have [create] privilege on [$db1/$table1], " +
+                s"[write] privilege on [[file://$path, file://$path/]]"
+            })
           doAs(
             admin,
             sql(

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
@@ -901,7 +901,7 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
         val df = doAs(
           admin,
           sql(s"SELECT * FROM VALUES(1, 100),(2, 200),(3, 300) AS t(id, scope)")).persist()
-        interceptContains[AccessControlException](
+        interceptEndsWith[AccessControlException](
           doAs(someone, df.write.mode("overwrite").saveAsTable(table1)))(
           s"does not have [create] privilege on [$defaultDb/$table1]")
       }
@@ -926,39 +926,39 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
                |AS
                |SELECT count(*) as cnt, sum(id) as sum_id FROM $db1.$table1
               """.stripMargin))
-        interceptContains[AccessControlException](
+        interceptEndsWith[AccessControlException](
           doAs(someone, sql(s"SELECT count(*) FROM $db1.$table1").show()))(
           s"does not have [select] privilege on [$db1/$table1/id,$db1/$table1/scope]")
 
-        interceptContains[AccessControlException](
+        interceptEndsWith[AccessControlException](
           doAs(someone, sql(s"SELECT count(*) FROM $db1.$view1").show()))(
           s"does not have [select] privilege on [$db1/$view1/id,$db1/$view1/scope]")
 
-        interceptContains[AccessControlException](
+        interceptEndsWith[AccessControlException](
           doAs(someone, sql(s"SELECT count(*) FROM $db1.$view2").show()))(
           s"does not have [select] privilege on [$db1/$view2/cnt,$db1/$view2/sum_id]")
 
-        interceptContains[AccessControlException](
+        interceptEndsWith[AccessControlException](
           doAs(someone, sql(s"SELECT count(id) FROM $db1.$table1 WHERE id > 10").show()))(
           s"does not have [select] privilege on [$db1/$table1/id]")
 
-        interceptContains[AccessControlException](
+        interceptEndsWith[AccessControlException](
           doAs(someone, sql(s"SELECT count(id) FROM $db1.$view1 WHERE id > 10").show()))(
           s"does not have [select] privilege on [$db1/$view1/id]")
 
-        interceptContains[AccessControlException](
+        interceptEndsWith[AccessControlException](
           doAs(someone, sql(s"SELECT count(sum_id) FROM $db1.$view2 WHERE sum_id > 10").show()))(
           s"does not have [select] privilege on [$db1/$view2/sum_id]")
 
-        interceptContains[AccessControlException](
+        interceptEndsWith[AccessControlException](
           doAs(someone, sql(s"SELECT count(scope) FROM $db1.$table1 WHERE id > 10").show()))(
           s"does not have [select] privilege on [$db1/$table1/scope,$db1/$table1/id]")
 
-        interceptContains[AccessControlException](
+        interceptEndsWith[AccessControlException](
           doAs(someone, sql(s"SELECT count(scope) FROM $db1.$view1 WHERE id > 10").show()))(
           s"does not have [select] privilege on [$db1/$view1/scope,$db1/$view1/id]")
 
-        interceptContains[AccessControlException](
+        interceptEndsWith[AccessControlException](
           doAs(someone, sql(s"SELECT count(cnt) FROM $db1.$view2 WHERE sum_id > 10").show()))(
           s"does not have [select] privilege on [$db1/$view2/cnt,$db1/$view2/sum_id]")
       }
@@ -980,7 +980,7 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
         doAs(admin, sql(s"CREATE TABLE IF NOT EXISTS $db1.$table1 (id int, scope int)"))
         doAs(admin, sql(s"CREATE TABLE IF NOT EXISTS $db1.$table2 (id int, scope int)"))
         doAs(admin, sql(s"CREATE VIEW $db1.$perm_view AS SELECT * FROM $db1.$table2"))
-        interceptContains[AccessControlException](
+        interceptEndsWith[AccessControlException](
           doAs(
             someone,
             sql(
@@ -995,7 +995,7 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
                  |""".stripMargin).show()))(
           s"does not have [select] privilege on " +
             s"[$db1/$perm_view/id,$db1/$perm_view/scope]")
-        interceptContains[AccessControlException](
+        interceptEndsWith[AccessControlException](
           doAs(
             permViewOnlyUser,
             sql(
@@ -1011,7 +1011,7 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
           s"does not have [select] privilege on " +
             s"[$db1/$table1/id]")
 
-        interceptContains[AccessControlException](
+        interceptEndsWith[AccessControlException](
           doAs(
             someone,
             sql(
@@ -1026,7 +1026,7 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
                  |""".stripMargin).show()))(
           s"does not have [select] privilege on " +
             s"[$db1/$table2/id,$db1/$table2/scope]")
-        interceptContains[AccessControlException](
+        interceptEndsWith[AccessControlException](
           doAs(
             table2OnlyUser,
             sql(
@@ -1052,7 +1052,7 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
       withSingleCallEnabled {
         withCleanTmpResources(Seq((s"$db1.$table1", "table"))) {
           doAs(admin, sql(s"CREATE TABLE IF NOT EXISTS $db1.$table1 (id int, scope int)"))
-          interceptContains[AccessControlException](doAs(
+          interceptEndsWith[AccessControlException](doAs(
             someone,
             sql(
               s"""
@@ -1073,7 +1073,7 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
       withSingleCallEnabled {
         withCleanTmpResources(Seq((s"$db1.$table1", "table"))) {
           doAs(admin, sql(s"CREATE TABLE IF NOT EXISTS $db1.$table1 (id int, scope int)"))
-          interceptContains[AccessControlException](doAs(
+          interceptEndsWith[AccessControlException](doAs(
             someone,
             sql(
               s"""
@@ -1091,7 +1091,7 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
     withTempDir { path =>
       withSingleCallEnabled {
         val df = sql("SELECT 1 as id, 'Tony' as name")
-        interceptContains[AccessControlException](doAs(
+        interceptEndsWith[AccessControlException](doAs(
           someone,
           df.write.format("console").mode("append").save(path.toString)))(
           s"does not have [write] privilege on [[$path, $path/]]")
@@ -1114,7 +1114,7 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
                  |USING parquet
                  |SELECT * FROM $db1.$table1""".stripMargin))
 
-          interceptContains[AccessControlException](
+          interceptEndsWith[AccessControlException](
             doAs(
               someone,
               sql(
@@ -1126,7 +1126,7 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
               s"[write] privilege on [[$path, $path/]]")
 
           doAs(admin, sql(s"SELECT * FROM parquet.`$path`".stripMargin).explain(true))
-          interceptContains[AccessControlException](
+          interceptEndsWith[AccessControlException](
             doAs(someone, sql(s"SELECT * FROM parquet.`$path`".stripMargin).explain(true)))(
             s"does not have [read] privilege on " +
               s"[[file:$path, file:$path/]]")
@@ -1148,10 +1148,10 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
                |OVERWRITE INTO TABLE $db1.$table1
                |""".stripMargin
           doAs(admin, sql(loadDataSql).explain(true))
-          interceptContains[AccessControlException](
+          interceptEndsWith[AccessControlException](
             doAs(someone, sql(loadDataSql).explain(true)))(
-            s"does not have [read] privilege on " +
-              s"[[$path, $path/]]")
+            s"does not have [read] privilege on [[$path, $path/]], " +
+              s"[update] privilege on [$db1/$table1]")
         }
       }
     }
@@ -1166,7 +1166,7 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
           Seq("JAR", "FILE")
         }
         supportedCommand.foreach { cmd =>
-          interceptContains[AccessControlException](
+          interceptEndsWith[AccessControlException](
             doAs(someone, sql(s"ADD $cmd $path")))(
             s"does not have [read] privilege on [[$path, $path/]]")
         }
@@ -1180,12 +1180,12 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
       withTempDir { path1 =>
         withTempDir { path2 =>
           withCleanTmpResources(Seq((s"$db1", "database"))) {
-            interceptContains[AccessControlException](
+            interceptEndsWith[AccessControlException](
               doAs(someone, sql(s"CREATE DATABASE $db1 LOCATION '$path1'")))(
               s"does not have [create] privilege on [$db1], " +
                 s"[write] privilege on [[$path1, $path1/]]")
             doAs(admin, sql(s"CREATE DATABASE $db1 LOCATION '$path1'"))
-            interceptContains[AccessControlException](
+            interceptEndsWith[AccessControlException](
               doAs(someone, sql(s"ALTER DATABASE $db1 SET LOCATION '$path2'")))(
               s"does not have [alter] privilege on [$db1], " +
                 s"[write] privilege on [[$path2, $path2/]]")
@@ -1215,14 +1215,14 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
                  |day string)
                  |PARTITIONED BY (day)
                  |""".stripMargin))
-          interceptContains[AccessControlException](
+          interceptEndsWith[AccessControlException](
             doAs(someone, sql(s"ALTER TABLE $db1.$table1 SET LOCATION '$path1'")))(
             s"does not have [alter] privilege on [$db1/$table1], " +
               s"[write] privilege on [[$path1, $path1/]]")
 
           withTempDir { path2 =>
             withTempDir { path3 =>
-              interceptContains[AccessControlException](
+              interceptEndsWith[AccessControlException](
                 doAs(
                   someone,
                   sql(
@@ -1248,20 +1248,21 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
     withSingleCallEnabled {
       withTempDir { path =>
         withCleanTmpResources(Seq((s"$db1.$table1", "table"), (s"$db1.$table2", "table"))) {
-          interceptContains[AccessControlException](doAs(
+          interceptEndsWith[AccessControlException](doAs(
             someone,
             sql(
               s"""
                  |CREATE TABLE IF NOT EXISTS $db1.$table1(id int, scope int)
                  |LOCATION '$path'""".stripMargin)))(
-            s"does not have [create] privilege on [$db1/$table1]")
+            s"does not have [create] privilege on [$db1/$table1], " +
+              s"[write] privilege on [[$path, $path/]]")
           doAs(
             admin,
             sql(
               s"""
                  |CREATE TABLE IF NOT EXISTS $db1.$table1(id int, scope int)
                  |LOCATION '$path'""".stripMargin))
-          interceptContains[AccessControlException](
+          interceptEndsWith[AccessControlException](
             doAs(
               someone,
               sql(
@@ -1273,7 +1274,7 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
             s"does not have [select] privilege on [$db1/$table1], " +
               s"[create] privilege on [$db1/$table2], " +
               s"[write] privilege on [[$path, $path/]]")
-          interceptContains[AccessControlException](
+          interceptEndsWith[AccessControlException](
             doAs(
               someone,
               sql(
@@ -1312,12 +1313,12 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
                |day string)
                |""".stripMargin))
         doAs(admin, sql(s"INSERT INTO $db1.$table1 SELECT 1, 2, 'TONY'"))
-        interceptContains[AccessControlException](
+        interceptEndsWith[AccessControlException](
           doAs(
             someone,
             sql(s"SELECT typeof(id), typeof(typeof(day)) FROM $db1.$table1").collect()))(
           s"does not have [select] privilege on [$db1/$table1/id,$db1/$table1/day]")
-        interceptContains[AccessControlException](
+        interceptEndsWith[AccessControlException](
           doAs(
             someone,
             sql(
@@ -1356,7 +1357,7 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
         val result = doAs(someone, sql(explainSql).collect()).head.getString(0)
         assert(!result.contains("Error occurred during query planning"))
         assert(!result.contains(s"does not have [select] privilege on [$db1/$table1/id]"))
-        interceptContains[AccessControlException](
+        interceptEndsWith[AccessControlException](
           doAs(someone, sql(s"SELECT id FROM $db1.$table1").collect()))(
           s"does not have [select] privilege on [$db1/$table1/id]")
       }


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #5743.

## Describe Your Solution 🔧

Add and use new function AssertionUtils.interceptEndswith.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests
Exists test cases.


---

# Checklists
## 📝 Author Self Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [style guidelines](https://kyuubi.readthedocs.io/en/master/contributing/code/style.html) of this project
- [x] I have performed a self-review
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

## 📝 Committer Pre-Merge Checklist

- [x] Pull request title is okay.
- [x] No license issues.
- [x] Milestone correctly set?
- [x] Test coverage is ok
- [x] Assignees are selected.
- [x] Minimum number of approvals
- [x] No changes are requested


**Be nice. Be informative.**
