### PR TITLE
[KYUUBI #5743][AUTHZ] Improve AccessControlException verification of DeltaCatalogRangerSparkExtensionSuite

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/DeltaCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/DeltaCatalogRangerSparkExtensionSuite.scala
@@ -98,13 +98,13 @@ class DeltaCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
            |  birthDate TIMESTAMP
            |) USING DELTA
            |""".stripMargin
-      interceptContains[AccessControlException] {
+      interceptEndsWith[AccessControlException] {
         doAs(someone, sql(createNonPartitionTableSql))
       }(s"does not have [create] privilege on [$namespace1/$table1]")
       doAs(admin, sql(createNonPartitionTableSql))
 
       val createPartitionTableSql = createTableSql(namespace1, table2)
-      interceptContains[AccessControlException] {
+      interceptEndsWith[AccessControlException] {
         doAs(someone, sql(createPartitionTableSql))
       }(s"does not have [create] privilege on [$namespace1/$table2]")
       doAs(admin, sql(createPartitionTableSql))
@@ -123,7 +123,7 @@ class DeltaCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
            |  birthDate TIMESTAMP
            |) USING DELTA
            |""".stripMargin
-      interceptContains[AccessControlException] {
+      interceptEndsWith[AccessControlException] {
         doAs(someone, sql(createOrReplaceTableSql))
       }(s"does not have [create] privilege on [$namespace1/$table1]")
       doAs(admin, sql(createOrReplaceTableSql))
@@ -136,12 +136,12 @@ class DeltaCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
       doAs(admin, sql(createTableSql(namespace1, table1)))
 
       // add columns
-      interceptContains[AccessControlException](
+      interceptEndsWith[AccessControlException](
         doAs(someone, sql(s"ALTER TABLE $namespace1.$table1 ADD COLUMNS (age int)")))(
         s"does not have [alter] privilege on [$namespace1/$table1]")
 
       // change column
-      interceptContains[AccessControlException](
+      interceptEndsWith[AccessControlException](
         doAs(
           someone,
           sql(s"ALTER TABLE $namespace1.$table1" +
@@ -149,7 +149,7 @@ class DeltaCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
         s"does not have [alter] privilege on [$namespace1/$table1]")
 
       // replace columns
-      interceptContains[AccessControlException](
+      interceptEndsWith[AccessControlException](
         doAs(
           someone,
           sql(s"ALTER TABLE $namespace1.$table1" +
@@ -157,7 +157,7 @@ class DeltaCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
         s"does not have [alter] privilege on [$namespace1/$table1]")
 
       // rename column
-      interceptContains[AccessControlException](
+      interceptEndsWith[AccessControlException](
         doAs(
           someone,
           sql(s"ALTER TABLE $namespace1.$table1" +
@@ -165,12 +165,12 @@ class DeltaCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
         s"does not have [alter] privilege on [$namespace1/$table1]")
 
       // drop column
-      interceptContains[AccessControlException](
+      interceptEndsWith[AccessControlException](
         doAs(someone, sql(s"ALTER TABLE $namespace1.$table1 DROP COLUMN birthDate")))(
         s"does not have [alter] privilege on [$namespace1/$table1]")
 
       // set properties
-      interceptContains[AccessControlException](
+      interceptEndsWith[AccessControlException](
         doAs(
           someone,
           sql(s"ALTER TABLE $namespace1.$table1" +
@@ -184,7 +184,7 @@ class DeltaCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
       doAs(admin, sql(s"CREATE DATABASE IF NOT EXISTS $namespace1"))
       doAs(admin, sql(createTableSql(namespace1, table1)))
       val deleteFromTableSql = s"DELETE FROM $namespace1.$table1 WHERE birthDate < '1955-01-01'"
-      interceptContains[AccessControlException](
+      interceptEndsWith[AccessControlException](
         doAs(someone, sql(deleteFromTableSql)))(
         s"does not have [update] privilege on [$namespace1/$table1]")
       doAs(admin, sql(deleteFromTableSql))
@@ -204,7 +204,7 @@ class DeltaCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
         // insert into
         val insertIntoSql = s"INSERT INTO $namespace1.$table1" +
           s" SELECT * FROM $namespace1.$table2"
-        interceptContains[AccessControlException](
+        interceptEndsWith[AccessControlException](
           doAs(someone, sql(insertIntoSql)))(
           s"does not have [select] privilege on [$namespace1/$table2/id,$namespace1/$table2/name," +
             s"$namespace1/$table2/gender,$namespace1/$table2/birthDate]," +
@@ -214,7 +214,7 @@ class DeltaCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
         // insert overwrite
         val insertOverwriteSql = s"INSERT OVERWRITE $namespace1.$table1" +
           s" SELECT * FROM $namespace1.$table2"
-        interceptContains[AccessControlException](
+        interceptEndsWith[AccessControlException](
           doAs(someone, sql(insertOverwriteSql)))(
           s"does not have [select] privilege on [$namespace1/$table2/id,$namespace1/$table2/name," +
             s"$namespace1/$table2/gender,$namespace1/$table2/birthDate]," +
@@ -230,7 +230,7 @@ class DeltaCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
       doAs(admin, sql(createTableSql(namespace1, table1)))
       val updateTableSql = s"UPDATE $namespace1.$table1" +
         s" SET gender = 'Female' WHERE gender = 'F'"
-      interceptContains[AccessControlException](
+      interceptEndsWith[AccessControlException](
         doAs(someone, sql(updateTableSql)))(
         s"does not have [update] privilege on [$namespace1/$table1]")
       doAs(admin, sql(updateTableSql))
@@ -272,7 +272,7 @@ class DeltaCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
              |    source.birthDate
              |  )
              |""".stripMargin
-        interceptContains[AccessControlException](
+        interceptEndsWith[AccessControlException](
           doAs(someone, sql(mergeIntoSql)))(
           s"does not have [select] privilege on [$namespace1/$table2/id,$namespace1/$table2/name," +
             s"$namespace1/$table2/gender,$namespace1/$table2/birthDate]," +
@@ -289,7 +289,7 @@ class DeltaCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
       doAs(admin, sql(s"CREATE DATABASE IF NOT EXISTS $namespace1"))
       doAs(admin, sql(createTableSql(namespace1, table1)))
       val optimizeTableSql = s"OPTIMIZE $namespace1.$table1"
-      interceptContains[AccessControlException](
+      interceptEndsWith[AccessControlException](
         doAs(someone, sql(optimizeTableSql)))(
         s"does not have [alter] privilege on [$namespace1/$table1]")
       doAs(admin, sql(optimizeTableSql))
@@ -301,7 +301,7 @@ class DeltaCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
       doAs(admin, sql(s"CREATE DATABASE IF NOT EXISTS $namespace1"))
       doAs(admin, sql(createTableSql(namespace1, table1)))
       val vacuumTableSql = s"VACUUM $namespace1.$table1"
-      interceptContains[AccessControlException](
+      interceptEndsWith[AccessControlException](
         doAs(someone, sql(vacuumTableSql)))(
         s"does not have [alter] privilege on [$namespace1/$table1]")
       doAs(admin, sql(vacuumTableSql))
@@ -311,7 +311,7 @@ class DeltaCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
   test("create path-based table") {
     withTempDir(path => {
       val createTableSql = createPathBasedTableSql(path)
-      interceptContains[AccessControlException] {
+      interceptEndsWith[AccessControlException] {
         doAs(someone, sql(createTableSql))
       }(s"does not have [write] privilege on [[$path, $path/]]")
       doAs(admin, sql(createTableSql))
@@ -329,7 +329,7 @@ class DeltaCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
            |  birthDate TIMESTAMP
            |) USING DELTA
            |""".stripMargin
-      interceptContains[AccessControlException] {
+      interceptEndsWith[AccessControlException] {
         doAs(someone, sql(createOrReplaceTableSql))
       }(s"does not have [write] privilege on [[$path, $path/]]")
       doAs(admin, sql(createOrReplaceTableSql))
@@ -340,7 +340,7 @@ class DeltaCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
     withTempDir(path => {
       doAs(admin, sql(createPathBasedTableSql(path)))
       val deleteFromTableSql = s"DELETE FROM delta.`$path` WHERE birthDate < '1955-01-01'"
-      interceptContains[AccessControlException] {
+      interceptEndsWith[AccessControlException] {
         doAs(someone, sql(deleteFromTableSql))
       }(s"does not have [write] privilege on [[$path, $path/]]")
       doAs(admin, sql(deleteFromTableSql))
@@ -351,7 +351,7 @@ class DeltaCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
     withTempDir(path => {
       doAs(admin, sql(createPathBasedTableSql(path)))
       val updateTableSql = s"UPDATE delta.`$path` SET gender = 'Female' WHERE gender = 'F'"
-      interceptContains[AccessControlException] {
+      interceptEndsWith[AccessControlException] {
         doAs(someone, sql(updateTableSql))
       }(s"does not have [write] privilege on [[$path, $path/]]")
       doAs(admin, sql(updateTableSql))
@@ -367,7 +367,7 @@ class DeltaCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
           doAs(admin, sql(createPathBasedTableSql(path)))
           // insert into
           val insertIntoSql = s"INSERT INTO delta.`$path` SELECT * FROM $namespace1.$table2"
-          interceptContains[AccessControlException](
+          interceptEndsWith[AccessControlException](
             doAs(someone, sql(insertIntoSql)))(
             s"does not have [select] privilege on [$namespace1/$table2/id," +
               s"$namespace1/$table2/name,$namespace1/$table2/gender," +
@@ -377,7 +377,7 @@ class DeltaCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
           // insert overwrite
           val insertOverwriteSql =
             s"INSERT OVERWRITE delta.`$path` SELECT * FROM $namespace1.$table2"
-          interceptContains[AccessControlException](
+          interceptEndsWith[AccessControlException](
             doAs(someone, sql(insertOverwriteSql)))(
             s"does not have [select] privilege on [$namespace1/$table2/id," +
               s"$namespace1/$table2/name,$namespace1/$table2/gender," +
@@ -422,7 +422,7 @@ class DeltaCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
                |    source.birthDate
                |  )
                |""".stripMargin
-          interceptContains[AccessControlException](
+          interceptEndsWith[AccessControlException](
             doAs(someone, sql(mergeIntoSql)))(
             s"does not have [select] privilege on [$namespace1/$table2/id," +
               s"$namespace1/$table2/name,$namespace1/$table2/gender," +
@@ -439,13 +439,13 @@ class DeltaCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
     withTempDir(path => {
       doAs(admin, sql(createPathBasedTableSql(path)))
       val optimizeTableSql1 = s"OPTIMIZE delta.`$path`"
-      interceptContains[AccessControlException](
+      interceptEndsWith[AccessControlException](
         doAs(someone, sql(optimizeTableSql1)))(
         s"does not have [write] privilege on [[$path, $path/]]")
       doAs(admin, sql(optimizeTableSql1))
 
       val optimizeTableSql2 = s"OPTIMIZE '$path'"
-      interceptContains[AccessControlException](
+      interceptEndsWith[AccessControlException](
         doAs(someone, sql(optimizeTableSql2)))(
         s"does not have [write] privilege on [[$path, $path/]]")
       doAs(admin, sql(optimizeTableSql2))

--- a/kyuubi-util-scala/src/test/scala/org/apache/kyuubi/util/AssertionUtils.scala
+++ b/kyuubi-util-scala/src/test/scala/org/apache/kyuubi/util/AssertionUtils.scala
@@ -172,7 +172,7 @@ object AssertionUtils {
 
   /**
    * Asserts that the given function throws an exception of the given type
-   * and with the exception message equals to expected string
+   * and with the exception message contains expected string
    */
   def interceptContains[T <: Exception](f: => Any)(contained: String)(implicit
       classTag: ClassTag[T],
@@ -180,5 +180,17 @@ object AssertionUtils {
     assert(contained != null)
     val exception = intercept[T](f)(classTag, pos)
     assert(exception.getMessage.contains(contained))
+  }
+
+  /**
+   * Asserts that the given function throws an exception of the given type
+   * and with the exception message ends with expected string
+   */
+  def interceptEndsWith[T <: Exception](f: => Any)(end: String)(implicit
+      classTag: ClassTag[T],
+      pos: Position): Unit = {
+    assert(end != null)
+    val exception = intercept[T](f)(classTag, pos)
+    assert(exception.getMessage.endsWith(end))
   }
 }


### PR DESCRIPTION

# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #5743.

## Describe Your Solution 🔧

Add and use new function AssertionUtils.interceptEndswith.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests
Exists test cases.


---

# Checklists
## 📝 Author Self Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [style guidelines](https://kyuubi.readthedocs.io/en/master/contributing/code/style.html) of this project
- [x] I have performed a self-review
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

## 📝 Committer Pre-Merge Checklist

- [x] Pull request title is okay.
- [x] No license issues.
- [x] Milestone correctly set?
- [x] Test coverage is ok
- [x] Assignees are selected.
- [x] Minimum number of approvals
- [x] No changes are requested


**Be nice. Be informative.**
