### PR TITLE
JDBC driver implements getDate, getTimestamp and getTime with Calendar in ResultSet

### DIFF
--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/SparkDataTypeTests.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/SparkDataTypeTests.scala
@@ -168,6 +168,9 @@ trait SparkDataTypeTests extends HiveJDBCTestHelper with SparkVersionUtil {
       assert(resultSet.getDate(
         "col",
         Calendar.getInstance()) === Date.valueOf("2018-11-17"))
+      assert(resultSet.getDate(
+        1,
+        Calendar.getInstance()) === Date.valueOf("2018-11-17"))
       val metaData = resultSet.getMetaData
       assert(metaData.getColumnType(1) === java.sql.Types.DATE)
       assert(metaData.getPrecision(1) === 10)
@@ -235,6 +238,10 @@ trait SparkDataTypeTests extends HiveJDBCTestHelper with SparkVersionUtil {
       assert(resultSet.next())
       assert(resultSet.getTimestamp(
         "col",
+        Calendar.getInstance(TimeZone.getTimeZone("UTC"))) === Timestamp.valueOf(
+        "2018-11-17 13:33:33"))
+      assert(resultSet.getTimestamp(
+        1,
         Calendar.getInstance(TimeZone.getTimeZone("UTC"))) === Timestamp.valueOf(
         "2018-11-17 13:33:33"))
       val metaData = resultSet.getMetaData

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/SparkDataTypeTests.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/SparkDataTypeTests.scala
@@ -18,7 +18,7 @@
 package org.apache.kyuubi.operation
 
 import java.sql.{Date, Timestamp}
-import java.util.{Calendar, TimeZone}
+import java.util.Calendar
 
 import org.apache.kyuubi.util.SparkVersionUtil
 
@@ -238,11 +238,11 @@ trait SparkDataTypeTests extends HiveJDBCTestHelper with SparkVersionUtil {
       assert(resultSet.next())
       assert(resultSet.getTimestamp(
         "col",
-        Calendar.getInstance(TimeZone.getTimeZone("UTC"))) === Timestamp.valueOf(
+        Calendar.getInstance()) === Timestamp.valueOf(
         "2018-11-17 13:33:33"))
       assert(resultSet.getTimestamp(
         1,
-        Calendar.getInstance(TimeZone.getTimeZone("UTC"))) === Timestamp.valueOf(
+        Calendar.getInstance()) === Timestamp.valueOf(
         "2018-11-17 13:33:33"))
       val metaData = resultSet.getMetaData
       assert(metaData.getColumnType(1) === java.sql.Types.TIMESTAMP)

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/SparkDataTypeTests.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/SparkDataTypeTests.scala
@@ -18,6 +18,7 @@
 package org.apache.kyuubi.operation
 
 import java.sql.{Date, Timestamp}
+import java.util.{Calendar, TimeZone}
 
 import org.apache.kyuubi.util.SparkVersionUtil
 
@@ -160,6 +161,20 @@ trait SparkDataTypeTests extends HiveJDBCTestHelper with SparkVersionUtil {
     }
   }
 
+  test("execute statement - select date with calendar") {
+    withJdbcStatement() { statement =>
+      val resultSet = statement.executeQuery("SELECT DATE '2018-11-17' AS col")
+      assert(resultSet.next())
+      assert(resultSet.getDate(
+        "col",
+        Calendar.getInstance()) === Date.valueOf("2018-11-17"))
+      val metaData = resultSet.getMetaData
+      assert(metaData.getColumnType(1) === java.sql.Types.DATE)
+      assert(metaData.getPrecision(1) === 10)
+      assert(metaData.getScale(1) === 0)
+    }
+  }
+
   test("execute statement - select timestamp - second") {
     withJdbcStatement() { statement =>
       val resultSet = statement.executeQuery(
@@ -206,6 +221,22 @@ trait SparkDataTypeTests extends HiveJDBCTestHelper with SparkVersionUtil {
         "SELECT make_timestamp_ntz(2022, 03, 24, 18, 08, 31.8888) AS col")
       assert(resultSet.next())
       assert(resultSet.getTimestamp("col") === Timestamp.valueOf("2022-03-24 18:08:31.8888"))
+      val metaData = resultSet.getMetaData
+      assert(metaData.getColumnType(1) === java.sql.Types.TIMESTAMP)
+      assert(metaData.getPrecision(1) === 29)
+      assert(metaData.getScale(1) === 9)
+    }
+  }
+
+  test("execute statement - select timestamp - second with calendar") {
+    withJdbcStatement() { statement =>
+      val resultSet = statement.executeQuery(
+        "SELECT TIMESTAMP '2018-11-17 13:33:33' AS col")
+      assert(resultSet.next())
+      assert(resultSet.getTimestamp(
+        "col",
+        Calendar.getInstance(TimeZone.getTimeZone("UTC"))) === Timestamp.valueOf(
+        "2018-11-17 13:33:33"))
       val metaData = resultSet.getMetaData
       assert(metaData.getColumnType(1) === java.sql.Types.TIMESTAMP)
       assert(metaData.getPrecision(1) === 29)

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiArrowBasedResultSet.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiArrowBasedResultSet.java
@@ -23,6 +23,7 @@ import java.math.BigDecimal;
 import java.math.MathContext;
 import java.nio.charset.StandardCharsets;
 import java.sql.*;
+import java.util.Calendar;
 import java.util.List;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
@@ -196,6 +197,32 @@ public abstract class KyuubiArrowBasedResultSet implements SQLResultSet {
   @Override
   public Date getDate(String columnName) throws SQLException {
     return getDate(findColumn(columnName));
+  }
+
+  public Date getDate(int columnIndex, Calendar cal) throws SQLException {
+    Date value = getDate(columnIndex);
+    if (value == null) {
+      return null;
+    } else {
+      try {
+        return parseDate(value, cal);
+      } catch (IllegalArgumentException e) {
+        throw new KyuubiSQLException("Cannot convert column " + columnIndex + " to date: " + e, e);
+      }
+    }
+  }
+
+  @Override
+  public Date getDate(String columnLabel, Calendar cal) throws SQLException {
+    return this.getDate(findColumn(columnLabel), cal);
+  }
+
+  private Date parseDate(Date value, Calendar cal) {
+    if (cal == null) {
+      cal = Calendar.getInstance();
+    }
+    cal.setTime(value);
+    return new Date(cal.getTimeInMillis());
   }
 
   @Override

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiArrowBasedResultSet.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiArrowBasedResultSet.java
@@ -443,7 +443,8 @@ public abstract class KyuubiArrowBasedResultSet implements SQLResultSet {
       try {
         return parseTimestamp(value, cal);
       } catch (IllegalArgumentException e) {
-        throw new KyuubiSQLException("Cannot convert column " + columnIndex + " to timestamp: " + e, e);
+        throw new KyuubiSQLException(
+            "Cannot convert column " + columnIndex + " to timestamp: " + e, e);
       }
     }
   }

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiArrowBasedResultSet.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiArrowBasedResultSet.java
@@ -198,7 +198,7 @@ public abstract class KyuubiArrowBasedResultSet implements SQLResultSet {
   public Date getDate(String columnName) throws SQLException {
     return getDate(findColumn(columnName));
   }
-  
+
   @Override
   public Date getDate(int columnIndex, Calendar cal) throws SQLException {
     Date value = getDate(columnIndex);
@@ -432,6 +432,84 @@ public abstract class KyuubiArrowBasedResultSet implements SQLResultSet {
   @Override
   public Timestamp getTimestamp(String columnName) throws SQLException {
     return getTimestamp(findColumn(columnName));
+  }
+
+  @Override
+  public Timestamp getTimestamp(int columnIndex, Calendar cal) throws SQLException {
+    Timestamp value = getTimestamp(columnIndex);
+    if (value == null) {
+      return null;
+    } else {
+      try {
+        return parseTimestamp(value, cal);
+      } catch (IllegalArgumentException e) {
+        throw new KyuubiSQLException("Cannot convert column " + columnIndex + " to timestamp: " + e, e);
+      }
+    }
+  }
+
+  @Override
+  public Timestamp getTimestamp(String columnLabel, Calendar cal) throws SQLException {
+    return this.getTimestamp(findColumn(columnLabel), cal);
+  }
+
+  private Timestamp parseTimestamp(Timestamp timestamp, Calendar cal) {
+    if (cal == null) {
+      cal = Calendar.getInstance();
+    }
+    long v = timestamp.getTime();
+    v -= cal.getTimeZone().getOffset(v);
+    timestamp = new Timestamp(v);
+    return timestamp;
+  }
+
+  @Override
+  public Time getTime(int columnIndex) throws SQLException {
+    Object obj = getObject(columnIndex);
+    if (obj == null) {
+      return null;
+    }
+    if (obj instanceof Time) {
+      return (Time) obj;
+    }
+    if (obj instanceof String) {
+      return Time.valueOf((String) obj);
+    }
+    throw new KyuubiSQLException("Illegal conversion");
+  }
+
+  @Override
+  public Time getTime(String columnLabel) throws SQLException {
+    return getTime(findColumn(columnLabel));
+  }
+
+  @Override
+  public Time getTime(int columnIndex, Calendar cal) throws SQLException {
+    Time value = getTime(columnIndex);
+    if (value == null) {
+      return null;
+    } else {
+      try {
+        return parseTime(value, cal);
+      } catch (IllegalArgumentException e) {
+        throw new KyuubiSQLException("Cannot convert column " + columnIndex + " to time: " + e, e);
+      }
+    }
+  }
+
+  @Override
+  public Time getTime(String columnLabel, Calendar cal) throws SQLException {
+    return this.getTime(findColumn(columnLabel), cal);
+  }
+
+  private Time parseTime(Time date, Calendar cal) {
+    if (cal == null) {
+      cal = Calendar.getInstance();
+    }
+    long v = date.getTime();
+    v -= cal.getTimeZone().getOffset(v);
+    date = new Time(v);
+    return date;
   }
 
   @Override

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiArrowBasedResultSet.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiArrowBasedResultSet.java
@@ -439,13 +439,12 @@ public abstract class KyuubiArrowBasedResultSet implements SQLResultSet {
     Timestamp value = getTimestamp(columnIndex);
     if (value == null) {
       return null;
-    } else {
-      try {
-        return parseTimestamp(value, cal);
-      } catch (IllegalArgumentException e) {
-        throw new KyuubiSQLException(
-            "Cannot convert column " + columnIndex + " to timestamp: " + e, e);
-      }
+    }
+    try {
+      return parseTimestamp(value, cal);
+    } catch (IllegalArgumentException e) {
+      throw new KyuubiSQLException(
+          "Cannot convert column " + columnIndex + " to timestamp: " + e, e);
     }
   }
 

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiArrowBasedResultSet.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiArrowBasedResultSet.java
@@ -489,12 +489,11 @@ public abstract class KyuubiArrowBasedResultSet implements SQLResultSet {
     Time value = getTime(columnIndex);
     if (value == null) {
       return null;
-    } else {
-      try {
-        return parseTime(value, cal);
-      } catch (IllegalArgumentException e) {
-        throw new KyuubiSQLException("Cannot convert column " + columnIndex + " to time: " + e, e);
-      }
+    }
+    try {
+      return parseTime(value, cal);
+    } catch (IllegalArgumentException e) {
+      throw new KyuubiSQLException("Cannot convert column " + columnIndex + " to time: " + e, e);
     }
   }
 

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiArrowBasedResultSet.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiArrowBasedResultSet.java
@@ -198,7 +198,8 @@ public abstract class KyuubiArrowBasedResultSet implements SQLResultSet {
   public Date getDate(String columnName) throws SQLException {
     return getDate(findColumn(columnName));
   }
-
+  
+  @Override
   public Date getDate(int columnIndex, Calendar cal) throws SQLException {
     Date value = getDate(columnIndex);
     if (value == null) {

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiArrowBasedResultSet.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiArrowBasedResultSet.java
@@ -459,8 +459,8 @@ public abstract class KyuubiArrowBasedResultSet implements SQLResultSet {
       cal = Calendar.getInstance();
     }
     long v = timestamp.getTime();
-    v -= cal.getTimeZone().getOffset(v);
-    timestamp = new Timestamp(v);
+    cal.setTimeInMillis(v);
+    timestamp = new Timestamp(cal.getTime().getTime());
     return timestamp;
   }
 
@@ -508,8 +508,8 @@ public abstract class KyuubiArrowBasedResultSet implements SQLResultSet {
       cal = Calendar.getInstance();
     }
     long v = date.getTime();
-    v -= cal.getTimeZone().getOffset(v);
-    date = new Time(v);
+    cal.setTimeInMillis(v);
+    date = new Time(cal.getTime().getTime());
     return date;
   }
 

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiArrowBasedResultSet.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiArrowBasedResultSet.java
@@ -204,12 +204,11 @@ public abstract class KyuubiArrowBasedResultSet implements SQLResultSet {
     Date value = getDate(columnIndex);
     if (value == null) {
       return null;
-    } else {
-      try {
-        return parseDate(value, cal);
-      } catch (IllegalArgumentException e) {
-        throw new KyuubiSQLException("Cannot convert column " + columnIndex + " to date: " + e, e);
-      }
+    }
+    try {
+      return parseDate(value, cal);
+    } catch (IllegalArgumentException e) {
+      throw new KyuubiSQLException("Cannot convert column " + columnIndex + " to date: " + e, e);
     }
   }
 

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiBaseResultSet.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiBaseResultSet.java
@@ -445,13 +445,12 @@ public abstract class KyuubiBaseResultSet implements SQLResultSet {
     Timestamp value = getTimestamp(columnIndex);
     if (value == null) {
       return null;
-    } else {
-      try {
-        return parseTimestamp(value, cal);
-      } catch (IllegalArgumentException e) {
-        throw new KyuubiSQLException(
-            "Cannot convert column " + columnIndex + " to timestamp: " + e, e);
-      }
+    }
+    try {
+      return parseTimestamp(value, cal);
+    } catch (IllegalArgumentException e) {
+      throw new KyuubiSQLException(
+          "Cannot convert column " + columnIndex + " to timestamp: " + e, e);
     }
   }
 

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiBaseResultSet.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiBaseResultSet.java
@@ -465,8 +465,8 @@ public abstract class KyuubiBaseResultSet implements SQLResultSet {
       cal = Calendar.getInstance();
     }
     long v = timestamp.getTime();
-    v -= cal.getTimeZone().getOffset(v);
-    timestamp = new Timestamp(v);
+    cal.setTimeInMillis(v);
+    timestamp = new Timestamp(cal.getTime().getTime());
     return timestamp;
   }
 
@@ -514,8 +514,8 @@ public abstract class KyuubiBaseResultSet implements SQLResultSet {
       cal = Calendar.getInstance();
     }
     long v = date.getTime();
-    v -= cal.getTimeZone().getOffset(v);
-    date = new Time(v);
+    cal.setTimeInMillis(v);
+    date = new Time(cal.getTime().getTime());
     return date;
   }
 

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiBaseResultSet.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiBaseResultSet.java
@@ -439,6 +439,7 @@ public abstract class KyuubiBaseResultSet implements SQLResultSet {
   public Timestamp getTimestamp(String columnName) throws SQLException {
     return getTimestamp(findColumn(columnName));
   }
+
   @Override
   public Timestamp getTimestamp(int columnIndex, Calendar cal) throws SQLException {
     Timestamp value = getTimestamp(columnIndex);
@@ -448,7 +449,8 @@ public abstract class KyuubiBaseResultSet implements SQLResultSet {
       try {
         return parseTimestamp(value, cal);
       } catch (IllegalArgumentException e) {
-        throw new KyuubiSQLException("Cannot convert column " + columnIndex + " to timestamp: " + e, e);
+        throw new KyuubiSQLException(
+            "Cannot convert column " + columnIndex + " to timestamp: " + e, e);
       }
     }
   }

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiBaseResultSet.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiBaseResultSet.java
@@ -23,6 +23,7 @@ import java.math.BigDecimal;
 import java.math.MathContext;
 import java.nio.charset.StandardCharsets;
 import java.sql.*;
+import java.util.Calendar;
 import java.util.List;
 import org.apache.hive.service.rpc.thrift.TTableSchema;
 import org.apache.hive.service.rpc.thrift.TTypeId;
@@ -180,6 +181,33 @@ public abstract class KyuubiBaseResultSet implements SQLResultSet {
   @Override
   public Date getDate(String columnName) throws SQLException {
     return getDate(findColumn(columnName));
+  }
+
+  @Override
+  public Date getDate(int columnIndex, Calendar cal) throws SQLException {
+    Date value = getDate(columnIndex);
+    if (value == null) {
+      return null;
+    } else {
+      try {
+        return parseDate(value, cal);
+      } catch (IllegalArgumentException e) {
+        throw new KyuubiSQLException("Cannot convert column " + columnIndex + " to date: " + e, e);
+      }
+    }
+  }
+
+  @Override
+  public Date getDate(String columnLabel, Calendar cal) throws SQLException {
+    return this.getDate(findColumn(columnLabel), cal);
+  }
+
+  private Date parseDate(Date value, Calendar cal) {
+    if (cal == null) {
+      cal = Calendar.getInstance();
+    }
+    cal.setTime(value);
+    return new Date(cal.getTimeInMillis());
   }
 
   @Override

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiBaseResultSet.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiBaseResultSet.java
@@ -188,12 +188,11 @@ public abstract class KyuubiBaseResultSet implements SQLResultSet {
     Date value = getDate(columnIndex);
     if (value == null) {
       return null;
-    } else {
-      try {
-        return parseDate(value, cal);
-      } catch (IllegalArgumentException e) {
-        throw new KyuubiSQLException("Cannot convert column " + columnIndex + " to date: " + e, e);
-      }
+    }
+    try {
+      return parseDate(value, cal);
+    } catch (IllegalArgumentException e) {
+      throw new KyuubiSQLException("Cannot convert column " + columnIndex + " to date: " + e, e);
     }
   }
 

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiBaseResultSet.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiBaseResultSet.java
@@ -439,6 +439,83 @@ public abstract class KyuubiBaseResultSet implements SQLResultSet {
   public Timestamp getTimestamp(String columnName) throws SQLException {
     return getTimestamp(findColumn(columnName));
   }
+  @Override
+  public Timestamp getTimestamp(int columnIndex, Calendar cal) throws SQLException {
+    Timestamp value = getTimestamp(columnIndex);
+    if (value == null) {
+      return null;
+    } else {
+      try {
+        return parseTimestamp(value, cal);
+      } catch (IllegalArgumentException e) {
+        throw new KyuubiSQLException("Cannot convert column " + columnIndex + " to timestamp: " + e, e);
+      }
+    }
+  }
+
+  @Override
+  public Timestamp getTimestamp(String columnLabel, Calendar cal) throws SQLException {
+    return this.getTimestamp(findColumn(columnLabel), cal);
+  }
+
+  private Timestamp parseTimestamp(Timestamp timestamp, Calendar cal) {
+    if (cal == null) {
+      cal = Calendar.getInstance();
+    }
+    long v = timestamp.getTime();
+    v -= cal.getTimeZone().getOffset(v);
+    timestamp = new Timestamp(v);
+    return timestamp;
+  }
+
+  @Override
+  public Time getTime(int columnIndex) throws SQLException {
+    Object obj = getObject(columnIndex);
+    if (obj == null) {
+      return null;
+    }
+    if (obj instanceof Time) {
+      return (Time) obj;
+    }
+    if (obj instanceof String) {
+      return Time.valueOf((String) obj);
+    }
+    throw new KyuubiSQLException("Illegal conversion");
+  }
+
+  @Override
+  public Time getTime(String columnLabel) throws SQLException {
+    return getTime(findColumn(columnLabel));
+  }
+
+  @Override
+  public Time getTime(int columnIndex, Calendar cal) throws SQLException {
+    Time value = getTime(columnIndex);
+    if (value == null) {
+      return null;
+    } else {
+      try {
+        return parseTime(value, cal);
+      } catch (IllegalArgumentException e) {
+        throw new KyuubiSQLException("Cannot convert column " + columnIndex + " to time: " + e, e);
+      }
+    }
+  }
+
+  @Override
+  public Time getTime(String columnLabel, Calendar cal) throws SQLException {
+    return this.getTime(findColumn(columnLabel), cal);
+  }
+
+  private Time parseTime(Time date, Calendar cal) {
+    if (cal == null) {
+      cal = Calendar.getInstance();
+    }
+    long v = date.getTime();
+    v -= cal.getTimeZone().getOffset(v);
+    date = new Time(v);
+    return date;
+  }
 
   @Override
   public int getType() throws SQLException {

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiBaseResultSet.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiBaseResultSet.java
@@ -495,12 +495,11 @@ public abstract class KyuubiBaseResultSet implements SQLResultSet {
     Time value = getTime(columnIndex);
     if (value == null) {
       return null;
-    } else {
-      try {
-        return parseTime(value, cal);
-      } catch (IllegalArgumentException e) {
-        throw new KyuubiSQLException("Cannot convert column " + columnIndex + " to time: " + e, e);
-      }
+    }
+    try {
+      return parseTime(value, cal);
+    } catch (IllegalArgumentException e) {
+      throw new KyuubiSQLException("Cannot convert column " + columnIndex + " to time: " + e, e);
     }
   }
 

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/adapter/SQLResultSet.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/adapter/SQLResultSet.java
@@ -22,7 +22,6 @@ import java.io.Reader;
 import java.math.BigDecimal;
 import java.net.URL;
 import java.sql.*;
-import java.util.Calendar;
 import java.util.Map;
 
 @SuppressWarnings("deprecation")

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/adapter/SQLResultSet.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/adapter/SQLResultSet.java
@@ -435,12 +435,6 @@ public interface SQLResultSet extends ResultSet {
   default Array getArray(String columnLabel) throws SQLException {
     throw new SQLFeatureNotSupportedException("Method not supported");
   }
-
-  @Override
-  default Date getDate(int columnIndex, Calendar cal) throws SQLException {
-    throw new SQLFeatureNotSupportedException("Method not supported");
-  }
-
   @Override
   default Date getDate(String columnLabel, Calendar cal) throws SQLException {
     throw new SQLFeatureNotSupportedException("Method not supported");

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/adapter/SQLResultSet.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/adapter/SQLResultSet.java
@@ -435,30 +435,6 @@ public interface SQLResultSet extends ResultSet {
   default Array getArray(String columnLabel) throws SQLException {
     throw new SQLFeatureNotSupportedException("Method not supported");
   }
-  @Override
-  default Date getDate(String columnLabel, Calendar cal) throws SQLException {
-    throw new SQLFeatureNotSupportedException("Method not supported");
-  }
-
-  @Override
-  default Time getTime(int columnIndex, Calendar cal) throws SQLException {
-    throw new SQLFeatureNotSupportedException("Method not supported");
-  }
-
-  @Override
-  default Time getTime(String columnLabel, Calendar cal) throws SQLException {
-    throw new SQLFeatureNotSupportedException("Method not supported");
-  }
-
-  @Override
-  default Timestamp getTimestamp(int columnIndex, Calendar cal) throws SQLException {
-    throw new SQLFeatureNotSupportedException("Method not supported");
-  }
-
-  @Override
-  default Timestamp getTimestamp(String columnLabel, Calendar cal) throws SQLException {
-    throw new SQLFeatureNotSupportedException("Method not supported");
-  }
 
   @Override
   default URL getURL(int columnIndex) throws SQLException {


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗

<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #5650

## Describe Your Solution 🔧

 implemented getDate, getTimestamp and getTime with Calendar in Kyuubi JDBC driver side


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklists
## 📝 Author Self Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [style guidelines](https://kyuubi.readthedocs.io/en/master/contributing/code/style.html) of this project
- [x] I have performed a self-review
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

## 📝 Committer Pre-Merge Checklist

- [ ] Pull request title is okay.
- [ ] No license issues.
- [ ] Milestone correctly set?
- [ ] Test coverage is ok
- [ ] Assignees are selected.
- [ ] Minimum number of approvals
- [ ] No changes are requested


**Be nice. Be informative.**
