### PR TITLE
[KYUUBI #5768][AUTHZ] Authz internal place holder should skip privilege check

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -307,7 +307,7 @@ object PrivilegesBuilder {
       case ObjectFilterPlaceHolder(child) if child.nodeName == "ShowTables" =>
         OperationType.SHOWTABLES
       case ObjectFilterPlaceHolder(child) if child.nodeName == "ShowNamespaces" =>
-        OperationType.SHOWTABLES
+        OperationType.SHOWDATABASES
       case _: FilteredShowTablesCommand => OperationType.SHOWTABLES
       case _: FilteredShowFunctionsCommand => OperationType.SHOWFUNCTIONS
       case _: FilteredShowColumnsCommand => OperationType.SHOWCOLUMNS

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -29,6 +29,7 @@ import org.apache.kyuubi.plugin.spark.authz.OperationType.OperationType
 import org.apache.kyuubi.plugin.spark.authz.PrivilegeObjectActionType._
 import org.apache.kyuubi.plugin.spark.authz.rule.Authorization._
 import org.apache.kyuubi.plugin.spark.authz.rule.permanentview.PermanentViewMarker
+import org.apache.kyuubi.plugin.spark.authz.rule.rowfilter._
 import org.apache.kyuubi.plugin.spark.authz.serde._
 import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
 import org.apache.kyuubi.util.reflect.ReflectUtils._
@@ -303,6 +304,14 @@ object PrivilegesBuilder {
     val inputObjs = new ArrayBuffer[PrivilegeObject]
     val outputObjs = new ArrayBuffer[PrivilegeObject]
     val opType = plan match {
+      case ObjectFilterPlaceHolder(child) if child.nodeName == "ShowTables" =>
+        OperationType.SHOWTABLES
+      case ObjectFilterPlaceHolder(child) if child.nodeName == "ShowNamespaces" =>
+        OperationType.SHOWTABLES
+      case _: FilteredShowTablesCommand => OperationType.SHOWTABLES
+      case _: FilteredShowFunctionsCommand => OperationType.SHOWFUNCTIONS
+      case _: FilteredShowColumnsCommand => OperationType.SHOWCOLUMNS
+
       // ExplainCommand run will execute the plan, should avoid check privilege for the plan.
       case _: ExplainCommand =>
         setExplainCommandExecutionId(spark)

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleAuthorization.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleAuthorization.scala
@@ -35,10 +35,6 @@ class RuleAuthorization(spark: SparkSession) extends Authorization(spark) {
     val ugi = getAuthzUgi(spark.sparkContext)
     val (inputs, outputs, opType) = PrivilegesBuilder.build(plan, spark)
     val requests = new ArrayBuffer[AccessRequest]()
-    if (inputs.isEmpty && opType == OperationType.SHOWDATABASES) {
-      val resource = AccessResource(DATABASE, null, None)
-      requests += AccessRequest(resource, ugi, opType, AccessType.USE)
-    }
 
     def addAccessRequest(objects: Iterable[PrivilegeObject], isInput: Boolean): Unit = {
       objects.foreach { obj =>


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #5768

## Describe Your Solution 🔧

Currently all UT have a  `ShowNamespace command` and wrapped by `ObjectFilterPlaceHolder`
<img width="1196" alt="截屏2023-11-24 下午3 29 53" src="https://github.com/apache/kyuubi/assets/46485123/ab7a93ec-22aa-425f-bbbc-894d3d8f19c0">
And `ObjectFilterPlaceHolder` such command will go through `buildQuery()`, it's noisy when dev to debug and unnecessary, we should just skip it since we have check privilege when executing.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklists
## 📝 Author Self Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [style guidelines](https://kyuubi.readthedocs.io/en/master/contributing/code/style.html) of this project
- [x] I have performed a self-review
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

## 📝 Committer Pre-Merge Checklist

- [x] Pull request title is okay.
- [x] No license issues.
- [x] Milestone correctly set?
- [x] Test coverage is ok
- [x] Assignees are selected.
- [x] Minimum number of approvals
- [x] No changes are requested


**Be nice. Be informative.**
