### PR TITLE
[KYUUBI #5766] Do not check engine initialization timeout when engine attempt

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
@@ -348,7 +348,8 @@ object SparkSQLEngine extends Logging {
     }
     val initTimeout = kyuubiConf.get(ENGINE_INIT_TIMEOUT)
     val totalInitTime = startedTime - submitTime
-    if (totalInitTime > initTimeout) {
+    val maybeAttempt = KyuubiSparkUtil.maybeAttempt(_sparkConf)
+    if (!maybeAttempt && totalInitTime > initTimeout) {
       throw new KyuubiException(s"The total engine initialization time ($totalInitTime ms)" +
         s" exceeds ${ENGINE_INIT_TIMEOUT.key} ($initTimeout ms)," +
         s" and submitted at $submitTime.")


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #5766

## Describe Your Solution 🔧

Use `CONTAINER_ID` environment to determine whether the execution is attempted, and if so, skip the engine initialization timeout check.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklists
## 📝 Author Self Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [style guidelines](https://kyuubi.readthedocs.io/en/master/contributing/code/style.html) of this project
- [ ] I have performed a self-review
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

## 📝 Committer Pre-Merge Checklist

- [ ] Pull request title is okay.
- [ ] No license issues.
- [ ] Milestone correctly set?
- [ ] Test coverage is ok
- [ ] Assignees are selected.
- [ ] Minimum number of approvals
- [ ] No changes are requested


**Be nice. Be informative.**
