### PR TITLE
[KYUUBI #5766] Default `spark.yarn.maxAppAttempts` to 1 for spark engine

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
@@ -140,8 +140,9 @@ class SparkProcessBuilder(
       allConf = allConf ++ zkAuthKeytabFileConf(allConf)
     }
     // pass spark engine log path to spark conf
-    (allConf ++ engineLogPathConf ++ extraYarnConf ++ appendPodNameConf(allConf)).foreach { case (k, v) =>
-      buffer ++= confKeyValue(convertConfigKey(k), v)
+    (allConf ++ engineLogPathConf ++ extraYarnConf ++ appendPodNameConf(allConf)).foreach {
+      case (k, v) =>
+        buffer ++= confKeyValue(convertConfigKey(k), v)
     }
 
     setupKerberos(buffer)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
@@ -261,7 +261,8 @@ class SparkProcessBuilder(
 
   def extraYarnConf: Map[String, String] = {
     if (clusterManager().exists(_.toLowerCase(Locale.ROOT).startsWith("yarn"))) {
-      // set `spark.yarn.maxAppAttempts` to 1 to avoid invalid attempts.
+      // Set `spark.yarn.maxAppAttempts` to 1 to avoid invalid attempts.
+      // As mentioned in YARN-5617, it is improved after hadoop `2.8.2/2.9.0/3.0.0`.
       Map(YARN_MAX_APP_ATTEMPTS_KEY -> "1")
     } else {
       Map.empty[String, String]

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
@@ -140,7 +140,7 @@ class SparkProcessBuilder(
       allConf = allConf ++ zkAuthKeytabFileConf(allConf)
     }
     // pass spark engine log path to spark conf
-    (allConf ++ engineLogPathConf ++ extraYarnConf ++ appendPodNameConf(allConf)).foreach {
+    (extraYarnConf ++ allConf ++ engineLogPathConf ++ appendPodNameConf(allConf)).foreach {
       case (k, v) =>
         buffer ++= confKeyValue(convertConfigKey(k), v)
     }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilderSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilderSuite.scala
@@ -430,7 +430,7 @@ class SparkProcessBuilderSuite extends KerberizedTestHelper with MockitoSugar {
     conf1.set("spark.master", "k8s://test:12345")
     val builder1 = new SparkProcessBuilder("", conf1)
     val commands1 = builder1.toString.split(' ')
-    assert(!commands1.contains("spark.yarn.maxAppAttempts=1"))
+    assert(!commands1.contains("spark.yarn.maxAppAttempts"))
 
     val conf2 = KyuubiConf(false)
     conf2.set("spark.master", "yarn")

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilderSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilderSuite.scala
@@ -424,6 +424,20 @@ class SparkProcessBuilderSuite extends KerberizedTestHelper with MockitoSugar {
           }
     }
   }
+
+  test("default spark.yarn.maxAppAttempts conf in yarn mode") {
+    val conf1 = KyuubiConf(false)
+    conf1.set("spark.master", "k8s://test:12345")
+    val builder1 = new SparkProcessBuilder("", conf1)
+    val commands1 = builder1.toString.split(' ')
+    assert(!commands1.contains("spark.yarn.maxAppAttempts=1"))
+
+    val conf2 = KyuubiConf(false)
+    conf2.set("spark.master", "yarn")
+    val builder2 = new SparkProcessBuilder("", conf2)
+    val commands2 = builder2.toString.split(' ')
+    assert(commands2.contains("spark.yarn.maxAppAttempts=1"))
+  }
 }
 
 class FakeSparkProcessBuilder(config: KyuubiConf)


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #5766

## Describe Your Solution 🔧

As discussed in https://github.com/apache/kyuubi/issues/5766#issuecomment-1835285025, we should add `spark.yarn.maxAppAttempts=1` for spark engine when `spark.master` is `yarn`.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklists
## 📝 Author Self Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [style guidelines](https://kyuubi.readthedocs.io/en/master/contributing/code/style.html) of this project
- [x] I have performed a self-review
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

## 📝 Committer Pre-Merge Checklist

- [x] Pull request title is okay.
- [x] No license issues.
- [x] Milestone correctly set?
- [ ] Test coverage is ok
- [x] Assignees are selected.
- [x] Minimum number of approvals
- [x] No changes are requested


**Be nice. Be informative.**
