### PR TITLE
[KYUUBI #5849] Incorrectly parse JDBC URL while variable includes colon

### DIFF
--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/Utils.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/Utils.java
@@ -208,7 +208,7 @@ public class Utils {
       uri = uri.replace(urlPrefix, urlPrefix + authorityFromClientJdbcURL);
     }
     connParams.setSuppliedURLAuthority(authorityFromClientJdbcURL);
-    uri = uri.replace(authorityFromClientJdbcURL, dummyAuthorityString);
+    uri = uri.replaceFirst(authorityFromClientJdbcURL, dummyAuthorityString);
 
     // Now parse the connection uri with dummy authority
     URI jdbcURI = URI.create(uri.substring(URI_JDBC_PREFIX.length()));

--- a/kyuubi-hive-jdbc/src/test/java/org/apache/kyuubi/jdbc/hive/UtilsTest.java
+++ b/kyuubi-hive-jdbc/src/test/java/org/apache/kyuubi/jdbc/hive/UtilsTest.java
@@ -121,11 +121,7 @@ public class UtilsTest {
                   .put("k2", "v2")
                   .put("k3", "hostname:10018")
                   .build(),
-              "jdbc:hive2://hostname:10018/catalog/db;k1=v1?"
-                  + URLEncoder.encode(
-                      "k2=v2;k3=hostname:10018",
-                      StandardCharsets.UTF_8.toString())
-                  .replaceAll("\\+", "%20")
+              "jdbc:hive2://hostname:10018/catalog/db;k1=v1?k2=v2;k3=hostname:10018"
           }
         });
   }

--- a/kyuubi-hive-jdbc/src/test/java/org/apache/kyuubi/jdbc/hive/UtilsTest.java
+++ b/kyuubi-hive-jdbc/src/test/java/org/apache/kyuubi/jdbc/hive/UtilsTest.java
@@ -113,15 +113,15 @@ public class UtilsTest {
                 + "#k4=v4"
           },
           {
-              "hostname",
-              "10018",
-              "catalog",
-              "db",
-              new ImmutableMap.Builder<String, String>()
-                  .put("k2", "v2")
-                  .put("k3", "hostname:10018")
-                  .build(),
-              "jdbc:hive2://hostname:10018/catalog/db;k1=v1?k2=v2;k3=hostname:10018"
+            "hostname",
+            "10018",
+            "catalog",
+            "db",
+            new ImmutableMap.Builder<String, String>()
+                .put("k2", "v2")
+                .put("k3", "hostname:10018")
+                .build(),
+            "jdbc:hive2://hostname:10018/catalog/db;k1=v1?k2=v2;k3=hostname:10018"
           }
         });
   }

--- a/kyuubi-hive-jdbc/src/test/java/org/apache/kyuubi/jdbc/hive/UtilsTest.java
+++ b/kyuubi-hive-jdbc/src/test/java/org/apache/kyuubi/jdbc/hive/UtilsTest.java
@@ -111,6 +111,21 @@ public class UtilsTest {
                         StandardCharsets.UTF_8.toString())
                     .replaceAll("\\+", "%20")
                 + "#k4=v4"
+          },
+          {
+              "hostname",
+              "10018",
+              "catalog",
+              "db",
+              new ImmutableMap.Builder<String, String>()
+                  .put("k2", "v2")
+                  .put("k3", "hostname:10018")
+                  .build(),
+              "jdbc:hive2://hostname:10018/catalog/db;k1=v1?"
+                  + URLEncoder.encode(
+                      "k2=v2;k3=hostname:10018",
+                      StandardCharsets.UTF_8.toString())
+                  .replaceAll("\\+", "%20")
           }
         });
   }


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #5849

## Describe Your Solution 🔧

When replacing the `host:port` information in the jdbc url, only the first matching string should be replaced.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklists
## 📝 Author Self Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [style guidelines](https://kyuubi.readthedocs.io/en/master/contributing/code/style.html) of this project
- [x] I have performed a self-review
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

## 📝 Committer Pre-Merge Checklist

- [x] Pull request title is okay.
- [x] No license issues.
- [x] Milestone correctly set?
- [x] Test coverage is ok
- [x] Assignees are selected.
- [x] Minimum number of approvals
- [x] No changes are requested


**Be nice. Be informative.**
