### PR TITLE
[KYUUBI #5877][FOLLOWUP] Dumps python object to json at last

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/resources/python/execute_python.py
+++ b/externals/kyuubi-spark-sql-engine/src/main/resources/python/execute_python.py
@@ -145,14 +145,13 @@ def parse_code_into_nodes(code):
 
 
 def execute_reply(status, content):
-    msg = {
+    return {
         "msg_type": "execute_reply",
         "content": dict(
             content,
             status=status,
         ),
     }
-    return json.dumps(msg)
 
 
 def execute_reply_ok(data):
@@ -278,6 +277,22 @@ def main():
                 break
 
             result = execute_request(content)
+
+            try:
+                result = json.dumps(result)
+            except ValueError:
+                result = json.dumps(
+                    {
+                        "msg_type": "inspect_reply",
+                        "content": {
+                            "status": "error",
+                            "ename": "ValueError",
+                            "evalue": "cannot json-ify %s" % response,
+                            "traceback": [],
+                        },
+                    }
+                )
+
             print(result, file=sys_stdout)
             sys_stdout.flush()
             clearOutputs()


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->
This is a followup of #5877.

Before that, all the code node are NormalNode.

And all the exception of NormalNode will be caught and raise ExecutionError.
https://github.com/apache/kyuubi/blob/e2d9a8efb6ed3398c05ba76f4a5f10f6a0eef792/externals/kyuubi-spark-sql-engine/src/main/resources/python/execute_python.py#L74-L95


But since #5877, for MagicNode, it invoke `execute_reply_error` to return error as result instead of raising ExecutionError.

And the returned error will be cast to `str` in execute_reply by `json.dumps()`.

https://github.com/apache/kyuubi/blob/e2d9a8efb6ed3398c05ba76f4a5f10f6a0eef792/externals/kyuubi-spark-sql-engine/src/main/resources/python/execute_python.py#L147-L155


And then it will throw exception in `output = result.pop("text/plain", "")`, because here the result is a python `str` instead of python `object`.
https://github.com/apache/kyuubi/blob/e2d9a8efb6ed3398c05ba76f4a5f10f6a0eef792/externals/kyuubi-spark-sql-engine/src/main/resources/python/execute_python.py#L211-L225

```
23/12/20 00:04:22 ERROR ExecutePython: python worker exit
23/12/20 00:04:22 ERROR ExecutePython: Traceback (most recent call last):
23/12/20 00:04:22 ERROR ExecutePython:   File "/hadoop/1/yarn/local/usercache/b_stf/appcache/application_1701822894495_1546794/container_e3973_1701822894495_1546794_01_000001/tmp/kyuubi-f9a43e80-749d-4fb4-b0a1-280533c4aa4c/execute_python.py", line 497, in <module>
23/12/20 00:04:22 ERROR ExecutePython:     sys.exit(main())
23/12/20 00:04:22 ERROR ExecutePython:   File "/hadoop/1/yarn/local/usercache/b_stf/appcache/application_1701822894495_1546794/container_e3973_1701822894495_1546794_01_000001/tmp/kyuubi-f9a43e80-749d-4fb4-b0a1-280533c4aa4c/execute_python.py", line 485, in main
23/12/20 00:04:22 ERROR ExecutePython:     result = execute_request(content)
23/12/20 00:04:22 ERROR ExecutePython:   File "/hadoop/1/yarn/local/usercache/b_stf/appcache/application_1701822894495_1546794/container_e3973_1701822894495_1546794_01_000001/tmp/kyuubi-f9a43e80-749d-4fb4-b0a1-280533c4aa4c/execute_python.py", line 264, in execute_request
23/12/20 00:04:22 ERROR ExecutePython:     output = result.pop("text/plain", "")
23/12/20 00:04:22 ERROR ExecutePython: AttributeError: 'str' object has no attribute 'pop'
23/12/20 00:04:23 ERROR ExecutePython: Process has died with 1
```

In this pr, I invoke `json.dumps` at last instead of in `execute_reply`.

## Describe Your Solution 🔧

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklists
## 📝 Author Self Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [style guidelines](https://kyuubi.readthedocs.io/en/master/contributing/code/style.html) of this project
- [ ] I have performed a self-review
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

## 📝 Committer Pre-Merge Checklist

- [ ] Pull request title is okay.
- [ ] No license issues.
- [ ] Milestone correctly set?
- [ ] Test coverage is ok
- [ ] Assignees are selected.
- [ ] Minimum number of approvals
- [ ] No changes are requested


**Be nice. Be informative.**
