### PR TITLE
[KYUUBI #5869][1.8] Add volatile to variables in KyuubiSessionImpl that may be operated by multiple threads

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
@@ -99,12 +99,12 @@ class KyuubiSessionImpl(
       sessionManager.getConf)
   }
 
-  private var _client: KyuubiSyncThriftClient = _
+  @volatile private var _client: KyuubiSyncThriftClient = _
   def client: KyuubiSyncThriftClient = _client
 
-  private var _engineSessionHandle: SessionHandle = _
+  @volatile private var _engineSessionHandle: SessionHandle = _
 
-  private var openSessionError: Option[Throwable] = None
+  @volatile private var openSessionError: Option[Throwable] = None
 
   override def open(): Unit = handleSessionException {
     traceMetricsOnOpen()
@@ -290,7 +290,7 @@ class KyuubiSessionImpl(
   private val engineAliveTimeout = sessionConf.get(KyuubiConf.ENGINE_ALIVE_TIMEOUT)
   private val aliveProbeEnabled = sessionConf.get(KyuubiConf.ENGINE_ALIVE_PROBE_ENABLED)
   private val engineAliveMaxFailCount = sessionConf.get(KyuubiConf.ENGINE_ALIVE_MAX_FAILURES)
-  private var engineAliveFailCount = 0
+  @volatile private var engineAliveFailCount = 0
 
   def checkEngineConnectionAlive(): Boolean = {
     try {


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗

minor fix

## Describe Your Solution 🔧

Add volatile to variables that may be operated by multiple threads.

## Types of changes :bookmark:

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:

#### Behavior With This Pull Request :tada:

#### Related Unit Tests

---

# Checklists
## 📝 Author Self Checklist

- [x] My code follows the [style guidelines](https://kyuubi.readthedocs.io/en/master/contributing/code/style.html) of this project
- [x] I have performed a self-review
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

## 📝 Committer Pre-Merge Checklist

- [x] Pull request title is okay.
- [x] No license issues.
- [x] Milestone correctly set?
- [ ] Test coverage is ok
- [ ] Assignees are selected.
- [ ] Minimum number of approvals
- [ ] No changes are requested

**Be nice. Be informative.**

Closes #5869 from wForget/hotfix.

Closes #5869

1169f13f5 [wforget] Add volatile to variables that may be operated by multiple threads

Authored-by: wforget <643348094@qq.com>
Signed-off-by: wforget <643348094@qq.com>

(cherry picked from commit 37620d40b6a98dec6889d1ffb81e57b4966c4447)