### PR TITLE
[DOC] Workaround for long inlined code sample in config page

### DIFF
--- a/docs/configuration/settings.md
+++ b/docs/configuration/settings.md
@@ -554,8 +554,7 @@ The below options in `kyuubi-defaults.conf` will set `parallelism.default: 2` an
 
 ### Via JDBC Connection URL
 
-Setting them in the JDBC Connection URL supplies session-specific
-for each SQL engine. For example:
+Setting them in the JDBC Connection URL supplies session-specific for each SQL engine. For example:
 
 ```
 jdbc:hive2://localhost:10009/default;#flink.parallelism.default=2;flink.taskmanager.memory.process.size=5g

--- a/docs/configuration/settings.md
+++ b/docs/configuration/settings.md
@@ -550,10 +550,7 @@ The below options in `kyuubi-defaults.conf` will set `parallelism.default: 2` an
 
 ### Via JDBC Connection URL
 
-Setting them in the JDBC Connection URL supplies session-specific for each SQL engine. For example: 
-```
-jdbc:hive2://localhost:10009/default;#flink.parallelism.default=2;flink.taskmanager.memory.process.size=5g
-```
+Setting them in the JDBC Connection URL supplies session-specific for each SQL engine. For example: ``` jdbc:hive2://localhost:10009/default;#flink.parallelism.default=2;flink.taskmanager.memory.process.size=5g ```
 
 ### Via SET Statements
 
@@ -580,10 +577,7 @@ The below options in `kyuubi-defaults.conf` will set `query_max_stage_count: 500
 
 ### Via JDBC Connection URL
 
-Setting them in the JDBC Connection URL supplies session-specific for each SQL engine. For example: 
-```
-jdbc:hive2://localhost:10009/default;#trino.query_max_stage_count=500;trino.parse_decimal_literals_as_double=true
-```
+Setting them in the JDBC Connection URL supplies session-specific for each SQL engine. For example: ``` jdbc:hive2://localhost:10009/default;#trino.query_max_stage_count=500;trino.parse_decimal_literals_as_double=true ```
 
 ### Via SET Statements
 

--- a/docs/configuration/settings.md
+++ b/docs/configuration/settings.md
@@ -550,7 +550,10 @@ The below options in `kyuubi-defaults.conf` will set `parallelism.default: 2` an
 
 ### Via JDBC Connection URL
 
-Setting them in the JDBC Connection URL supplies session-specific for each SQL engine. For example: ```jdbc:hive2://localhost:10009/default;#flink.parallelism.default=2;flink.taskmanager.memory.process.size=5g```
+Setting them in the JDBC Connection URL supplies session-specific for each SQL engine. For example: 
+```
+jdbc:hive2://localhost:10009/default;#flink.parallelism.default=2;flink.taskmanager.memory.process.size=5g
+```
 
 ### Via SET Statements
 

--- a/docs/configuration/settings.md
+++ b/docs/configuration/settings.md
@@ -518,7 +518,11 @@ Setting them in `$KYUUBI_HOME/conf/kyuubi-defaults.conf` supplies with default v
 
 ### Via JDBC Connection URL
 
-Setting them in the JDBC Connection URL supplies session-specific for each SQL engine. For example: ```jdbc:hive2://localhost:10009/default;#spark.sql.shuffle.partitions=2;spark.executor.memory=5g```
+Setting them in the JDBC Connection URL supplies session-specific for each SQL engine. For example:
+
+```
+jdbc:hive2://localhost:10009/default;#spark.sql.shuffle.partitions=2;spark.executor.memory=5g
+```
 
 - **Runtime SQL Configuration**
   - For [Runtime SQL Configurations](https://spark.apache.org/docs/latest/configuration.html#runtime-sql-configuration), they will take affect every time

--- a/docs/configuration/settings.md
+++ b/docs/configuration/settings.md
@@ -550,7 +550,12 @@ The below options in `kyuubi-defaults.conf` will set `parallelism.default: 2` an
 
 ### Via JDBC Connection URL
 
-Setting them in the JDBC Connection URL supplies session-specific for each SQL engine. For example: ``` jdbc:hive2://localhost:10009/default;#flink.parallelism.default=2;flink.taskmanager.memory.process.size=5g ```
+Setting them in the JDBC Connection URL supplies session-specific
+for each SQL engine. For example:
+
+```
+jdbc:hive2://localhost:10009/default;#flink.parallelism.default=2;flink.taskmanager.memory.process.size=5g
+```
 
 ### Via SET Statements
 
@@ -577,7 +582,11 @@ The below options in `kyuubi-defaults.conf` will set `query_max_stage_count: 500
 
 ### Via JDBC Connection URL
 
-Setting them in the JDBC Connection URL supplies session-specific for each SQL engine. For example: ``` jdbc:hive2://localhost:10009/default;#trino.query_max_stage_count=500;trino.parse_decimal_literals_as_double=true ```
+Setting them in the JDBC Connection URL supplies session-specific for each SQL engine. For example:
+
+```
+jdbc:hive2://localhost:10009/default;#trino.query_max_stage_count=500;trino.parse_decimal_literals_as_double=true
+```
 
 ### Via SET Statements
 

--- a/docs/configuration/settings.md
+++ b/docs/configuration/settings.md
@@ -577,7 +577,10 @@ The below options in `kyuubi-defaults.conf` will set `query_max_stage_count: 500
 
 ### Via JDBC Connection URL
 
-Setting them in the JDBC Connection URL supplies session-specific for each SQL engine. For example: ```jdbc:hive2://localhost:10009/default;#trino.query_max_stage_count=500;trino.parse_decimal_literals_as_double=true```
+Setting them in the JDBC Connection URL supplies session-specific for each SQL engine. For example: 
+```
+jdbc:hive2://localhost:10009/default;#trino.query_max_stage_count=500;trino.parse_decimal_literals_as_double=true
+```
 
 ### Via SET Statements
 

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/config/AllKyuubiConfiguration.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/config/AllKyuubiConfiguration.scala
@@ -126,9 +126,11 @@ class AllKyuubiConfiguration extends KyuubiFunSuite {
       "### Via JDBC Connection URL" +=
       """ Setting them in the JDBC Connection URL
         | supplies session-specific for each SQL engine. For example:""" ++=
+      // scalastyle:off
       """```
         |jdbc:hive2://localhost:10009/default;#spark.sql.shuffle.partitions=2;spark.executor.memory=5g
         |```""" +=
+      // scalastyle:on
       "" +=
       "- **Runtime SQL Configuration**" +=
       """  - For [Runtime SQL Configurations](
@@ -169,9 +171,11 @@ class AllKyuubiConfiguration extends KyuubiFunSuite {
       "### Via JDBC Connection URL" ++=
       "Setting them in the JDBC Connection URL supplies session-specific for each SQL engine." +
         " For example:" ++=
+      // scalastyle:off
       """```
         | jdbc:hive2://localhost:10009/default;#flink.parallelism.default=2;flink.taskmanager.memory.process.size=5g
         |```""" +=
+      // scalastyle:on
       "### Via SET Statements" +=
       """Please refer to the Flink official online documentation for [SET Statements]
         |(https://nightlies.apache.org/flink/flink-docs-stable/docs/dev/table/sql/set/)"""
@@ -200,10 +204,12 @@ class AllKyuubiConfiguration extends KyuubiFunSuite {
       "### Via JDBC Connection URL" +=
       "Setting them in the JDBC Connection URL supplies session-specific for each SQL engine." +
         " For example:" ++=
+      // scalastyle:off
       """ ```
         | jdbc:hive2://localhost:10009/default;#trino.query_max_stage_count=500;trino.parse_decimal_literals_as_double=true
         | ```
         |""" +=
+      // scalastyle:on
       "### Via SET Statements" +=
       """Please refer to the Trino official online documentation for [SET Statements]
         |(https://trino.io/docs/current/sql/set-session.html)"""

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/config/AllKyuubiConfiguration.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/config/AllKyuubiConfiguration.scala
@@ -168,12 +168,11 @@ class AllKyuubiConfiguration extends KyuubiFunSuite {
         |```""" +=
       """The below options in `kyuubi-defaults.conf` will set `parallelism.default: 2`
         | and `taskmanager.memory.process.size: 5g` into flink configurations.""" +=
-      "### Via JDBC Connection URL" +=
+      "### Via JDBC Connection URL" ++=
       """Setting them in the JDBC Connection URL supplies session-specific
         | for each SQL engine. For example:
         | ```
-        | jdbc:hive2://localhost:10009/default;
-        |#flink.parallelism.default=2;flink.taskmanager.memory.process.size=5g
+        | jdbc:hive2://localhost:10009/default;#flink.parallelism.default=2;flink.taskmanager.memory.process.size=5g
         | ```
         |""" +=
       "### Via SET Statements" +=
@@ -203,10 +202,9 @@ class AllKyuubiConfiguration extends KyuubiFunSuite {
         | and `parse_decimal_literals_as_double: true` into trino session properties.""" +=
       "### Via JDBC Connection URL" +=
       """Setting them in the JDBC Connection URL supplies session-specific
-        | for each SQL engine. For example:
-        | ```
-        | jdbc:hive2://localhost:10009/default;
-        |#trino.query_max_stage_count=500;trino.parse_decimal_literals_as_double=true
+        | for each SQL engine. For example:""" ++=
+      """ ```
+        | jdbc:hive2://localhost:10009/default;#trino.query_max_stage_count=500;trino.parse_decimal_literals_as_double=true
         | ```
         |""" +=
       "### Via SET Statements" +=

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/config/AllKyuubiConfiguration.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/config/AllKyuubiConfiguration.scala
@@ -125,12 +125,10 @@ class AllKyuubiConfiguration extends KyuubiFunSuite {
         | override all settings in `$SPARK_HOME/conf/spark-defaults.conf`""" +=
       "### Via JDBC Connection URL" +=
       """ Setting them in the JDBC Connection URL
-        | supplies session-specific for each SQL engine. For example:
-        | ```
-        |jdbc:hive2://localhost:10009/default;#
-        |spark.sql.shuffle.partitions=2;spark.executor.memory=5g
-        |```
-        |""" +=
+        | supplies session-specific for each SQL engine. For example:""" ++=
+      """```
+        |jdbc:hive2://localhost:10009/default;#spark.sql.shuffle.partitions=2;spark.executor.memory=5g
+        |```""" +=
       "" +=
       "- **Runtime SQL Configuration**" +=
       """  - For [Runtime SQL Configurations](
@@ -201,8 +199,8 @@ class AllKyuubiConfiguration extends KyuubiFunSuite {
       """The below options in `kyuubi-defaults.conf` will set `query_max_stage_count: 500`
         | and `parse_decimal_literals_as_double: true` into trino session properties.""" +=
       "### Via JDBC Connection URL" +=
-      """Setting them in the JDBC Connection URL supplies session-specific
-        | for each SQL engine. For example:""" ++=
+      "Setting them in the JDBC Connection URL supplies session-specific for each SQL engine." +
+        " For example:" ++=
       """ ```
         | jdbc:hive2://localhost:10009/default;#trino.query_max_stage_count=500;trino.parse_decimal_literals_as_double=true
         | ```

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/config/AllKyuubiConfiguration.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/config/AllKyuubiConfiguration.scala
@@ -167,12 +167,11 @@ class AllKyuubiConfiguration extends KyuubiFunSuite {
       """The below options in `kyuubi-defaults.conf` will set `parallelism.default: 2`
         | and `taskmanager.memory.process.size: 5g` into flink configurations.""" +=
       "### Via JDBC Connection URL" ++=
-      """Setting them in the JDBC Connection URL supplies session-specific
-        | for each SQL engine. For example:
-        | ```
+      "Setting them in the JDBC Connection URL supplies session-specific for each SQL engine." +
+        " For example:" ++=
+      """```
         | jdbc:hive2://localhost:10009/default;#flink.parallelism.default=2;flink.taskmanager.memory.process.size=5g
-        | ```
-        |""" +=
+        |```""" +=
       "### Via SET Statements" +=
       """Please refer to the Flink official online documentation for [SET Statements]
         |(https://nightlies.apache.org/flink/flink-docs-stable/docs/dev/table/sql/set/)"""

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/config/AllKyuubiConfiguration.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/config/AllKyuubiConfiguration.scala
@@ -170,8 +170,11 @@ class AllKyuubiConfiguration extends KyuubiFunSuite {
         | and `taskmanager.memory.process.size: 5g` into flink configurations.""" +=
       "### Via JDBC Connection URL" +=
       """Setting them in the JDBC Connection URL supplies session-specific
-        | for each SQL engine. For example: ```jdbc:hive2://localhost:10009/default;
-        |#flink.parallelism.default=2;flink.taskmanager.memory.process.size=5g```
+        | for each SQL engine. For example:
+        | ```
+        | jdbc:hive2://localhost:10009/default;
+        |#flink.parallelism.default=2;flink.taskmanager.memory.process.size=5g
+        | ```
         |""" +=
       "### Via SET Statements" +=
       """Please refer to the Flink official online documentation for [SET Statements]
@@ -200,8 +203,11 @@ class AllKyuubiConfiguration extends KyuubiFunSuite {
         | and `parse_decimal_literals_as_double: true` into trino session properties.""" +=
       "### Via JDBC Connection URL" +=
       """Setting them in the JDBC Connection URL supplies session-specific
-        | for each SQL engine. For example: ```jdbc:hive2://localhost:10009/default;
-        |#trino.query_max_stage_count=500;trino.parse_decimal_literals_as_double=true```
+        | for each SQL engine. For example:
+        | ```
+        | jdbc:hive2://localhost:10009/default;
+        |#trino.query_max_stage_count=500;trino.parse_decimal_literals_as_double=true
+        | ```
         |""" +=
       "### Via SET Statements" +=
       """Please refer to the Trino official online documentation for [SET Statements]


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->



## Describe Your Solution 🔧

Workaround to fix the display issue of long inlined code sample on config page.

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:
![image](https://github.com/apache/kyuubi/assets/1935105/7910808d-7235-4d21-bdc5-84260af53e80)


#### Behavior With This Pull Request :tada:
![image](https://github.com/apache/kyuubi/assets/1935105/877f45a5-c49b-45fc-90a1-3c23eb2aa508)


#### Related Unit Tests


---

# Checklists
## 📝 Author Self Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [style guidelines](https://kyuubi.readthedocs.io/en/master/contributing/code/style.html) of this project
- [x] I have performed a self-review
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

## 📝 Committer Pre-Merge Checklist

- [x] Pull request title is okay.
- [x] No license issues.
- [x] Milestone correctly set?
- [ ] Test coverage is ok
- [x] Assignees are selected.
- [x] Minimum number of approvals
- [x] No changes are requested


**Be nice. Be informative.**
