### PR TITLE
[KYUUBI #5911] Make `fetch_result_rows_rate` metric correct when result format is arrow

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
@@ -237,6 +237,11 @@ class ArrowBasedExecuteStatement(
     executeCollect(convertComplexType(resultDF.limit(maxRows)))
   }
 
+  override def getResultSetMetadataHints(): Seq[String] =
+    Seq(
+      s"__kyuubi_operation_result_format__=$resultFormat",
+      s"__kyuubi_operation_result_arrow_timestampAsString__=$timestampAsString")
+
   override protected def isArrowBasedOperation: Boolean = true
 
   override val resultFormat = "arrow"

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkOperation.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkOperation.scala
@@ -265,7 +265,12 @@ abstract class SparkOperation(session: Session)
       }
     } catch onError(cancel = true)
 
-    val resp = new TFetchResultsResp(OK_STATUS)
+    val resp = new TFetchResultsResp
+    if (isArrowBasedOperation) {
+      resp.setStatus(okStatusWithHints(getResultSetMetadataHints()))
+    } else {
+      resp.setStatus(OK_STATUS)
+    }
     resp.setResults(resultRowSet)
     resp.setHasMoreRows(false)
     resp

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/client/KyuubiSyncThriftClient.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/client/KyuubiSyncThriftClient.scala
@@ -416,13 +416,21 @@ class KyuubiSyncThriftClient private (
       orientation: FetchOrientation,
       maxRows: Int,
       fetchLog: Boolean): TRowSet = {
+    fetchResp(operationHandle, orientation, maxRows, fetchLog).getResults
+  }
+
+  def fetchResp(
+      operationHandle: TOperationHandle,
+      orientation: FetchOrientation,
+      maxRows: Int,
+      fetchLog: Boolean): TFetchResultsResp = {
     val or = FetchOrientation.toTFetchOrientation(orientation)
     val req = new TFetchResultsReq(operationHandle, or, maxRows)
     val fetchType = if (fetchLog) 1.toShort else 0.toShort
     req.setFetchType(fetchType)
     val resp = withLockAcquiredAsyncRequest(FetchResults(req))
     ThriftUtils.verifyTStatus(resp.getStatus)
-    resp.getResults
+    resp
   }
 
   def sendCredentials(encodedCredentials: String): Unit = {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/KyuubiOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/KyuubiOperation.scala
@@ -196,9 +196,9 @@ abstract class KyuubiOperation(session: Session) extends AbstractOperation(sessi
     validateDefaultFetchOrientation(order)
     assertState(OperationState.FINISHED)
     setHasResultSet(true)
-    val rowset = client.fetchResults(_remoteOpHandle, order, rowSetSize, fetchLog = false)
-    val resp = new TFetchResultsResp(OK_STATUS)
-    resp.setResults(rowset)
+    val remoteResp = client.fetchResp(_remoteOpHandle, order, rowSetSize, fetchLog = false)
+    val resp = new TFetchResultsResp(remoteResp.getStatus)
+    resp.setResults(remoteResp.getResults)
     resp.setHasMoreRows(false)
     resp
   }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/BackendServiceMetric.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/BackendServiceMetric.scala
@@ -17,6 +17,17 @@
 
 package org.apache.kyuubi.server
 
+import java.io.{ByteArrayInputStream, IOException}
+import java.nio.channels.Channels
+import java.util.Locale
+
+import scala.collection.JavaConverters._
+
+import org.apache.arrow.flatbuf.RecordBatch
+import org.apache.arrow.vector.ipc.ReadChannel
+import org.apache.arrow.vector.ipc.message.MessageSerializer
+
+import org.apache.kyuubi.Utils.warn
 import org.apache.kyuubi.metrics.{MetricsConstants, MetricsSystem}
 import org.apache.kyuubi.operation.{KyuubiOperation, OperationHandle, OperationStatus}
 import org.apache.kyuubi.operation.FetchOrientation.FetchOrientation
@@ -185,7 +196,17 @@ trait BackendServiceMetric extends BackendService {
       fetchLog: Boolean): TFetchResultsResp = {
     MetricsSystem.timerTracing(MetricsConstants.BS_FETCH_RESULTS) {
       val fetchResultsResp = super.fetchResults(operationHandle, orientation, maxRows, fetchLog)
+      val infoMessages = fetchResultsResp.getStatus.getInfoMessages
+      val properties = if (infoMessages != null) {
+        infoMessages.asScala.map(line => {
+          val keyValue = line.toLowerCase(Locale.ROOT).split("=")
+          assert(keyValue.length == 2, "Illegal Kyuubi operation hint found!")
+          (keyValue(0), keyValue(1))
+        }).toMap
+      } else Map[String, String]()
+      val resultFormat = properties.getOrElse("__kyuubi_operation_result_format__", "thrift")
       val rowSet = fetchResultsResp.getResults
+
       // TODO: the statistics are wrong when we enabled the arrow.
       val rowsSize =
         if (rowSet.getColumnsSize > 0) {
@@ -197,6 +218,24 @@ trait BackendServiceMetric extends BackendService {
             case t: TI16Column => t.getValues.size()
             case t: TBoolColumn => t.getValues.size()
             case t: TByteColumn => t.getValues.size()
+            case t: TBinaryColumn
+                if resultFormat == "arrow" =>
+              t.getValues.asScala.map(listBuff => {
+                val batchBytes = listBuff.array()
+                val input = new ByteArrayInputStream(batchBytes)
+                val readChannel = new ReadChannel(Channels.newChannel(input))
+                val messageMeta = MessageSerializer.readMessage(readChannel)
+                val recordBatch: RecordBatch =
+                  messageMeta.getMessage.header(new RecordBatch()).asInstanceOf[RecordBatch]
+                try {
+                  input.close()
+                  readChannel.close()
+                } catch {
+                  case e: IOException =>
+                    warn(e.getMessage, e)
+                }
+                recordBatch.length().toInt
+              }).sum
             case t: TBinaryColumn => t.getValues.size()
             case _ => 0
           }
@@ -210,7 +249,6 @@ trait BackendServiceMetric extends BackendService {
       val operation = sessionManager.operationManager
         .getOperation(operationHandle)
         .asInstanceOf[KyuubiOperation]
-
       if (fetchLog) {
         operation.increaseFetchLogCount(rowsSize)
       } else {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/BackendServiceMetric.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/BackendServiceMetric.scala
@@ -206,8 +206,7 @@ trait BackendServiceMetric extends BackendService {
       } else Map[String, String]()
       val resultFormat = properties.getOrElse("__kyuubi_operation_result_format__", "thrift")
       val rowSet = fetchResultsResp.getResults
-
-      // TODO: the statistics are wrong when we enabled the arrow.
+      
       val rowsSize =
         if (rowSet.getColumnsSize > 0) {
           rowSet.getColumns.get(0).getFieldValue match {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/BackendServiceMetric.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/BackendServiceMetric.scala
@@ -206,7 +206,7 @@ trait BackendServiceMetric extends BackendService {
       } else Map[String, String]()
       val resultFormat = properties.getOrElse("__kyuubi_operation_result_format__", "thrift")
       val rowSet = fetchResultsResp.getResults
-      
+
       val rowsSize =
         if (rowSet.getColumnsSize > 0) {
           rowSet.getColumns.get(0).getFieldValue match {


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #5911 .

Make `fetch_result_rows_rate` metric correct when result format is arrow

## Describe Your Solution 🔧

fetch_result_rows_rate metric wrong when set kyuubi.operation.result.format be arrow. This pr fix this issue by reading  arrow header.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:
select a table , `fetch_result_rows_rate` metric is wrong .

#### Behavior With This Pull Request :tada:
select a table , `fetch_result_rows_rate` metric will be correct .

#### Related Unit Tests
No, Manual testing.

---

# Checklists
## 📝 Author Self Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [style guidelines](https://kyuubi.readthedocs.io/en/master/contributing/code/style.html) of this project
- [ ] I have performed a self-review
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

## 📝 Committer Pre-Merge Checklist

- [ ] Pull request title is okay.
- [ ] No license issues.
- [ ] Milestone correctly set?
- [ ] Test coverage is ok
- [ ] Assignees are selected.
- [ ] Minimum number of approvals
- [ ] No changes are requested


**Be nice. Be informative.**
