### PR TITLE
`EngineRef#deregister` should return the value

### DIFF
--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/EngineRefTests.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/EngineRefTests.scala
@@ -357,9 +357,9 @@ trait EngineRefTests extends KyuubiFunSuite {
     DiscoveryClientProvider.withDiscoveryClient(conf) { client =>
       val hp = engine.getOrCreate(client)
       assert(client.getServerHost(engine.engineSpace) == Option(hp))
-      assert(!engine.deregister(client, ("non_existing_host", 0))._2)
+      assert(!engine.deregister(client, ("non_existing_host", 0))._1)
       assert(client.getServerHost(engine.engineSpace) == Option(hp))
-      assert(engine.deregister(client, hp)._2)
+      assert(engine.deregister(client, hp)._1)
       eventually(Timeout(10.seconds)) {
         assert(client.getServerHost(engine.engineSpace).isEmpty)
       }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/EngineRefTests.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/EngineRefTests.scala
@@ -22,6 +22,7 @@ import java.util.concurrent.Executors
 
 import scala.collection.JavaConverters._
 
+import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
 
 import org.apache.kyuubi.{KYUUBI_VERSION, Utils}
@@ -356,10 +357,12 @@ trait EngineRefTests extends KyuubiFunSuite {
     DiscoveryClientProvider.withDiscoveryClient(conf) { client =>
       val hp = engine.getOrCreate(client)
       assert(client.getServerHost(engine.engineSpace) == Option(hp))
-      engine.deregister(client, ("non_existing_host", 0))
+      assert(!engine.deregister(client, ("non_existing_host", 0))._2)
       assert(client.getServerHost(engine.engineSpace) == Option(hp))
-      engine.deregister(client, hp)
-      assert(client.getServerHost(engine.engineSpace).isEmpty)
+      assert(engine.deregister(client, hp)._2)
+      eventually(Timeout(10.seconds)) {
+        assert(client.getServerHost(engine.engineSpace).isEmpty)
+      }
     }
   }
 }


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗

This pull request fixes #

## Describe Your Solution 🔧

1. Let `org.apache.kyuubi.engine.EngineRef#deregister` have a return value so that you can determine whether `deregister` is successful.

2. Fix a flaky test, add `eventually`, because there is a delay in delete, causing UT to fail.
```
- deregister engine with existing host port *** FAILED ***
  Some(("localhost", 42445)) was not empty (EngineRefTests.scala:362)
```
https://github.com/apache/kyuubi/actions/runs/7320908364/job/19940635471



## Types of changes :bookmark:
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:
flaky test

https://github.com/apache/kyuubi/actions/runs/7320908364/job/19940635471

#### Behavior With This Pull Request :tada:
GA

#### Related Unit Tests
EngineRefTests.scala

"deregister engine with existing host port"


---

# Checklists
## 📝 Author Self Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [style guidelines](https://kyuubi.readthedocs.io/en/master/contributing/code/style.html) of this project
- [ ] I have performed a self-review
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

## 📝 Committer Pre-Merge Checklist

- [x] Pull request title is okay.
- [x] No license issues.
- [x] Milestone correctly set?
- [x] Test coverage is ok
- [x] Assignees are selected.
- [x] Minimum number of approvals
- [x] No changes are requested


**Be nice. Be informative.**
