### PR TITLE
[KYUUBI #5894] Separate closed and online sessions/statements in the SparkUI's engine tab

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EnginePage.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EnginePage.scala
@@ -275,14 +275,14 @@ case class EnginePage(parent: EngineTab) extends WebUIPage("") {
       closed: Seq[SessionEvent]): Seq[Node] = {
     val content = mutable.ListBuffer[Node]()
     if (online.nonEmpty) {
-      val sessionTableTag = "online"
+      val sessionTableTag = "online-sessionstat"
       val table = sessionTable(
         request,
         sessionTableTag,
         parent,
         online)
       content ++=
-        <span id="online" class="collapse-aggregated-onlineSessionstat collapse-table"
+        <span id="online-sessionstat" class="collapse-aggregated-onlineSessionstat collapse-table"
               onClick="collapseTable('collapse-aggregated-onlineSessionstat',
               'aggregated-onlineSessionstat')">
           <h4>
@@ -299,7 +299,7 @@ case class EnginePage(parent: EngineTab) extends WebUIPage("") {
 
     if (closed.nonEmpty) {
       val table = {
-        val sessionTableTag = "closed"
+        val sessionTableTag = "closed-sessionstat"
         sessionTable(
           request,
           sessionTableTag,
@@ -308,7 +308,7 @@ case class EnginePage(parent: EngineTab) extends WebUIPage("") {
       }
 
       content ++=
-        <span id="closed" class="collapse-aggregated-closedSessionstat collapse-table"
+        <span id="closed-sessionstat" class="collapse-aggregated-closedSessionstat collapse-table"
               onClick="collapseTable('collapse-aggregated-closedSessionstat',
               'aggregated-closedSessionstat')">
           <h4>

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EnginePage.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EnginePage.scala
@@ -169,7 +169,7 @@ case class EnginePage(parent: EngineTab) extends WebUIPage("") {
       content ++=
         <span id="running" class="collapse-aggregated-runningSqlstat collapse-table"
               onClick="collapseTable('collapse-aggregated-runningSqlstat',
-									'aggregated-runningSqlstat')">
+              'aggregated-runningSqlstat')">
           <h4>
             <span class="collapse-table-arrow arrow-open"></span>
             <a>Running Statement Statistics (
@@ -195,7 +195,7 @@ case class EnginePage(parent: EngineTab) extends WebUIPage("") {
       content ++=
         <span id="completed" class="collapse-aggregated-completedSqlstat collapse-table"
               onClick="collapseTable('collapse-aggregated-completedSqlstat',
-									'aggregated-completedSqlstat')">
+              'aggregated-completedSqlstat')">
           <h4>
             <span class="collapse-table-arrow arrow-open"></span>
             <a>Completed Statement Statistics (
@@ -221,7 +221,7 @@ case class EnginePage(parent: EngineTab) extends WebUIPage("") {
       content ++=
         <span id="failed" class="collapse-aggregated-failedSqlstat collapse-table"
               onClick="collapseTable('collapse-aggregated-failedSqlstat',
-									'aggregated-failedSqlstat')">
+              'aggregated-failedSqlstat')">
           <h4>
             <span class="collapse-table-arrow arrow-open"></span>
             <a>Failed Statement Statistics (
@@ -280,7 +280,7 @@ case class EnginePage(parent: EngineTab) extends WebUIPage("") {
       content ++=
         <span id="online" class="collapse-aggregated-onlineSessionstat collapse-table"
               onClick="collapseTable('collapse-aggregated-onlineSessionstat',
-									'aggregated-onlineSessionstat')">
+              'aggregated-onlineSessionstat')">
           <h4>
             <span class="collapse-table-arrow arrow-open"></span>
             <a>Online Session Statistics (
@@ -306,7 +306,7 @@ case class EnginePage(parent: EngineTab) extends WebUIPage("") {
       content ++=
         <span id="closed" class="collapse-aggregated-closedSessionstat collapse-table"
               onClick="collapseTable('collapse-aggregated-closedSessionstat',
-								'aggregated-closedSessionstat')">
+              'aggregated-closedSessionstat')">
           <h4>
             <span class="collapse-table-arrow arrow-open"></span>
             <a>Closed Session Statistics (

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EnginePage.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EnginePage.scala
@@ -167,11 +167,11 @@ case class EnginePage(parent: EngineTab) extends WebUIPage("") {
 
     val content = mutable.ListBuffer[Node]()
     if (running.nonEmpty) {
-      val sqlTableTag = "running"
+      val sqlTableTag = "running-sqlstat"
       val table =
         statementStatsTable(request, sqlTableTag, parent, running)
       content ++=
-        <span id="running" class="collapse-aggregated-runningSqlstat collapse-table"
+        <span id="running-sqlstat" class="collapse-aggregated-runningSqlstat collapse-table"
               onClick="collapseTable('collapse-aggregated-runningSqlstat',
               'aggregated-runningSqlstat')">
           <h4>
@@ -188,7 +188,7 @@ case class EnginePage(parent: EngineTab) extends WebUIPage("") {
 
     if (completed.nonEmpty) {
       val table = {
-        val sqlTableTag = "completed"
+        val sqlTableTag = "completed-sqlstat"
         statementStatsTable(
           request,
           sqlTableTag,
@@ -197,7 +197,7 @@ case class EnginePage(parent: EngineTab) extends WebUIPage("") {
       }
 
       content ++=
-        <span id="completed" class="collapse-aggregated-completedSqlstat collapse-table"
+        <span id="completed-sqlstat" class="collapse-aggregated-completedSqlstat collapse-table"
               onClick="collapseTable('collapse-aggregated-completedSqlstat',
               'aggregated-completedSqlstat')">
           <h4>
@@ -214,7 +214,7 @@ case class EnginePage(parent: EngineTab) extends WebUIPage("") {
 
     if (failed.nonEmpty) {
       val table = {
-        val sqlTableTag = "failed"
+        val sqlTableTag = "failed-sqlstat"
         statementStatsTable(
           request,
           sqlTableTag,
@@ -223,7 +223,7 @@ case class EnginePage(parent: EngineTab) extends WebUIPage("") {
       }
 
       content ++=
-        <span id="failed" class="collapse-aggregated-failedSqlstat collapse-table"
+        <span id="failed-sqlstat" class="collapse-aggregated-failedSqlstat collapse-table"
               onClick="collapseTable('collapse-aggregated-failedSqlstat',
               'aggregated-failedSqlstat')">
           <h4>

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EnginePage.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EnginePage.scala
@@ -23,6 +23,7 @@ import java.util.Date
 import javax.servlet.http.HttpServletRequest
 
 import scala.collection.JavaConverters.mapAsScalaMapConverter
+import scala.collection.mutable
 import scala.xml.{Node, Unparsed}
 
 import org.apache.commons.text.StringEscapeUtils
@@ -36,18 +37,42 @@ case class EnginePage(parent: EngineTab) extends WebUIPage("") {
   private val store = parent.store
 
   override def render(request: HttpServletRequest): Seq[Node] = {
+    val onlineSession = new mutable.ArrayBuffer[SessionEvent]()
+    val closedSession = new mutable.ArrayBuffer[SessionEvent]()
+
+    val runningSqlStat = new mutable.ArrayBuffer[SparkOperationEvent]()
+    val completedSqlStat = new mutable.ArrayBuffer[SparkOperationEvent]()
+    val failedSqlStat = new mutable.ArrayBuffer[SparkOperationEvent]()
+
+    store.getSessionList.foreach { s =>
+      if (s.endTime <= 0L) {
+        onlineSession += s
+      } else {
+        closedSession += s
+      }
+    }
+
+    store.getStatementList.foreach { op =>
+      if (op.completeTime <= 0L) {
+        runningSqlStat += op
+      } else if (op.exception.isDefined) {
+        failedSqlStat += op
+      } else {
+        completedSqlStat += op
+      }
+    }
+
     val content =
       generateBasicStats() ++
         <br/> ++
         stop(request) ++
         <br/> ++
         <h4>
-        {store.getSessionCount} session(s) are online,
-        running {store.getStatementCount}
-        operations
+        {onlineSession.size} session(s) are online,
+        running {runningSqlStat.size} operation(s)
       </h4> ++
-        generateSessionStatsTable(request) ++
-        generateStatementStatsTable(request)
+        generateSessionStatsTable(request, onlineSession, closedSession) ++
+        generateStatementStatsTable(request, runningSqlStat, completedSqlStat, failedSqlStat)
     UIUtils.headerSparkPage(request, parent.name, content, parent)
   }
 
@@ -129,100 +154,197 @@ case class EnginePage(parent: EngineTab) extends WebUIPage("") {
     }
   }
 
-  /** Generate stats of statements for the engine */
-  private def generateStatementStatsTable(request: HttpServletRequest): Seq[Node] = {
+  /** Generate stats of running statements for the engine */
+  private def generateStatementStatsTable(
+      request: HttpServletRequest,
+      running: Seq[SparkOperationEvent],
+      completed: Seq[SparkOperationEvent],
+      failed: Seq[SparkOperationEvent]): Seq[Node] = {
 
-    val numStatement = store.getStatementList.size
+    val content = mutable.ListBuffer[Node]()
+    if (running.nonEmpty) {
+      val sqlTableTag = "running"
+      val table =
+        statementStatsTable(request, sqlTableTag, parent, running)
+      content ++=
+        <span id="running" class="collapse-aggregated-runningSqlstat collapse-table"
+              onClick="collapseTable('collapse-aggregated-runningSqlstat',
+									'aggregated-runningSqlstat')">
+          <h4>
+            <span class="collapse-table-arrow arrow-open"></span>
+            <a>Running Statement Statistics (
+              {running.size}
+              )</a>
+          </h4>
+        </span> ++
+          <div class="aggregated-runningSqlstat collapsible-table">
+            {table}
+          </div>
+    }
 
-    val table =
-      if (numStatement > 0) {
-
-        val sqlTableTag = "sqlstat"
-
-        val sqlTablePage =
-          Option(request.getParameter(s"$sqlTableTag.page")).map(_.toInt).getOrElse(1)
-
-        try {
-          Some(new StatementStatsPagedTable(
-            request,
-            parent,
-            store.getStatementList,
-            "kyuubi",
-            UIUtils.prependBaseUri(request, parent.basePath),
-            sqlTableTag).table(sqlTablePage))
-        } catch {
-          case e @ (_: IllegalArgumentException | _: IndexOutOfBoundsException) =>
-            Some(<div class="alert alert-error">
-            <p>Error while rendering job table:</p>
-            <pre>
-              {Utils.stringifyException(e)}
-            </pre>
-          </div>)
-        }
-      } else {
-        None
+    if (completed.nonEmpty) {
+      val table = {
+        val sessionTableTag = "completed"
+        statementStatsTable(
+          request,
+          sessionTableTag,
+          parent,
+          completed)
       }
-    val content =
-      <span id="sqlstat" class="collapse-aggregated-sqlstat collapse-table"
-            onClick="collapseTable('collapse-aggregated-sqlstat',
-                'aggregated-sqlstat')">
-        <h4>
-          <span class="collapse-table-arrow arrow-open"></span>
-          <a>Statement Statistics ({numStatement})</a>
-        </h4>
-      </span> ++
-        <div class="aggregated-sqlstat collapsible-table">
-          {table.getOrElse("No statistics have been generated yet.")}
+
+      content ++=
+        <span id="completed" class="collapse-aggregated-completedSqlstat collapse-table"
+              onClick="collapseTable('collapse-aggregated-completedSqlstat',
+									'aggregated-completedSqlstat')">
+          <h4>
+            <span class="collapse-table-arrow arrow-open"></span>
+            <a>Completed Statement Statistics (
+              {completed.size}
+              )</a>
+          </h4>
+        </span> ++
+          <div class="aggregated-completedSqlstat collapsible-table">
+          {table}
         </div>
+    }
+
+    if (failed.nonEmpty) {
+      val table = {
+        val sessionTableTag = "failed"
+        statementStatsTable(
+          request,
+          sessionTableTag,
+          parent,
+          failed)
+      }
+
+      content ++=
+        <span id="failed" class="collapse-aggregated-failedSqlstat collapse-table"
+              onClick="collapseTable('collapse-aggregated-failedSqlstat',
+									'aggregated-failedSqlstat')">
+          <h4>
+            <span class="collapse-table-arrow arrow-open"></span>
+            <a>Failed Statement Statistics (
+              {failed.size}
+              )</a>
+          </h4>
+        </span> ++
+          <div class="aggregated-failedSqlstat collapsible-table">
+          {table}
+        </div>
+    }
     content
   }
 
-  /** Generate stats of sessions for the engine */
-  private def generateSessionStatsTable(request: HttpServletRequest): Seq[Node] = {
-    val numSessions = store.getSessionList.size
-    val table =
-      if (numSessions > 0) {
+  private def statementStatsTable(
+      request: HttpServletRequest,
+      sqlTableTag: String,
+      parent: EngineTab,
+      data: Seq[SparkOperationEvent]): Seq[Node] = {
 
-        val sessionTableTag = "sessionstat"
+    val sqlTablePage =
+      Option(request.getParameter(s"$sqlTableTag.page")).map(_.toInt).getOrElse(1)
 
-        val sessionTablePage =
-          Option(request.getParameter(s"$sessionTableTag.page")).map(_.toInt).getOrElse(1)
+    try {
+      new StatementStatsPagedTable(
+        request,
+        parent,
+        data,
+        "kyuubi",
+        UIUtils.prependBaseUri(request, parent.basePath),
+        sqlTableTag).table(sqlTablePage)
+    } catch {
+      case e @ (_: IllegalArgumentException | _: IndexOutOfBoundsException) =>
+        <div class="alert alert-error">
+              <p>Error while rendering job table:</p>
+              <pre>
+                {Utils.stringifyException(e)}
+              </pre>
+            </div>
+    }
+  }
 
-        try {
-          Some(new SessionStatsPagedTable(
-            request,
-            parent,
-            store.getSessionList,
-            "kyuubi",
-            UIUtils.prependBaseUri(request, parent.basePath),
-            sessionTableTag).table(sessionTablePage))
-        } catch {
-          case e @ (_: IllegalArgumentException | _: IndexOutOfBoundsException) =>
-            Some(<div class="alert alert-error">
-            <p>Error while rendering job table:</p>
-            <pre>
-              {Utils.stringifyException(e)}
-            </pre>
-          </div>)
-        }
-      } else {
-        None
+  /** Generate stats of online sessions for the engine */
+  private def generateSessionStatsTable(
+      request: HttpServletRequest,
+      online: Seq[SessionEvent],
+      closed: Seq[SessionEvent]): Seq[Node] = {
+    val content = mutable.ListBuffer[Node]()
+    if (online.nonEmpty) {
+      val sessionTableTag = "online"
+      val table = sessionTable(
+        request,
+        sessionTableTag,
+        parent,
+        online)
+      content ++=
+        <span id="online" class="collapse-aggregated-onlineSessionstat collapse-table"
+              onClick="collapseTable('collapse-aggregated-onlineSessionstat',
+									'aggregated-onlineSessionstat')">
+          <h4>
+            <span class="collapse-table-arrow arrow-open"></span>
+            <a>Online Session Statistics (
+              {online.size}
+              )</a>
+          </h4>
+        </span> ++
+          <div class="aggregated-onlineSessionstat collapsible-table">
+            {table}
+          </div>
+    }
+
+    if (closed.nonEmpty) {
+      val table = {
+        val sessionTableTag = "closed"
+        sessionTable(
+          request,
+          sessionTableTag,
+          parent,
+          closed)
       }
 
-    val content =
-      <span id="sessionstat" class="collapse-aggregated-sessionstat collapse-table"
-            onClick="collapseTable('collapse-aggregated-sessionstat',
-                'aggregated-sessionstat')">
-        <h4>
-          <span class="collapse-table-arrow arrow-open"></span>
-          <a>Session Statistics ({numSessions})</a>
-        </h4>
-      </span> ++
-        <div class="aggregated-sessionstat collapsible-table">
-          {table.getOrElse("No statistics have been generated yet.")}
+      content ++=
+        <span id="closed" class="collapse-aggregated-closedSessionstat collapse-table"
+              onClick="collapseTable('collapse-aggregated-closedSessionstat',
+								'aggregated-closedSessionstat')">
+          <h4>
+            <span class="collapse-table-arrow arrow-open"></span>
+            <a>Closed Session Statistics (
+              {closed.size}
+              )</a>
+          </h4>
+        </span> ++
+          <div class="aggregated-closedSessionstat collapsible-table">
+          {table}
         </div>
-
+    }
     content
+  }
+
+  private def sessionTable(
+      request: HttpServletRequest,
+      sessionTage: String,
+      parent: EngineTab,
+      data: Seq[SessionEvent]): Seq[Node] = {
+    val sessionPage =
+      Option(request.getParameter(s"$sessionTage.page")).map(_.toInt).getOrElse(1)
+    try {
+      new SessionStatsPagedTable(
+        request,
+        parent,
+        data,
+        "kyuubi",
+        UIUtils.prependBaseUri(request, parent.basePath),
+        sessionTage).table(sessionPage)
+    } catch {
+      case e @ (_: IllegalArgumentException | _: IndexOutOfBoundsException) =>
+        <div class="alert alert-error">
+          <p>Error while rendering job table:</p>
+          <pre>
+            {Utils.stringifyException(e)}
+          </pre>
+        </div>
+    }
   }
 
   private class SessionStatsPagedTable(

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EnginePage.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EnginePage.scala
@@ -188,10 +188,10 @@ case class EnginePage(parent: EngineTab) extends WebUIPage("") {
 
     if (completed.nonEmpty) {
       val table = {
-        val sessionTableTag = "completed"
+        val sqlTableTag = "completed"
         statementStatsTable(
           request,
-          sessionTableTag,
+          sqlTableTag,
           parent,
           completed)
       }
@@ -214,10 +214,10 @@ case class EnginePage(parent: EngineTab) extends WebUIPage("") {
 
     if (failed.nonEmpty) {
       val table = {
-        val sessionTableTag = "failed"
+        val sqlTableTag = "failed"
         statementStatsTable(
           request,
-          sessionTableTag,
+          sqlTableTag,
           parent,
           failed)
       }

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EnginePage.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EnginePage.scala
@@ -71,8 +71,12 @@ case class EnginePage(parent: EngineTab) extends WebUIPage("") {
         {onlineSession.size} session(s) are online,
         running {runningSqlStat.size} operation(s)
       </h4> ++
-        generateSessionStatsTable(request, onlineSession, closedSession) ++
-        generateStatementStatsTable(request, runningSqlStat, completedSqlStat, failedSqlStat)
+        generateSessionStatsTable(request, onlineSession.toSeq, closedSession.toSeq) ++
+        generateStatementStatsTable(
+          request,
+          runningSqlStat.toSeq,
+          completedSqlStat.toSeq,
+          failedSqlStat.toSeq)
     UIUtils.headerSparkPage(request, parent.name, content, parent)
   }
 
@@ -252,7 +256,7 @@ case class EnginePage(parent: EngineTab) extends WebUIPage("") {
         data,
         "kyuubi",
         UIUtils.prependBaseUri(request, parent.basePath),
-        sqlTableTag).table(sqlTablePage)
+        s"${sqlTableTag}-table").table(sqlTablePage)
     } catch {
       case e @ (_: IllegalArgumentException | _: IndexOutOfBoundsException) =>
         <div class="alert alert-error">
@@ -335,7 +339,7 @@ case class EnginePage(parent: EngineTab) extends WebUIPage("") {
         data,
         "kyuubi",
         UIUtils.prependBaseUri(request, parent.basePath),
-        sessionTage).table(sessionPage)
+        s"${sessionTage}-table").table(sessionPage)
     } catch {
       case e @ (_: IllegalArgumentException | _: IndexOutOfBoundsException) =>
         <div class="alert alert-error">

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EngineSessionPage.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EngineSessionPage.scala
@@ -149,7 +149,7 @@ case class EngineSessionPage(parent: EngineTab)
       val sqlTableTag = "running-sqlstat"
       val table = statementStatsTable(request, sqlTableTag, parent, running.toSeq)
       content ++=
-        <span id="running" class="collapse-aggregated-runningSqlstat collapse-table"
+        <span id="running-sqlstat" class="collapse-aggregated-runningSqlstat collapse-table"
               onClick="collapseTable('collapse-aggregated-runningSqlstat',
               'aggregated-runningSqlstat')">
           <h4>
@@ -173,7 +173,7 @@ case class EngineSessionPage(parent: EngineTab)
       }
 
       content ++=
-        <span id="completed" class="collapse-aggregated-completedSqlstat collapse-table"
+        <span id="completed-sqlstat" class="collapse-aggregated-completedSqlstat collapse-table"
               onClick="collapseTable('collapse-aggregated-completedSqlstat',
               'aggregated-completedSqlstat')">
           <h4>
@@ -199,7 +199,7 @@ case class EngineSessionPage(parent: EngineTab)
       }
 
       content ++=
-        <span id="failed" class="collapse-aggregated-failedSqlstat collapse-table"
+        <span id="failed-sqlstat" class="collapse-aggregated-failedSqlstat collapse-table"
               onClick="collapseTable('collapse-aggregated-failedSqlstat',
               'aggregated-failedSqlstat')">
           <h4>

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EngineSessionPage.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EngineSessionPage.scala
@@ -151,7 +151,7 @@ case class EngineSessionPage(parent: EngineTab)
       content ++=
         <span id="sqlsessionstat" class="collapse-aggregated-runningSqlstat collapse-table"
               onClick="collapseTable('collapse-aggregated-runningSqlstat',
-									'aggregated-runningSqlstat')">
+              'aggregated-runningSqlstat')">
           <h4>
             <span class="collapse-table-arrow arrow-open"></span>
             <a>Running Statement Statistics</a>
@@ -175,7 +175,7 @@ case class EngineSessionPage(parent: EngineTab)
       content ++=
         <span id="completed" class="collapse-aggregated-completedSqlstat collapse-table"
               onClick="collapseTable('collapse-aggregated-completedSqlstat',
-							'aggregated-completedSqlstat')">
+              'aggregated-completedSqlstat')">
           <h4>
             <span class="collapse-table-arrow arrow-open"></span>
             <a>Completed Statement Statistics (
@@ -201,7 +201,7 @@ case class EngineSessionPage(parent: EngineTab)
       content ++=
         <span id="failed" class="collapse-aggregated-failedSqlstat collapse-table"
               onClick="collapseTable('collapse-aggregated-failedSqlstat',
-							'aggregated-failedSqlstat')">
+              'aggregated-failedSqlstat')">
           <h4>
             <span class="collapse-table-arrow arrow-open"></span>
             <a>Failed Statement Statistics (

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EngineSessionPage.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EngineSessionPage.scala
@@ -149,7 +149,7 @@ case class EngineSessionPage(parent: EngineTab)
       val sqlTableTag = "running"
       val table = statementStatsTable(request, sqlTableTag, parent, running.toSeq)
       content ++=
-        <span id="sqlsessionstat" class="collapse-aggregated-runningSqlstat collapse-table"
+        <span id="running" class="collapse-aggregated-runningSqlstat collapse-table"
               onClick="collapseTable('collapse-aggregated-runningSqlstat',
               'aggregated-runningSqlstat')">
           <h4>

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EngineSessionPage.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EngineSessionPage.scala
@@ -20,12 +20,15 @@ package org.apache.spark.ui
 import java.util.Date
 import javax.servlet.http.HttpServletRequest
 
+import scala.collection.mutable
 import scala.xml.Node
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.SECRET_REDACTION_PATTERN
 import org.apache.spark.ui.UIUtils._
 import org.apache.spark.util.Utils
+
+import org.apache.kyuubi.engine.spark.events.SparkOperationEvent
 
 /** Page for Spark Web UI that shows statistics of jobs running in the engine server */
 case class EngineSessionPage(parent: EngineTab)
@@ -126,50 +129,118 @@ case class EngineSessionPage(parent: EngineTab)
 
   /** Generate stats of batch statements of the engine server */
   private def generateSQLStatsTable(request: HttpServletRequest, sessionID: String): Seq[Node] = {
-    val executionList = store.getStatementList
+    val running = new mutable.ArrayBuffer[SparkOperationEvent]()
+    val completed = new mutable.ArrayBuffer[SparkOperationEvent]()
+    val failed = new mutable.ArrayBuffer[SparkOperationEvent]()
+
+    store.getStatementList
       .filter(_.sessionId == sessionID)
-    val numStatement = executionList.size
-    val table =
-      if (numStatement > 0) {
-
-        val sqlTableTag = "sqlsessionstat"
-
-        val sqlTablePage =
-          Option(request.getParameter(s"$sqlTableTag.page")).map(_.toInt).getOrElse(1)
-
-        try {
-          Some(new StatementStatsPagedTable(
-            request,
-            parent,
-            executionList,
-            "kyuubi/session",
-            UIUtils.prependBaseUri(request, parent.basePath),
-            sqlTableTag).table(sqlTablePage))
-        } catch {
-          case e @ (_: IllegalArgumentException | _: IndexOutOfBoundsException) =>
-            Some(<div class="alert alert-error">
-            <p>Error while rendering job table:</p>
-            <pre>
-              {Utils.exceptionString(e)}
-            </pre>
-          </div>)
+      .foreach { op =>
+        if (op.completeTime <= 0L) {
+          running += op
+        } else if (op.exception.isDefined) {
+          failed += op
+        } else {
+          completed += op
         }
-      } else {
-        None
       }
-    val content =
-      <span id="sqlsessionstat" class="collapse-aggregated-sqlsessionstat collapse-table"
-            onClick="collapseTable('collapse-aggregated-sqlsessionstat',
-                'aggregated-sqlsessionstat')">
-        <h4>
-          <span class="collapse-table-arrow arrow-open"></span>
-          <a>Statement Statistics</a>
-        </h4>
-      </span> ++
-        <div class="aggregated-sqlsessionstat collapsible-table">
-          {table.getOrElse("No statistics have been generated yet.")}
-        </div>
+    val content = mutable.ListBuffer[Node]()
+    if (running.nonEmpty) {
+      val sqlTableTag = "running"
+      val table = statementStatsTable(request, sqlTableTag, parent, running)
+      content ++=
+        <span id="sqlsessionstat" class="collapse-aggregated-runningSqlstat collapse-table"
+              onClick="collapseTable('collapse-aggregated-runningSqlstat',
+									'aggregated-runningSqlstat')">
+          <h4>
+            <span class="collapse-table-arrow arrow-open"></span>
+            <a>Running Statement Statistics</a>
+          </h4>
+        </span> ++
+          <div class="aggregated-runningSqlstat collapsible-table">
+            {table}
+          </div>
+    }
+
+    if (completed.nonEmpty) {
+      val table = {
+        val sessionTableTag = "completed"
+        statementStatsTable(
+          request,
+          sessionTableTag,
+          parent,
+          completed)
+      }
+
+      content ++=
+        <span id="completed" class="collapse-aggregated-completedSqlstat collapse-table"
+              onClick="collapseTable('collapse-aggregated-completedSqlstat',
+							'aggregated-completedSqlstat')">
+          <h4>
+            <span class="collapse-table-arrow arrow-open"></span>
+            <a>Completed Statement Statistics (
+              {completed.size}
+              )</a>
+          </h4>
+        </span> ++
+          <div class="aggregated-completedSqlstat collapsible-table">
+            {table}
+          </div>
+    }
+
+    if (failed.nonEmpty) {
+      val table = {
+        val sessionTableTag = "failed"
+        statementStatsTable(
+          request,
+          sessionTableTag,
+          parent,
+          failed)
+      }
+
+      content ++=
+        <span id="failed" class="collapse-aggregated-failedSqlstat collapse-table"
+              onClick="collapseTable('collapse-aggregated-failedSqlstat',
+							'aggregated-failedSqlstat')">
+          <h4>
+            <span class="collapse-table-arrow arrow-open"></span>
+            <a>Failed Statement Statistics (
+              {failed.size}
+              )</a>
+          </h4>
+        </span> ++
+          <div class="aggregated-failedSqlstat collapsible-table">
+            {table}
+          </div>
+    }
 
     content
+  }
+
+  private def statementStatsTable(
+      request: HttpServletRequest,
+      sqlTableTag: String,
+      parent: EngineTab,
+      data: Seq[SparkOperationEvent]): Seq[Node] = {
+    val sqlTablePage =
+      Option(request.getParameter(s"$sqlTableTag.page")).map(_.toInt).getOrElse(1)
+
+    try {
+      new StatementStatsPagedTable(
+        request,
+        parent,
+        data,
+        "kyuubi/session",
+        UIUtils.prependBaseUri(request, parent.basePath),
+        sqlTableTag).table(sqlTablePage)
+    } catch {
+      case e @ (_: IllegalArgumentException | _: IndexOutOfBoundsException) =>
+        <div class="alert alert-error">
+          <p>Error while rendering job table:</p>
+          <pre>
+            {Utils.exceptionString(e)}
+          </pre>
+        </div>
+    }
   }
 }

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EngineSessionPage.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EngineSessionPage.scala
@@ -146,7 +146,7 @@ case class EngineSessionPage(parent: EngineTab)
       }
     val content = mutable.ListBuffer[Node]()
     if (running.nonEmpty) {
-      val sqlTableTag = "running"
+      val sqlTableTag = "running-sqlstat"
       val table = statementStatsTable(request, sqlTableTag, parent, running.toSeq)
       content ++=
         <span id="running" class="collapse-aggregated-runningSqlstat collapse-table"
@@ -164,7 +164,7 @@ case class EngineSessionPage(parent: EngineTab)
 
     if (completed.nonEmpty) {
       val table = {
-        val sqlTableTag = "completed"
+        val sqlTableTag = "completed-sqlstat"
         statementStatsTable(
           request,
           sqlTableTag,
@@ -190,7 +190,7 @@ case class EngineSessionPage(parent: EngineTab)
 
     if (failed.nonEmpty) {
       val table = {
-        val sqlTableTag = "failed"
+        val sqlTableTag = "failed-sqlstat"
         statementStatsTable(
           request,
           sqlTableTag,

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EngineSessionPage.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EngineSessionPage.scala
@@ -147,7 +147,7 @@ case class EngineSessionPage(parent: EngineTab)
     val content = mutable.ListBuffer[Node]()
     if (running.nonEmpty) {
       val sqlTableTag = "running"
-      val table = statementStatsTable(request, sqlTableTag, parent, running)
+      val table = statementStatsTable(request, sqlTableTag, parent, running.toSeq)
       content ++=
         <span id="sqlsessionstat" class="collapse-aggregated-runningSqlstat collapse-table"
               onClick="collapseTable('collapse-aggregated-runningSqlstat',
@@ -164,12 +164,12 @@ case class EngineSessionPage(parent: EngineTab)
 
     if (completed.nonEmpty) {
       val table = {
-        val sessionTableTag = "completed"
+        val sqlTableTag = "completed"
         statementStatsTable(
           request,
-          sessionTableTag,
+          sqlTableTag,
           parent,
-          completed)
+          completed.toSeq)
       }
 
       content ++=
@@ -190,12 +190,12 @@ case class EngineSessionPage(parent: EngineTab)
 
     if (failed.nonEmpty) {
       val table = {
-        val sessionTableTag = "failed"
+        val sqlTableTag = "failed"
         statementStatsTable(
           request,
-          sessionTableTag,
+          sqlTableTag,
           parent,
-          failed)
+          failed.toSeq)
       }
 
       content ++=
@@ -232,7 +232,7 @@ case class EngineSessionPage(parent: EngineTab)
         data,
         "kyuubi/session",
         UIUtils.prependBaseUri(request, parent.basePath),
-        sqlTableTag).table(sqlTablePage)
+        s"${sqlTableTag}").table(sqlTablePage)
     } catch {
       case e @ (_: IllegalArgumentException | _: IndexOutOfBoundsException) =>
         <div class="alert alert-error">

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/spark/ui/EngineTabSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/spark/ui/EngineTabSuite.scala
@@ -143,6 +143,9 @@ class EngineTabSuite extends WithSparkSQLEngine with HiveJDBCTestHelper {
 
       // check sql stats table title
       assert(resp.contains("Query Details"))
+      while (true) {
+        Thread.sleep(1000000)
+      }
     }
     response = client.execute(req)
     assert(response.getStatusLine.getStatusCode === 200)

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/spark/ui/EngineTabSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/spark/ui/EngineTabSuite.scala
@@ -143,9 +143,6 @@ class EngineTabSuite extends WithSparkSQLEngine with HiveJDBCTestHelper {
 
       // check sql stats table title
       assert(resp.contains("Query Details"))
-      while (true) {
-        Thread.sleep(1000000)
-      }
     }
     response = client.execute(req)
     assert(response.getStatusLine.getStatusCode === 200)


### PR DESCRIPTION
Separate closed and online sessions[statements] in the SparkUI's engine tab

# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #5894 

## Describe Your Solution 🔧
Separate closed and online sessions[statements] in the SparkUI's engine tab
![image](https://github.com/apache/kyuubi/assets/25627922/b39f9215-f629-4c5d-ac3d-9d7c4a8ebff0)



## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests

unit test will add soon.

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
