### PR TITLE
[KYUUBI #5955][TEST][GLUTEN] Disable gluten ui when running integration test

### DIFF
--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/GlutenSuiteMixin.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/GlutenSuiteMixin.scala
@@ -29,5 +29,6 @@ trait GlutenSuiteMixin {
     "spark.memory.offHeap.size" -> "4g",
     "spark.memory.offHeap.enabled" -> "true",
     "spark.shuffle.manager" -> "org.apache.spark.shuffle.sort.ColumnarShuffleManager",
+    "spark.gluten.ui.enabled" -> "false",
     "spark.jars" -> extraJars)
 }


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #5955

## Describe Your Solution 🔧

Disable gluten UI when run integration test.

In integration test case, gluten ui is meaningless.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Improve

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests
CI IT test

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
