### PR TITLE
[KYUUBI #5959][Bug] Flink engine fetch the unbounded data timeout

### DIFF
--- a/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/result/IncrementalResultFetchIterator.scala
+++ b/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/result/IncrementalResultFetchIterator.scala
@@ -130,6 +130,7 @@ class IncrementalResultFetchIterator(
     } catch {
       case e: TimeoutException =>
         if (bufferedRows.nonEmpty) {
+          debug(s"Timeout fetching more data,Returning the current fetched data.")
           hasNext = false
         } else {
           throw e


### PR DESCRIPTION
Flink engine should return the result when fetch timeout but already fetched some data

There are already 3 rows in Kafka when we query from the earlist offset,
I tested some cases:

 1. `kyuubi.session.engine.flink.max.rows=3` & `kyuubi.session.engine.flink.fetch.timeout=PT60S`
client return 3 rows,this meet our expect

 2.`kyuubi.session.engine.flink.max.rows=5` & `kyuubi.session.engine.flink.fetch.timeout=PT60S`
client returns:  Futures timed out after [60000 milliseconds], this does not meet our expect.
we shoud return the result when fetch timeout but already fetched some data

# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #5959 

## Describe Your Solution 🔧

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

1. catch the TimeoutException, set the hasNext flag to false to preventing  fetchNext  method call again 
2. add a UT  in `org.apache.kyuubi.engine.flink.operation.FlinkOperationSuite`  recur this issue.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests
org.apache.kyuubi.engine.flink.operation.FlinkOperationSuite# test result fetch timeout but already fetched some data


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
