### PR TITLE
[KYUUBI #5377][FOLLOWUP] Get limit from more spark plan and regard result max rows

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/sql/kyuubi/SparkDatasetHelper.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/sql/kyuubi/SparkDatasetHelper.scala
@@ -300,7 +300,12 @@ object SparkDatasetHelper extends Logging {
       return false
     }
     lazy val limit = result.queryExecution.executedPlan match {
-      case collectLimit: CollectLimitExec => collectLimit.limit
+      case collectLimit: CollectLimitExec =>
+        if (resultMaxRows > 0) {
+          math.min(resultMaxRows, collectLimit.limit)
+        } else {
+          collectLimit.limit
+        }
       case _ => resultMaxRows
     }
     lazy val stats = if (limit > 0) {

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/sql/kyuubi/SparkDatasetHelper.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/sql/kyuubi/SparkDatasetHelper.scala
@@ -25,9 +25,8 @@ import org.apache.spark.network.util.{ByteUnit, JavaUtils}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.plans.logical.{GlobalLimit, LogicalPlan}
 import org.apache.spark.sql.catalyst.plans.logical.statsEstimation.EstimationUtils
-import org.apache.spark.sql.execution.{CollectLimitExec, HiveResult, LocalTableScanExec, SparkPlan, SQLExecution}
+import org.apache.spark.sql.execution.{CollectLimitExec, HiveResult, LocalTableScanExec, SparkPlan, SQLExecution, TakeOrderedAndProjectExec}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
 import org.apache.spark.sql.execution.arrow.KyuubiArrowConverters
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
@@ -295,8 +294,10 @@ object SparkDatasetHelper extends Logging {
     SQLMetrics.postDriverMetricUpdates(sc, executionId, metrics.values.toSeq)
   }
 
-  private[kyuubi] def logicalPlanLimit(plan: LogicalPlan): Option[Long] = plan match {
-    case globalLimit: GlobalLimit => globalLimit.maxRows
+  private[kyuubi] def planLimit(plan: SparkPlan): Option[Int] = plan match {
+    case tp: TakeOrderedAndProjectExec => Option(tp.limit)
+    case c: CollectLimitExec => Option(c.limit)
+    case ap: AdaptiveSparkPlanExec => planLimit(ap.inputPlan)
     case _ => None
   }
 
@@ -304,7 +305,7 @@ object SparkDatasetHelper extends Logging {
     if (isCommandExec(result.queryExecution.executedPlan.nodeName)) {
       return false
     }
-    val finalLimit = logicalPlanLimit(result.queryExecution.logical) match {
+    val finalLimit = planLimit(result.queryExecution.sparkPlan) match {
       case Some(limit) if resultMaxRows > 0 => math.min(limit, resultMaxRows)
       case Some(limit) => limit
       case None => resultMaxRows

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/sql/kyuubi/SparkDatasetHelper.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/sql/kyuubi/SparkDatasetHelper.scala
@@ -304,13 +304,13 @@ object SparkDatasetHelper extends Logging {
     if (isCommandExec(result.queryExecution.executedPlan.nodeName)) {
       return false
     }
-    val limit = logicalPlanLimit(result.queryExecution.logical) match {
+    val finalLimit = logicalPlanLimit(result.queryExecution.logical) match {
       case Some(limit) if resultMaxRows > 0 => math.min(limit, resultMaxRows)
       case Some(limit) => limit
       case None => resultMaxRows
     }
-    lazy val stats = if (limit > 0) {
-      limit * EstimationUtils.getSizePerRow(
+    lazy val stats = if (finalLimit > 0) {
+      finalLimit * EstimationUtils.getSizePerRow(
         result.queryExecution.executedPlan.output)
     } else {
       result.queryExecution.optimizedPlan.stats.sizeInBytes

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/spark/sql/kyuubi/SparkDatasetHelperSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/spark/sql/kyuubi/SparkDatasetHelperSuite.scala
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.kyuubi
+
+import org.apache.spark.sql.execution.{CollectLimitExec, TakeOrderedAndProjectExec}
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
+import org.apache.spark.sql.internal.SQLConf
+
+import org.apache.kyuubi.engine.spark.WithSparkSQLEngine
+
+class SparkDatasetHelperSuite extends WithSparkSQLEngine {
+  override def withKyuubiConf: Map[String, String] = Map.empty
+
+  test("get limit from spark plan") {
+    Seq(true, false).foreach { aqe =>
+      val topKThreshold = 3
+      spark.sessionState.conf.setConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED, aqe)
+      spark.sessionState.conf.setConf(SQLConf.TOP_K_SORT_FALLBACK_THRESHOLD, topKThreshold)
+      spark.sql("CREATE OR REPLACE TEMPORARY VIEW tv AS" +
+        " SELECT * FROM VALUES(1),(2),(3),(4) AS t(id)")
+
+      val topKStatement = s"SELECT * FROM tv ORDER BY id LIMIT ${topKThreshold - 1}"
+      var sparkPlan = spark.sql(topKStatement).queryExecution.sparkPlan
+      assert(sparkPlan.isInstanceOf[TakeOrderedAndProjectExec] || sparkPlan.asInstanceOf[
+        AdaptiveSparkPlanExec].inputPlan.isInstanceOf[TakeOrderedAndProjectExec])
+      assert(SparkDatasetHelper.planLimit(sparkPlan) === Option(topKThreshold - 1))
+
+      val collectLimitStatement = s"SELECT * FROM tv ORDER BY id LIMIT $topKThreshold"
+      sparkPlan = spark.sql(collectLimitStatement).queryExecution.sparkPlan
+      assert(sparkPlan.isInstanceOf[CollectLimitExec] || sparkPlan.asInstanceOf[
+        AdaptiveSparkPlanExec].inputPlan.isInstanceOf[CollectLimitExec])
+      assert(SparkDatasetHelper.planLimit(sparkPlan) === Option(topKThreshold))
+    }
+  }
+}

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/spark/sql/kyuubi/SparkDatasetHelperSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/spark/sql/kyuubi/SparkDatasetHelperSuite.scala
@@ -33,13 +33,13 @@ class SparkDatasetHelperSuite extends WithSparkSQLEngine {
         " SELECT * FROM VALUES(1),(2),(3),(4) AS t(id)")
 
       val topKStatement = s"SELECT * FROM(SELECT * FROM tv ORDER BY id LIMIT ${topKThreshold - 1})"
-      assert(SparkDatasetHelper.planLimit(
-        spark.sql(topKStatement).queryExecution.sparkPlan) === Option(topKThreshold - 1))
+      assert(SparkDatasetHelper.optimizedPlanLimit(
+        spark.sql(topKStatement).queryExecution) === Option(topKThreshold - 1))
 
       val collectLimitStatement =
         s"SELECT * FROM (SELECT * FROM tv ORDER BY id LIMIT $topKThreshold)"
-      assert(SparkDatasetHelper.planLimit(
-        spark.sql(collectLimitStatement).queryExecution.sparkPlan) === Option(topKThreshold))
+      assert(SparkDatasetHelper.optimizedPlanLimit(
+        spark.sql(collectLimitStatement).queryExecution) === Option(topKThreshold))
     }
   }
 }


### PR DESCRIPTION
# :mag: Description
Followup #5591 
Support to get existing limit from more plan and regard the result max rows.
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #

## Describe Your Solution 🔧

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
