### PR TITLE
[AUTHZ] Supports check hoodie procedures show_commits resource privileges

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/serde/tableExtractors.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/serde/tableExtractors.scala
@@ -439,6 +439,9 @@ abstract class HudiCallProcedureTableExtractor extends TableExtractor {
       s"$PROCEDURE_CLASS_PATH.ShowClusteringProcedure",
       ProcedureArgsInputOutputPair(input = Some("table"))),
     (
+      s"$PROCEDURE_CLASS_PATH.ShowCommitsProcedure",
+      ProcedureArgsInputOutputPair(input = Some("table"))),
+    (
       s"$PROCEDURE_CLASS_PATH.ShowCommitExtraMetadataProcedure",
       ProcedureArgsInputOutputPair(input = Some("table"))),
     (

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/HudiCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/HudiCatalogRangerSparkExtensionSuite.scala
@@ -618,4 +618,30 @@ class HudiCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
       doAs(admin, sql(dropIndex))
     }
   }
+
+  test("ShowCommitsProcedure") {
+    withCleanTmpResources(Seq((s"$namespace1.$table1", "table"), (namespace1, "database"))) {
+      doAs(admin, sql(s"CREATE DATABASE IF NOT EXISTS $namespace1"))
+      doAs(
+        admin,
+        sql(
+          s"""
+             |CREATE TABLE IF NOT EXISTS $namespace1.$table1(id int, name string, city string)
+             |USING HUDI
+             |OPTIONS (
+             | type = 'mor',
+             | primaryKey = 'id',
+             | 'hoodie.datasource.hive_sync.enable' = 'false'
+             |)
+             |PARTITIONED BY(city)
+             |TBLPROPERTIES ('hoodie.datasource.write.precombine.field' = 'id')
+             |""".stripMargin))
+
+      val showCommitsSql = s"CALL SHOW_COMMITS(table => '$namespace1.$table1', limit => 10)"
+      interceptEndsWith[AccessControlException] {
+        doAs(someone, sql(showCommitsSql))
+      }(s"does not have [select] privilege on [$namespace1/$table1]")
+      doAs(admin, sql(showCommitsSql))
+    }
+  }
 }


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request aims to make AuthZ supports check [hoodie procedures show_commits](https://hudi.apache.org/docs/procedures#show_commits) resource privileges

## Describe Your Solution 🔧

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:
`CALL show_commits` passes permission checks whether they have permission or not

#### Behavior With This Pull Request :tada:
`CALL show_commits` will not pass without permission

#### Related Unit Tests
New test added, extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/HudiCatalogRangerSparkExtensionSuite.scala#ShowCommitsProcedure

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
