### PR TITLE
[KYUUBI #5966] Error occurs on clicking on the Spark UI Kyuubi Query Engine tab

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/package.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/package.scala
@@ -43,20 +43,20 @@ package object kyuubi {
       Try(buildFileStream.close())
     }
 
-    val version: String = props.getProperty("kyuubi_version", unknown)
-    val java_version: String = props.getProperty("kyuubi_java_version", unknown)
-    val scala_version: String = props.getProperty("kyuubi_scala_version", unknown)
-    val spark_version: String = props.getProperty("kyuubi_spark_version", unknown)
-    val hive_version: String = props.getProperty("kyuubi_hive_version", unknown)
-    val hadoop_version: String = props.getProperty("kyuubi_hadoop_version", unknown)
-    val flink_version: String = props.getProperty("kyuubi_flink_version", unknown)
-    val trino_version: String = props.getProperty("kyuubi_trino_version", unknown)
-    val branch: String = props.getProperty("branch", unknown)
-    val revision: String = props.getProperty("revision", unknown)
-    val revisionTime: String = props.getProperty("revision_time", unknown)
-    val user: String = props.getProperty("user", unknown)
-    val repoUrl: String = props.getProperty("url", unknown)
-    val buildDate: String = props.getProperty("date", unknown)
+    val version: String = getProperty(props, "kyuubi_version", unknown)
+    val java_version: String = getProperty(props, "kyuubi_java_version", unknown)
+    val scala_version: String = getProperty(props, "kyuubi_scala_version", unknown)
+    val spark_version: String = getProperty(props, "kyuubi_spark_version", unknown)
+    val hive_version: String = getProperty(props, "kyuubi_hive_version", unknown)
+    val hadoop_version: String = getProperty(props, "kyuubi_hadoop_version", unknown)
+    val flink_version: String = getProperty(props, "kyuubi_flink_version", unknown)
+    val trino_version: String = getProperty(props, "kyuubi_trino_version", unknown)
+    val branch: String = getProperty(props, "branch", unknown)
+    val revision: String = getProperty(props, "revision", unknown)
+    val revisionTime: String = getProperty(props, "revision_time", unknown)
+    val user: String = getProperty(props, "user", unknown)
+    val repoUrl: String = getProperty(props, "url", unknown)
+    val buildDate: String = getProperty(props, "date", unknown)
   }
 
   val KYUUBI_VERSION: String = BuildInfo.version
@@ -73,4 +73,8 @@ package object kyuubi {
   val BUILD_USER: String = BuildInfo.user
   val REPO_URL: String = BuildInfo.repoUrl
   val BUILD_DATE: String = BuildInfo.buildDate
+
+  private def getProperty(props: Properties, key: String, defaultValue: String): String = {
+    Option(props.getProperty(key, defaultValue)).filterNot(_.isEmpty).getOrElse(defaultValue)
+  }
 }

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/package.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/package.scala
@@ -42,27 +42,24 @@ package object kyuubi {
       Try(buildFileStream.close())
     }
 
-    private def getProperty(
-        props: Properties,
-        key: String,
-        defaultValue: String = unknown): String = {
+    private def getProperty(key: String, defaultValue: String = unknown): String = {
       Option(props.getProperty(key, defaultValue)).filterNot(_.isEmpty).getOrElse(defaultValue)
     }
 
-    val version: String = getProperty(props, "kyuubi_version", unknown)
-    val java_version: String = getProperty(props, "kyuubi_java_version", unknown)
-    val scala_version: String = getProperty(props, "kyuubi_scala_version", unknown)
-    val spark_version: String = getProperty(props, "kyuubi_spark_version", unknown)
-    val hive_version: String = getProperty(props, "kyuubi_hive_version", unknown)
-    val hadoop_version: String = getProperty(props, "kyuubi_hadoop_version", unknown)
-    val flink_version: String = getProperty(props, "kyuubi_flink_version", unknown)
-    val trino_version: String = getProperty(props, "kyuubi_trino_version", unknown)
-    val branch: String = getProperty(props, "branch", unknown)
-    val revision: String = getProperty(props, "revision", unknown)
-    val revisionTime: String = getProperty(props, "revision_time", unknown)
-    val user: String = getProperty(props, "user", unknown)
-    val repoUrl: String = getProperty(props, "url", unknown)
-    val buildDate: String = getProperty(props, "date", unknown)
+    val version: String = getProperty("kyuubi_version")
+    val java_version: String = getProperty("kyuubi_java_version")
+    val scala_version: String = getProperty("kyuubi_scala_version")
+    val spark_version: String = getProperty("kyuubi_spark_version")
+    val hive_version: String = getProperty("kyuubi_hive_version")
+    val hadoop_version: String = getProperty("kyuubi_hadoop_version")
+    val flink_version: String = getProperty("kyuubi_flink_version")
+    val trino_version: String = getProperty("kyuubi_trino_version")
+    val branch: String = getProperty("branch")
+    val revision: String = getProperty("revision")
+    val revisionTime: String = getProperty("revision_time")
+    val user: String = getProperty("user")
+    val repoUrl: String = getProperty("url")
+    val buildDate: String = getProperty("date")
   }
 
   val KYUUBI_VERSION: String = BuildInfo.version

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/package.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/package.scala
@@ -18,6 +18,7 @@
 package org.apache
 
 import java.util.Properties
+
 import scala.util.Try
 
 package object kyuubi {

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/package.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/package.scala
@@ -18,7 +18,6 @@
 package org.apache
 
 import java.util.Properties
-
 import scala.util.Try
 
 package object kyuubi {
@@ -41,6 +40,13 @@ package object kyuubi {
       props.load(buildFileStream)
     } finally {
       Try(buildFileStream.close())
+    }
+
+    private def getProperty(
+        props: Properties,
+        key: String,
+        defaultValue: String = unknown): String = {
+      Option(props.getProperty(key, defaultValue)).filterNot(_.isEmpty).getOrElse(defaultValue)
     }
 
     val version: String = getProperty(props, "kyuubi_version", unknown)
@@ -73,8 +79,4 @@ package object kyuubi {
   val BUILD_USER: String = BuildInfo.user
   val REPO_URL: String = BuildInfo.repoUrl
   val BUILD_DATE: String = BuildInfo.buildDate
-
-  private def getProperty(props: Properties, key: String, defaultValue: String): String = {
-    Option(props.getProperty(key, defaultValue)).filterNot(_.isEmpty).getOrElse(defaultValue)
-  }
 }


### PR DESCRIPTION
# :mag: Description

## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #5966

Fix Kyuubi Query Engine tab error:StringIndexOutOfBoundsException: String index out of range: 7

## Describe Your Solution 🔧
When the variables branch, revision, revisionTime, repoUrl are empty strings ("")，assign them the default value "\<unknown\>".
## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
