### PR TITLE
Bump jetcd 0.7.7

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -214,6 +214,7 @@ commons-logging:commons-logging
 org.apache.commons:commons-lang3
 org.apache.derby:derby
 com.google.errorprone:error_prone_annotations
+dev.failsafe:failsafe
 net.jodah:failsafe
 com.jakewharton.fliptables:fliptables
 com.github.mifmif:generex

--- a/dev/dependencyList
+++ b/dev/dependencyList
@@ -35,6 +35,7 @@ commons-logging/1.1.3//commons-logging-1.1.3.jar
 derby/10.14.2.0//derby-10.14.2.0.jar
 error_prone_annotations/2.20.0//error_prone_annotations-2.20.0.jar
 failsafe/2.4.4//failsafe-2.4.4.jar
+failsafe/3.3.2//failsafe-3.3.2.jar
 failureaccess/1.0.1//failureaccess-1.0.1.jar
 flatbuffers-java/1.12.0//flatbuffers-java-1.12.0.jar
 fliptables/1.0.2//fliptables-1.0.2.jar
@@ -92,10 +93,10 @@ jersey-hk2/2.39.1//jersey-hk2-2.39.1.jar
 jersey-media-json-jackson/2.39.1//jersey-media-json-jackson-2.39.1.jar
 jersey-media-multipart/2.39.1//jersey-media-multipart-2.39.1.jar
 jersey-server/2.39.1//jersey-server-2.39.1.jar
-jetcd-api/0.7.3//jetcd-api-0.7.3.jar
-jetcd-common/0.7.3//jetcd-common-0.7.3.jar
-jetcd-core/0.7.3//jetcd-core-0.7.3.jar
-jetcd-grpc/0.7.3//jetcd-grpc-0.7.3.jar
+jetcd-api/0.7.7//jetcd-api-0.7.7.jar
+jetcd-common/0.7.7//jetcd-common-0.7.7.jar
+jetcd-core/0.7.7//jetcd-core-0.7.7.jar
+jetcd-grpc/0.7.7//jetcd-grpc-0.7.7.jar
 jetty-client/9.4.52.v20230823//jetty-client-9.4.52.v20230823.jar
 jetty-http/9.4.52.v20230823//jetty-http-9.4.52.v20230823.jar
 jetty-io/9.4.52.v20230823//jetty-io-9.4.52.v20230823.jar
@@ -194,7 +195,7 @@ swagger-jaxrs2/2.2.1//swagger-jaxrs2-2.2.1.jar
 swagger-models/2.2.1//swagger-models-2.2.1.jar
 trino-client/363//trino-client-363.jar
 units/1.6//units-1.6.jar
-vertx-core/4.3.2//vertx-core-4.3.2.jar
-vertx-grpc/4.3.2//vertx-grpc-4.3.2.jar
+vertx-core/4.5.1//vertx-core-4.5.1.jar
+vertx-grpc/4.5.1//vertx-grpc-4.5.1.jar
 zjsonpatch/0.3.0//zjsonpatch-0.3.0.jar
 zstd-jni/1.5.5-1//zstd-jni-1.5.5-1.jar

--- a/externals/kyuubi-spark-sql-engine/pom.xml
+++ b/externals/kyuubi-spark-sql-engine/pom.xml
@@ -269,6 +269,13 @@
                     </filters>
                     <relocations>
                         <relocation>
+                            <pattern>dev.failsafe</pattern>
+                            <shadedPattern>${kyuubi.shade.packageName}.dev.failsafe</shadedPattern>
+                            <includes>
+                                <include>dev.failsafe.**</include>
+                            </includes>
+                        </relocation>
+                        <relocation>
                             <pattern>io.etcd</pattern>
                             <shadedPattern>${kyuubi.shade.packageName}.io.etcd</shadedPattern>
                             <includes>
@@ -295,13 +302,6 @@
                             <shadedPattern>${kyuubi.shade.packageName}.io.vertx</shadedPattern>
                             <includes>
                                 <include>io.vertx.**</include>
-                            </includes>
-                        </relocation>
-                        <relocation>
-                            <pattern>net.jodah</pattern>
-                            <shadedPattern>${kyuubi.shade.packageName}.net.jodah</shadedPattern>
-                            <includes>
-                                <include>net.jodah.**</include>
                             </includes>
                         </relocation>
                         <relocation>

--- a/externals/kyuubi-spark-sql-engine/pom.xml
+++ b/externals/kyuubi-spark-sql-engine/pom.xml
@@ -237,12 +237,12 @@
                             <include>com.google.guava:*</include>
                             <include>com.google.j2objc:j2objc-annotations</include>
                             <include>com.google.protobuf:*</include>
+                            <include>dev.failsafe:failsafe</include>
                             <include>io.etcd:*</include>
                             <include>io.grpc:*</include>
                             <include>io.netty:*</include>
                             <include>io.perfmark:perfmark-api</include>
                             <include>io.vertx:*</include>
-                            <include>net.jodah:failsafe</include>
                             <include>org.apache.kyuubi:*</include>
                             <include>org.checkerframework:checker-qual</include>
                             <include>org.codehaus.mojo:animal-sniffer-annotations</include>

--- a/pom.xml
+++ b/pom.xml
@@ -133,10 +133,10 @@
         <commons-io.version>2.11.0</commons-io.version>
         <commons-lang.version>2.6</commons-lang.version>
         <commons-lang3.version>3.13.0</commons-lang3.version>
-        <etcd.version>0.7.3</etcd.version>
         <delta.artifact>delta-core</delta.artifact>
         <delta.version>2.4.0</delta.version>
-        <failsafe.verion>2.4.4</failsafe.verion>
+        <failsafe2.verion>2.4.4</failsafe2.verion>
+        <failsafe.verion>3.3.2</failsafe.verion>
         <fb303.version>0.9.3</fb303.version>
         <flexmark.version>0.62.2</flexmark.version>
         <flink.version>1.17.2</flink.version>
@@ -168,6 +168,7 @@
         <jakarta.xml-bind.version>2.3.2</jakarta.xml-bind.version>
         <jakarta.activation.version>1.2.2</jakarta.activation.version>
         <jersey.version>2.39.1</jersey.version>
+        <jetcd.version>0.7.7</jetcd.version>
         <jetty.version>9.4.52.v20230823</jetty.version>
         <jline.version>0.9.94</jline.version>
         <junit.version>4.13.2</junit.version>
@@ -1105,7 +1106,7 @@
             <dependency>
                 <groupId>io.etcd</groupId>
                 <artifactId>jetcd-core</artifactId>
-                <version>${etcd.version}</version>
+                <version>${jetcd.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>javax.annotation</groupId>
@@ -1117,7 +1118,7 @@
             <dependency>
                 <groupId>io.etcd</groupId>
                 <artifactId>jetcd-launcher</artifactId>
-                <version>${etcd.version}</version>
+                <version>${jetcd.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.testcontainers</groupId>
@@ -1176,6 +1177,12 @@
 
             <dependency>
                 <groupId>net.jodah</groupId>
+                <artifactId>failsafe</artifactId>
+                <version>${failsafe2.verion}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>dev.failsafe</groupId>
                 <artifactId>failsafe</artifactId>
                 <version>${failsafe.verion}</version>
             </dependency>


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

It's regular dependency upgrading, and jetcd 0.7.7 may be the latest version that supports Java 8.

## Describe Your Solution 🔧

Upgrading jetcd to 0.7.7, and this upgrading involves the transitive dep `failsafe` major upgrades, the group is changed from `net.jodah` to `dev.failsafe`

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

Pass GA.


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
