### PR TITLE
Bump trino-client 411

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -215,7 +215,6 @@ org.apache.commons:commons-lang3
 org.apache.derby:derby
 com.google.errorprone:error_prone_annotations
 dev.failsafe:failsafe
-net.jodah:failsafe
 com.jakewharton.fliptables:fliptables
 com.github.mifmif:generex
 io.grpc:grpc-api

--- a/dev/dependencyList
+++ b/dev/dependencyList
@@ -34,7 +34,6 @@ commons-lang3/3.13.0//commons-lang3-3.13.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
 derby/10.14.2.0//derby-10.14.2.0.jar
 error_prone_annotations/2.20.0//error_prone_annotations-2.20.0.jar
-failsafe/2.4.4//failsafe-2.4.4.jar
 failsafe/3.3.2//failsafe-3.3.2.jar
 failureaccess/1.0.1//failureaccess-1.0.1.jar
 flatbuffers-java/1.12.0//flatbuffers-java-1.12.0.jar
@@ -193,8 +192,8 @@ swagger-core/2.2.1//swagger-core-2.2.1.jar
 swagger-integration/2.2.1//swagger-integration-2.2.1.jar
 swagger-jaxrs2/2.2.1//swagger-jaxrs2-2.2.1.jar
 swagger-models/2.2.1//swagger-models-2.2.1.jar
-trino-client/363//trino-client-363.jar
-units/1.6//units-1.6.jar
+trino-client/411//trino-client-411.jar
+units/1.7//units-1.7.jar
 vertx-core/4.5.1//vertx-core-4.5.1.jar
 vertx-grpc/4.5.1//vertx-grpc-4.5.1.jar
 zjsonpatch/0.3.0//zjsonpatch-0.3.0.jar

--- a/docs/client/cli/trino_cli.md
+++ b/docs/client/cli/trino_cli.md
@@ -30,11 +30,11 @@ kyuubi.frontend.trino.bind.port 10999 #default port
 
 ## Install
 
-Download [trino-cli-363-executable.jar](https://repo1.maven.org/maven2/io/trino/trino-jdbc/363/trino-jdbc-363.jar), rename it to `trino`, make it executable with `chmod +x`, and run it to show the version of the CLI:
+Download [trino-cli-411-executable.jar](https://repo1.maven.org/maven2/io/trino/trino-jdbc/411/trino-jdbc-411.jar), rename it to `trino`, make it executable with `chmod +x`, and run it to show the version of the CLI:
 
 ```
-wget https://repo1.maven.org/maven2/io/trino/trino-jdbc/363/trino-jdbc-363.jar
-mv trino-jdbc-363.jar trino
+wget https://repo1.maven.org/maven2/io/trino/trino-jdbc/411/trino-jdbc-411.jar
+mv trino-jdbc-411.jar trino
 chmod +x trino
 ./trino --version
 ```

--- a/docs/client/jdbc/trino_jdbc.md
+++ b/docs/client/jdbc/trino_jdbc.md
@@ -33,7 +33,7 @@ kyuubi.frontend.trino.bind.port 10999 #default port
 
 ## Install Trino JDBC
 
-Download [trino-jdbc-363.jar](https://repo1.maven.org/maven2/io/trino/trino-jdbc/363/trino-jdbc-363.jar) and add it to the classpath of your Java application.
+Download [trino-jdbc-411.jar](https://repo1.maven.org/maven2/io/trino/trino-jdbc/411/trino-jdbc-363.jar) and add it to the classpath of your Java application.
 
 The driver is also available from Maven Central:
 
@@ -41,7 +41,7 @@ The driver is also available from Maven Central:
 <dependency>
     <groupId>io.trino</groupId>
     <artifactId>trino-jdbc</artifactId>
-    <version>363</version>
+    <version>411</version>
 </dependency>
 ```
 

--- a/docs/quick_start/quick_start.rst
+++ b/docs/quick_start/quick_start.rst
@@ -36,23 +36,23 @@ For quick start deployment, we need to prepare the following stuffs:
 These essential components are JVM-based applications. So, the JRE needs to be
 pre-installed and the ``JAVA_HOME`` is correctly set to each component.
 
- ================ ============ ==================== ===========================================
+ ================ ============ ==================== =======================================================
   Component        Role         Version              Remarks
- ================ ============ ==================== ===========================================
+ ================ ============ ==================== =======================================================
   **Java**         JRE          8/11/17              Officially released against JDK8
   **Kyuubi**       Gateway      \ |release| \        - Kyuubi Server
                    Engine lib                        - Kyuubi Engine
                    Beeline                           - Kyuubi Hive Beeline
   **Spark**        Engine       3.1 to 3.5           A Spark distribution
   **Flink**        Engine       1.16/1.17/1.18       A Flink distribution
-  **Trino**        Engine       >=363                A Trino cluster
+  **Trino**        Engine       N/A                  A Trino cluster allows to access via trino-client v411
   **Doris**        Engine       N/A                  A Doris cluster
   **Hive**         Engine       - 2.1-cdh6/2.3/3.1   - A Hive distribution
                    Metastore    - N/A                - An optional and external metadata store,
                                                        whose version is decided by engines
   **Zookeeper**    HA           >=3.4.x
   **Disk**         Storage      N/A                  N/A
- ================ ============ ==================== ===========================================
+ ================ ============ ==================== =======================================================
 
 The other internal or external parts listed in the above sheet can be used individually
 or all together. For example, you can use Kyuubi, Spark and Flink to build a streaming

--- a/externals/kyuubi-spark-sql-engine/src/main/resources/META-INF/LICENSE
+++ b/externals/kyuubi-spark-sql-engine/src/main/resources/META-INF/LICENSE
@@ -221,6 +221,7 @@ com.google.errorprone:error_prone_annotations
 com.google.guava:guava
 com.google.guava:failureaccess
 com.google.j2objc:j2objc-annotations
+dev.failsafe:failsafe
 io.etcd:jetcd-api
 io.etcd:jetcd-common
 io.etcd:jetcd-core
@@ -252,7 +253,6 @@ io.netty:netty-transport-native-unix-common
 io.perfmark:perfmark-api
 io.vertx:vertx-grpc
 io.vertx:vertx-core
-net.jodah:failsafe
 
 BSD License
 --------------------------

--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/TrinoStatement.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/TrinoStatement.scala
@@ -128,13 +128,13 @@ class TrinoStatement(
     // update catalog and schema
     if (trino.getSetCatalog.isPresent || trino.getSetSchema.isPresent) {
       builder = builder
-        .withCatalog(trino.getSetCatalog.orElse(session.getCatalog))
-        .withSchema(trino.getSetSchema.orElse(session.getSchema))
+        .catalog(trino.getSetCatalog.orElse(session.getCatalog))
+        .schema(trino.getSetSchema.orElse(session.getSchema))
     }
 
     // update path if present
     if (trino.getSetPath.isPresent) {
-      builder = builder.withPath(trino.getSetPath.get)
+      builder = builder.path(trino.getSetPath.get)
     }
 
     // update session properties if present
@@ -142,7 +142,7 @@ class TrinoStatement(
       val properties = session.getProperties.asScala.clone()
       properties ++= trino.getSetSessionProperties.asScala
       properties --= trino.getResetSessionProperties.asScala
-      builder = builder.withProperties(properties.asJava)
+      builder = builder.properties(properties.asJava)
     }
 
     trinoContext.clientSession.set(builder.build())

--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/SetCurrentCatalog.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/SetCurrentCatalog.scala
@@ -33,7 +33,7 @@ class SetCurrentCatalog(session: Session, catalog: String)
     try {
       val session = trinoContext.clientSession.get
       var builder = ClientSession.builder(session)
-      builder = builder.withCatalog(catalog)
+      builder = builder.catalog(catalog)
       trinoContext.clientSession.set(builder.build())
       setHasResultSet(false)
     } catch onError()

--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/SetCurrentDatabase.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/SetCurrentDatabase.scala
@@ -33,7 +33,7 @@ class SetCurrentDatabase(session: Session, database: String)
     try {
       val session = trinoContext.clientSession.get
       var builder = ClientSession.builder(session)
-      builder = builder.withSchema(database)
+      builder = builder.schema(database)
       trinoContext.clientSession.set(builder.build())
       setHasResultSet(false)
     } catch onError()

--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/session/TrinoSessionImpl.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/session/TrinoSessionImpl.scala
@@ -19,7 +19,7 @@ package org.apache.kyuubi.engine.trino.session
 
 import java.net.URI
 import java.time.ZoneId
-import java.util.{Collections, Locale, Optional}
+import java.util.{Locale, Optional}
 import java.util.concurrent.TimeUnit
 
 import scala.collection.JavaConverters._
@@ -93,27 +93,18 @@ class TrinoSessionImpl(
 
     val properties = getTrinoSessionConf(sessionConf).asJava
 
-    new ClientSession(
-      URI.create(connectionUrl),
-      username,
-      Optional.empty(),
-      "kyuubi",
-      Optional.empty(),
-      Collections.emptySet(),
-      null,
-      catalogName,
-      databaseName,
-      null,
-      ZoneId.systemDefault(),
-      Locale.getDefault,
-      Collections.emptyMap(),
-      properties,
-      Collections.emptyMap(),
-      Collections.emptyMap(),
-      Collections.emptyMap(),
-      null,
-      new Duration(clientRequestTimeout, TimeUnit.MILLISECONDS),
-      true)
+    ClientSession.builder()
+      .server(URI.create(connectionUrl))
+      .principal(Optional.of(username))
+      .source("kyuubi")
+      .catalog(catalogName)
+      .schema(databaseName)
+      .timeZone(ZoneId.systemDefault())
+      .locale(Locale.getDefault)
+      .properties(properties)
+      .clientRequestTimeout(new Duration(clientRequestTimeout, TimeUnit.MILLISECONDS))
+      .compressionDisabled(true)
+      .build()
   }
 
   private def createHttpClient(): OkHttpClient = {
@@ -135,7 +126,8 @@ class TrinoSessionImpl(
       Optional.ofNullable(keystoreType.orNull),
       Optional.ofNullable(truststorePath.orNull),
       Optional.ofNullable(truststorePassword.orNull),
-      Optional.ofNullable(truststoreType.orNull), true)
+      Optional.ofNullable(truststoreType.orNull),
+      true)
 
     sessionConf.get(KyuubiConf.ENGINE_TRINO_CONNECTION_PASSWORD).foreach { password =>
       require(

--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/session/TrinoSessionImpl.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/session/TrinoSessionImpl.scala
@@ -135,7 +135,7 @@ class TrinoSessionImpl(
       Optional.ofNullable(keystoreType.orNull),
       Optional.ofNullable(truststorePath.orNull),
       Optional.ofNullable(truststorePassword.orNull),
-      Optional.ofNullable(truststoreType.orNull))
+      Optional.ofNullable(truststoreType.orNull), true)
 
     sessionConf.get(KyuubiConf.ENGINE_TRINO_CONNECTION_PASSWORD).foreach { password =>
       require(

--- a/externals/kyuubi-trino-engine/src/test/scala/org/apache/kyuubi/engine/trino/WithTrinoContainerServer.scala
+++ b/externals/kyuubi-trino-engine/src/test/scala/org/apache/kyuubi/engine/trino/WithTrinoContainerServer.scala
@@ -38,7 +38,7 @@ import org.apache.kyuubi.config.KyuubiConf
 
 trait WithTrinoContainerServer extends KyuubiFunSuite with TestContainerForAll {
 
-  final val IMAGE_VERSION = 363
+  final val IMAGE_VERSION = 411
   final val DOCKER_IMAGE_NAME = s"trinodb/trino:${IMAGE_VERSION}"
 
   override val containerDef = TrinoContainer.Def(DockerImageName.parse(DOCKER_IMAGE_NAME))

--- a/externals/kyuubi-trino-engine/src/test/scala/org/apache/kyuubi/engine/trino/WithTrinoContainerServer.scala
+++ b/externals/kyuubi-trino-engine/src/test/scala/org/apache/kyuubi/engine/trino/WithTrinoContainerServer.scala
@@ -23,12 +23,9 @@ import java.util.Locale
 import java.util.Optional
 import java.util.concurrent.TimeUnit
 
-import scala.collection.JavaConverters._
-
 import com.dimafeng.testcontainers.TrinoContainer
 import com.dimafeng.testcontainers.scalatest.TestContainerForAll
 import io.airlift.units.Duration
-import io.trino.client.ClientSelectedRole
 import io.trino.client.ClientSession
 import okhttp3.OkHttpClient
 import org.testcontainers.utility.DockerImageName
@@ -39,7 +36,7 @@ import org.apache.kyuubi.config.KyuubiConf
 trait WithTrinoContainerServer extends KyuubiFunSuite with TestContainerForAll {
 
   final val IMAGE_VERSION = 411
-  final val DOCKER_IMAGE_NAME = s"trinodb/trino:${IMAGE_VERSION}"
+  final val DOCKER_IMAGE_NAME = s"trinodb/trino:$IMAGE_VERSION"
 
   override val containerDef = TrinoContainer.Def(DockerImageName.parse(DOCKER_IMAGE_NAME))
 
@@ -56,27 +53,17 @@ trait WithTrinoContainerServer extends KyuubiFunSuite with TestContainerForAll {
     }
   }
 
-  protected def session(connectionUrl: String): ClientSession = new ClientSession(
-    URI.create(connectionUrl),
-    "kyuubi_test",
-    Optional.empty(),
-    "kyuubi",
-    Optional.empty(),
-    Set[String]().asJava,
-    null,
-    catalog,
-    schema,
-    null,
-    ZoneId.systemDefault(),
-    Locale.getDefault,
-    Map[String, String]().asJava,
-    Map[String, String]().asJava,
-    Map[String, String]().asJava,
-    Map[String, ClientSelectedRole]().asJava,
-    Map[String, String]().asJava,
-    null,
-    new Duration(2, TimeUnit.MINUTES),
-    true)
+  protected def session(connectionUrl: String): ClientSession = ClientSession.builder()
+    .server(URI.create(connectionUrl))
+    .principal(Optional.of("kyuubi_test"))
+    .source("kyuubi")
+    .catalog(catalog)
+    .schema(schema)
+    .timeZone(ZoneId.systemDefault())
+    .locale(Locale.getDefault)
+    .clientRequestTimeout(new Duration(2, TimeUnit.MINUTES))
+    .compressionDisabled(true)
+    .build()
 
   lazy val httpClient = new OkHttpClient.Builder().build()
 }

--- a/integration-tests/kyuubi-trino-it/src/test/scala/org/apache/kyuubi/it/trino/WithKyuubiServerAndTrinoContainer.scala
+++ b/integration-tests/kyuubi-trino-it/src/test/scala/org/apache/kyuubi/it/trino/WithKyuubiServerAndTrinoContainer.scala
@@ -28,8 +28,8 @@ trait WithKyuubiServerAndTrinoContainer extends WithKyuubiServer with TestContai
 
   val kyuubiHome: String = Utils.getCodeSourceLocation(getClass).split("integration-tests").head
 
-  final val IMAGE_VERSION = 363
-  final val DOCKER_IMAGE_NAME = s"trinodb/trino:${IMAGE_VERSION}"
+  final val IMAGE_VERSION = 411
+  final val DOCKER_IMAGE_NAME = s"trinodb/trino:$IMAGE_VERSION"
 
   override val containerDef: TrinoContainer.Def = TrinoContainer.Def(DOCKER_IMAGE_NAME)
 

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/trino/api/TrinoClientApiSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/trino/api/TrinoClientApiSuite.scala
@@ -123,32 +123,26 @@ class TrinoClientApiSuite extends KyuubiFunSuite with TrinoRestFrontendTestHelpe
   }
 
   private def createTestClientSession(connectUrl: URI): ClientSession = {
-    new ClientSession(
-      connectUrl,
-      "kyuubi_test",
-      Optional.of("test_user"),
-      "kyuubi",
-      Optional.of("test_token_tracing"),
-      Set[String]().asJava,
-      "test_client_info",
-      "test_catalog",
-      "test_schema",
-      null,
-      ZoneId.systemDefault(),
-      Locale.getDefault,
-      Collections.emptyMap(),
-      Map[String, String](
+    ClientSession.builder()
+      .server(connectUrl)
+      .principal(Optional.of("kyuubi_test"))
+      .user(Optional.of("test_user"))
+      .source("kyuubi")
+      .traceToken(Optional.of("test_token_tracing"))
+      .clientInfo("test_client_info")
+      .catalog("test_catalog")
+      .schema("test_schema")
+      .timeZone(ZoneId.systemDefault())
+      .locale(Locale.getDefault)
+      .properties(Map[String, String](
         "test_property_key0" -> "test_property_value0",
-        "test_property_key1" -> "test_propert_value1").asJava,
-      Map[String, String](
+        "test_property_key1" -> "test_propert_value1").asJava)
+      .preparedStatements(Map[String, String](
         "test_statement_key0" -> "select 1",
-        "test_statement_key1" -> "select 2").asJava,
-      Collections.emptyMap(),
-      Collections.emptyMap(),
-      null,
-      new Duration(2, TimeUnit.MINUTES),
-      true)
-
+        "test_statement_key1" -> "select 2").asJava)
+      .clientRequestTimeout(new Duration(2, TimeUnit.MINUTES))
+      .compressionDisabled(true)
+      .build()
   }
 
 }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/trino/api/TrinoClientApiSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/trino/api/TrinoClientApiSuite.scala
@@ -19,7 +19,7 @@ package org.apache.kyuubi.server.trino.api
 
 import java.net.URI
 import java.time.ZoneId
-import java.util.{Collections, Locale, Optional}
+import java.util.{Locale, Optional}
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/trino/api/TrinoClientApiSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/trino/api/TrinoClientApiSuite.scala
@@ -74,13 +74,13 @@ class TrinoClientApiSuite extends KyuubiFunSuite with TrinoRestFrontendTestHelpe
     // update catalog and schema
     if (trino.getSetCatalog.isPresent || trino.getSetSchema.isPresent) {
       builder = builder
-        .withCatalog(trino.getSetCatalog.orElse(session.getCatalog))
-        .withSchema(trino.getSetSchema.orElse(session.getSchema))
+        .catalog(trino.getSetCatalog.orElse(session.getCatalog))
+        .schema(trino.getSetSchema.orElse(session.getSchema))
     }
 
     // update path if present
     if (trino.getSetPath.isPresent) {
-      builder = builder.withPath(trino.getSetPath.get)
+      builder = builder.path(trino.getSetPath.get)
     }
 
     // update session properties if present
@@ -88,7 +88,7 @@ class TrinoClientApiSuite extends KyuubiFunSuite with TrinoRestFrontendTestHelpe
       val properties = session.getProperties.asScala.clone()
       properties ++= trino.getSetSessionProperties.asScala
       properties --= trino.getResetSessionProperties.asScala
-      builder = builder.withProperties(properties.asJava)
+      builder = builder.properties(properties.asJava)
     }
     clientSession.set(builder.build())
   }

--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,8 @@
         <!-- https://github.com/ThreeTen/threeten-extra/issues/226 -->
         <threeten.version>1.7.0</threeten.version>
         <thrift.version>0.9.3</thrift.version>
-        <trino.client.version>363</trino.client.version>
+        <!-- trino-client involves kotlin runtime dependencies since 412 because of upgrading okhttp -->
+        <trino.client.version>411</trino.client.version>
         <trino.tpcds.version>1.4</trino.tpcds.version>
         <trino.tpch.version>1.1</trino.tpch.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,6 @@
         <commons-lang3.version>3.13.0</commons-lang3.version>
         <delta.artifact>delta-core</delta.artifact>
         <delta.version>2.4.0</delta.version>
-        <failsafe2.verion>2.4.4</failsafe2.verion>
         <failsafe.verion>3.3.2</failsafe.verion>
         <fb303.version>0.9.3</fb303.version>
         <flexmark.version>0.62.2</flexmark.version>
@@ -1174,12 +1173,6 @@
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java-util</artifactId>
                 <version>${protobuf.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>net.jodah</groupId>
-                <artifactId>failsafe</artifactId>
-                <version>${failsafe2.verion}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This is a regular dependency upgrading,

## Describe Your Solution 🔧

Upgrade `trino-client` from 363 to 411. 411 is the latest version which uses okhttp 3.x, hence it does not have kotlin runtime dependencies.

This PR also updates the docs, especially the Trino cluster version requirement.

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

Pass GA.


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
