### PR TITLE
[KYUUBI #5961][FOLLOWUP] Prevent NPE when checking ticket cache exists

### DIFF
--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/auth/KerberosAuthentication.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/auth/KerberosAuthentication.java
@@ -107,10 +107,10 @@ public class KerberosAuthentication {
     if (StringUtils.isBlank(ticketCache)) {
       ticketCache = System.getenv("KRB5CCNAME");
     }
-    if (!Files.exists(Paths.get(ticketCache))) {
-      LOG.warn("TicketCache {} does not exist", ticketCache);
-    }
     if (StringUtils.isNotBlank(ticketCache)) {
+      if (!Files.exists(Paths.get(ticketCache))) {
+        LOG.warn("TicketCache {} does not exist", ticketCache);
+      }
       optionsBuilder.put("ticketCache", ticketCache);
     }
     return createConfiguration(optionsBuilder);


### PR DESCRIPTION
# :mag: Description
Followup #5961 

```
scala> Files.exists(Paths.get(null))
<console>:14: error: ambiguous reference to overloaded definition,
both method get in class Paths of type (x$1: java.net.URI)java.nio.file.Path
and  method get in class Paths of type (x$1: String, x$2: String*)java.nio.file.Path
match argument types (Null) and expected result type java.nio.file.Path
       Files.exists(Paths.get(null))
                          ^

scala> Files.exists(Paths.get(""))
res0: Boolean = true

scala> 

```
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #

## Describe Your Solution 🔧

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
