### PR TITLE
[KYUUBI #5995] Avoid unnecessary loop for injected analyzer rule

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtension.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtension.scala
@@ -45,12 +45,12 @@ class RangerSparkExtension extends (SparkSessionExtensions => Unit) {
 
   override def apply(v1: SparkSessionExtensions): Unit = {
     v1.injectCheckRule(AuthzConfigurationChecker)
-    v1.injectResolutionRule(_ => RuleReplaceShowObjectCommands)
-    v1.injectResolutionRule(_ => RuleApplyPermanentViewMarker)
-    v1.injectResolutionRule(_ => RuleApplyTypeOfMarker)
-    v1.injectResolutionRule(RuleApplyRowFilter)
-    v1.injectResolutionRule(RuleApplyDataMaskingStage0)
-    v1.injectResolutionRule(RuleApplyDataMaskingStage1)
+    v1.injectPostHocResolutionRule(_ => RuleReplaceShowObjectCommands)
+    v1.injectPostHocResolutionRule(_ => RuleApplyPermanentViewMarker)
+    v1.injectPostHocResolutionRule(_ => RuleApplyTypeOfMarker)
+    v1.injectPostHocResolutionRule(RuleApplyRowFilter)
+    v1.injectPostHocResolutionRule(RuleApplyDataMaskingStage0)
+    v1.injectPostHocResolutionRule(RuleApplyDataMaskingStage1)
     v1.injectOptimizerRule(_ => RuleEliminateMarker)
     v1.injectOptimizerRule(RuleAuthorization)
     v1.injectOptimizerRule(RuleEliminatePermanentViewMarker)

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtension.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtension.scala
@@ -45,12 +45,12 @@ class RangerSparkExtension extends (SparkSessionExtensions => Unit) {
 
   override def apply(v1: SparkSessionExtensions): Unit = {
     v1.injectCheckRule(AuthzConfigurationChecker)
-    v1.injectPostHocResolutionRule(_ => RuleReplaceShowObjectCommands)
+    v1.injectResolutionRule(_ => RuleReplaceShowObjectCommands)
     v1.injectPostHocResolutionRule(_ => RuleApplyPermanentViewMarker)
     v1.injectPostHocResolutionRule(_ => RuleApplyTypeOfMarker)
-    v1.injectPostHocResolutionRule(RuleApplyRowFilter)
-    v1.injectPostHocResolutionRule(RuleApplyDataMaskingStage0)
-    v1.injectPostHocResolutionRule(RuleApplyDataMaskingStage1)
+    v1.injectResolutionRule(RuleApplyRowFilter)
+    v1.injectResolutionRule(RuleApplyDataMaskingStage0)
+    v1.injectResolutionRule(RuleApplyDataMaskingStage1)
     v1.injectOptimizerRule(_ => RuleEliminateMarker)
     v1.injectOptimizerRule(RuleAuthorization)
     v1.injectOptimizerRule(RuleEliminatePermanentViewMarker)


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #5995

## Describe Your Solution 🔧

Current injected rule already handle the whole plan, we don't need to apply it again and again, when query is huge, the catalyst performance is very bad.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
