### PR TITLE
loads the interval of sessionConfCache from configurable file in FileSessionConfAdvisor

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/session/FileSessionConfAdvisor.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/session/FileSessionConfAdvisor.scala
@@ -43,7 +43,8 @@ class FileSessionConfAdvisor extends SessionConfAdvisor {
 }
 
 object FileSessionConfAdvisor extends Logging {
-  private val reloadInterval: Long = KyuubiConf().get(KyuubiConf.SESSION_CONF_FILE_RELOAD_INTERVAL)
+  private val reloadInterval: Long =
+    KyuubiConf().loadFileDefaults().get(KyuubiConf.SESSION_CONF_FILE_RELOAD_INTERVAL)
   private lazy val sessionConfCache: LoadingCache[String, JMap[String, String]] =
     CacheBuilder.newBuilder()
       .expireAfterWrite(


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes the issue that FileSessionConfAdvisor failed to load the interval defined in configuration file.

## Describe Your Solution 🔧

load the Kyuubi configuration from configurable file instead of using environment parameters.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
