### PR TITLE
RESTful API supports killing engine forcibly

### DIFF
--- a/docs/client/rest/rest_api.md
+++ b/docs/client/rest/rest_api.md
@@ -457,13 +457,14 @@ Delete the specified engine.
 
 #### Request Parameters
 
-| Name                    | Description                   | Type             |
-|:------------------------|:------------------------------|:-----------------|
-| type                    | the engine type               | String(optional) |
-| sharelevel              | the engine share level        | String(optional) |
-| subdomain               | the engine subdomain          | String(optional) |
-| proxyUser               | the proxy user to impersonate | String(optional) |
-| hive.server2.proxy.user | the proxy user to impersonate | String(optional) |
+| Name                    | Description                         | Type              |
+|:------------------------|:------------------------------------|:------------------|
+| type                    | the engine type                     | String(optional)  |
+| sharelevel              | the engine share level              | String(optional)  |
+| subdomain               | the engine subdomain                | String(optional)  |
+| proxyUser               | the proxy user to impersonate       | String(optional)  |
+| hive.server2.proxy.user | the proxy user to impersonate       | String(optional)  |
+| kill                    | whether to kill the engine forcibly | Boolean(optional) |
 
 `proxyUser` is an alternative to `hive.server2.proxy.user`, and the current behavior is consistent with
 `hive.server2.proxy.user`. When both parameters are set, `proxyUser` takes precedence.

--- a/docs/client/rest/rest_api.md
+++ b/docs/client/rest/rest_api.md
@@ -457,14 +457,14 @@ Delete the specified engine.
 
 #### Request Parameters
 
-| Name                    | Description                         | Type              |
-|:------------------------|:------------------------------------|:------------------|
-| type                    | the engine type                     | String(optional)  |
-| sharelevel              | the engine share level              | String(optional)  |
-| subdomain               | the engine subdomain                | String(optional)  |
-| proxyUser               | the proxy user to impersonate       | String(optional)  |
-| hive.server2.proxy.user | the proxy user to impersonate       | String(optional)  |
-| kill                    | whether to kill the engine forcibly | Boolean(optional) |
+| Name                    | Description                                                  | Type              |
+|:------------------------|:-------------------------------------------------------------|:------------------|
+| type                    | the engine type                                              | String(optional)  |
+| sharelevel              | the engine share level                                       | String(optional)  |
+| subdomain               | the engine subdomain                                         | String(optional)  |
+| proxyUser               | the proxy user to impersonate                                | String(optional)  |
+| hive.server2.proxy.user | the proxy user to impersonate                                | String(optional)  |
+| kill                    | whether to kill the engine forcibly. Default value is false. | Boolean(optional) |
 
 `proxyUser` is an alternative to `hive.server2.proxy.user`, and the current behavior is consistent with
 `hive.server2.proxy.user`. When both parameters are set, `proxyUser` takes precedence.

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkTBinaryFrontendService.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkTBinaryFrontendService.scala
@@ -100,7 +100,8 @@ class SparkTBinaryFrontendService(
     val extraAttributes = conf.get(KyuubiConf.ENGINE_SPARK_REGISTER_ATTRIBUTES).map { attr =>
       attr -> KyuubiSparkUtil.globalSparkContext.getConf.get(attr, "")
     }.toMap
-    val attributes = extraAttributes ++ Map(KYUUBI_ENGINE_ID -> KyuubiSparkUtil.engineId)
+    val attributes =
+      super.attributes ++ extraAttributes ++ Map(KYUUBI_ENGINE_ID -> KyuubiSparkUtil.engineId)
     // TODO Support Spark Web UI Enabled SSL
     sc.uiWebUrl match {
       case Some(url) => attributes ++ Map(KYUUBI_ENGINE_URL -> url.split("//").last)

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -3544,7 +3544,12 @@ object KyuubiConf {
       .version("1.8.0")
       .stringConf
       .toSequence()
-      .createWithDefault(Seq("spark.driver.memory", "spark.executor.memory"))
+      .createWithDefault(Seq(
+        "spark.driver.memory",
+        "spark.executor.memory",
+        "spark.kubernetes.context",
+        "spark.kubernetes.namespace",
+        "spark.master"))
 
   val ENGINE_SPARK_INITIALIZE_SQL: ConfigEntry[Seq[String]] =
     buildConf("kyuubi.engine.spark.initialize.sql")

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -3544,9 +3544,7 @@ object KyuubiConf {
       .version("1.8.0")
       .stringConf
       .toSequence()
-      .createWithDefault(Seq(
-        "spark.driver.memory",
-        "spark.executor.memory"))
+      .createWithDefault(Seq("spark.driver.memory", "spark.executor.memory"))
 
   val ENGINE_SPARK_INITIALIZE_SQL: ConfigEntry[Seq[String]] =
     buildConf("kyuubi.engine.spark.initialize.sql")

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -3546,10 +3546,7 @@ object KyuubiConf {
       .toSequence()
       .createWithDefault(Seq(
         "spark.driver.memory",
-        "spark.executor.memory",
-        "spark.kubernetes.context",
-        "spark.kubernetes.namespace",
-        "spark.master"))
+        "spark.executor.memory"))
 
   val ENGINE_SPARK_INITIALIZE_SQL: ConfigEntry[Seq[String]] =
     buildConf("kyuubi.engine.spark.initialize.sql")

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiReservedKeys.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiReservedKeys.scala
@@ -36,7 +36,7 @@ object KyuubiReservedKeys {
   final val KYUUBI_ENGINE_URL = "kyuubi.engine.url"
   final val KYUUBI_ENGINE_SUBMIT_TIME_KEY = "kyuubi.engine.submit.time"
   final val KYUUBI_ENGINE_CREDENTIALS_KEY = "kyuubi.engine.credentials"
-  final val KYUUBI_ENGINE_APP_MGR_INFO = "kyuubi.engine.appMgrInfo"
+  final val KYUUBI_ENGINE_APP_MGR_INFO_KEY = "kyuubi.engine.appMgrInfo"
   final val KYUUBI_SESSION_HANDLE_KEY = "kyuubi.session.handle"
   final val KYUUBI_SESSION_ALIVE_PROBE = "kyuubi.session.alive.probe"
   final val KYUUBI_SESSION_ENGINE_LAUNCH_HANDLE_GUID =

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiReservedKeys.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiReservedKeys.scala
@@ -36,6 +36,7 @@ object KyuubiReservedKeys {
   final val KYUUBI_ENGINE_URL = "kyuubi.engine.url"
   final val KYUUBI_ENGINE_SUBMIT_TIME_KEY = "kyuubi.engine.submit.time"
   final val KYUUBI_ENGINE_CREDENTIALS_KEY = "kyuubi.engine.credentials"
+  final val KYUUBI_ENGINE_APP_MGR_INFO = "kyuubi.engine.appMgrInfo"
   final val KYUUBI_SESSION_HANDLE_KEY = "kyuubi.session.handle"
   final val KYUUBI_SESSION_ALIVE_PROBE = "kyuubi.session.alive.probe"
   final val KYUUBI_SESSION_ENGINE_LAUNCH_HANDLE_GUID =

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/AbstractFrontendService.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/AbstractFrontendService.scala
@@ -17,7 +17,7 @@
 
 package org.apache.kyuubi.service
 
-import org.apache.kyuubi.config.KyuubiConf
+import org.apache.kyuubi.config.{KyuubiConf, KyuubiReservedKeys}
 import org.apache.kyuubi.service.ServiceState.LATENT
 
 /**
@@ -39,5 +39,9 @@ abstract class AbstractFrontendService(name: String)
   override def initialize(conf: KyuubiConf): Unit = synchronized {
     discoveryService.foreach(addService)
     super.initialize(conf)
+  }
+
+  override def attributes: Map[String, String] = {
+    conf.getAll.filter(_._1 == KyuubiReservedKeys.KYUUBI_ENGINE_APP_MGR_INFO)
   }
 }

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/AbstractFrontendService.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/AbstractFrontendService.scala
@@ -42,6 +42,6 @@ abstract class AbstractFrontendService(name: String)
   }
 
   override def attributes: Map[String, String] = {
-    conf.getAll.filter(_._1 == KyuubiReservedKeys.KYUUBI_ENGINE_APP_MGR_INFO)
+    conf.getAll.filter(_._1 == KyuubiReservedKeys.KYUUBI_ENGINE_APP_MGR_INFO_KEY)
   }
 }

--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/AdminRestApi.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/AdminRestApi.java
@@ -65,13 +65,21 @@ public class AdminRestApi {
     return this.getClient().post(path, null, client.getAuthHeader());
   }
 
+  // deprecated since 1.10
+  @Deprecated
   public String deleteEngine(
       String engineType, String shareLevel, String subdomain, String hs2ProxyUser) {
+    return this.deleteEngine(engineType, shareLevel, subdomain, hs2ProxyUser, false);
+  }
+
+  public String deleteEngine(
+      String engineType, String shareLevel, String subdomain, String hs2ProxyUser, boolean kill) {
     Map<String, Object> params = new HashMap<>();
     params.put("type", engineType);
     params.put("sharelevel", shareLevel);
     params.put("subdomain", subdomain);
     params.put("hive.server2.proxy.user", hs2ProxyUser);
+    params.put("kill", kill);
     return this.getClient().delete(API_BASE_PATH + "/engine", params, client.getAuthHeader());
   }
 

--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/AdminRestApi.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/AdminRestApi.java
@@ -23,8 +23,12 @@ import org.apache.kyuubi.client.api.v1.dto.Engine;
 import org.apache.kyuubi.client.api.v1.dto.OperationData;
 import org.apache.kyuubi.client.api.v1.dto.ServerData;
 import org.apache.kyuubi.client.api.v1.dto.SessionData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AdminRestApi {
+  private static final Logger LOG = LoggerFactory.getLogger(AdminRestApi.class);
+
   private KyuubiRestClient client;
 
   private static final String API_BASE_PATH = "admin";
@@ -65,10 +69,14 @@ public class AdminRestApi {
     return this.getClient().post(path, null, client.getAuthHeader());
   }
 
-  // deprecated since 1.10
+  /** This method is deprecated since 1.10 */
   @Deprecated
   public String deleteEngine(
       String engineType, String shareLevel, String subdomain, String hs2ProxyUser) {
+    LOG.warn(
+        "The method `deleteEngine(engineType, shareLevel, subdomain, hs2ProxyUser)` "
+            + "is deprecated since 1.10.0, using "
+            + "`deleteEngine(engineType, shareLevel, subdomain, hs2ProxyUser, kill)` instead.");
     return this.deleteEngine(engineType, shareLevel, subdomain, hs2ProxyUser, false);
   }
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ApplicationOperation.scala
@@ -161,13 +161,14 @@ object ApplicationManagerInfo extends Logging {
 
   def deserialize(encodedStr: String): ApplicationManagerInfo = {
     try {
-      info(s"The original string encoded:$encodedStr")
       val json = new String(
         Base64.getDecoder.decode(encodedStr.getBytes),
         StandardCharsets.UTF_8)
       mapper.readValue(json, classOf[ApplicationManagerInfo])
     } catch {
-      case _: Throwable => ApplicationManagerInfo(None)
+      case _: Throwable =>
+        error(s"The original string encoded:$encodedStr")
+        ApplicationManagerInfo(None)
     }
   }
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ApplicationOperation.scala
@@ -19,8 +19,10 @@ package org.apache.kyuubi.engine
 
 import java.nio.charset.StandardCharsets
 import java.util.Base64
+
 import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
+
 import org.apache.kyuubi.Logging
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.engine.ApplicationState.ApplicationState

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ApplicationOperation.scala
@@ -17,6 +17,12 @@
 
 package org.apache.kyuubi.engine
 
+import java.nio.charset.StandardCharsets
+import java.util.Base64
+
+import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.engine.ApplicationState.ApplicationState
 
@@ -134,6 +140,9 @@ case class ApplicationManagerInfo(
 
 object ApplicationManagerInfo {
   final val DEFAULT_KUBERNETES_NAMESPACE = "default"
+  val mapper: ObjectMapper = new ObjectMapper()
+    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+    .registerModule(DefaultScalaModule)
 
   def apply(
       resourceManager: Option[String],
@@ -142,5 +151,21 @@ object ApplicationManagerInfo {
     new ApplicationManagerInfo(
       resourceManager,
       KubernetesInfo(kubernetesContext, kubernetesNamespace))
+  }
+
+  def serialize(appMgrInfo: ApplicationManagerInfo): String = {
+    Base64.getEncoder.encodeToString(
+      mapper.writeValueAsString(appMgrInfo).getBytes(StandardCharsets.UTF_8))
+  }
+
+  def deserialize(encodedStr: String): ApplicationManagerInfo = {
+    try {
+      val json = new String(
+        Base64.getDecoder.decode(encodedStr.getBytes),
+        StandardCharsets.UTF_8)
+      mapper.readValue(json, classOf[ApplicationManagerInfo])
+    } catch {
+      case _: Throwable => ApplicationManagerInfo(None)
+    }
   }
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ApplicationOperation.scala
@@ -167,7 +167,7 @@ object ApplicationManagerInfo extends Logging {
       mapper.readValue(json, classOf[ApplicationManagerInfo])
     } catch {
       case _: Throwable =>
-        error(s"The original string encoded:$encodedStr")
+        error(s"Fail to desirable the encoded string: $encodedStr")
         ApplicationManagerInfo(None)
     }
   }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ApplicationOperation.scala
@@ -19,10 +19,9 @@ package org.apache.kyuubi.engine
 
 import java.nio.charset.StandardCharsets
 import java.util.Base64
-
 import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
-
+import org.apache.kyuubi.Logging
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.engine.ApplicationState.ApplicationState
 
@@ -138,7 +137,7 @@ case class ApplicationManagerInfo(
     resourceManager: Option[String],
     kubernetesInfo: KubernetesInfo = KubernetesInfo())
 
-object ApplicationManagerInfo {
+object ApplicationManagerInfo extends Logging {
   final val DEFAULT_KUBERNETES_NAMESPACE = "default"
   val mapper: ObjectMapper = new ObjectMapper()
     .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
@@ -160,6 +159,7 @@ object ApplicationManagerInfo {
 
   def deserialize(encodedStr: String): ApplicationManagerInfo = {
     try {
+      info(s"The original string encoded:$encodedStr")
       val json = new String(
         Base64.getDecoder.decode(encodedStr.getBytes),
         StandardCharsets.UTF_8)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ApplicationOperation.scala
@@ -167,7 +167,7 @@ object ApplicationManagerInfo extends Logging {
       mapper.readValue(json, classOf[ApplicationManagerInfo])
     } catch {
       case _: Throwable =>
-        error(s"Fail to desirable the encoded string: $encodedStr")
+        error(s"Fail to deserialize the encoded string: $encodedStr")
         ApplicationManagerInfo(None)
     }
   }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ProcBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ProcBuilder.scala
@@ -171,7 +171,7 @@ trait ProcBuilder {
 
   // Set engine application manger info conf
   conf.set(
-    KyuubiReservedKeys.KYUUBI_ENGINE_APP_MGR_INFO,
+    KyuubiReservedKeys.KYUUBI_ENGINE_APP_MGR_INFO_KEY,
     ApplicationManagerInfo.serialize(appMgrInfo()))
 
   private[kyuubi] lazy val engineLog: File = ProcBuilder.synchronized {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ProcBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ProcBuilder.scala
@@ -29,7 +29,7 @@ import org.apache.commons.lang3.StringUtils
 import org.apache.commons.lang3.StringUtils.containsIgnoreCase
 
 import org.apache.kyuubi._
-import org.apache.kyuubi.config.KyuubiConf
+import org.apache.kyuubi.config.{KyuubiConf, KyuubiReservedKeys}
 import org.apache.kyuubi.config.KyuubiConf.KYUUBI_HOME
 import org.apache.kyuubi.operation.log.OperationLog
 import org.apache.kyuubi.util.{JavaUtils, NamedThreadFactory}
@@ -168,6 +168,11 @@ trait ProcBuilder {
   private var logCaptureThread: Thread = _
   @volatile private[kyuubi] var process: Process = _
   @volatile private[kyuubi] var processLaunched: Boolean = false
+
+  // Set engine application manger info conf
+  conf.set(
+    KyuubiReservedKeys.KYUUBI_ENGINE_APP_MGR_INFO,
+    ApplicationManagerInfo.serialize(appMgrInfo()))
 
   private[kyuubi] lazy val engineLog: File = ProcBuilder.synchronized {
     val engineLogTimeout = conf.get(KyuubiConf.ENGINE_LOG_TIMEOUT)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/AdminResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/AdminResource.scala
@@ -279,7 +279,7 @@ private[v1] class AdminResource extends ApiRequestContext with Logging {
       @QueryParam("subdomain") subdomain: String,
       @QueryParam("proxyUser") kyuubiProxyUser: String,
       @QueryParam("hive.server2.proxy.user") hs2ProxyUser: String,
-      @QueryParam("forceKill") @DefaultValue("false") forceKill: Boolean): Response = {
+      @QueryParam("kill") @DefaultValue("false") kill: Boolean): Response = {
     val activeProxyUser = Option(kyuubiProxyUser).getOrElse(hs2ProxyUser)
     val userName = if (fe.isAdministrator(fe.getRealUser())) {
       Option(activeProxyUser).getOrElse(fe.getRealUser())
@@ -307,7 +307,7 @@ private[v1] class AdminResource extends ApiRequestContext with Logging {
               s"${e.getMessage}")
         }
 
-        if (forceKill && engineRefId != null) {
+        if (kill && engineRefId != null) {
           val appMgrInfo =
             engineNode.attributes.get(KyuubiReservedKeys.KYUUBI_ENGINE_APP_MGR_INFO)
               .map(ApplicationManagerInfo.deserialize).getOrElse(ApplicationManagerInfo(None))

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/AdminResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/AdminResource.scala
@@ -291,45 +291,34 @@ private[v1] class AdminResource extends ApiRequestContext with Logging {
     val engine = normalizeEngineInfo(userName, engineType, shareLevel, subdomain, "default")
     val engineSpace = calculateEngineSpace(engine)
     var msg = s"Engine $engineSpace is deleted successfully."
-
     withDiscoveryClient(fe.getConf) { discoveryClient =>
-      val engineNodes = discoveryClient.getChildren(engineSpace)
-      engineNodes.foreach { node =>
-        val nodePath = s"$engineSpace/$node"
-        if (forceKill) {
-          val refIds = node.split(";")
-            .flatMap(_.split("=", 2) match {
-              case Array("refId", value) if StringUtils.isNotBlank(value) => Some(value)
-              case _ => None
-            })
+      val engineNodes = discoveryClient.getServiceNodesInfo(engineSpace, silent = true)
+      engineNodes.foreach { engineNode =>
+        val nodePath = s"$engineSpace/${engineNode.nodeName}"
+        info(s"Deleting engine node:$nodePath")
+        try {
+          discoveryClient.delete(nodePath)
+        } catch {
+          case e: Exception =>
+            error(s"Failed to delete engine node:$nodePath", e)
+            throw new NotFoundException(s"Failed to delete engine node:$nodePath," +
+              s"${e.getMessage}")
+        }
 
-          refIds.foreach(refId => {
-            val applicationManagerInfo = ApplicationManagerInfo(
-              Option(resourceManager),
-              Option(kubernetesContext),
-              Option(kubernetesNamespace))
-            val killMessage = fe.be.sessionManager.asInstanceOf[KyuubiSessionManager]
-              .applicationManager.killApplication(applicationManagerInfo, refId)
-            if (!killMessage._1) {
-              msg = s"Engine $engineSpace failed to get deleted forcibly," +
-                s"cause ${killMessage._2}"
-              error(msg)
-              throw new NotFoundException(msg)
-            }
-          })
-        } else {
-          info(s"Deleting engine node:$nodePath")
-          try {
-            discoveryClient.delete(nodePath)
-          } catch {
-            case e: Exception =>
-              error(s"Failed to delete engine node:$nodePath", e)
-              throw new NotFoundException(s"Failed to delete engine node:$nodePath," +
-                s"${e.getMessage}")
+        if (forceKill) {
+          val applicationManagerInfo = ApplicationManagerInfo(
+            Option(resourceManager),
+            Option(kubernetesContext),
+            Option(kubernetesNamespace))
+          engineNode.engineRefId.foreach { engineRefId =>
+            fe.be.sessionManager.asInstanceOf[KyuubiSessionManager]
+              .applicationManager.killApplication(applicationManagerInfo, engineRefId)
+
           }
         }
       }
     }
+
     Response.ok(msg).build()
   }
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/AdminResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/AdminResource.scala
@@ -45,7 +45,6 @@ import org.apache.kyuubi.session.{KyuubiSession, KyuubiSessionManager, SessionHa
 @Tag(name = "Admin")
 @Produces(Array(MediaType.APPLICATION_JSON))
 private[v1] class AdminResource extends ApiRequestContext with Logging {
-  private var killMessage: KillResponse = (false, "UNKNOWN")
   @ApiResponse(
     responseCode = "200",
     content = Array(new Content(mediaType = MediaType.APPLICATION_JSON)),
@@ -293,27 +292,14 @@ private[v1] class AdminResource extends ApiRequestContext with Logging {
     val engine = normalizeEngineInfo(userName, engineType, shareLevel, subdomain, "default")
     val engineSpace = calculateEngineSpace(engine)
     var msg = s"Engine $engineSpace is deleted successfully."
-    withDiscoveryClient(fe.getConf) { discoveryClient =>
-      val engineNodes = discoveryClient.getChildren(engineSpace)
-      engineNodes.foreach { node =>
-        val nodePath = s"$engineSpace/$node"
-        info(s"Deleting engine node:$nodePath")
-        try {
-          discoveryClient.delete(nodePath)
-        } catch {
-          case e: Exception =>
-            error(s"Failed to delete engine node:$nodePath", e)
-            throw new NotFoundException(s"Failed to delete engine node:$nodePath," +
-              s"${e.getMessage}")
-        }
-      }
-      if (forceKill) {
-
+    forceKill match {
+      case true =>
         val applicationManagerInfo = ApplicationManagerInfo(
           Option(sparkMaster),
           Option(sparK8Context),
           Option(sparK8Namespace))
 
+        var killMessage: KillResponse = (false, "UNKNOWN")
         killMessage = fe.be.sessionManager.asInstanceOf[KyuubiSessionManager]
           .applicationManager.killApplication(applicationManagerInfo, refId)
         if (!killMessage._1) {
@@ -321,7 +307,24 @@ private[v1] class AdminResource extends ApiRequestContext with Logging {
             s"cause ${killMessage._2}"
           error(msg)
         }
-      }
+
+      case false =>
+        withDiscoveryClient(fe.getConf) { discoveryClient =>
+          val engineNodes = discoveryClient.getChildren(engineSpace)
+          engineNodes.foreach { node =>
+            val nodePath = s"$engineSpace/$node"
+            info(s"Deleting engine node:$nodePath")
+            try {
+              discoveryClient.delete(nodePath)
+            } catch {
+              case e: Exception =>
+                error(s"Failed to delete engine node:$nodePath", e)
+                throw new NotFoundException(s"Failed to delete engine node:$nodePath," +
+                  s"${e.getMessage}")
+            }
+          }
+        }
+
     }
     Response.ok(msg).build()
   }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/AdminResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/AdminResource.scala
@@ -33,7 +33,7 @@ import org.apache.kyuubi.{KYUUBI_VERSION, Logging}
 import org.apache.kyuubi.client.api.v1.dto._
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf._
-import org.apache.kyuubi.engine.{ApplicationManagerInfo, KillResponse}
+import org.apache.kyuubi.engine.ApplicationManagerInfo
 import org.apache.kyuubi.ha.HighAvailabilityConf.HA_NAMESPACE
 import org.apache.kyuubi.ha.client.{DiscoveryPaths, ServiceNodeInfo}
 import org.apache.kyuubi.ha.client.DiscoveryClientProvider.withDiscoveryClient

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/AdminResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/AdminResource.scala
@@ -297,9 +297,11 @@ private[v1] class AdminResource extends ApiRequestContext with Logging {
       engineNodes.foreach { node =>
         val nodePath = s"$engineSpace/$node"
         if (forceKill) {
-          val refIds = discoveryClient.getServiceNodesInfo(nodePath)
-            .flatMap(_.attributes.get("refId"))
-            .filter(StringUtils.isNotBlank(_))
+          val refIds = node.split(";")
+            .flatMap(_.split("=", 2) match {
+              case Array("refId", value) if StringUtils.isNotBlank(value) => Some(value)
+              case _ => None
+            })
 
           refIds.foreach(refId => {
             val applicationManagerInfo = ApplicationManagerInfo(

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/AdminResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/AdminResource.scala
@@ -309,7 +309,7 @@ private[v1] class AdminResource extends ApiRequestContext with Logging {
 
         if (kill && engineRefId != null) {
           val appMgrInfo =
-            engineNode.attributes.get(KyuubiReservedKeys.KYUUBI_ENGINE_APP_MGR_INFO)
+            engineNode.attributes.get(KyuubiReservedKeys.KYUUBI_ENGINE_APP_MGR_INFO_KEY)
               .map(ApplicationManagerInfo.deserialize).getOrElse(ApplicationManagerInfo(None))
           val killResponse = fe.be.sessionManager.asInstanceOf[KyuubiSessionManager]
             .applicationManager.killApplication(appMgrInfo, engineRefId)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/AdminResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/AdminResource.scala
@@ -279,7 +279,6 @@ private[v1] class AdminResource extends ApiRequestContext with Logging {
       @QueryParam("proxyUser") kyuubiProxyUser: String,
       @QueryParam("hive.server2.proxy.user") hs2ProxyUser: String,
       @QueryParam("forceKill") @DefaultValue("false") forceKill: Boolean,
-      @QueryParam("refId") refId: String,
       @QueryParam("kubernetesContext") kubernetesContext: String,
       @QueryParam("kubernetesNamespace") kubernetesNamespace: String,
       @QueryParam("resourceManager") resourceManager: String): Response = {
@@ -292,33 +291,31 @@ private[v1] class AdminResource extends ApiRequestContext with Logging {
     val engine = normalizeEngineInfo(userName, engineType, shareLevel, subdomain, "default")
     val engineSpace = calculateEngineSpace(engine)
     var msg = s"Engine $engineSpace is deleted successfully."
-    if (forceKill) {
-      val refIds = listEngines(
-        engineType,
-        shareLevel,
-        subdomain,
-        kyuubiProxyUser,
-        hs2ProxyUser).map(_.getAttributes.get("refId"))
 
-      refIds.filter(StringUtils.isNotBlank(_)).foreach(refId => {
-          val applicationManagerInfo = ApplicationManagerInfo(
-            Option(resourceManager),
-            Option(kubernetesContext),
-            Option(kubernetesNamespace))
-          val killMessage = fe.be.sessionManager.asInstanceOf[KyuubiSessionManager]
-            .applicationManager.killApplication(applicationManagerInfo, refId)
-          if (!killMessage._1) {
-            msg = s"Engine $engineSpace failed to get deleted forcibly," +
-              s"cause ${killMessage._2}"
-            error(msg)
-            throw new NotFoundException(msg)
-          }
-      })
-    } else {
-      withDiscoveryClient(fe.getConf) { discoveryClient =>
-        val engineNodes = discoveryClient.getChildren(engineSpace)
-        engineNodes.foreach { node =>
-          val nodePath = s"$engineSpace/$node"
+    withDiscoveryClient(fe.getConf) { discoveryClient =>
+      val engineNodes = discoveryClient.getChildren(engineSpace)
+      engineNodes.foreach { node =>
+        val nodePath = s"$engineSpace/$node"
+        if (forceKill) {
+          val refIds = discoveryClient.getServiceNodesInfo(nodePath)
+            .flatMap(_.attributes.get("refId"))
+            .filter(StringUtils.isNotBlank(_))
+
+          refIds.foreach(refId => {
+            val applicationManagerInfo = ApplicationManagerInfo(
+              Option(resourceManager),
+              Option(kubernetesContext),
+              Option(kubernetesNamespace))
+            val killMessage = fe.be.sessionManager.asInstanceOf[KyuubiSessionManager]
+              .applicationManager.killApplication(applicationManagerInfo, refId)
+            if (!killMessage._1) {
+              msg = s"Engine $engineSpace failed to get deleted forcibly," +
+                s"cause ${killMessage._2}"
+              error(msg)
+              throw new NotFoundException(msg)
+            }
+          })
+        } else {
           info(s"Deleting engine node:$nodePath")
           try {
             discoveryClient.delete(nodePath)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/AdminResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/AdminResource.scala
@@ -280,9 +280,9 @@ private[v1] class AdminResource extends ApiRequestContext with Logging {
       @QueryParam("hive.server2.proxy.user") hs2ProxyUser: String,
       @QueryParam("forceKill") @DefaultValue("false") forceKill: Boolean,
       @QueryParam("refId") refId: String,
-      @QueryParam("sparK8Context") sparK8Context: String,
-      @QueryParam("sparK8Namespace") sparK8Namespace: String,
-      @QueryParam("sparkMaster") sparkMaster: String): Response = {
+      @QueryParam("kubernetesContext") kubernetesContext: String,
+      @QueryParam("kubernetesNamespace") kubernetesNamespace: String,
+      @QueryParam("resourceManager") resourceManager: String): Response = {
     val activeProxyUser = Option(kyuubiProxyUser).getOrElse(hs2ProxyUser)
     val userName = if (fe.isAdministrator(fe.getRealUser())) {
       Option(activeProxyUser).getOrElse(fe.getRealUser())
@@ -298,9 +298,9 @@ private[v1] class AdminResource extends ApiRequestContext with Logging {
       }
 
       val applicationManagerInfo = ApplicationManagerInfo(
-        Option(sparkMaster),
-        Option(sparK8Context),
-        Option(sparK8Namespace))
+        Option(resourceManager),
+        Option(kubernetesContext),
+        Option(kubernetesNamespace))
 
       val killMessage = fe.be.sessionManager.asInstanceOf[KyuubiSessionManager]
         .applicationManager.killApplication(applicationManagerInfo, refId)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/AdminResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/AdminResource.scala
@@ -294,8 +294,7 @@ private[v1] class AdminResource extends ApiRequestContext with Logging {
     var msg = s"Engine $engineSpace is deleted successfully."
     if (forceKill) {
       if (StringUtils.isBlank(refId)) {
-        error(s"Invalid refId: $refId")
-        throw new NotFoundException(s"Invalid refId: $refId")
+        throw new IllegalArgumentException(s"Invalid refId: $refId")
       }
 
       val applicationManagerInfo = ApplicationManagerInfo(
@@ -310,6 +309,7 @@ private[v1] class AdminResource extends ApiRequestContext with Logging {
         msg = s"Engine $engineSpace failed to get deleted forcibly," +
           s"cause ${killMessage._2}"
         error(msg)
+        throw new NotFoundException(msg)
       }
     } else {
       withDiscoveryClient(fe.getConf) { discoveryClient =>

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/AdminResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/AdminResource.scala
@@ -278,7 +278,7 @@ private[v1] class AdminResource extends ApiRequestContext with Logging {
       @QueryParam("subdomain") subdomain: String,
       @QueryParam("proxyUser") kyuubiProxyUser: String,
       @QueryParam("hive.server2.proxy.user") hs2ProxyUser: String,
-      @QueryParam("forceKill") forceKill: Boolean,
+      @QueryParam("forceKill") @DefaultValue("false") forceKill: Boolean,
       @QueryParam("refId") refId: String,
       @QueryParam("sparK8Context") sparK8Context: String,
       @QueryParam("sparK8Namespace") sparK8Namespace: String,

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/AdminResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/AdminResource.scala
@@ -33,7 +33,7 @@ import org.apache.kyuubi.{KYUUBI_VERSION, Logging}
 import org.apache.kyuubi.client.api.v1.dto._
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf._
-import org.apache.kyuubi.engine.ApplicationManagerInfo
+import org.apache.kyuubi.engine.{ApplicationManagerInfo, KillResponse}
 import org.apache.kyuubi.ha.HighAvailabilityConf.HA_NAMESPACE
 import org.apache.kyuubi.ha.client.{DiscoveryPaths, ServiceNodeInfo}
 import org.apache.kyuubi.ha.client.DiscoveryClientProvider.withDiscoveryClient
@@ -45,7 +45,7 @@ import org.apache.kyuubi.session.{KyuubiSession, KyuubiSessionManager, SessionHa
 @Tag(name = "Admin")
 @Produces(Array(MediaType.APPLICATION_JSON))
 private[v1] class AdminResource extends ApiRequestContext with Logging {
-
+  private var killMessage: KillResponse = (false, "UNKNOWN")
   @ApiResponse(
     responseCode = "200",
     content = Array(new Content(mediaType = MediaType.APPLICATION_JSON)),
@@ -279,6 +279,7 @@ private[v1] class AdminResource extends ApiRequestContext with Logging {
       @QueryParam("subdomain") subdomain: String,
       @QueryParam("proxyUser") kyuubiProxyUser: String,
       @QueryParam("hive.server2.proxy.user") hs2ProxyUser: String,
+      @QueryParam("forceKill") forceKill: Boolean,
       @QueryParam("refId") refId: String,
       @QueryParam("sparK8Context") sparK8Context: String,
       @QueryParam("sparK8Namespace") sparK8Namespace: String,
@@ -291,7 +292,7 @@ private[v1] class AdminResource extends ApiRequestContext with Logging {
     }
     val engine = normalizeEngineInfo(userName, engineType, shareLevel, subdomain, "default")
     val engineSpace = calculateEngineSpace(engine)
-
+    var msg = s"Engine $engineSpace is deleted successfully."
     withDiscoveryClient(fe.getConf) { discoveryClient =>
       val engineNodes = discoveryClient.getChildren(engineSpace)
       engineNodes.foreach { node =>
@@ -306,21 +307,23 @@ private[v1] class AdminResource extends ApiRequestContext with Logging {
               s"${e.getMessage}")
         }
       }
-
-      if (Option(refId).isDefined) {
+      if (forceKill) {
 
         val applicationManagerInfo = ApplicationManagerInfo(
           Option(sparkMaster),
           Option(sparK8Context),
           Option(sparK8Namespace))
 
-        fe.be.sessionManager.asInstanceOf[KyuubiSessionManager]
+        killMessage = fe.be.sessionManager.asInstanceOf[KyuubiSessionManager]
           .applicationManager.killApplication(applicationManagerInfo, refId)
+        if (!killMessage._1) {
+          msg = s"Engine $engineSpace failed to get deleted forcibly," +
+            s"cause ${killMessage._2}"
+          error(msg)
+        }
       }
-
     }
-
-    Response.ok(s"Engine $engineSpace is deleted successfully.").build()
+    Response.ok(msg).build()
   }
 
   @ApiResponse(

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/AdminResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/AdminResource.scala
@@ -302,8 +302,7 @@ private[v1] class AdminResource extends ApiRequestContext with Logging {
         Option(sparK8Context),
         Option(sparK8Namespace))
 
-      var killMessage: KillResponse = (false, "UNKNOWN")
-      killMessage = fe.be.sessionManager.asInstanceOf[KyuubiSessionManager]
+      val killMessage = fe.be.sessionManager.asInstanceOf[KyuubiSessionManager]
         .applicationManager.killApplication(applicationManagerInfo, refId)
       if (!killMessage._1) {
         msg = s"Engine $engineSpace failed to get deleted forcibly," +

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/flink/FlinkProcessBuilderSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/flink/FlinkProcessBuilderSuite.scala
@@ -27,7 +27,9 @@ import scala.util.matching.Regex
 import org.apache.kyuubi.KyuubiFunSuite
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.{ENGINE_FLINK_APPLICATION_JARS, ENGINE_FLINK_EXTRA_CLASSPATH, ENGINE_FLINK_JAVA_OPTIONS, ENGINE_FLINK_MEMORY}
-import org.apache.kyuubi.config.KyuubiReservedKeys.KYUUBI_ENGINE_CREDENTIALS_KEY
+import org.apache.kyuubi.config.KyuubiReservedKeys.{KYUUBI_ENGINE_APP_MGR_INFO_KEY, KYUUBI_ENGINE_CREDENTIALS_KEY}
+import org.apache.kyuubi.engine.ApplicationManagerInfo
+import org.apache.kyuubi.engine.ApplicationManagerInfo.serialize
 import org.apache.kyuubi.engine.flink.FlinkProcessBuilder._
 
 class FlinkProcessBuilderSuite extends KyuubiFunSuite {
@@ -39,6 +41,7 @@ class FlinkProcessBuilderSuite extends KyuubiFunSuite {
       ENGINE_FLINK_JAVA_OPTIONS,
       "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005")
     .set(KYUUBI_ENGINE_CREDENTIALS_KEY, "should-not-be-used")
+    .set(KYUUBI_ENGINE_APP_MGR_INFO_KEY, serialize(ApplicationManagerInfo(None)))
 
   private def applicationModeConf = KyuubiConf()
     .set("flink.execution.target", "yarn-application")
@@ -46,6 +49,7 @@ class FlinkProcessBuilderSuite extends KyuubiFunSuite {
     .set(APP_KEY, "kyuubi_connection_flink_paul")
     .set("kyuubi.on", "off")
     .set(KYUUBI_ENGINE_CREDENTIALS_KEY, "should-not-be-used")
+    .set(KYUUBI_ENGINE_APP_MGR_INFO_KEY, serialize(ApplicationManagerInfo(None)))
 
   private val tempFlinkHome = Files.createTempDirectory("flink-home").toFile
   private val tempOpt =

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/AdminResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/AdminResourceSuite.scala
@@ -310,7 +310,13 @@ class AdminResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper {
     conf.set(KyuubiConf.GROUP_PROVIDER, "hadoop")
 
     val engine =
-      new EngineRef(conf.clone, Utils.currentUser, PluginLoader.loadGroupProvider(conf), id, null)
+      new EngineRef(
+        conf.clone,
+        Utils.currentUser,
+        true,
+        PluginLoader.loadGroupProvider(conf),
+        id,
+        null)
 
     val engineSpace = DiscoveryPaths.makePath(
       s"kyuubi_test_${KYUUBI_VERSION}_USER_SPARK_SQL",

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/AdminResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/AdminResourceSuite.scala
@@ -333,7 +333,6 @@ class AdminResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper {
         .queryParam("sharelevel", "USER")
         .queryParam("type", "spark_sql")
         .queryParam("forceKill", "true")
-        .queryParam("refId", id)
         .request(MediaType.APPLICATION_JSON_TYPE)
         .header(AUTHORIZATION_HEADER, HttpAuthUtils.basicAuthorizationHeader(Utils.currentUser))
         .delete()

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/AdminResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/AdminResourceSuite.scala
@@ -33,7 +33,7 @@ import org.apache.kyuubi.client.api.v1.dto._
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf._
 import org.apache.kyuubi.config.KyuubiReservedKeys.KYUUBI_SESSION_CONNECTION_URL_KEY
-import org.apache.kyuubi.engine.{ApplicationManagerInfo, ApplicationState, EngineRef, KyuubiApplicationManager}
+import org.apache.kyuubi.engine.{ApplicationManagerInfo, ApplicationState, EngineRef, KubernetesInfo, KyuubiApplicationManager}
 import org.apache.kyuubi.engine.EngineType.SPARK_SQL
 import org.apache.kyuubi.engine.ShareLevel.{CONNECTION, GROUP, USER}
 import org.apache.kyuubi.ha.HighAvailabilityConf
@@ -325,7 +325,6 @@ class AdminResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper {
 
     withDiscoveryClient(conf) { client =>
       engine.getOrCreate(client)
-
       assert(client.pathExists(engineSpace))
       assert(client.getChildren(engineSpace).size == 1)
 
@@ -343,8 +342,12 @@ class AdminResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper {
       }
 
       eventually(timeout(30.seconds), interval(100.milliseconds)) {
-        assert(engineMgr.getApplicationInfo(ApplicationManagerInfo(None), id).exists(
-          _.state == ApplicationState.NOT_FOUND))
+        assert(engineMgr.getApplicationInfo(
+          ApplicationManagerInfo(
+            None,
+            KubernetesInfo(None, None)),
+          id)
+          .exists(_.state == ApplicationState.NOT_FOUND))
       }
     }
   }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/AdminResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/AdminResourceSuite.scala
@@ -342,11 +342,8 @@ class AdminResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper {
       }
 
       eventually(timeout(30.seconds), interval(100.milliseconds)) {
-        assert(engineMgr.getApplicationInfo(
-          ApplicationManagerInfo(
-            None,
-            KubernetesInfo(None, None)),
-          id)
+        val appMgrInfo = ApplicationManagerInfo(None, KubernetesInfo(None, None))
+        assert(engineMgr.getApplicationInfo(appMgrInfo, id)
           .exists(_.state == ApplicationState.NOT_FOUND))
       }
     }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/AdminResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/AdminResourceSuite.scala
@@ -331,7 +331,7 @@ class AdminResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper {
       val response = webTarget.path("api/v1/admin/engine")
         .queryParam("sharelevel", "USER")
         .queryParam("type", "spark_sql")
-        .queryParam("forceKill", "true")
+        .queryParam("kill", "true")
         .request(MediaType.APPLICATION_JSON_TYPE)
         .header(AUTHORIZATION_HEADER, HttpAuthUtils.basicAuthorizationHeader(Utils.currentUser))
         .delete()

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/AdminResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/AdminResourceSuite.scala
@@ -339,13 +339,10 @@ class AdminResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper {
         .delete()
 
       assert(response.getStatus === 200)
-      assert(client.pathExists(engineSpace))
       eventually(timeout(5.seconds), interval(100.milliseconds)) {
         assert(client.getChildren(engineSpace).isEmpty, s"refId same with $id?")
       }
 
-      // kill the engine application
-      engineMgr.killApplication(ApplicationManagerInfo(None), id)
       eventually(timeout(30.seconds), interval(100.milliseconds)) {
         assert(engineMgr.getApplicationInfo(ApplicationManagerInfo(None), id).exists(
           _.state == ApplicationState.NOT_FOUND))

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/AdminResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/AdminResourceSuite.scala
@@ -301,6 +301,52 @@ class AdminResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper {
     assert(!operations.map(op => op.getIdentifier).contains(operation.identifier.toString))
   }
 
+  test("force to kill engine - user share level") {
+    val id = UUID.randomUUID().toString
+    conf.set(KyuubiConf.ENGINE_SHARE_LEVEL, USER.toString)
+    conf.set(KyuubiConf.ENGINE_TYPE, SPARK_SQL.toString)
+    conf.set(KyuubiConf.FRONTEND_THRIFT_BINARY_BIND_PORT, 0)
+    conf.set(HighAvailabilityConf.HA_NAMESPACE, "kyuubi_test")
+    conf.set(KyuubiConf.GROUP_PROVIDER, "hadoop")
+
+    val engine =
+      new EngineRef(conf.clone, Utils.currentUser, PluginLoader.loadGroupProvider(conf), id, null)
+
+    val engineSpace = DiscoveryPaths.makePath(
+      s"kyuubi_test_${KYUUBI_VERSION}_USER_SPARK_SQL",
+      Utils.currentUser,
+      "default")
+
+    withDiscoveryClient(conf) { client =>
+      engine.getOrCreate(client)
+
+      assert(client.pathExists(engineSpace))
+      assert(client.getChildren(engineSpace).size == 1)
+
+      val response = webTarget.path("api/v1/admin/engine")
+        .queryParam("sharelevel", "USER")
+        .queryParam("type", "spark_sql")
+        .queryParam("forceKill", "true")
+        .queryParam("refId", id)
+        .request(MediaType.APPLICATION_JSON_TYPE)
+        .header(AUTHORIZATION_HEADER, HttpAuthUtils.basicAuthorizationHeader(Utils.currentUser))
+        .delete()
+
+      assert(response.getStatus === 200)
+      assert(client.pathExists(engineSpace))
+      eventually(timeout(5.seconds), interval(100.milliseconds)) {
+        assert(client.getChildren(engineSpace).isEmpty, s"refId same with $id?")
+      }
+
+      // kill the engine application
+      engineMgr.killApplication(ApplicationManagerInfo(None), id)
+      eventually(timeout(30.seconds), interval(100.milliseconds)) {
+        assert(engineMgr.getApplicationInfo(ApplicationManagerInfo(None), id).exists(
+          _.state == ApplicationState.NOT_FOUND))
+      }
+    }
+  }
+
   test("delete engine - user share level") {
     val id = UUID.randomUUID().toString
     conf.set(KyuubiConf.ENGINE_SHARE_LEVEL, USER.toString)

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/rest/client/AdminCtlSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/rest/client/AdminCtlSuite.scala
@@ -93,7 +93,7 @@ class AdminCtlSuite extends RestClientTestHelper with TestPrematureExit {
       ldapUserPasswd)
     testPrematureExitForAdminControlCli(
       args,
-      s"Engine ${engineSpace} is deleted successfully.")
+      s"Engine ${engineSpace} refId=${id} is deleted successfully.")
 
     args = Array(
       "list",

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/rest/client/AdminRestApiSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/rest/client/AdminRestApiSuite.scala
@@ -87,7 +87,7 @@ class AdminRestApiSuite extends RestClientTestHelper {
 
     // kill engine to release memory quickly
     val result = adminRestApi.deleteEngine("spark_sql", "user", "default", "", true)
-    assert(result == s"Engine ${engineSpace} refId=${id} is deleted successfully.")
+    assert(result startsWith s"Engine ${engineSpace} refId=${id} is deleted successfully.")
 
     engines = adminRestApi.listEngines("spark_sql", "user", "default", "").asScala
     assert(engines.isEmpty)

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/rest/client/AdminRestApiSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/rest/client/AdminRestApiSuite.scala
@@ -85,7 +85,8 @@ class AdminRestApiSuite extends RestClientTestHelper {
     assert(engines(0).getNamespace == engineSpace)
     assert(engines(0).getAttributes.get(KyuubiReservedKeys.KYUUBI_ENGINE_ID).startsWith("local-"))
 
-    val result = adminRestApi.deleteEngine("spark_sql", "user", "default", "")
+    // kill engine to release memory quickly
+    val result = adminRestApi.deleteEngine("spark_sql", "user", "default", "", true)
     assert(result == s"Engine ${engineSpace} refId=${id} is deleted successfully.")
 
     engines = adminRestApi.listEngines("spark_sql", "user", "default", "").asScala

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/rest/client/AdminRestApiSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/rest/client/AdminRestApiSuite.scala
@@ -86,7 +86,7 @@ class AdminRestApiSuite extends RestClientTestHelper {
     assert(engines(0).getAttributes.get(KyuubiReservedKeys.KYUUBI_ENGINE_ID).startsWith("local-"))
 
     val result = adminRestApi.deleteEngine("spark_sql", "user", "default", "")
-    assert(result == s"Engine ${engineSpace} is deleted successfully.")
+    assert(result == s"Engine ${engineSpace} refId=${id} is deleted successfully.")
 
     engines = adminRestApi.listEngines("spark_sql", "user", "default", "").asScala
     assert(engines.isEmpty)


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

## Describe Your Solution 🔧

I'd like to introduce the feature that allows users to forcibly kill an engine through API.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
