### PR TITLE
[KYUUBI #5367] Spark crashes with ClassCastException when resolving a join of masked tables

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/rule/datamasking/DataMaskingStage0Marker.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/rule/datamasking/DataMaskingStage0Marker.scala
@@ -18,9 +18,10 @@
 package org.apache.kyuubi.plugin.spark.authz.rule.datamasking
 
 import org.apache.spark.sql.catalyst.expressions.{Attribute, ExprId}
-import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, UnaryNode}
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project, UnaryNode}
 
 import org.apache.kyuubi.plugin.spark.authz.util.WithInternalChild
+
 case class DataMaskingStage0Marker(child: LogicalPlan, scan: LogicalPlan)
   extends UnaryNode with WithInternalChild {
 
@@ -32,6 +33,11 @@ case class DataMaskingStage0Marker(child: LogicalPlan, scan: LogicalPlan)
 
   override def output: Seq[Attribute] = child.output
 
-  override def withNewChildInternal(newChild: LogicalPlan): LogicalPlan = copy(child = newChild)
+  override def withNewChildInternal(newChild: LogicalPlan): LogicalPlan = newChild match {
+    case p: Project =>
+      copy(child = newChild, scan = p.child)
+    case _ =>
+      copy(child = newChild)
+  }
 
 }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingTestBase.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingTestBase.scala
@@ -302,7 +302,6 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
     val s2 = s"SELECT * FROM default.src where key = 11"
     // scalastyle:off
     checkAnswer(
-
       bob,
       s1,
       Seq(Row(
@@ -335,9 +334,7 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
           df0.as("a").join(
             right = df0.as("b"),
             joinExprs = $"a.key" === $"b.key",
-            joinType = "left_outer").collect() === Seq(Row(1, 1))
-        )
-      }
-    )
+            joinType = "left_outer").collect() === Seq(Row(1, 1)))
+      })
   }
 }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingTestBase.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingTestBase.scala
@@ -329,7 +329,9 @@ trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with Bef
     doAs(
       "bob", {
         val df0 = spark.table("default.src")
-          .select("key").sort($"key").limit(1)
+          .select("key")
+          .filter($"key" === 1)
+          .sort($"key")
         assert(
           df0.as("a").join(
             right = df0.as("b"),


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #5092

Spark crashes with ClassCastException when resolving a join of masked tables

## Describe Your Solution 🔧

As per @sauliusvl [comment](https://github.com/apache/kyuubi/pull/5468#issuecomment-1831774255) in this unfinished [PR](https://github.com/apache/kyuubi/pull/5468) `Stage0Marker` column ids are not updated on the right side of the join which leads to `Stage1Marker` being incorrectly applied which in turn causes 
```
java.lang.ClassCastException: org.apache.kyuubi.plugin.spark.authz.ranger.datamasking.DataMaskingStage1Marker cannot be cast to org.apache.spark.sql.catalyst.plans.logical.Join
```

So the solution was to copy the scan plan together with the child plan in `withNewChildInternal` method so that column ids are aligned.

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:
Self join of tables containing masked columns using `joinExprs` arg fails with ClassCastException.

#### Behavior With This Pull Request :tada:
Self join of tables containing masked columns using `joinExprs` arg succeeds.

#### Related Unit Tests
DataMaskingTestBase

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
