### PR TITLE
Conditional call GetInfo CLI_ODBC_KEYWORDS to restore compatible with lower version Kyuubi and HS2

### DIFF
--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
@@ -1132,7 +1132,7 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
     if (isClosed) {
       throw new KyuubiSQLException("Connection is closed");
     }
-    return new KyuubiDatabaseMetaData(this, client, sessHandle);
+    return new KyuubiDatabaseMetaData(this, protocol, client, sessHandle);
   }
 
   @Override
@@ -1179,7 +1179,7 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
     }
     boolean rc = false;
     try {
-      new KyuubiDatabaseMetaData(this, client, sessHandle).getDatabaseProductName();
+      new KyuubiDatabaseMetaData(this, protocol, client, sessHandle).getDatabaseProductName();
       rc = true;
     } catch (SQLException ignore) {
     }

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiDatabaseMetaData.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiDatabaseMetaData.java
@@ -19,10 +19,7 @@ package org.apache.kyuubi.jdbc.hive;
 
 import static org.apache.kyuubi.shaded.hive.service.rpc.thrift.TTypeId.*;
 
-import java.sql.Connection;
-import java.sql.DatabaseMetaData;
-import java.sql.ResultSet;
-import java.sql.SQLException;
+import java.sql.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -37,6 +34,7 @@ import org.apache.kyuubi.shaded.thrift.TException;
 public class KyuubiDatabaseMetaData implements SQLDatabaseMetaData {
 
   private final KyuubiConnection connection;
+  private final TProtocolVersion protocol;
   private final TCLIService.Iface client;
   private final TSessionHandle sessHandle;
   private static final String CATALOG_SEPARATOR = ".";
@@ -50,8 +48,12 @@ public class KyuubiDatabaseMetaData implements SQLDatabaseMetaData {
   private String dbVersion = null;
 
   public KyuubiDatabaseMetaData(
-      KyuubiConnection connection, TCLIService.Iface client, TSessionHandle sessHandle) {
+      KyuubiConnection connection,
+      TProtocolVersion protocol,
+      TCLIService.Iface client,
+      TSessionHandle sessHandle) {
     this.connection = connection;
+    this.protocol = protocol;
     this.client = client;
     this.sessHandle = sessHandle;
   }
@@ -568,6 +570,12 @@ public class KyuubiDatabaseMetaData implements SQLDatabaseMetaData {
 
   @Override
   public String getSQLKeywords() throws SQLException {
+    if (protocol.compareTo(TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V11) < 0) {
+      throw new SQLFeatureNotSupportedException(
+          String.format(
+              "Feature is not supported, protocol version is %s, requires %s or higher",
+              protocol, TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V11));
+    }
     // Note: the definitions of what ODBC and JDBC keywords exclude are different in different
     //       places. For now, just return the ODBC version here; that excludes Hive keywords
     //       that are also ODBC reserved keywords. We could also exclude SQL:2003.


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

Currently, the Kyuubi Beeline is not compatible with HS2 2.3 and lower versions of Kyuubi, because the server can not recognize `TGetInfoType.CLI_ODBC_KEYWORDS` and then corrupts the socket.

## Describe Your Solution 🔧

Conditional call GetInfo CLI_ODBC_KEYWORDS, when protocol version lower than TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V11, just throw an SQLFeatureNotSupportedException

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

Use beeline to connect a HS2 2.3

#### Behavior Without This Pull Request :coffin:
```
root@hadoop-master1:/opt/kyuubi-dev# bin/beeline -u 'jdbc:hive2://localhost:10000/default'
Warn: Not find kyuubi environment file /etc/kyuubi/conf/kyuubi-env.sh, using default ones...
Connecting to jdbc:hive2://localhost:10000/default
Connected to: Apache Hive (version 2.3.9)
Driver: Kyuubi Project Hive JDBC Client (version 1.8.0)
Beeline version 1.8.0 by Apache Kyuubi
0: jdbc:hive2://localhost:10000/default> select 1;
Unexpected end of file when reading from HS2 server. The root cause might be too many concurrent connections. Please ask the administrator to check the number of active connections, and adjust hive.server2.thrift.max.worker.threads if applicable.
Error: org.apache.thrift.transport.TTransportException (state=08S01,code=0)
```

And the HS2 server-side error message is
```
24/01/25 03:50:53 [37217e6b-e8a9-4069-9973-10471df52e6d HiveServer2-Handler-Pool: Thread-37]: INFO conf.HiveConf: Using the default value passed in for log id: 37217e6b-e8a9-4069-9973-10471df52e6d
24/01/25 03:50:53 [HiveServer2-Handler-Pool: Thread-37]: ERROR server.TThreadPoolServer: Thrift error occurred during processing of message.
org.apache.thrift.protocol.TProtocolException: Missing version in readMessageBegin, old client?
	at org.apache.thrift.protocol.TBinaryProtocol.readMessageBegin(TBinaryProtocol.java:228) ~[hive-exec-2.3.9.jar:2.3.9]
	at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:27) ~[hive-exec-2.3.9.jar:2.3.9]
	at org.apache.hive.service.auth.TSetIpAddressProcessor.process(TSetIpAddressProcessor.java:56) ~[hive-service-2.3.9.jar:2.3.9]
	at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:286) ~[hive-exec-2.3.9.jar:2.3.9]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_392]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_392]
	at java.lang.Thread.run(Thread.java:750) [?:1.8.0_392]
24/01/25 03:50:53 [HiveServer2-Handler-Pool: Thread-37]: INFO thrift.ThriftCLIService: Session disconnected without closing properly.
24/01/25 03:50:53 [HiveServer2-Handler-Pool: Thread-37]: INFO thrift.ThriftCLIService: Closing the session: SessionHandle [37217e6b-e8a9-4069-9973-10471df52e6d]
```

#### Behavior With This Pull Request :tada:

```
root@hadoop-master1:/opt/kyuubi-dev# bin/beeline -u 'jdbc:hive2://localhost:10000/default'
Warn: Not find kyuubi environment file /etc/kyuubi/conf/kyuubi-env.sh, using default ones...
Connecting to jdbc:hive2://localhost:10000/default
Connected to: Apache Hive (version 2.3.9)
Driver: Kyuubi Project Hive JDBC Client (version 1.9.0-SNAPSHOT)
Beeline version 1.9.0-SNAPSHOT by Apache Kyuubi
0: jdbc:hive2://localhost:10000/default> select 1;
+------+
| _c0  |
+------+
| 1    |
+------+
1 row selected (2.403 seconds)
0: jdbc:hive2://localhost:10000/default>
```


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
