### PR TITLE
[KYUUBI #6006][HELM] Support additional labels for service monitor

### DIFF
--- a/charts/kyuubi/templates/kyuubi-servicemonitor.yaml
+++ b/charts/kyuubi/templates/kyuubi-servicemonitor.yaml
@@ -22,6 +22,9 @@ metadata:
   name: {{ .Release.Name }}
   labels:
     {{- include "kyuubi.labels" . | nindent 4 }}
+    {{- if .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml .Values.serviceMonitor.additionalLabels | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/kyuubi/templates/kyuubi-servicemonitor.yaml
+++ b/charts/kyuubi/templates/kyuubi-servicemonitor.yaml
@@ -22,8 +22,8 @@ metadata:
   name: {{ .Release.Name }}
   labels:
     {{- include "kyuubi.labels" . | nindent 4 }}
-    {{- if .Values.serviceMonitor.additionalLabels }}
-    {{- toYaml .Values.serviceMonitor.additionalLabels | nindent 4 }}
+    {{- if .Values.serviceMonitor.labels }}
+    {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
     {{- end }}
 spec:
   selector:

--- a/charts/kyuubi/values.yaml
+++ b/charts/kyuubi/values.yaml
@@ -298,7 +298,7 @@ serviceMonitor:
   # This allows you to collect metrics from multiple Services across your Kubernetes cluster in a standardized and automated way.
   endpoints: []
   # Additional labels that can be used so ServiceMonitor will be discovered by Prometheus
-  additionalLabels: {}
+  labels: {}
 
 # Rules for the Prometheus Operator
 prometheusRule:

--- a/charts/kyuubi/values.yaml
+++ b/charts/kyuubi/values.yaml
@@ -297,6 +297,8 @@ serviceMonitor:
   # The endpoints section in a ServiceMonitor specifies the metrics information for each target endpoint.
   # This allows you to collect metrics from multiple Services across your Kubernetes cluster in a standardized and automated way.
   endpoints: []
+  # Additional labels that can be used so ServiceMonitor will be discovered by Prometheus
+  additionalLabels: {}
 
 # Rules for the Prometheus Operator
 prometheusRule:


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #6006

## Describe Your Solution 🔧

Add new value `additionalLabels` in `serviceMonitor` to support templating the labels so that Prometheus can discover it


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:
Our Prometheus is based on `kube-prometheus-stack` chart, so it requires label `release: kube-prometheus-stack`
The current setup of kyuubi helm does not allow the ServiceMonitor can be discovered by Prome because it's not able to pass extra labels to it.

#### Behavior With This Pull Request :tada:
The MR enables templating extra labels


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
