### PR TITLE
[KYUUBI #5469] JDBC Engine supports Redis

### DIFF
--- a/externals/kyuubi-jdbc-engine/src/main/resources/META-INF/services/org.apache.kyuubi.engine.jdbc.connection.JdbcConnectionProvider
+++ b/externals/kyuubi-jdbc-engine/src/main/resources/META-INF/services/org.apache.kyuubi.engine.jdbc.connection.JdbcConnectionProvider
@@ -20,3 +20,4 @@ org.apache.kyuubi.engine.jdbc.mysql.MySQLConnectionProvider
 org.apache.kyuubi.engine.jdbc.phoenix.PhoenixConnectionProvider
 org.apache.kyuubi.engine.jdbc.postgresql.PostgreSQLConnectionProvider
 org.apache.kyuubi.engine.jdbc.starrocks.StarRocksConnectionProvider
+org.apache.kyuubi.engine.jdbc.redis.RedisConnectionProvider

--- a/externals/kyuubi-jdbc-engine/src/main/resources/META-INF/services/org.apache.kyuubi.engine.jdbc.dialect.JdbcDialect
+++ b/externals/kyuubi-jdbc-engine/src/main/resources/META-INF/services/org.apache.kyuubi.engine.jdbc.dialect.JdbcDialect
@@ -20,3 +20,4 @@ org.apache.kyuubi.engine.jdbc.dialect.MySQLDialect
 org.apache.kyuubi.engine.jdbc.dialect.PhoenixDialect
 org.apache.kyuubi.engine.jdbc.dialect.PostgreSQLDialect
 org.apache.kyuubi.engine.jdbc.dialect.StarRocksDialect
+org.apache.kyuubi.engine.jdbc.dialect.RedisDialect

--- a/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/dialect/RedisDialect.scala
+++ b/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/dialect/RedisDialect.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kyuubi.engine.jdbc.dialect
+import java.util
+
+import org.apache.kyuubi.engine.jdbc.redis.{RedisSchemaHelper, RedisTRowSetGenerator}
+import org.apache.kyuubi.engine.jdbc.schema.{JdbcTRowSetGenerator, SchemaHelper}
+import org.apache.kyuubi.session.Session
+
+class RedisDialect extends JdbcDialect {
+
+  override def getTablesQuery(
+      catalog: String,
+      schema: String,
+      tableName: String,
+      tableTypes: util.List[String]): String = {
+    ""
+  }
+
+  override def getColumnsQuery(
+      session: Session,
+      catalogName: String,
+      schemaName: String,
+      tableName: String,
+      columnName: String): String = {
+    ""
+  }
+
+  override def getTRowSetGenerator(): JdbcTRowSetGenerator = {
+    new RedisTRowSetGenerator
+  }
+
+  override def getSchemaHelper(): SchemaHelper = {
+    new RedisSchemaHelper
+  }
+
+  override def name(): String = {
+    "redis"
+  }
+}

--- a/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/redis/RedisConnectionProvider.scala
+++ b/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/redis/RedisConnectionProvider.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kyuubi.engine.jdbc.redis
+
+import org.apache.kyuubi.engine.jdbc.mysql.MySQLConnectionProvider
+
+class RedisConnectionProvider extends MySQLConnectionProvider{
+
+  override val name: String = classOf[RedisConnectionProvider].getSimpleName
+
+  override val driverClass: String = "com.itmuch.redis.jdbc.redis.RedisDrive"
+
+  override def canHandle(providerClass: String): Boolean = {
+    driverClass.equalsIgnoreCase(providerClass)
+  }
+
+}

--- a/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/redis/RedisSchemaHelper.scala
+++ b/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/redis/RedisSchemaHelper.scala
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kyuubi.engine.jdbc.redis
+
+import org.apache.kyuubi.engine.jdbc.schema.SchemaHelper
+
+class RedisSchemaHelper extends SchemaHelper{
+
+}

--- a/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/redis/RedisTRowSetGenerator.scala
+++ b/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/redis/RedisTRowSetGenerator.scala
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kyuubi.engine.jdbc.redis
+
+import org.apache.kyuubi.engine.jdbc.schema.DefaultJdbcTRowSetGenerator
+
+class RedisTRowSetGenerator extends DefaultJdbcTRowSetGenerator{
+
+}

--- a/externals/kyuubi-jdbc-engine/src/test/scala/org/apache/kyuubi/engine/jdbc/redis/RedisJDBCTestHelper.scala
+++ b/externals/kyuubi-jdbc-engine/src/test/scala/org/apache/kyuubi/engine/jdbc/redis/RedisJDBCTestHelper.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kyuubi.engine.jdbc.redis
+
+import org.apache.kyuubi.operation.JDBCTestHelper
+
+trait RedisJDBCTestHelper extends JDBCTestHelper{
+  override def jdbcDriverClass: String = "com.itmuch.redis.jdbc.redis.RedisDriver"
+
+  protected val URL_PREFIX = "jdbc:redis://"
+
+  protected def matchAllPatterns = Seq("", "*", "%", null, ".*", "_*", "_%", ".%")
+
+  override protected lazy val user: String = null
+  override protected val password = null
+  private var _sessionConfigs: Map[String, String] = Map.empty
+  private var _jdbcConfigs: Map[String, String] = Map.empty
+  private var _jdbcVars: Map[String, String] = Map.empty
+
+  override protected def sessionConfigs: Map[String, String] = _sessionConfigs
+
+  override protected def jdbcConfigs: Map[String, String] = _jdbcConfigs
+
+  override protected def jdbcVars: Map[String, String] = _jdbcVars
+
+  override protected def jdbcUrlWithConf(jdbcUrl: String): String = {
+    jdbcUrl
+  }
+
+}

--- a/externals/kyuubi-jdbc-engine/src/test/scala/org/apache/kyuubi/engine/jdbc/redis/RedisSessionSuite.scala
+++ b/externals/kyuubi-jdbc-engine/src/test/scala/org/apache/kyuubi/engine/jdbc/redis/RedisSessionSuite.scala
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kyuubi.engine.jdbc.redis
+
+
+class RedisSessionSuite extends WithRedisEngine with RedisJDBCTestHelper {
+
+  test("redis - test session") {
+    withJdbcStatement() { statement =>
+      statement.execute("set a 1")
+      val resultSet = statement.executeQuery(
+        "get a")
+      // in redis, the metaData always null, so we don't need check the metadata
+      while (resultSet.next()) {
+        val data = resultSet.getString(0)
+        assert(data == "1")
+      }
+    }
+  }
+
+  override protected def jdbcUrl: String = redisJdbcUrl
+}

--- a/externals/kyuubi-jdbc-engine/src/test/scala/org/apache/kyuubi/engine/jdbc/redis/RedisStatementSuite.scala
+++ b/externals/kyuubi-jdbc-engine/src/test/scala/org/apache/kyuubi/engine/jdbc/redis/RedisStatementSuite.scala
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kyuubi.engine.jdbc.redis
+
+class RedisStatementSuite extends WithRedisEngine  with RedisJDBCTestHelper {
+
+  test("test change db") {
+    withJdbcStatement() {statement =>
+      statement.execute("use db0")
+
+    }
+  }
+
+  test("test types") {
+    withJdbcStatement() {statement =>
+      statement.execute("")
+    }
+  }
+
+
+  override protected def jdbcUrl: String = redisJdbcUrl
+}

--- a/externals/kyuubi-jdbc-engine/src/test/scala/org/apache/kyuubi/engine/jdbc/redis/WithRedisContainer.scala
+++ b/externals/kyuubi-jdbc-engine/src/test/scala/org/apache/kyuubi/engine/jdbc/redis/WithRedisContainer.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kyuubi.engine.jdbc.redis
+
+import com.dimafeng.testcontainers.GenericContainer
+import org.testcontainers.containers.wait.strategy.Wait
+
+import org.apache.kyuubi.engine.jdbc.WithJdbcServerContainer
+
+trait WithRedisContainer extends WithJdbcServerContainer {
+
+  private val REDIS_PORT = 6379
+  private val redisDockerImage = "redis"
+
+  override val containerDef: GenericContainer.Def[GenericContainer] = GenericContainer.Def(
+    dockerImage = redisDockerImage,
+    exposedPorts = Seq(REDIS_PORT),
+    waitStrategy = Wait.forListeningPort())
+
+  protected def redisJdbcUrl: String = withContainers { container =>
+    val redisServerHost: String = container.host
+    val redisServerPort: Int = container.mappedPort(REDIS_PORT)
+    val url = s"jdbc:redis://$redisServerHost:$redisServerPort"
+    url
+  }
+}

--- a/externals/kyuubi-jdbc-engine/src/test/scala/org/apache/kyuubi/engine/jdbc/redis/WithRedisEngine.scala
+++ b/externals/kyuubi-jdbc-engine/src/test/scala/org/apache/kyuubi/engine/jdbc/redis/WithRedisEngine.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kyuubi.engine.jdbc.redis
+
+import org.apache.kyuubi.config.KyuubiConf._
+import org.apache.kyuubi.engine.jdbc.WithJdbcEngine
+
+trait WithRedisEngine extends WithJdbcEngine with WithRedisContainer {
+  override def withKyuubiConf: Map[String, String] = withContainers { container =>
+    Map(
+      ENGINE_SHARE_LEVEL.key -> "SERVER",
+      ENGINE_JDBC_CONNECTION_URL.key -> redisJdbcUrl,
+      ENGINE_JDBC_CONNECTION_USER.key -> "root",
+      ENGINE_JDBC_CONNECTION_PASSWORD.key -> "123456",
+      ENGINE_TYPE.key -> "jdbc",
+      ENGINE_JDBC_SHORT_NAME.key -> "redis",
+      ENGINE_JDBC_DRIVER_CLASS.key -> "com.itmuch.redis.jdbc.redis.RedisDrive")
+  }
+
+}

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/StageStatus.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/StageStatus.scala
@@ -31,8 +31,3 @@ class SparkStageInfo(val stageId: Int, val numTasks: Int) {
 class SparkJobInfo(val numStages: Int, val stageIds: Set[Int]) {
   val numCompleteStages = new AtomicInteger(0)
 }
-
-
-class SparkJobInfo(val numStages: Int, val stageIds: Seq[Int]) {
-  var numCompleteStages = new AtomicInteger(0)
-}

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/StageStatus.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/StageStatus.scala
@@ -31,3 +31,8 @@ class SparkStageInfo(val stageId: Int, val numTasks: Int) {
 class SparkJobInfo(val numStages: Int, val stageIds: Set[Int]) {
   val numCompleteStages = new AtomicInteger(0)
 }
+
+
+class SparkJobInfo(val numStages: Int, val stageIds: Seq[Int]) {
+  var numCompleteStages = new AtomicInteger(0)
+}


### PR DESCRIPTION
# :mag: Description
This pr could support use jdbc mode to connect with redis, we can use the url like 'jdbc:redis://host:port' to connect redis server
[This is a Draft pr, beacause there are some questions need resolve]
1. Redis differs from common JDBC drivers like MySQL and Phoenix. Therefore, some common JDBC driver test cases are not applicable to Redis. Which components of Redis do we need to test?
2. Should we add a test case for Redis cluster mode?
## Issue References 🔗
This pull request fixes #5469 
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->


## Describe Your Solution 🔧
1. Choose a redis-jdbc-driver for this component, currently, the redis jdbc driver is from https://github.com/eacdy/redis-jdbc
3. Add Redis Dialect 
4. Write Redis Unit Test
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests
org/apache/kyuubi/engine/jdbc/redis/RedisSessionSuite.scala
org/apache/kyuubi/engine/jdbc/redis/RedisStatementSuite.scala

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
