### PR TITLE
JDBC driver conditional sets fetchSize on opening session

### DIFF
--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
@@ -746,13 +746,13 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
               "Unsupported Hive2 protocol version %s specified by session conf key %s",
               clientProtocolStr, CLIENT_PROTOCOL_VERSION));
     }
+    openReq.setClient_protocol(clientProtocol);
     // HIVE-14901: set the fetchSize
     if (clientProtocol.compareTo(TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V10) >= 0) {
       openConf.put(
           "set:hiveconf:hive.server2.thrift.resultset.default.fetch.size",
           Integer.toString(fetchSize));
     }
-    openReq.setClient_protocol(clientProtocol);
     try {
       openConf.put("kyuubi.client.ipAddress", InetAddress.getLocalHost().getHostAddress());
     } catch (UnknownHostException e) {

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
@@ -723,12 +723,6 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
     }
     // switch the database
     openConf.put("use:database", connParams.getDbName());
-    // HIVE-14901: set the fetchSize
-    if (protocol.compareTo(TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V10) >= 0) {
-      openConf.put(
-          "set:hiveconf:hive.server2.thrift.resultset.default.fetch.size",
-          Integer.toString(fetchSize));
-    }
     if (wmPool != null) {
       openConf.put("set:hivevar:wmpool", wmPool);
     }
@@ -751,6 +745,12 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
           String.format(
               "Unsupported Hive2 protocol version %s specified by session conf key %s",
               clientProtocolStr, CLIENT_PROTOCOL_VERSION));
+    }
+    // HIVE-14901: set the fetchSize
+    if (clientProtocol.compareTo(TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V10) >= 0) {
+      openConf.put(
+          "set:hiveconf:hive.server2.thrift.resultset.default.fetch.size",
+          Integer.toString(fetchSize));
     }
     openReq.setClient_protocol(clientProtocol);
     try {

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
@@ -723,10 +723,12 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
     }
     // switch the database
     openConf.put("use:database", connParams.getDbName());
-    // set the fetchSize
-    openConf.put(
-        "set:hiveconf:hive.server2.thrift.resultset.default.fetch.size",
-        Integer.toString(fetchSize));
+    // HIVE-14901: set the fetchSize
+    if (protocol.compareTo(TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V10) >= 0) {
+      openConf.put(
+          "set:hiveconf:hive.server2.thrift.resultset.default.fetch.size",
+          Integer.toString(fetchSize));
+    }
     if (wmPool != null) {
       openConf.put("set:hivevar:wmpool", wmPool);
     }


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

I get reported by a user that using Kyuubi JDBC driver 1.8.0 to access Spark Thrift Server 2.4 (with Hive 1.2.1) with getting an error on opening the session even with `clientProtocol=7`

```
org.apache.hive.service.cli.HiveSQLException: java.lang.IllegalArgumentException: hive configuration hive.server2.thrift.resultset.default.fetch.size does not exists.
        at org.apache.hive.service.cli.session.HiveSessionImpl.configureSession(HiveSessionImpl.java:220)
        at org.apache.hive.service.cli.session.HiveSessionImpl.open(HiveSessionImpl.java:154)
        at org.apache.hive.service.cli.session.SessionManager.openSession(SessionManager.java:258)
        ... 13 more
```

## Describe Your Solution 🔧

When `hive.conf.validation` is `true` (it also is the default value), an IllegalArgumentException will be thrown if the provided configurations start with `hive.` and can not be recognized by the server.

One solution is to disable `hive.conf.validation` on the server side, but we can also address it by avoiding passing this configuration if we know that the server does not support it.

HIVE-14901 (2.3.0, HIVE_CLI_SERVICE_PROTOCOL_V10) introduces `hive.server2.thrift.resultset.default.fetch.size`, so we can set this configuration only when protocol >= HIVE_CLI_SERVICE_PROTOCOL_V10

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

Verified locally by connecting to HS2 2.1.1 and HS2 2.3.9

#### Behavior Without This Pull Request :coffin:

IllegalArgumentException throws when using  `jdbc:hive2://localhost:10000/default;clientProtocol=8` to connect HS2 2.1.1

Everything is OK when using `jdbc:hive2://localhost:10000/default` to connect HS2 2.3.9

#### Behavior With This Pull Request :tada:

Everything is OK when using `jdbc:hive2://localhost:10000/default;clientProtocol=8` to connect HS2 2.1.1

Everything is OK when using `jdbc:hive2://localhost:10000/default` to connect HS2 2.3.9

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
