### PR TITLE
Fix the JDBC engine provider name

### DIFF
--- a/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/connection/JdbcConnectionProvider.scala
+++ b/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/connection/JdbcConnectionProvider.scala
@@ -26,7 +26,7 @@ import org.apache.kyuubi.engine.jdbc.util.SupportServiceLoader
 
 abstract class JdbcConnectionProvider extends SupportServiceLoader with Logging {
 
-  override def name(): String = classOf[JdbcConnectionProvider].getSimpleName
+  override def name(): String = classOf[JdbcConnectionProvider].getName
 
   val driverClass: String
 

--- a/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/doris/DorisConnectionProvider.scala
+++ b/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/doris/DorisConnectionProvider.scala
@@ -20,5 +20,5 @@ import org.apache.kyuubi.engine.jdbc.mysql.MySQL8ConnectionProvider
 
 class DorisConnectionProvider extends MySQL8ConnectionProvider {
 
-  override val name: String = classOf[DorisConnectionProvider].getSimpleName
+  override val name: String = classOf[DorisConnectionProvider].getName
 }

--- a/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/mysql/MySQL8ConnectionProvider.scala
+++ b/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/mysql/MySQL8ConnectionProvider.scala
@@ -20,7 +20,7 @@ import org.apache.kyuubi.engine.jdbc.connection.JdbcConnectionProvider
 
 class MySQL8ConnectionProvider extends JdbcConnectionProvider {
 
-  override val name: String = classOf[MySQL8ConnectionProvider].getSimpleName
+  override val name: String = classOf[MySQL8ConnectionProvider].getName
 
   override val driverClass: String = MySQL8ConnectionProvider.driverClass
 

--- a/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/mysql/MySQLConnectionProvider.scala
+++ b/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/mysql/MySQLConnectionProvider.scala
@@ -18,5 +18,5 @@ package org.apache.kyuubi.engine.jdbc.mysql
 
 class MySQLConnectionProvider extends MySQL8ConnectionProvider {
 
-  override val name: String = classOf[MySQLConnectionProvider].getSimpleName
+  override val name: String = classOf[MySQLConnectionProvider].getName
 }

--- a/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/phoenix/PhoenixConnectionProvider.scala
+++ b/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/phoenix/PhoenixConnectionProvider.scala
@@ -20,7 +20,7 @@ import org.apache.kyuubi.engine.jdbc.connection.JdbcConnectionProvider
 
 class PhoenixConnectionProvider extends JdbcConnectionProvider {
 
-  override val name: String = classOf[PhoenixConnectionProvider].getSimpleName
+  override val name: String = classOf[PhoenixConnectionProvider].getName
 
   override val driverClass: String = "org.apache.phoenix.queryserver.client.Driver"
 

--- a/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/postgresql/PostgreSQLConnectionProvider.scala
+++ b/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/postgresql/PostgreSQLConnectionProvider.scala
@@ -20,7 +20,7 @@ import org.apache.kyuubi.engine.jdbc.connection.JdbcConnectionProvider
 
 class PostgreSQLConnectionProvider extends JdbcConnectionProvider {
 
-  override val name: String = classOf[PostgreSQLConnectionProvider].getSimpleName
+  override val name: String = classOf[PostgreSQLConnectionProvider].getName
 
   override val driverClass: String = "org.postgresql.Driver"
 

--- a/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/starrocks/StarRocksConnectionProvider.scala
+++ b/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/starrocks/StarRocksConnectionProvider.scala
@@ -20,5 +20,5 @@ import org.apache.kyuubi.engine.jdbc.mysql.MySQL8ConnectionProvider
 
 class StarRocksConnectionProvider extends MySQL8ConnectionProvider {
 
-  override val name: String = classOf[StarRocksConnectionProvider].getSimpleName
+  override val name: String = classOf[StarRocksConnectionProvider].getName
 }


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes create Jdbc Engine error:
```
 java.lang.IllegalArgumentException: Could not find a JDBC connection provider with name 'org.apache.kyuubi.engine.jdbc.mysql.MySQLConnectionProvider' that can handle the specified driver and options. Available providers are [org.apache.kyuubi.engine.jdbc.doris.DorisConnectionProvider@57459491, org.apache.kyuubi.engine.jdbc.mysql.MySQLConnectionProvider@dcfda20, org.apache.kyuubi.engine.jdbc.phoenix.PhoenixConnectionProvider@5c87bfe2, org.apache.kyuubi.engine.jdbc.postgresql.PostgreSQLConnectionProvider@51cd7ffc, org.apache.kyuubi.engine.jdbc.starrocks.StarRocksConnectionProvider@40f1be1b]
```

## Describe Your Solution 🔧

```
  val ENGINE_JDBC_CONNECTION_PROVIDER: OptionalConfigEntry[String] =
    buildConf("kyuubi.engine.jdbc.connection.provider")
      .doc("A JDBC connection provider plugin for the Kyuubi Server " +
        "to establish a connection to the JDBC URL." +
        " The configuration value should be a subclass of " +
        "`org.apache.kyuubi.engine.jdbc.connection.JdbcConnectionProvider`. " +
        "Kyuubi provides the following built-in implementations: " +
        "<li>doris: For establishing Doris connections.</li> " +
        "<li>mysql: For establishing MySQL connections.</li> " +
        "<li>phoenix: For establishing Phoenix connections.</li> " +
        "<li>postgresql: For establishing PostgreSQL connections.</li>" +
        "<li>starrocks: For establishing StarRocks connections.</li>")
      .version("1.6.0")
      .stringConf
      .transform {
        case "Doris" | "doris" | "DorisConnectionProvider" =>
          "org.apache.kyuubi.engine.jdbc.doris.DorisConnectionProvider"
        case "MySQL" | "mysql" | "MySQLConnectionProvider" =>
          "org.apache.kyuubi.engine.jdbc.mysql.MySQLConnectionProvider"
        case "Phoenix" | "phoenix" | "PhoenixConnectionProvider" =>
          "org.apache.kyuubi.engine.jdbc.phoenix.PhoenixConnectionProvider"
        case "PostgreSQL" | "postgresql" | "PostgreSQLConnectionProvider" =>
          "org.apache.kyuubi.engine.jdbc.postgresql.PostgreSQLConnectionProvider"
        case "StarRocks" | "starrocks" | "StarRocksConnectionProvider" =>
          "org.apache.kyuubi.engine.jdbc.starrocks.StarRocksConnectionProvider"
        case other => other
      }
      .createOptional
```

because the provider name transforms the fully qualified class name, but class simple name is compared

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:

I have passed this pull request at local integration testing

#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
