### PR TITLE
[KYUUBI #4546][FOLLOWUP] only exclude `metrics` dir in root directory of repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,7 @@ metastore_db
 derby.log
 rest-audit.log
 **/dependency-reduced-pom.xml
-metrics/
+/metrics/
 /kyuubi-ha/embedded_zookeeper/
 embedded_zookeeper/
 /externals/kyuubi-spark-sql-engine/operation_logs/


### PR DESCRIPTION
## Why are the changes needed?

Follow-Up of patch: https://github.com/apache/kyuubi/pull/4547

The modification introduced by https://github.com/apache/kyuubi/pull/4547 will result in all folder whose name is metrics being ignored.

```
# for example, a normal metrics package  for spark-engine will be ignored
externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/metrics/
```

This patch changes the rule in `.gitignore` to only exclude metrics directory created by JSON reporter in root directory of REPO which is usually working directory of debug process.

Close https://github.com/apache/kyuubi/issues/4546

## Simple test 

![image](https://github.com/apache/kyuubi/assets/21239012/b5ebd9fb-9be5-4077-8d76-ab361d1eecef)



## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request