### PR TITLE
Delete svn staging dir before checking out

### DIFF
--- a/build/release/release.sh
+++ b/build/release/release.sh
@@ -83,6 +83,7 @@ package() {
 }
 
 upload_svn_staging() {
+  rm -rf "${SVN_STAGING_DIR}"
   svn checkout --depth=empty "${SVN_STAGING_REPO}" "${SVN_STAGING_DIR}"
   mkdir -p "${SVN_STAGING_DIR}/${RELEASE_TAG}"
   rm -f "${SVN_STAGING_DIR}/${RELEASE_TAG}/*"


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

The release process will fail with the following errors if `SVN_STAGING_DIR`(`${KYUUBI_DIR}/work/svn-dev"`) exist.
```
+ upload_svn_staging
+ svn checkout --depth=empty https://dist.apache.org/repos/dist/dev/kyuubi /home/ubuntu/apache-kyuubi/work/svn-dev
svn: warning: cannot set LC_CTYPE locale
svn: warning: environment variable LC_CTYPE is UTF-8
svn: warning: please check that your locale name is correct
svn: E155016: The working copy database at '/home/ubuntu/apache-kyuubi/work/svn-dev' is missing.
```

## Describe Your Solution 🔧

Delete `SVN_STAGING_DIR` before checking out

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

Manually test.

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
