### PR TITLE
[KYUUBI #5104][TEST] BatchesResourceSuite - expose the metrics with operation type and current state

### DIFF
--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
@@ -766,10 +766,8 @@ abstract class BatchesResourceSuiteBase extends KyuubiFunSuite
         batch.getState === OperationState.RUNNING.toString)
     }
 
-    eventually(timeout(10.seconds)) {
-      assert(getBatchJobSubmissionStateCounter(OperationState.INITIALIZED) +
-        getBatchJobSubmissionStateCounter(OperationState.PENDING) +
-        getBatchJobSubmissionStateCounter(OperationState.RUNNING) === 1)
+    eventually(timeout(20.seconds)) {
+      assert(getBatchJobSubmissionStateCounter(OperationState.RUNNING) === 1)
     }
 
     val deleteResp = webTarget.path(s"api/v1/batches/$batchId")

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
@@ -751,9 +751,15 @@ abstract class BatchesResourceSuiteBase extends KyuubiFunSuite
         getBatchJobSubmissionStateCounter(OperationState.ERROR)
 
     val batchId = UUID.randomUUID().toString
-    val requestObj = newSparkBatchRequest(Map(
-      "spark.master" -> "local",
-      KYUUBI_BATCH_ID_KEY -> batchId))
+    val requestObj = newBatchRequest(
+      sparkBatchTestBatchType,
+      sparkBatchTestResource.get,
+      "org.apache.spark.examples.DriverSubmissionTest",
+      "DriverSubmissionTest-" + batchId,
+      Map(
+        "spark.master" -> "local",
+        KYUUBI_BATCH_ID_KEY -> batchId),
+      Seq("120"))
 
     eventually(timeout(10.seconds)) {
       val response = webTarget.path("api/v1/batches")


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗

This pull request fixes #5104

## Describe Your Solution 🔧

Make sure that the batch is already running before deleting it.

## Types of changes :bookmark:
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:
GA sometimes fails

#### Behavior With This Pull Request :tada:
GA success

#### Related Unit Tests
BatchesV2ResourceSuite

`expose the metrics with operation type and current state`

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
