### PR TITLE
Fix PostgreSQL metastore migration script failure if indexes already exist

### DIFF
--- a/kyuubi-server/src/main/resources/sql/postgresql/metadata-store-schema-1.9.0.postgresql.sql
+++ b/kyuubi-server/src/main/resources/sql/postgresql/metadata-store-schema-1.9.0.postgresql.sql
@@ -52,8 +52,8 @@ COMMENT ON COLUMN metadata.end_time IS 'the metadata end time';
 COMMENT ON COLUMN metadata.priority IS 'the application priority, high value means high priority';
 COMMENT ON COLUMN metadata.peer_instance_closed IS 'closed by peer kyuubi instance';
 
-CREATE UNIQUE INDEX unique_identifier_index ON metadata(identifier);
-CREATE INDEX user_name_index ON metadata(user_name);
-CREATE INDEX engine_type_index ON metadata(engine_type);
-CREATE INDEX create_time_index ON metadata(create_time);
-CREATE INDEX priority_create_time_index ON metadata(priority DESC, create_time ASC);
+CREATE UNIQUE INDEX IF NOT EXISTS unique_identifier_index ON metadata(identifier);
+CREATE INDEX IF NOT EXISTS user_name_index ON metadata(user_name);
+CREATE INDEX IF NOT EXISTS engine_type_index ON metadata(engine_type);
+CREATE INDEX IF NOT EXISTS create_time_index ON metadata(create_time);
+CREATE INDEX IF NOT EXISTS priority_create_time_index ON metadata(priority DESC, create_time ASC);


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request is a small fix for #5674 

## Describe Your Solution 🔧

PostgreSQL support as backend for metadata store was added in #6027. If we choose it and run schema init scripts several times, then the following errors will be logged: `Error executing sql: CREATE UNIQUE INDEX unique_identifier_index ON metadata(identifier), with params: . ERROR: relation "unique_identifier_index" already exists`. This PR adds lacking `IF NOT EXISTS` to db indexes creation ddls in the PostgreSQL metastore init script.

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

