### PR TITLE
RESTful client should retry on UnknownHostException

### DIFF
--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/RestClient.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/RestClient.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.net.ConnectException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import org.apache.commons.collections.MapUtils;
@@ -180,7 +181,10 @@ public class RestClient implements IRestClient {
 
       response = httpclient.execute(httpRequest, responseHandler);
       LOG.debug("Response: {}", response);
-    } catch (ConnectException | ConnectTimeoutException | NoHttpResponseException e) {
+    } catch (ConnectException
+        | UnknownHostException
+        | ConnectTimeoutException
+        | NoHttpResponseException e) {
       // net exception can be retried by connecting to other Kyuubi server
       throw new RetryableKyuubiRestException("Api request failed for " + uri.toString(), e);
     } catch (KyuubiRestException rethrow) {


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

When deploying Kyuubi as StatefulSet on Kubernetes, during the rolling upgrade, the Pod stops and creates one by one, and there are a few durations that the Pod is not available, then `UnknownHostException` is returned.

```
2024-02-23 23:04:45 [ERROR] [KyuubiRestFrontendService-122] org.apache.kyuubi.client.RestClient#189 - Error:
java.net.UnknownHostException: kyuubi-2.kyuubi-headless.spark.svc.cluster.local
	at java.net.InetAddress$CachedAddresses.get(InetAddress.java:764) ~[?:1.8.0_382]
	...
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:140) ~[httpclient-4.5.14.jar:4.5.14]
	at org.apache.kyuubi.client.RestClient.doRequest(RestClient.java:181) ~[kyuubi-rest-client-1.8.0.17.jar:1.8.0.17]
	at org.apache.kyuubi.client.RestClient.get(RestClient.java:80) ~[kyuubi-rest-client-1.8.0.17.jar:1.8.0.17]
	...
	at org.apache.kyuubi.client.BatchRestApi.getBatchLocalLog(BatchRestApi.java:104) ~[kyuubi-rest-client-1.8.0.17.jar:1.8.0.17]
	at org.apache.kyuubi.server.api.v1.InternalRestClient.$anonfun$getBatchLocalLog$1(InternalRestClient.scala:57) ~[kyuubi-server_2.12-1.8.0.17.jar:1.8.0.17]
	at org.apache.kyuubi.server.api.v1.InternalRestClient.withAuthUser(InternalRestClient.scala:81) ~[kyuubi-server_2.12-1.8.0.17.jar:1.8.0.17]
	at org.apache.kyuubi.server.api.v1.InternalRestClient.getBatchLocalLog(InternalRestClient.scala:57) ~[kyuubi-server_2.12-1.8.0.17.jar:1.8.0.17]
	at org.apache.kyuubi.server.api.v1.BatchesResource.$anonfun$getBatchLocalLog$4(BatchesResource.scala:424) ~[kyuubi-server_2.12-1.8.0.17.jar:1.8.0.17]
```

## Describe Your Solution 🔧

Treat `UnknownHostException` as a retriable exception to tolerant the transient Pod FQDN not available cases during rolling upgrade on K8s.

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

Pass GA.

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
