### PR TITLE
[KYUUBI #6078] KSHC should handle the commit of the partitioned table as dynamic partition at write path

### DIFF
--- a/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/write/HiveBatchWrite.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/write/HiveBatchWrite.scala
@@ -30,21 +30,18 @@ import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.connector.write.{BatchWrite, DataWriterFactory, PhysicalWriteInfo, WriterCommitMessage}
 import org.apache.spark.sql.execution.datasources.{WriteJobDescription, WriteTaskResult}
 import org.apache.spark.sql.execution.datasources.v2.FileBatchWrite
-import org.apache.spark.sql.hive.kyuubi.connector.HiveBridgeHelper.{hive, toSQLValue, HiveExternalCatalog}
+import org.apache.spark.sql.hive.kyuubi.connector.HiveBridgeHelper.toSQLValue
 import org.apache.spark.sql.types.StringType
 
 import org.apache.kyuubi.spark.connector.hive.{HiveConnectorUtils, HiveTableCatalog, KyuubiHiveConnectorException}
-import org.apache.kyuubi.spark.connector.hive.write.HiveWriteHelper.getPartitionSpec
 
 class HiveBatchWrite(
     sparkSession: SparkSession,
     table: CatalogTable,
     hiveTableCatalog: HiveTableCatalog,
     tmpLocation: Option[Path],
-    partition: Map[String, Option[String]],
-    partitionColumnNames: Seq[String],
+    dynamicPartition: Map[String, Option[String]],
     overwrite: Boolean,
-    ifPartitionNotExists: Boolean,
     hadoopConf: Configuration,
     fileBatchWrite: FileBatchWrite,
     externalCatalog: ExternalCatalog,
@@ -114,13 +111,10 @@ class HiveBatchWrite(
   }
 
   private def commitToMetastore(writtenParts: Set[String]): Unit = {
-    val numDynamicPartitions = partition.values.count(_.isEmpty)
-    val partitionSpec = getPartitionSpec(partition)
-    val staticPartitionSpec = partitionSpec.filter {
-      case (_, v) => !v.equals("")
-    }
+    val numDynamicPartitions = table.partitionColumnNames.size
+    val partitionSpec = table.partitionColumnNames.map(colName => colName -> "").toMap
 
-    if (partition.isEmpty) {
+    if (dynamicPartition.isEmpty) {
       externalCatalog.loadTable(
         table.database,
         table.identifier.table,
@@ -130,155 +124,67 @@ class HiveBatchWrite(
       return
     }
 
-    if (numDynamicPartitions > 0) {
-      if (overwrite && table.tableType == CatalogTableType.EXTERNAL) {
-        val numWrittenParts = writtenParts.size
-        val maxDynamicPartitionsKey = HiveConf.ConfVars.DYNAMICPARTITIONMAXPARTS.varname
-        val maxDynamicPartitions = hadoopConf.getInt(
-          maxDynamicPartitionsKey,
-          HiveConf.ConfVars.DYNAMICPARTITIONMAXPARTS.defaultIntVal)
-        if (numWrittenParts > maxDynamicPartitions) {
-          throw KyuubiHiveConnectorException(
-            s"Number of dynamic partitions created is $numWrittenParts, " +
-              s"which is more than $maxDynamicPartitions. " +
-              s"To solve this try to set $maxDynamicPartitionsKey " +
-              s"to at least $numWrittenParts.")
-        }
-        // SPARK-29295: When insert overwrite to a Hive external table partition, if the
-        // partition does not exist, Hive will not check if the external partition directory
-        // exists or not before copying files. So if users drop the partition, and then do
-        // insert overwrite to the same partition, the partition will have both old and new
-        // data. We construct partition path. If the path exists, we delete it manually.
-        writtenParts.foreach { partPath =>
-          val dpMap = partPath.split("/").map { part =>
-            val splitPart = part.split("=")
-            assert(splitPart.size == 2, s"Invalid written partition path: $part")
-            ExternalCatalogUtils.unescapePathName(splitPart(0)) ->
-              ExternalCatalogUtils.unescapePathName(splitPart(1))
-          }.toMap
-
-          val caseInsensitiveDpMap = CaseInsensitiveMap(dpMap)
-
-          val updatedPartitionSpec = partition.map {
-            case (key, Some(null)) => key -> ExternalCatalogUtils.DEFAULT_PARTITION_NAME
-            case (key, Some(value)) => key -> value
-            case (key, None) if caseInsensitiveDpMap.contains(key) =>
-              key -> caseInsensitiveDpMap(key)
-            case (key, _) =>
-              throw KyuubiHiveConnectorException(
-                s"Dynamic partition key ${toSQLValue(key, StringType)} " +
-                  "is not among written partition paths.")
-          }
-          val partitionColumnNames = table.partitionColumnNames
-          val tablePath = new Path(table.location)
-          val partitionPath = ExternalCatalogUtils.generatePartitionPath(
-            updatedPartitionSpec,
-            partitionColumnNames,
-            tablePath)
-
-          val fs = partitionPath.getFileSystem(hadoopConf)
-          if (fs.exists(partitionPath)) {
-            if (!fs.delete(partitionPath, true)) {
-              throw KyuubiHiveConnectorException(s"Cannot remove partition directory " +
-                s"'$partitionPath'")
-            }
-          }
-        }
+    if (overwrite && table.tableType == CatalogTableType.EXTERNAL) {
+      val numWrittenParts = writtenParts.size
+      val maxDynamicPartitionsKey = HiveConf.ConfVars.DYNAMICPARTITIONMAXPARTS.varname
+      val maxDynamicPartitions = hadoopConf.getInt(
+        maxDynamicPartitionsKey,
+        HiveConf.ConfVars.DYNAMICPARTITIONMAXPARTS.defaultIntVal)
+      if (numWrittenParts > maxDynamicPartitions) {
+        throw KyuubiHiveConnectorException(
+          s"Number of dynamic partitions created is $numWrittenParts, " +
+            s"which is more than $maxDynamicPartitions. " +
+            s"To solve this try to set $maxDynamicPartitionsKey " +
+            s"to at least $numWrittenParts.")
       }
+      // SPARK-29295: When insert overwrite to a Hive external table partition, if the
+      // partition does not exist, Hive will not check if the external partition directory
+      // exists or not before copying files. So if users drop the partition, and then do
+      // insert overwrite to the same partition, the partition will have both old and new
+      // data. We construct partition path. If the path exists, we delete it manually.
+      writtenParts.foreach { partPath =>
+        val dpMap = partPath.split("/").map { part =>
+          val splitPart = part.split("=")
+          assert(splitPart.size == 2, s"Invalid written partition path: $part")
+          ExternalCatalogUtils.unescapePathName(splitPart(0)) ->
+            ExternalCatalogUtils.unescapePathName(splitPart(1))
+        }.toMap
 
-      val loadPath = ExternalCatalogUtils.generatePartitionPath(
-        staticPartitionSpec,
-        partitionColumnNames.take(partitionColumnNames.length - numDynamicPartitions),
-        tmpLocation.get)
+        val caseInsensitiveDpMap = CaseInsensitiveMap(dpMap)
 
-      externalCatalog.loadDynamicPartitions(
-        db = table.database,
-        table = table.identifier.table,
-        loadPath.toString,
-        partitionSpec,
-        overwrite,
-        numDynamicPartitions)
-    } else {
-      // scalastyle:off
-      // ifNotExists is only valid with static partition, refer to
-      // https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DML#LanguageManualDML-InsertingdataintoHiveTablesfromqueries
-      // scalastyle:on
-      val oldPart =
-        externalCatalog.getPartitionOption(
-          table.database,
-          table.identifier.table,
-          partitionSpec)
+        val updatedPartitionSpec = dynamicPartition.map {
+          case (key, Some(null)) => key -> ExternalCatalogUtils.DEFAULT_PARTITION_NAME
+          case (key, Some(value)) => key -> value
+          case (key, None) if caseInsensitiveDpMap.contains(key) =>
+            key -> caseInsensitiveDpMap(key)
+          case (key, _) =>
+            throw KyuubiHiveConnectorException(
+              s"Dynamic partition key ${toSQLValue(key, StringType)} " +
+                "is not among written partition paths.")
+        }
+        val partitionColumnNames = table.partitionColumnNames
+        val tablePath = new Path(table.location)
+        val partitionPath = ExternalCatalogUtils.generatePartitionPath(
+          updatedPartitionSpec,
+          partitionColumnNames,
+          tablePath)
 
-      var doHiveOverwrite = overwrite
-
-      if (oldPart.isEmpty || !ifPartitionNotExists) {
-        // SPARK-29295: When insert overwrite to a Hive external table partition, if the
-        // partition does not exist, Hive will not check if the external partition directory
-        // exists or not before copying files. So if users drop the partition, and then do
-        // insert overwrite to the same partition, the partition will have both old and new
-        // data. We construct partition path. If the path exists, we delete it manually.
-        val partitionPath =
-          if (oldPart.isEmpty && overwrite
-            && table.tableType == CatalogTableType.EXTERNAL) {
-            val partitionColumnNames = table.partitionColumnNames
-            val tablePath = new Path(table.location)
-            Some(ExternalCatalogUtils.generatePartitionPath(
-              partitionSpec,
-              partitionColumnNames,
-              tablePath))
-          } else {
-            oldPart.flatMap(_.storage.locationUri.map(uri => new Path(uri)))
-          }
-
-        import hive._
-        // SPARK-18107: Insert overwrite runs much slower than hive-client.
-        // Newer Hive largely improves insert overwrite performance. As Spark uses older Hive
-        // version and we may not want to catch up new Hive version every time. We delete the
-        // Hive partition first and then load data file into the Hive partition.
-        val hiveVersion = externalCatalog.asInstanceOf[ExternalCatalogWithListener]
-          .unwrapped.asInstanceOf[HiveExternalCatalog]
-          .client
-          .version
-        // SPARK-31684:
-        // For Hive 2.0.0 and onwards, as https://issues.apache.org/jira/browse/HIVE-11940
-        // has been fixed, and there is no performance issue anymore. We should leave the
-        // overwrite logic to hive to avoid failure in `FileSystem#checkPath` when the table
-        // and partition locations do not belong to the same `FileSystem`
-        // TODO(SPARK-31675): For Hive 2.2.0 and earlier, if the table and partition locations
-        // do not belong together, we will still get the same error thrown by hive encryption
-        // check. see https://issues.apache.org/jira/browse/HIVE-14380.
-        // So we still disable for Hive overwrite for Hive 1.x for better performance because
-        // the partition and table are on the same cluster in most cases.
-        if (partitionPath.nonEmpty && overwrite && hiveVersion < v2_0) {
-          partitionPath.foreach { path =>
-            val fs = path.getFileSystem(hadoopConf)
-            if (fs.exists(path)) {
-              if (!fs.delete(path, true)) {
-                throw new RuntimeException(s"Cannot remove partition directory '$partitionPath'")
-              }
-              // Don't let Hive do overwrite operation since it is slower.
-              doHiveOverwrite = false
-            }
+        val fs = partitionPath.getFileSystem(hadoopConf)
+        if (fs.exists(partitionPath)) {
+          if (!fs.delete(partitionPath, true)) {
+            throw KyuubiHiveConnectorException(s"Cannot remove partition directory " +
+              s"'$partitionPath'")
           }
         }
-
-        // inheritTableSpecs is set to true. It should be set to false for an IMPORT query
-        // which is currently considered as a Hive native command.
-        val inheritTableSpecs = true
-        val loadPath = ExternalCatalogUtils.generatePartitionPath(
-          staticPartitionSpec,
-          partitionColumnNames.take(partitionColumnNames.length - numDynamicPartitions),
-          tmpLocation.get)
-
-        externalCatalog.loadPartition(
-          table.database,
-          table.identifier.table,
-          loadPath.toString,
-          partitionSpec,
-          isOverwrite = doHiveOverwrite,
-          inheritTableSpecs = inheritTableSpecs,
-          isSrcLocal = false)
       }
     }
+
+    externalCatalog.loadDynamicPartitions(
+      db = table.database,
+      table = table.identifier.table,
+      tmpLocation.get.toString,
+      partitionSpec,
+      overwrite,
+      numDynamicPartitions)
   }
 }

--- a/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/write/HiveWriteHelper.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/write/HiveWriteHelper.scala
@@ -27,11 +27,8 @@ import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.hadoop.hive.common.FileUtils
 import org.apache.hadoop.hive.ql.exec.TaskRunner
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.catalyst.catalog.ExternalCatalogUtils
 import org.apache.spark.sql.catalyst.catalog.ExternalCatalogWithListener
 import org.apache.spark.sql.hive.kyuubi.connector.HiveBridgeHelper.{hive, HiveExternalCatalog, HiveVersion}
-
-import org.apache.kyuubi.spark.connector.hive.KyuubiHiveConnectorException
 
 // scalastyle:off line.size.limit
 /**
@@ -197,16 +194,5 @@ object HiveWriteHelper extends Logging {
 
   def cannotCreateStagingDirError(message: String, e: IOException = null): Throwable = {
     new RuntimeException(s"Cannot create staging directory: $message", e)
-  }
-
-  def getPartitionSpec(partition: Map[String, Option[String]]): Map[String, String] = {
-    partition.map {
-      case (key, Some(null)) => key -> ExternalCatalogUtils.DEFAULT_PARTITION_NAME
-      case (key, Some(value)) if value.equals("") =>
-        throw KyuubiHiveConnectorException(s"Partition spec is invalid. " +
-          s"The spec ($key='$value') contains an empty partition column value")
-      case (key, Some(value)) => key -> value
-      case (key, None) => key -> ""
-    }
   }
 }


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes https://github.com/apache/kyuubi/issues/6078, KSHC should handle the commit of the partitioned table as dynamic partition at write path, that's beacuse the process of writing with Apache Spark DataSourceV2 using dynamic partitioning to handle static partitions.

## Describe Your Solution 🔧

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
