### PR TITLE
Log deprecation message on Spark SQL engine with 3.1

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
@@ -381,6 +381,9 @@ object SparkSQLEngine extends Logging {
   }
 
   def main(args: Array[String]): Unit = {
+    if (KyuubiSparkUtil.SPARK_ENGINE_RUNTIME_VERSION === "3.1") {
+      warn("The support for Spark 3.1 is deprecated, and will be removed in the next version.")
+    }
     val startedTime = System.currentTimeMillis()
     val submitTime = kyuubiConf.getOption(KYUUBI_ENGINE_SUBMIT_TIME_KEY) match {
       case Some(t) => t.toLong


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

The Spark 3.1 was EOL[1] on 02/18/2022 with the latest patch release 3.1.3. And we'd like[2] to

- Remove support of Spark 3.1 in all extensions in 1.9.0
- (this PR) Keep the support of Spark 3.1 in the Spark SQL engine in 1.9.0, and remove the support after 1.9.0 (maybe 1.10.0 or 2.0.0)

[1] https://github.com/apache/spark-website/pull/425
[2] https://lists.apache.org/thread/4l5b2w1mp419dd4j1hmws0ns5czq8h3s

## Describe Your Solution 🔧

Print deprecation message on the engine logs when using Spark 3.1


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

Log only, review.

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
