### PR TITLE
Bump Delta from 3.0.0 to 3.1.0 for Spark 3.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2303,7 +2303,7 @@
             </modules>
             <properties>
                 <delta.artifact>delta-spark</delta.artifact>
-                <delta.version>3.0.0</delta.version>
+                <delta.version>3.1.0</delta.version>
                 <!-- Remove this when Hudi supports Spark 3.5 -->
                 <hudi.spark.binary.version>3.4</hudi.spark.binary.version>
                 <!-- Remove this when Paimon supports Spark 3.5 -->


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

[Delta 3.1.0](https://github.com/delta-io/delta/releases/tag/v3.1.0) is available, which is built on top of Spark 3.5.

## Describe Your Solution 🔧

Bump Delta from 3.0.0 to 3.1.0 for Spark 3.5


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

Pass GA.

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
