### PR TITLE
[KYUUBI #6084] JDBC driver supports configuration not to pull engine startup logs

### DIFF
--- a/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/KyuubiBeeLine.java
+++ b/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/KyuubiBeeLine.java
@@ -60,7 +60,9 @@ public class KyuubiBeeLine extends BeeLine {
   private static final int ERRNO_OTHER = 2;
 
   private static final String PYTHON_MODE_PREFIX = "--python-mode";
+  private static final String IGNORE_LAUNCH_ENGINE_PREFIX = "--ignore-launch-engine";
   private boolean pythonMode = false;
+  private boolean ignoreLaunchEngine = false;
 
   public KyuubiBeeLine() {
     this(true);
@@ -90,6 +92,8 @@ public class KyuubiBeeLine extends BeeLine {
     super.usage();
     output("Usage: java " + KyuubiBeeLine.class.getCanonicalName());
     output("   --python-mode                   Execute python code/script.");
+    output("Usage: java " + KyuubiBeeLine.class.getCanonicalName());
+    output("   --ignore-launch-engine          Ignore launch engine log.");
   }
 
   public boolean isPythonMode() {
@@ -99,6 +103,15 @@ public class KyuubiBeeLine extends BeeLine {
   // Visible for testing
   public void setPythonMode(boolean pythonMode) {
     this.pythonMode = pythonMode;
+  }
+
+  public boolean isIgnoreLaunchEngine() {
+    return ignoreLaunchEngine;
+  }
+
+  // Visible for testing
+  public void setIgnoreLaunchEngine(boolean ignoreLaunchEngine) {
+    this.ignoreLaunchEngine = ignoreLaunchEngine;
   }
 
   /** Starts the program. */
@@ -169,6 +182,8 @@ public class KyuubiBeeLine extends BeeLine {
             protected void processOption(String arg, ListIterator iter) throws ParseException {
               if (PYTHON_MODE_PREFIX.equals(arg)) {
                 pythonMode = true;
+              } else if (IGNORE_LAUNCH_ENGINE_PREFIX.equals(arg)) {
+                ignoreLaunchEngine = true;
               } else {
                 super.processOption(arg, iter);
               }

--- a/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/KyuubiBeeLine.java
+++ b/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/KyuubiBeeLine.java
@@ -191,6 +191,10 @@ public class KyuubiBeeLine extends BeeLine {
           };
       cl = beelineParser.parse(options, args);
 
+      if (getOpts().getVerbose()) {
+        ignoreLaunchEngine = false;
+      }
+
       connSuccessful =
           DynMethods.builder("connectUsingArgs")
               .hiddenImpl(BeeLine.class, BeelineParser.class, CommandLine.class)

--- a/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/KyuubiCommands.java
+++ b/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/KyuubiCommands.java
@@ -18,6 +18,7 @@
 package org.apache.hive.beeline;
 
 import static org.apache.kyuubi.jdbc.hive.JdbcConnectionParams.*;
+import static org.apache.kyuubi.jdbc.hive.KyuubiConnection.IGNORE_LAUNCH_ENGINE_PROPERTY;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.io.*;
@@ -449,6 +450,10 @@ public class KyuubiCommands extends Commands {
             new String[] {
               AUTH_PASSWD, "javax.jdo.option.ConnectionPassword", "ConnectionPassword",
             });
+
+    if (beeLine.isIgnoreLaunchEngine()) {
+      props.put(IGNORE_LAUNCH_ENGINE_PROPERTY, "true");
+    }
 
     if (url == null || url.length() == 0) {
       return beeLine.error("Property \"url\" is required");

--- a/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/KyuubiBeeLineTest.java
+++ b/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/KyuubiBeeLineTest.java
@@ -19,6 +19,7 @@
 package org.apache.hive.beeline;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -104,7 +105,13 @@ public class KyuubiBeeLineTest {
 
     String[] args3 = {"-u", "badUrl"};
     kyuubiBeeLine.initArgs(args3);
-    assertTrue(!kyuubiBeeLine.isIgnoreLaunchEngine());
+    assertFalse(kyuubiBeeLine.isIgnoreLaunchEngine());
+    kyuubiBeeLine.setIgnoreLaunchEngine(false);
+
+    String[] args4 = {"--ignore-launch-engine", "--verbose", "-f", "test.sql"};
+    kyuubiBeeLine.initArgs(args4);
+    assertFalse(kyuubiBeeLine.isIgnoreLaunchEngine());
+    assert kyuubiBeeLine.getOpts().getScriptFile().equals("test.sql");
     kyuubiBeeLine.setIgnoreLaunchEngine(false);
   }
 

--- a/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/KyuubiBeeLineTest.java
+++ b/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/KyuubiBeeLineTest.java
@@ -89,6 +89,26 @@ public class KyuubiBeeLineTest {
   }
 
   @Test
+  public void testKyuubiBeelineIgnoreLaunchEngine() {
+    KyuubiBeeLine kyuubiBeeLine = new KyuubiBeeLine();
+    String[] args1 = {"-u", "badUrl", "--ignore-launch-engine"};
+    kyuubiBeeLine.initArgs(args1);
+    assertTrue(kyuubiBeeLine.isIgnoreLaunchEngine());
+    kyuubiBeeLine.setIgnoreLaunchEngine(false);
+
+    String[] args2 = {"--ignore-launch-engine", "-f", "test.sql"};
+    kyuubiBeeLine.initArgs(args2);
+    assertTrue(kyuubiBeeLine.isIgnoreLaunchEngine());
+    assert kyuubiBeeLine.getOpts().getScriptFile().equals("test.sql");
+    kyuubiBeeLine.setIgnoreLaunchEngine(false);
+
+    String[] args3 = {"-u", "badUrl"};
+    kyuubiBeeLine.initArgs(args3);
+    assertTrue(!kyuubiBeeLine.isIgnoreLaunchEngine());
+    kyuubiBeeLine.setIgnoreLaunchEngine(false);
+  }
+
+  @Test
   public void testKyuubiBeelineComment() {
     KyuubiBeeLine kyuubiBeeLine = new KyuubiBeeLine();
     int result = kyuubiBeeLine.initArgsFromCliVars(new String[] {"-e", "--comment show database;"});

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
@@ -78,6 +78,7 @@ import org.slf4j.LoggerFactory;
 public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
   public static final Logger LOG = LoggerFactory.getLogger(KyuubiConnection.class.getName());
   public static final String BEELINE_MODE_PROPERTY = "BEELINE_MODE";
+  public static final String IGNORE_LAUNCH_ENGINE_PROPERTY = "IGNORE_LAUNCH_ENGINE_LOG";
   public static final String HS2_PROXY_USER = "hive.server2.proxy.user";
   public static int DEFAULT_ENGINE_LOG_THREAD_TIMEOUT = 10 * 1000;
 
@@ -112,6 +113,8 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
 
   private boolean isBeeLineMode;
 
+  private boolean ignoreLaunchEngineLog;
+
   /** Get all direct HiveServer2 URLs from a ZooKeeper based HiveServer2 URL */
   public static List<JdbcConnectionParams> getAllUrls(String zookeeperBasedHS2Url)
       throws Exception {
@@ -127,6 +130,7 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
 
   public KyuubiConnection(String uri, Properties info) throws SQLException {
     isBeeLineMode = Boolean.parseBoolean(info.getProperty(BEELINE_MODE_PROPERTY));
+    ignoreLaunchEngineLog = Boolean.parseBoolean(info.getProperty(IGNORE_LAUNCH_ENGINE_PROPERTY));
     try {
       connParams = Utils.parseURL(uri, info);
     } catch (ZooKeeperHiveClientException e) {
@@ -262,7 +266,7 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
           "Method getExecLog() failed. The " + "connection has been closed.");
     }
 
-    if (launchEngineOpHandle == null) {
+    if (launchEngineOpHandle == null || ignoreLaunchEngineLog) {
       return Collections.emptyList();
     }
 

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
@@ -289,7 +289,7 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
   }
 
   private void showLaunchEngineLog() {
-    if (launchEngineOpHandle != null) {
+    if (launchEngineOpHandle != null && !ignoreLaunchEngineLog) {
       LOG.info("Starting to get launch engine log.");
       engineLogThread =
           new Thread("engine-launch-log") {


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #6084

## Describe Your Solution 🔧

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Support `--ignore-launch-engine` option and not pull engine starup logs

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
