### PR TITLE
[KYUUBI #6107] [Spark] Collect and summarize the `executorRunTime` and `executorCpuTime` of the statement

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/KyuubiSparkUtil.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/KyuubiSparkUtil.scala
@@ -113,4 +113,29 @@ object KyuubiSparkUtil extends Logging {
       SparkSQLEngine.kyuubiConf.get(configEntry)
     }
   }
+
+  def formatDurationNano(nanoseconds: Long): String = {
+    formatDuration(nanoseconds / 1000000)
+  }
+
+  def formatDuration(milliseconds: Long): String = {
+    if (milliseconds < 100) {
+      return "%d ms".format(milliseconds)
+    }
+    val seconds = milliseconds.toDouble / 1000
+    if (seconds < 1) {
+      return "%.1f s".format(seconds)
+    }
+    if (seconds < 60) {
+      return "%.0f s".format(seconds)
+    }
+    val minutes = seconds / 60
+    if (minutes < 10) {
+      return "%.1f min".format(minutes)
+    } else if (minutes < 60) {
+      return "%.0f min".format(minutes)
+    }
+    val hours = minutes / 60
+    "%.1f h".format(hours)
+  }
 }

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/KyuubiSparkUtil.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/KyuubiSparkUtil.scala
@@ -113,29 +113,4 @@ object KyuubiSparkUtil extends Logging {
       SparkSQLEngine.kyuubiConf.get(configEntry)
     }
   }
-
-  def formatDurationNano(nanoseconds: Long): String = {
-    formatDuration(nanoseconds / 1000000)
-  }
-
-  def formatDuration(milliseconds: Long): String = {
-    if (milliseconds < 100) {
-      return "%d ms".format(milliseconds)
-    }
-    val seconds = milliseconds.toDouble / 1000
-    if (seconds < 1) {
-      return "%.1f s".format(seconds)
-    }
-    if (seconds < 60) {
-      return "%.0f s".format(seconds)
-    }
-    val minutes = seconds / 60
-    if (minutes < 10) {
-      return "%.1f min".format(minutes)
-    } else if (minutes < 60) {
-      return "%.0f min".format(minutes)
-    }
-    val hours = minutes / 60
-    "%.1f h".format(hours)
-  }
 }

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/events/SessionEvent.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/events/SessionEvent.scala
@@ -47,7 +47,9 @@ case class SessionEvent(
     conf: Map[String, String],
     startTime: Long,
     var endTime: Long = -1L,
-    var totalOperations: Int = 0) extends KyuubiEvent with SparkListenerEvent {
+    var totalOperations: Int = 0,
+    var sessionRunTime: Long = 0,
+    var sessionCpuTime: Long = 0) extends KyuubiEvent with SparkListenerEvent {
 
   override lazy val partitions: Seq[(String, String)] =
     ("day", Utils.getDateFromTimestamp(startTime)) :: Nil

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/events/SparkOperationEvent.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/events/SparkOperationEvent.scala
@@ -59,7 +59,9 @@ case class SparkOperationEvent(
     exception: Option[Throwable],
     sessionId: String,
     sessionUser: String,
-    executionId: Option[Long]) extends KyuubiEvent with SparkListenerEvent {
+    executionId: Option[Long],
+    operationRunTime: Option[Long],
+    operationCpuTime: Option[Long]) extends KyuubiEvent with SparkListenerEvent {
 
   override def partitions: Seq[(String, String)] =
     ("day", Utils.getDateFromTimestamp(createTime)) :: Nil
@@ -79,7 +81,9 @@ case class SparkOperationEvent(
 object SparkOperationEvent {
   def apply(
       operation: SparkOperation,
-      executionId: Option[Long] = None): SparkOperationEvent = {
+      executionId: Option[Long] = None,
+      operationRunTime: Option[Long] = None,
+      operationCpuTime: Option[Long] = None): SparkOperationEvent = {
     val session = operation.getSession
     val status = operation.getStatus
     new SparkOperationEvent(
@@ -94,6 +98,8 @@ object SparkOperationEvent {
       status.exception,
       session.handle.identifier.toString,
       session.user,
-      executionId)
+      executionId,
+      operationRunTime,
+      operationCpuTime)
   }
 }

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkOperation.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkOperation.scala
@@ -128,15 +128,15 @@ abstract class SparkOperation(session: Session)
       EventBus.post(SparkOperationEvent(
         this,
         operationListener.flatMap(_.getExecutionId),
-        operationListener.map(_.operationRunTime.get()),
-        operationListener.map(_.operationCpuTime.get())))
+        operationListener.map(_.getOperationRunTime),
+        operationListener.map(_.getOperationCpuTime)))
       if (OperationState.isTerminal(newState)) {
         operationListener.foreach(l => {
           info(s"statementId=${statementId}, " +
-            s"operationRunTime=${formatDurationVerbose(l.operationRunTime.get())}, " +
-            s"operationCpuTime=${formatDurationVerbose(l.operationCpuTime.get() / 1000000)}")
-          session.asInstanceOf[SparkSessionImpl].increaseRunTime(l.operationRunTime.get())
-          session.asInstanceOf[SparkSessionImpl].increaseCpuTime(l.operationCpuTime.get())
+            s"operationRunTime=${formatDurationVerbose(l.getOperationRunTime)}, " +
+            s"operationCpuTime=${formatDurationVerbose(l.getOperationCpuTime / 1000000)}")
+          session.asInstanceOf[SparkSessionImpl].increaseRunTime(l.getOperationRunTime)
+          session.asInstanceOf[SparkSessionImpl].increaseCpuTime(l.getOperationCpuTime)
         })
       }
     }

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkOperation.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkOperation.scala
@@ -25,7 +25,7 @@ import org.apache.spark.kyuubi.SparkUtilsHelper.redact
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 import org.apache.spark.sql.execution.SQLExecution
 import org.apache.spark.sql.types.{BinaryType, StructField, StructType}
-import org.apache.spark.ui.SparkUIUtilsHelper.formatDurationVerbose
+import org.apache.spark.ui.SparkUIUtilsHelper.formatDuration
 
 import org.apache.kyuubi.{KyuubiSQLException, Utils}
 import org.apache.kyuubi.config.KyuubiConf
@@ -133,8 +133,8 @@ abstract class SparkOperation(session: Session)
       if (OperationState.isTerminal(newState)) {
         operationListener.foreach(l => {
           info(s"statementId=${statementId}, " +
-            s"operationRunTime=${formatDurationVerbose(l.getOperationRunTime)}, " +
-            s"operationCpuTime=${formatDurationVerbose(l.getOperationCpuTime / 1000000)}")
+            s"operationRunTime=${formatDuration(l.getOperationRunTime)}, " +
+            s"operationCpuTime=${formatDuration(l.getOperationCpuTime / 1000000)}")
           session.asInstanceOf[SparkSessionImpl].increaseRunTime(l.getOperationRunTime)
           session.asInstanceOf[SparkSessionImpl].increaseCpuTime(l.getOperationCpuTime)
         })

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkOperation.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkOperation.scala
@@ -25,12 +25,12 @@ import org.apache.spark.kyuubi.SparkUtilsHelper.redact
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 import org.apache.spark.sql.execution.SQLExecution
 import org.apache.spark.sql.types.{BinaryType, StructField, StructType}
+import org.apache.spark.ui.SparkUIUtilsHelper.formatDurationVerbose
 
 import org.apache.kyuubi.{KyuubiSQLException, Utils}
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.{ARROW_BASED_ROWSET_TIMESTAMP_AS_STRING, ENGINE_SPARK_OUTPUT_MODE, EngineSparkOutputMode, OPERATION_SPARK_LISTENER_ENABLED, SESSION_PROGRESS_ENABLE, SESSION_USER_SIGN_ENABLED}
 import org.apache.kyuubi.config.KyuubiReservedKeys.{KYUUBI_SESSION_SIGN_PUBLICKEY, KYUUBI_SESSION_USER_KEY, KYUUBI_SESSION_USER_SIGN, KYUUBI_STATEMENT_ID_KEY}
-import org.apache.kyuubi.engine.spark.KyuubiSparkUtil
 import org.apache.kyuubi.engine.spark.KyuubiSparkUtil.{getSessionConf, SPARK_SCHEDULER_POOL_KEY}
 import org.apache.kyuubi.engine.spark.events.SparkOperationEvent
 import org.apache.kyuubi.engine.spark.operation.SparkOperation.TIMEZONE_KEY
@@ -133,8 +133,8 @@ abstract class SparkOperation(session: Session)
       if (OperationState.isTerminal(newState)) {
         operationListener.foreach(l => {
           info(s"statementId=${statementId}, " +
-            s"operationRunTime=${KyuubiSparkUtil.formatDuration(l.operationRunTime.get())}, " +
-            s"operationCpuTime=${KyuubiSparkUtil.formatDurationNano(l.operationCpuTime.get())}")
+            s"operationRunTime=${formatDurationVerbose(l.operationRunTime.get())}, " +
+            s"operationCpuTime=${formatDurationVerbose(l.operationCpuTime.get() / 1000000)}")
           session.asInstanceOf[SparkSessionImpl].increaseRunTime(l.operationRunTime.get())
           session.asInstanceOf[SparkSessionImpl].increaseCpuTime(l.operationCpuTime.get())
         })

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/session/SparkSessionImpl.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/session/SparkSessionImpl.scala
@@ -21,10 +21,10 @@ import java.util.concurrent.atomic.AtomicLong
 
 import org.apache.commons.lang3.StringUtils
 import org.apache.spark.sql.{AnalysisException, SparkSession}
+import org.apache.spark.ui.SparkUIUtilsHelper.formatDurationVerbose
 
 import org.apache.kyuubi.KyuubiSQLException
 import org.apache.kyuubi.config.KyuubiReservedKeys.KYUUBI_SESSION_HANDLE_KEY
-import org.apache.kyuubi.engine.spark.KyuubiSparkUtil
 import org.apache.kyuubi.engine.spark.events.SessionEvent
 import org.apache.kyuubi.engine.spark.operation.SparkSQLOperationManager
 import org.apache.kyuubi.engine.spark.udf.KDFRegistry
@@ -114,8 +114,8 @@ class SparkSessionImpl(
 
   override def close(): Unit = {
     info(s"sessionId=${sessionEvent.sessionId}, " +
-      s"sessionRunTime=${KyuubiSparkUtil.formatDuration(sessionRunTime.get())}, " +
-      s"sessionCpuTime=${KyuubiSparkUtil.formatDurationNano(sessionCpuTime.get())}")
+      s"sessionRunTime=${formatDurationVerbose(sessionRunTime.get())}, " +
+      s"sessionCpuTime=${formatDurationVerbose(sessionCpuTime.get() / 1000000)}")
     sessionEvent.endTime = System.currentTimeMillis()
     sessionEvent.sessionRunTime = sessionRunTime.get()
     sessionEvent.sessionCpuTime = sessionCpuTime.get()

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/session/SparkSessionImpl.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/session/SparkSessionImpl.scala
@@ -46,6 +46,8 @@ class SparkSessionImpl(
 
   override val handle: SessionHandle =
     conf.get(KYUUBI_SESSION_HANDLE_KEY).map(SessionHandle.fromUUID).getOrElse(SessionHandle())
+  private val sessionRunTime = new AtomicLong(0)
+  private val sessionCpuTime = new AtomicLong(0)
 
   private def setModifiableConfig(key: String, value: String): Unit = {
     try {
@@ -126,9 +128,6 @@ class SparkSessionImpl(
     sessionManager.operationManager.asInstanceOf[SparkSQLOperationManager].closePythonProcess(
       handle)
   }
-
-  private val sessionRunTime = new AtomicLong(0)
-  private val sessionCpuTime = new AtomicLong(0)
 
   def increaseRunTime(time: Long): Unit = {
     sessionRunTime.getAndAdd(time)

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/session/SparkSessionImpl.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/session/SparkSessionImpl.scala
@@ -127,8 +127,8 @@ class SparkSessionImpl(
       handle)
   }
 
-  val sessionRunTime = new AtomicLong(0)
-  val sessionCpuTime = new AtomicLong(0)
+  private val sessionRunTime = new AtomicLong(0)
+  private val sessionCpuTime = new AtomicLong(0)
 
   def increaseRunTime(time: Long): Unit = {
     sessionRunTime.getAndAdd(time)

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/session/SparkSessionImpl.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/session/SparkSessionImpl.scala
@@ -17,11 +17,14 @@
 
 package org.apache.kyuubi.engine.spark.session
 
+import java.util.concurrent.atomic.AtomicLong
+
 import org.apache.commons.lang3.StringUtils
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 
 import org.apache.kyuubi.KyuubiSQLException
 import org.apache.kyuubi.config.KyuubiReservedKeys.KYUUBI_SESSION_HANDLE_KEY
+import org.apache.kyuubi.engine.spark.KyuubiSparkUtil
 import org.apache.kyuubi.engine.spark.events.SessionEvent
 import org.apache.kyuubi.engine.spark.operation.SparkSQLOperationManager
 import org.apache.kyuubi.engine.spark.udf.KDFRegistry
@@ -110,12 +113,28 @@ class SparkSessionImpl(
   }
 
   override def close(): Unit = {
+    info(s"sessionId=${sessionEvent.sessionId}, " +
+      s"sessionRunTime=${KyuubiSparkUtil.formatDuration(sessionRunTime.get())}, " +
+      s"sessionCpuTime=${KyuubiSparkUtil.formatDurationNano(sessionCpuTime.get())}")
     sessionEvent.endTime = System.currentTimeMillis()
+    sessionEvent.sessionRunTime = sessionRunTime.get()
+    sessionEvent.sessionCpuTime = sessionCpuTime.get()
     EventBus.post(sessionEvent)
     super.close()
     spark.sessionState.catalog.getTempViewNames().foreach(spark.catalog.uncacheTable)
     sessionManager.operationManager.asInstanceOf[SparkSQLOperationManager].closeILoop(handle)
     sessionManager.operationManager.asInstanceOf[SparkSQLOperationManager].closePythonProcess(
       handle)
+  }
+
+  val sessionRunTime = new AtomicLong(0)
+  val sessionCpuTime = new AtomicLong(0)
+
+  def increaseRunTime(time: Long): Unit = {
+    sessionRunTime.getAndAdd(time)
+  }
+
+  def increaseCpuTime(time: Long): Unit = {
+    sessionCpuTime.getAndAdd(time)
   }
 }

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/session/SparkSessionImpl.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/session/SparkSessionImpl.scala
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicLong
 
 import org.apache.commons.lang3.StringUtils
 import org.apache.spark.sql.{AnalysisException, SparkSession}
-import org.apache.spark.ui.SparkUIUtilsHelper.formatDurationVerbose
+import org.apache.spark.ui.SparkUIUtilsHelper.formatDuration
 
 import org.apache.kyuubi.KyuubiSQLException
 import org.apache.kyuubi.config.KyuubiReservedKeys.KYUUBI_SESSION_HANDLE_KEY
@@ -116,8 +116,8 @@ class SparkSessionImpl(
 
   override def close(): Unit = {
     info(s"sessionId=${sessionEvent.sessionId}, " +
-      s"sessionRunTime=${formatDurationVerbose(sessionRunTime.get())}, " +
-      s"sessionCpuTime=${formatDurationVerbose(sessionCpuTime.get() / 1000000)}")
+      s"sessionRunTime=${formatDuration(sessionRunTime.get())}, " +
+      s"sessionCpuTime=${formatDuration(sessionCpuTime.get() / 1000000)}")
     sessionEvent.endTime = System.currentTimeMillis()
     sessionEvent.sessionRunTime = sessionRunTime.get()
     sessionEvent.sessionCpuTime = sessionCpuTime.get()

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SQLOperationListener.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SQLOperationListener.scala
@@ -63,8 +63,12 @@ class SQLOperationListener(
       None
     }
 
-  val operationRunTime = new AtomicLong(0)
-  val operationCpuTime = new AtomicLong(0)
+  private val operationRunTime = new AtomicLong(0)
+  private val operationCpuTime = new AtomicLong(0)
+
+  def getOperationRunTime: Long = operationRunTime.get()
+
+  def getOperationCpuTime: Long = operationCpuTime.get()
 
   def getExecutionId: Option[Long] = executionId
 

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SQLOperationListener.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SQLOperationListener.scala
@@ -26,7 +26,7 @@ import scala.collection.JavaConverters._
 import org.apache.spark.scheduler._
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd
-import org.apache.spark.ui.UIUtils.formatDurationVerbose
+import org.apache.spark.ui.UIUtils.formatDuration
 
 import org.apache.kyuubi.Logging
 import org.apache.kyuubi.config.KyuubiConf.{ENGINE_SPARK_SHOW_PROGRESS, ENGINE_SPARK_SHOW_PROGRESS_TIME_FORMAT, ENGINE_SPARK_SHOW_PROGRESS_UPDATE_INTERVAL}
@@ -152,8 +152,8 @@ class SQLOperationListener(
     val taskMetrics = stageInfo.taskMetrics
     if (taskMetrics != null) {
       info(s"stageId=${stageCompleted.stageInfo.stageId}, " +
-        s"stageRunTime=${formatDurationVerbose(taskMetrics.executorRunTime)}, " +
-        s"stageCpuTime=${formatDurationVerbose(taskMetrics.executorCpuTime / 1000000)}")
+        s"stageRunTime=${formatDuration(taskMetrics.executorRunTime)}, " +
+        s"stageCpuTime=${formatDuration(taskMetrics.executorCpuTime / 1000000)}")
       operationRunTime.getAndAdd(taskMetrics.executorRunTime)
       operationCpuTime.getAndAdd(taskMetrics.executorCpuTime)
     }

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SQLOperationListener.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SQLOperationListener.scala
@@ -26,11 +26,11 @@ import scala.collection.JavaConverters._
 import org.apache.spark.scheduler._
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd
+import org.apache.spark.ui.UIUtils.formatDurationVerbose
 
 import org.apache.kyuubi.Logging
 import org.apache.kyuubi.config.KyuubiConf.{ENGINE_SPARK_SHOW_PROGRESS, ENGINE_SPARK_SHOW_PROGRESS_TIME_FORMAT, ENGINE_SPARK_SHOW_PROGRESS_UPDATE_INTERVAL}
 import org.apache.kyuubi.config.KyuubiReservedKeys.KYUUBI_STATEMENT_ID_KEY
-import org.apache.kyuubi.engine.spark.KyuubiSparkUtil
 import org.apache.kyuubi.engine.spark.KyuubiSparkUtil.{getSessionConf, SPARK_SQL_EXECUTION_ID_KEY}
 import org.apache.kyuubi.engine.spark.operation.ExecuteStatement
 import org.apache.kyuubi.operation.Operation
@@ -148,8 +148,8 @@ class SQLOperationListener(
     val taskMetrics = stageInfo.taskMetrics
     if (taskMetrics != null) {
       info(s"stageId=${stageCompleted.stageInfo.stageId}, " +
-        s"stageRunTime=${KyuubiSparkUtil.formatDuration(taskMetrics.executorRunTime)}, " +
-        s"stageCpuTime=${KyuubiSparkUtil.formatDurationNano(taskMetrics.executorCpuTime)}")
+        s"stageRunTime=${formatDurationVerbose(taskMetrics.executorRunTime)}, " +
+        s"stageCpuTime=${formatDurationVerbose(taskMetrics.executorCpuTime / 1000000)}")
       operationRunTime.getAndAdd(taskMetrics.executorRunTime)
       operationCpuTime.getAndAdd(taskMetrics.executorCpuTime)
     }

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SQLOperationListener.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SQLOperationListener.scala
@@ -149,14 +149,6 @@ class SQLOperationListener(
     val stageInfo = stageCompleted.stageInfo
     val stageId = stageInfo.stageId
     val stageAttempt = SparkStageAttempt(stageInfo.stageId, stageInfo.attemptNumber())
-    val taskMetrics = stageInfo.taskMetrics
-    if (taskMetrics != null) {
-      info(s"stageId=${stageCompleted.stageInfo.stageId}, " +
-        s"stageRunTime=${formatDuration(taskMetrics.executorRunTime)}, " +
-        s"stageCpuTime=${formatDuration(taskMetrics.executorCpuTime / 1000000)}")
-      operationRunTime.getAndAdd(taskMetrics.executorRunTime)
-      operationCpuTime.getAndAdd(taskMetrics.executorCpuTime)
-    }
     activeStages.synchronized {
       if (activeStages.remove(stageAttempt) != null) {
         stageInfo.getStatusString match {
@@ -166,6 +158,14 @@ class SQLOperationListener(
                 jobInfo.numCompleteStages.getAndIncrement()
               }
             }
+        }
+        val taskMetrics = stageInfo.taskMetrics
+        if (taskMetrics != null) {
+          info(s"stageId=${stageCompleted.stageInfo.stageId}, " +
+            s"stageRunTime=${formatDuration(taskMetrics.executorRunTime)}, " +
+            s"stageCpuTime=${formatDuration(taskMetrics.executorCpuTime / 1000000)}")
+          operationRunTime.getAndAdd(taskMetrics.executorRunTime)
+          operationCpuTime.getAndAdd(taskMetrics.executorCpuTime)
         }
         withOperationLog(super.onStageCompleted(stageCompleted))
       }

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/SparkUIUtilsHelper.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/SparkUIUtilsHelper.scala
@@ -23,8 +23,7 @@ package org.apache.spark.ui
  */
 object SparkUIUtilsHelper {
 
-  /** Generate a verbose human-readable string representing a duration such as "5 second 35 ms" */
-  def formatDurationVerbose(ms: Long): String = {
-    UIUtils.formatDurationVerbose(ms)
+  def formatDuration(ms: Long): String = {
+    UIUtils.formatDuration(ms)
   }
 }

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/SparkUIUtilsHelper.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/SparkUIUtilsHelper.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ui
+
+/**
+ * A place to invoke non-public APIs of [[UIUtils]], anything to be added here need to
+ * think twice
+ */
+object SparkUIUtilsHelper {
+
+  /** Generate a verbose human-readable string representing a duration such as "5 second 35 ms" */
+  def formatDurationVerbose(ms: Long): String = {
+    UIUtils.formatDurationVerbose(ms)
+  }
+}


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #6107

## Describe Your Solution 🔧

The total execution time of a statement (or a session) is the summary of the execution time of the stages belonging to the statement (or session).
The total execution time of a stage is collected from `SQLOperationListener#onStageCompleted`.
The total execution times of the statement or a session are stored in the engine events or output to the log.

<img width="962" alt="截屏2024-02-29 14 47 50" src="https://github.com/apache/kyuubi/assets/23011702/176df1db-bb20-428b-94b8-fa02c946fde2">
<img width="1143" alt="截屏2024-02-29 14 47 21" src="https://github.com/apache/kyuubi/assets/23011702/8cfc6a72-f6e8-45b6-bdda-30296c94c893">


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
