### PR TITLE
[KYUUBI #6108] Display the CPU time consumed by the statement in the Spark Engine tab

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkOperation.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkOperation.scala
@@ -135,8 +135,9 @@ abstract class SparkOperation(session: Session)
           info(s"statementId=${statementId}, " +
             s"operationRunTime=${formatDuration(l.getOperationRunTime)}, " +
             s"operationCpuTime=${formatDuration(l.getOperationCpuTime / 1000000)}")
-          session.asInstanceOf[SparkSessionImpl].increaseRunTime(l.getOperationRunTime)
-          session.asInstanceOf[SparkSessionImpl].increaseCpuTime(l.getOperationCpuTime)
+          session.asInstanceOf[SparkSessionImpl].increaseRunAndCpuTime(
+            l.getOperationRunTime,
+            l.getOperationCpuTime)
         })
       }
     }

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/session/SparkSessionImpl.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/session/SparkSessionImpl.scala
@@ -129,11 +129,8 @@ class SparkSessionImpl(
       handle)
   }
 
-  def increaseRunTime(time: Long): Unit = {
-    sessionRunTime.getAndAdd(time)
-  }
-
-  def increaseCpuTime(time: Long): Unit = {
-    sessionCpuTime.getAndAdd(time)
+  def increaseRunAndCpuTime(runTime: Long, cpuTime: Long): Unit = {
+    sessionEvent.sessionRunTime = sessionRunTime.addAndGet(runTime)
+    sessionEvent.sessionCpuTime = sessionCpuTime.addAndGet(cpuTime)
   }
 }

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EnginePage.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EnginePage.scala
@@ -402,6 +402,7 @@ case class EnginePage(parent: EngineTab) extends WebUIPage("") {
           ("Start Time", true, None),
           ("Finish Time", true, None),
           ("Duration", true, None),
+          ("Cpu Time", true, None),
           ("Total Statements", true, None))
 
       headerStatRow(
@@ -428,6 +429,7 @@ case class EnginePage(parent: EngineTab) extends WebUIPage("") {
         <td> {formatDate(session.startTime)} </td>
         <td> {if (session.endTime > 0) formatDate(session.endTime)} </td>
         <td> {formatDuration(session.duration)} </td>
+        <td> {formatDuration(session.sessionCpuTime / 1000000)} </td>
         <td> {session.totalOperations} </td>
       </tr>
     }
@@ -484,6 +486,7 @@ private class StatementStatsPagedTable(
         ("Create Time", true, None),
         ("Finish Time", true, None),
         ("Duration", true, None),
+        ("Cpu Time", true, None),
         ("Statement", true, None),
         ("State", true, None),
         ("Query Details", true, None),
@@ -523,6 +526,7 @@ private class StatementStatsPagedTable(
       <td >
         {formatDuration(event.duration)}
       </td>
+      <td> {formatDuration(event.operationCpuTime.getOrElse(0L) / 1000000)} </td>
       <td>
         <span class="description-input">
           {event.statement}
@@ -592,6 +596,7 @@ private class SessionStatsTableDataSource(
       case "Start Time" => Ordering.by(_.startTime)
       case "Finish Time" => Ordering.by(_.endTime)
       case "Duration" => Ordering.by(_.duration)
+      case "Cpu Time" => Ordering.by(_.sessionCpuTime)
       case "Total Statements" => Ordering.by(_.totalOperations)
       case unknownColumn => throw new IllegalArgumentException(s"Unknown column: $unknownColumn")
     }
@@ -627,6 +632,7 @@ private class StatementStatsTableDataSource(
       case "Create Time" => Ordering.by(_.createTime)
       case "Finish Time" => Ordering.by(_.completeTime)
       case "Duration" => Ordering.by(_.duration)
+      case "Cpu Time" => Ordering.by(_.operationCpuTime.getOrElse(0L))
       case "Statement" => Ordering.by(_.statement)
       case "State" => Ordering.by(_.state)
       case "Query Details" => Ordering.by(_.executionId)

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EnginePage.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EnginePage.scala
@@ -402,7 +402,7 @@ case class EnginePage(parent: EngineTab) extends WebUIPage("") {
           ("Start Time", true, None),
           ("Finish Time", true, None),
           ("Duration", true, None),
-          ("Cpu Time", true, None),
+          ("CPU Time", true, None),
           ("Total Statements", true, None))
 
       headerStatRow(
@@ -486,7 +486,7 @@ private class StatementStatsPagedTable(
         ("Create Time", true, None),
         ("Finish Time", true, None),
         ("Duration", true, None),
-        ("Cpu Time", true, None),
+        ("CPU Time", true, None),
         ("Statement", true, None),
         ("State", true, None),
         ("Query Details", true, None),
@@ -596,7 +596,7 @@ private class SessionStatsTableDataSource(
       case "Start Time" => Ordering.by(_.startTime)
       case "Finish Time" => Ordering.by(_.endTime)
       case "Duration" => Ordering.by(_.duration)
-      case "Cpu Time" => Ordering.by(_.sessionCpuTime)
+      case "CPU Time" => Ordering.by(_.sessionCpuTime)
       case "Total Statements" => Ordering.by(_.totalOperations)
       case unknownColumn => throw new IllegalArgumentException(s"Unknown column: $unknownColumn")
     }
@@ -632,7 +632,7 @@ private class StatementStatsTableDataSource(
       case "Create Time" => Ordering.by(_.createTime)
       case "Finish Time" => Ordering.by(_.completeTime)
       case "Duration" => Ordering.by(_.duration)
-      case "Cpu Time" => Ordering.by(_.operationCpuTime.getOrElse(0L))
+      case "CPU Time" => Ordering.by(_.operationCpuTime.getOrElse(0L))
       case "Statement" => Ordering.by(_.statement)
       case "State" => Ordering.by(_.state)
       case "Query Details" => Ordering.by(_.executionId)

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EnginePage.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EnginePage.scala
@@ -402,6 +402,7 @@ case class EnginePage(parent: EngineTab) extends WebUIPage("") {
           ("Start Time", true, None),
           ("Finish Time", true, None),
           ("Duration", true, None),
+          ("Run Time", true, None),
           ("CPU Time", true, None),
           ("Total Statements", true, None))
 
@@ -429,6 +430,7 @@ case class EnginePage(parent: EngineTab) extends WebUIPage("") {
         <td> {formatDate(session.startTime)} </td>
         <td> {if (session.endTime > 0) formatDate(session.endTime)} </td>
         <td> {formatDuration(session.duration)} </td>
+        <td> {formatDuration(session.sessionRunTime)} </td>
         <td> {formatDuration(session.sessionCpuTime / 1000000)} </td>
         <td> {session.totalOperations} </td>
       </tr>
@@ -486,6 +488,7 @@ private class StatementStatsPagedTable(
         ("Create Time", true, None),
         ("Finish Time", true, None),
         ("Duration", true, None),
+        ("Run Time", true, None),
         ("CPU Time", true, None),
         ("Statement", true, None),
         ("State", true, None),
@@ -526,6 +529,7 @@ private class StatementStatsPagedTable(
       <td >
         {formatDuration(event.duration)}
       </td>
+      <td> {formatDuration(event.operationRunTime.getOrElse(0L))} </td>
       <td> {formatDuration(event.operationCpuTime.getOrElse(0L) / 1000000)} </td>
       <td>
         <span class="description-input">
@@ -596,6 +600,7 @@ private class SessionStatsTableDataSource(
       case "Start Time" => Ordering.by(_.startTime)
       case "Finish Time" => Ordering.by(_.endTime)
       case "Duration" => Ordering.by(_.duration)
+      case "Run Time" => Ordering.by(_.sessionRunTime)
       case "CPU Time" => Ordering.by(_.sessionCpuTime)
       case "Total Statements" => Ordering.by(_.totalOperations)
       case unknownColumn => throw new IllegalArgumentException(s"Unknown column: $unknownColumn")
@@ -632,6 +637,7 @@ private class StatementStatsTableDataSource(
       case "Create Time" => Ordering.by(_.createTime)
       case "Finish Time" => Ordering.by(_.completeTime)
       case "Duration" => Ordering.by(_.duration)
+      case "Run Time" => Ordering.by(_.operationRunTime.getOrElse(0L))
       case "CPU Time" => Ordering.by(_.operationCpuTime.getOrElse(0L))
       case "Statement" => Ordering.by(_.statement)
       case "State" => Ordering.by(_.state)


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #6108 

## Describe Your Solution 🔧

Follow #6112 

Display the run time and CPU time of statements or sessions in the Spark UI.

<img width="1429" alt="screenshot 2024-03-05 10 37 26" src="https://github.com/apache/kyuubi/assets/23011702/337772e0-a681-4989-b6f9-ee3633bb6287">


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
