### PR TITLE
[KYUUBI #6114] Do not throw exception in KyuubiStatement#getMoreResults(int) in case of closing current result set

### DIFF
--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiStatement.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiStatement.java
@@ -544,6 +544,18 @@ public class KyuubiStatement implements SQLStatement, KyuubiLoggable {
   }
 
   @Override
+  public boolean getMoreResults(int current) throws SQLException {
+    // getMoreResults() javadoc says, that it should implicitly close
+    // any current ResultSet object, so here in case of Statement.CLOSE_CURRENT_RESULT
+    // we can implement the same logic
+    // see also https://issues.apache.org/jira/browse/HIVE-7680
+    if (current == Statement.CLOSE_CURRENT_RESULT) {
+      return false;
+    }
+    throw new SQLFeatureNotSupportedException("Method not supported");
+  }
+
+  @Override
   public boolean getMoreResults() throws SQLException {
     return false;
   }

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/adapter/SQLStatement.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/adapter/SQLStatement.java
@@ -65,11 +65,6 @@ public interface SQLStatement extends Statement {
   }
 
   @Override
-  default boolean getMoreResults(int current) throws SQLException {
-    throw new SQLFeatureNotSupportedException("Method not supported");
-  }
-
-  @Override
   default ResultSet getGeneratedKeys() throws SQLException {
     throw new SQLFeatureNotSupportedException("Method not supported");
   }


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #6114

## Describe Your Solution 🔧

After fixing [HIVE-7680](https://issues.apache.org/jira/browse/HIVE-7680) issue the method getMoreResults() of HiveStatement and respectively KyuubiStatementclasses returns false instead of throwing exception. The javadoc of the Statement#getMoreResults()method says, that it should implicitly close any current ResultSet object, i.e. is similar to calling the KyuubiStatement#getMoreResults(int) method with Statement.CLOSE_CURRENT_RESULT argument. Therefore, in the latter case, we should also return false instead of failing with an exception. This fix also allows Kyuubi JDBC driver to be used in the JDBC engine. 

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
