### PR TITLE
Migrate to shaded HMS client for getting delegation token on server

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -230,14 +230,6 @@ com.google.guava:failureaccess
 com.google.guava:guava
 org.apache.hadoop:hadoop-client-api
 org.apache.hadoop:hadoop-client-runtime
-org.apache.hive:hive-common
-org.apache.hive:hive-metastore
-org.apache.hive:hive-standalone-metastore
-org.apache.hive:hive-llap-client
-org.apache.hive:hive-serde
-org.apache.hive:hive-service-rpc
-org.apache.hive:hive-shims-0.23
-org.apache.hive:hive-shims-common
 com.google.j2objc:j2objc-annotations
 com.fasterxml.jackson.core:jackson-annotations
 com.fasterxml.jackson.core:jackson-core
@@ -270,8 +262,6 @@ org.eclipse.jetty:jetty-servlet
 org.eclipse.jetty:jetty-util-ajax
 org.eclipse.jetty:jetty-util
 org.eclipse.jetty:jetty-proxy
-org.apache.thrift:libfb303
-org.apache.thrift:libthrift
 org.apache.logging.log4j:log4j-1.2-api
 org.apache.logging.log4j:log4j-api
 org.apache.logging.log4j:log4j-core

--- a/NOTICE-binary
+++ b/NOTICE-binary
@@ -189,42 +189,6 @@ JUnit (4.12)
 
 * License: Eclipse Public License
 
-Hive Beeline
-Copyright 2022 The Apache Software Foundation
-
-Hive Common
-Copyright 2022 The Apache Software Foundation
-
-Hive JDBC
-Copyright 2022 The Apache Software Foundation
-
-Hive Llap Client
-Copyright 2022 The Apache Software Foundation
-
-Hive Metastore
-Copyright 2022 The Apache Software Foundation
-
-Hive Serde
-Copyright 2022 The Apache Software Foundation
-
-Hive Service
-Copyright 2022 The Apache Software Foundation
-
-Hive Service RPC
-Copyright 2022 The Apache Software Foundation
-
-Hive Shims 0.23
-Copyright 2022 The Apache Software Foundation
-
-Hive Shims Common
-Copyright 2022 The Apache Software Foundation
-
-Hive Standalone Metastore
-Copyright 2022 The Apache Software Foundation
-
-Hive Storage API
-Copyright 2020 The Apache Software Foundation
-
 Apache HttpClient
 Copyright 1999-2020 The Apache Software Foundation
 
@@ -797,9 +761,6 @@ modified April 2001  by Iris Van den Broeke, Daniel Deville.
 Permission to use, copy, modify and distribute UnixCrypt
 for non-commercial or commercial purposes and without fee is
 granted provided that the copyright notice appears in all copies.
-
-Apache Thrift
-Copyright 2006-2010 The Apache Software Foundation.
 
 Apache Log4j 1.x Compatibility API
 Copyright 1999-2022 The Apache Software Foundation

--- a/NOTICE-binary
+++ b/NOTICE-binary
@@ -189,6 +189,21 @@ JUnit (4.12)
 
 * License: Eclipse Public License
 
+Hive Beeline
+Copyright 2022 The Apache Software Foundation
+
+Hive Common
+Copyright 2022 The Apache Software Foundation
+
+Hive JDBC
+Copyright 2022 The Apache Software Foundation
+
+Hive Service
+Copyright 2022 The Apache Software Foundation
+
+Hive Service RPC
+Copyright 2022 The Apache Software Foundation
+
 Apache HttpClient
 Copyright 1999-2020 The Apache Software Foundation
 

--- a/dev/dependencyList
+++ b/dev/dependencyList
@@ -51,14 +51,6 @@ gson/2.10.1//gson-2.10.1.jar
 guava/32.0.1-jre//guava-32.0.1-jre.jar
 hadoop-client-api/3.3.6//hadoop-client-api-3.3.6.jar
 hadoop-client-runtime/3.3.6//hadoop-client-runtime-3.3.6.jar
-hive-common/3.1.3//hive-common-3.1.3.jar
-hive-metastore/3.1.3//hive-metastore-3.1.3.jar
-hive-serde/3.1.3//hive-serde-3.1.3.jar
-hive-service-rpc/3.1.3//hive-service-rpc-3.1.3.jar
-hive-shims-0.23/3.1.3//hive-shims-0.23-3.1.3.jar
-hive-shims-common/3.1.3//hive-shims-common-3.1.3.jar
-hive-standalone-metastore/3.1.3//hive-standalone-metastore-3.1.3.jar
-hive-storage-api/2.7.0//hive-storage-api-2.7.0.jar
 hk2-api/2.6.1//hk2-api-2.6.1.jar
 hk2-locator/2.6.1//hk2-locator-2.6.1.jar
 hk2-utils/2.6.1//hk2-utils-2.6.1.jar
@@ -133,8 +125,6 @@ kubernetes-model-rbac/6.8.1//kubernetes-model-rbac-6.8.1.jar
 kubernetes-model-resource/6.8.1//kubernetes-model-resource-6.8.1.jar
 kubernetes-model-scheduling/6.8.1//kubernetes-model-scheduling-6.8.1.jar
 kubernetes-model-storageclass/6.8.1//kubernetes-model-storageclass-6.8.1.jar
-libfb303/0.9.3//libfb303-0.9.3.jar
-libthrift/0.9.3//libthrift-0.9.3.jar
 log4j-1.2-api/2.20.0//log4j-1.2-api-2.20.0.jar
 log4j-api/2.20.0//log4j-api-2.20.0.jar
 log4j-core/2.20.0//log4j-core-2.20.0.jar

--- a/kyuubi-server/pom.xml
+++ b/kyuubi-server/pom.xml
@@ -79,6 +79,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.kyuubi</groupId>
+            <artifactId>kyuubi-relocated-hive-metastore-client</artifactId>
+            <version>${kyuubi-relocated.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>
         </dependency>
@@ -107,6 +113,7 @@
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-metastore</artifactId>
             <version>${hive.version}</version>
+            <scope>test</scope>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -119,6 +126,7 @@
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-standalone-metastore</artifactId>
             <version>${hive.version}</version>
+            <scope>test</scope>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -131,6 +139,7 @@
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-serde</artifactId>
             <version>${hive.version}</version>
+            <scope>test</scope>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -143,6 +152,7 @@
             <groupId>org.apache.hive.shims</groupId>
             <artifactId>hive-shims-common</artifactId>
             <version>${hive.version}</version>
+            <scope>test</scope>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -155,6 +165,7 @@
             <groupId>org.apache.hive.shims</groupId>
             <artifactId>hive-shims-0.23</artifactId>
             <version>${hive.version}</version>
+            <scope>test</scope>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -167,6 +178,7 @@
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-common</artifactId>
             <version>${hive.version}</version>
+            <scope>test</scope>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -179,6 +191,7 @@
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-storage-api</artifactId>
             <version>${hive.storage-api.version}</version>
+            <scope>test</scope>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -190,16 +203,19 @@
         <dependency>
             <groupId>org.apache.thrift</groupId>
             <artifactId>libfb303</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.thrift</groupId>
             <artifactId>libthrift</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-service-rpc</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/kyuubi-server/src/main/resources/META-INF/services/org.apache.hadoop.security.token.TokenIdentifier
+++ b/kyuubi-server/src/main/resources/META-INF/services/org.apache.hadoop.security.token.TokenIdentifier
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 
-org.apache.hadoop.hive.metastore.security.DelegationTokenIdentifier
+org.apache.kyuubi.shaded.hive.metastore.security.DelegationTokenIdentifier

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/credentials/HiveDelegationTokenProviderSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/credentials/HiveDelegationTokenProviderSuite.scala
@@ -31,10 +31,11 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars._
 import org.apache.hadoop.hive.metastore.{HiveMetaException, HiveMetaStore}
-import org.apache.hadoop.hive.metastore.security.{DelegationTokenIdentifier, HadoopThriftAuthBridge, HadoopThriftAuthBridge23}
+import org.apache.hadoop.hive.metastore.security.{HadoopThriftAuthBridge, HadoopThriftAuthBridge23}
 import org.apache.hadoop.io.Text
 import org.apache.hadoop.security.{Credentials, UserGroupInformation}
 import org.apache.hadoop.security.authorize.ProxyUsers
+import org.apache.hadoop.security.token.delegation.AbstractDelegationTokenIdentifier
 import org.apache.thrift.TProcessor
 import org.apache.thrift.protocol.TProtocol
 import org.scalatest.Assertions._
@@ -44,6 +45,7 @@ import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
 import org.apache.kyuubi.{KerberizedTestHelper, Logging, Utils}
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.credentials.LocalMetaServer.defaultHiveConf
+import org.apache.kyuubi.shaded.hive.metastore.security.DelegationTokenIdentifier
 
 class HiveDelegationTokenProviderSuite extends KerberizedTestHelper {
 
@@ -118,7 +120,7 @@ class HiveDelegationTokenProviderSuite extends KerberizedTestHelper {
       assert(aliasAndToken._2 != null)
 
       val token = aliasAndToken._2
-      val tokenIdent = token.decodeIdentifier().asInstanceOf[DelegationTokenIdentifier]
+      val tokenIdent = token.decodeIdentifier().asInstanceOf[AbstractDelegationTokenIdentifier]
       assertResult(DelegationTokenIdentifier.HIVE_DELEGATION_KIND)(token.getKind)
       assertResult(new Text(owner))(tokenIdent.getOwner)
       val currentUserName = UserGroupInformation.getCurrentUser.getUserName

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/credentials/HiveDelegationTokenProviderSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/credentials/HiveDelegationTokenProviderSuite.scala
@@ -35,7 +35,6 @@ import org.apache.hadoop.hive.metastore.security.{HadoopThriftAuthBridge, Hadoop
 import org.apache.hadoop.io.Text
 import org.apache.hadoop.security.{Credentials, UserGroupInformation}
 import org.apache.hadoop.security.authorize.ProxyUsers
-import org.apache.hadoop.security.token.delegation.AbstractDelegationTokenIdentifier
 import org.apache.thrift.TProcessor
 import org.apache.thrift.protocol.TProtocol
 import org.scalatest.Assertions._
@@ -120,7 +119,7 @@ class HiveDelegationTokenProviderSuite extends KerberizedTestHelper {
       assert(aliasAndToken._2 != null)
 
       val token = aliasAndToken._2
-      val tokenIdent = token.decodeIdentifier().asInstanceOf[AbstractDelegationTokenIdentifier]
+      val tokenIdent = token.decodeIdentifier().asInstanceOf[DelegationTokenIdentifier]
       assertResult(DelegationTokenIdentifier.HIVE_DELEGATION_KIND)(token.getKind)
       assertResult(new Text(owner))(tokenIdent.getOwner)
       val currentUserName = UserGroupInformation.getCurrentUser.getUserName


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗

## Describe Your Solution 🔧

Kyuubi Shaded 0.3 introduces a light kyuubi-relocated-hive-metastore-client, for refreshing 
delegation token, this PR aims to migrate from the vanilla HMS client to this light shaded HMS client, then we can get rid of Hive dependencies, especially the vulnerable thrift 0.9, from the Kyuubi server.

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

Pass GA.

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
