### PR TITLE
[BUILD] Remove the extension spark jars before build to avoid include unspecified version

### DIFF
--- a/build/dist
+++ b/build/dist
@@ -233,6 +233,14 @@ if [[ "$HIVE_PROVIDED" == "true" ]]; then
   MVN_DIST_OPT="$MVN_DIST_OPT -Phive-provided"
 fi
 
+# Before start build, clean up the extension spark jars,
+# to avoid include unspecified version
+SPARK_EXTENSION_VERSIONS=('3-1' '3-2' '3-3' '3-4' '3-5')
+# shellcheck disable=SC2068
+for SPARK_EXTENSION_VERSION in ${SPARK_EXTENSION_VERSIONS[@]}; do
+  rm -f "$KYUUBI_HOME/extensions/spark/kyuubi-extension-spark-$SPARK_EXTENSION_VERSION/target/kyuubi-extension-spark-${SPARK_EXTENSION_VERSION}_${SCALA_VERSION}-${VERSION}.jar"
+done
+
 export MAVEN_OPTS="${MAVEN_OPTS:--Xmx2g}"
 
 BUILD_COMMAND=("$MVN" clean install $MVN_DIST_OPT $@)
@@ -331,7 +339,6 @@ for jar in $(ls "$DISTDIR/jars/"); do
 done
 
 # Copy Kyuubi Spark extension
-SPARK_EXTENSION_VERSIONS=('3-1' '3-2' '3-3' '3-4' '3-5')
 # shellcheck disable=SC2068
 for SPARK_EXTENSION_VERSION in ${SPARK_EXTENSION_VERSIONS[@]}; do
   if [[ -f $"$KYUUBI_HOME/extensions/spark/kyuubi-extension-spark-$SPARK_EXTENSION_VERSION/target/kyuubi-extension-spark-${SPARK_EXTENSION_VERSION}_${SCALA_VERSION}-${VERSION}.jar" ]]; then

--- a/build/dist
+++ b/build/dist
@@ -233,8 +233,7 @@ if [[ "$HIVE_PROVIDED" == "true" ]]; then
   MVN_DIST_OPT="$MVN_DIST_OPT -Phive-provided"
 fi
 
-# Before start build, clean up the extension spark jars,
-# to avoid include unspecified version
+# clean up all versions of Spark extension, to avoid collecting outdated artifacts
 SPARK_EXTENSION_VERSIONS=('3-2' '3-3' '3-4' '3-5')
 # shellcheck disable=SC2068
 for SPARK_EXTENSION_VERSION in ${SPARK_EXTENSION_VERSIONS[@]}; do

--- a/build/dist
+++ b/build/dist
@@ -235,7 +235,7 @@ fi
 
 # Before start build, clean up the extension spark jars,
 # to avoid include unspecified version
-SPARK_EXTENSION_VERSIONS=('3-1' '3-2' '3-3' '3-4' '3-5')
+SPARK_EXTENSION_VERSIONS=('3-2' '3-3' '3-4' '3-5')
 # shellcheck disable=SC2068
 for SPARK_EXTENSION_VERSION in ${SPARK_EXTENSION_VERSIONS[@]}; do
   rm -f "$KYUUBI_HOME/extensions/spark/kyuubi-extension-spark-$SPARK_EXTENSION_VERSION/target/kyuubi-extension-spark-${SPARK_EXTENSION_VERSION}_${SCALA_VERSION}-${VERSION}.jar"


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes https://github.com/apache/kyuubi/pull/5836#discussion_r1424963477

## Describe Your Solution 🔧

Remove the remain extension spark jars in related target dir before start to package.

Aims to avoid include unspecified version.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:

Before this PR:
```shel
./build/dist -Pspark-3.1 ...
# your will get expected package, then you run the following command
./build/dist -Pspark-3.3
# you will find the final package include the spark 3.1 extension jar, which is un-expected.
```

#### Behavior With This Pull Request :tada:

After this PR, will clean up those extension spark jars before build to ensure we won't package the unspecified extension jar.

#### Related Unit Tests

None
---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
