### PR TITLE
[KYUUBI #6130] Stop engine immediately after close session for `CONNECTION` level FlinkSQLEngine

### DIFF
--- a/externals/kyuubi-flink-sql-engine/src/test/scala/org/apache/kyuubi/engine/flink/operation/FlinkEngineInitializeSuite.scala
+++ b/externals/kyuubi-flink-sql-engine/src/test/scala/org/apache/kyuubi/engine/flink/operation/FlinkEngineInitializeSuite.scala
@@ -19,14 +19,18 @@ package org.apache.kyuubi.engine.flink.operation
 
 import java.util.UUID
 
+import org.scalatest.concurrent.PatienceConfiguration.Timeout
+import org.scalatest.time.SpanSugar._
+
 import org.apache.kyuubi.config.KyuubiConf._
 import org.apache.kyuubi.config.KyuubiReservedKeys.KYUUBI_SESSION_USER_KEY
 import org.apache.kyuubi.engine.ShareLevel
+import org.apache.kyuubi.engine.ShareLevel.ShareLevel
 import org.apache.kyuubi.engine.flink.{WithDiscoveryFlinkSQLEngine, WithFlinkSQLEngineLocal}
 import org.apache.kyuubi.ha.HighAvailabilityConf.{HA_ENGINE_REF_ID, HA_NAMESPACE}
 import org.apache.kyuubi.operation.{HiveJDBCTestHelper, NoneMode}
 
-class FlinkEngineInitializeSuite extends HiveJDBCTestHelper
+trait FlinkEngineInitializeSuite extends HiveJDBCTestHelper
   with WithDiscoveryFlinkSQLEngine with WithFlinkSQLEngineLocal {
 
   protected def jdbcUrl: String = getFlinkEngineServiceUrl
@@ -51,7 +55,7 @@ class FlinkEngineInitializeSuite extends HiveJDBCTestHelper
       HA_NAMESPACE.key -> namespace,
       HA_ENGINE_REF_ID.key -> engineRefId,
       ENGINE_TYPE.key -> "FLINK_SQL",
-      ENGINE_SHARE_LEVEL.key -> shareLevel,
+      ENGINE_SHARE_LEVEL.key -> shareLevel.toString,
       OPERATION_PLAN_ONLY_MODE.key -> NoneMode.name,
       ENGINE_FLINK_INITIALIZE_SQL.key -> ENGINE_INITIALIZE_SQL_VALUE,
       ENGINE_SESSION_FLINK_INITIALIZE_SQL.key -> ENGINE_SESSION_INITIALIZE_SQL_VALUE,
@@ -62,7 +66,7 @@ class FlinkEngineInitializeSuite extends HiveJDBCTestHelper
 
   def namespace: String = "/kyuubi/flink-local-engine-test"
 
-  def shareLevel: String = ShareLevel.USER.toString
+  def shareLevel: ShareLevel
 
   def engineType: String = "flink"
 
@@ -100,5 +104,33 @@ class FlinkEngineInitializeSuite extends HiveJDBCTestHelper
       assert(dropResult.next())
       assert(dropResult.getString(1) === "OK")
     }
+    // check engine alive status after close session with connection level engine
+    if (shareLevel == ShareLevel.CONNECTION) {
+      eventually(Timeout(10.seconds)) {
+        assert(!engineProcess.isAlive)
+      }
+      val e = intercept[Exception] {
+        withJdbcStatement() { statement =>
+          statement.executeQuery("select 1")
+        }
+      }
+      e.printStackTrace()
+    }
+    // check engine alive status after close session with user level engine
+    if (shareLevel == ShareLevel.USER) {
+      assert(engineProcess.isAlive)
+      withJdbcStatement() { statement =>
+        val resultSet = statement.executeQuery("select 1")
+        assert(resultSet.next())
+      }
+    }
   }
+}
+
+class FlinkConnectionLevelEngineInitializeSuite extends FlinkEngineInitializeSuite {
+  def shareLevel: ShareLevel = ShareLevel.CONNECTION
+}
+
+class FlinkUserLevelEngineInitializeSuite extends FlinkEngineInitializeSuite {
+  def shareLevel: ShareLevel = ShareLevel.USER
 }

--- a/externals/kyuubi-flink-sql-engine/src/test/scala/org/apache/kyuubi/engine/flink/operation/FlinkEngineInitializeSuite.scala
+++ b/externals/kyuubi-flink-sql-engine/src/test/scala/org/apache/kyuubi/engine/flink/operation/FlinkEngineInitializeSuite.scala
@@ -109,12 +109,10 @@ trait FlinkEngineInitializeSuite extends HiveJDBCTestHelper
       eventually(Timeout(10.seconds)) {
         assert(!engineProcess.isAlive)
       }
-      val e = intercept[Exception] {
-        withJdbcStatement() { statement =>
-          statement.executeQuery("select 1")
-        }
+      withJdbcStatement() { statement =>
+        val resultSet = statement.executeQuery("select 1")
+        assert(resultSet.next())
       }
-      e.printStackTrace()
     }
     // check engine alive status after close session with user level engine
     if (shareLevel == ShareLevel.USER) {

--- a/externals/kyuubi-flink-sql-engine/src/test/scala/org/apache/kyuubi/engine/flink/operation/FlinkEngineInitializeSuite.scala
+++ b/externals/kyuubi-flink-sql-engine/src/test/scala/org/apache/kyuubi/engine/flink/operation/FlinkEngineInitializeSuite.scala
@@ -109,10 +109,12 @@ trait FlinkEngineInitializeSuite extends HiveJDBCTestHelper
       eventually(Timeout(10.seconds)) {
         assert(!engineProcess.isAlive)
       }
-      withJdbcStatement() { statement =>
-        val resultSet = statement.executeQuery("select 1")
-        assert(resultSet.next())
+      val e = intercept[Exception] {
+        withJdbcStatement() { statement =>
+          statement.executeQuery("select 1")
+        }
       }
+      assert(e.getMessage() == "Time out retrieving Flink engine service url.")
     }
     // check engine alive status after close session with user level engine
     if (shareLevel == ShareLevel.USER) {


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #6130

## Describe Your Solution 🔧

Stop engine immediately after close session for `CONNECTION` level FlinkSQLEngine


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
