### PR TITLE
[KYUUBI #5509][FOLLOWUP] JDBC IT should always depends on kyuubi-hive-jdbc-shaded

### DIFF
--- a/integration-tests/kyuubi-jdbc-it/pom.xml
+++ b/integration-tests/kyuubi-jdbc-it/pom.xml
@@ -68,7 +68,7 @@
 
         <dependency>
             <groupId>org.apache.kyuubi</groupId>
-            <artifactId>${hive.jdbc.artifact}</artifactId>
+            <artifactId>kyuubi-hive-jdbc-shaded</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

`build/dist` is going to fail without profile `-Pjdbc-shaded` after bumping a new version.

## Describe Your Solution 🔧

Making the JDBC IT module always depends on `kyuubi-hive-jdbc-shaded`, to ensure the shaded JDBC is packaged before the JDBC IT module performs copy jars.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

Bump a new version, then perform making the distribution.
```
build/mvn versions:set -DgenerateBackupPoms=false -DnewVersion="1.9.1-SNAPSHOT"
build/dist --spark-provided --hive-provided --flink-provided
```
Before, failed with
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-dependency-plugin:3.6.1:copy (copy) on project kyuubi-jdbc-it_2.12: Unable to find/resolve artifact.: Could not find artifact org.apache.kyuubi:kyuubi-hive-jdbc-shaded:jar:1.9.1-SNAPSHOT in aliyun-apache-snapshots (https://maven.aliyun.com/repository/apache-snapshots/) -> [Help 1]
```

After, everything goes well.

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
