### PR TITLE
Move getCodeSourceLocation to kyuubi-util

### DIFF
--- a/externals/kyuubi-flink-sql-engine/src/test/scala/org/apache/kyuubi/engine/flink/WithFlinkSQLEngineLocal.scala
+++ b/externals/kyuubi-flink-sql-engine/src/test/scala/org/apache/kyuubi/engine/flink/WithFlinkSQLEngineLocal.scala
@@ -28,7 +28,7 @@ import scala.collection.mutable
 import org.apache.flink.configuration.{Configuration, RestOptions}
 import org.apache.flink.runtime.minicluster.{MiniCluster, MiniClusterConfiguration}
 
-import org.apache.kyuubi.{KYUUBI_VERSION, KyuubiException, KyuubiFunSuite, SCALA_COMPILE_VERSION, Utils}
+import org.apache.kyuubi.{KYUUBI_VERSION, KyuubiException, KyuubiFunSuite, SCALA_COMPILE_VERSION}
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf._
 import org.apache.kyuubi.ha.HighAvailabilityConf.HA_ADDRESSES

--- a/externals/kyuubi-flink-sql-engine/src/test/scala/org/apache/kyuubi/engine/flink/WithFlinkSQLEngineLocal.scala
+++ b/externals/kyuubi-flink-sql-engine/src/test/scala/org/apache/kyuubi/engine/flink/WithFlinkSQLEngineLocal.scala
@@ -32,6 +32,7 @@ import org.apache.kyuubi.{KYUUBI_VERSION, KyuubiException, KyuubiFunSuite, SCALA
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf._
 import org.apache.kyuubi.ha.HighAvailabilityConf.HA_ADDRESSES
+import org.apache.kyuubi.util.JavaUtils
 import org.apache.kyuubi.util.command.CommandLineUtils._
 import org.apache.kyuubi.zookeeper.EmbeddedZookeeper
 import org.apache.kyuubi.zookeeper.ZookeeperConf.{ZK_CLIENT_PORT, ZK_CLIENT_PORT_ADDRESS}
@@ -71,7 +72,7 @@ trait WithFlinkSQLEngineLocal extends KyuubiFunSuite with WithFlinkTestResources
     conf.set(HA_ADDRESSES, zkServer.getConnectString)
 
     val envs = scala.collection.mutable.Map[String, String]()
-    val kyuubiExternals = Utils.getCodeSourceLocation(getClass)
+    val kyuubiExternals = JavaJavaUtils.getCodeSourceLocation(getClass)
       .split("externals").head
     val flinkHome = {
       val candidates = Paths.get(kyuubiExternals, "externals", "kyuubi-download", "target")
@@ -216,7 +217,7 @@ trait WithFlinkSQLEngineLocal extends KyuubiFunSuite with WithFlinkTestResources
         .find(Files.exists(_)).map(_.toAbsolutePath.toFile.getCanonicalPath)
     }.orElse {
       // 3. get the main resource from dev environment
-      val cwd = Utils.getCodeSourceLocation(getClass).split("externals")
+      val cwd = JavaUtils.getCodeSourceLocation(getClass).split("externals")
       assert(cwd.length > 1)
       Option(Paths.get(cwd.head, "externals", module, "target", jarName))
         .map(_.toAbsolutePath.toFile.getCanonicalPath)

--- a/externals/kyuubi-flink-sql-engine/src/test/scala/org/apache/kyuubi/engine/flink/WithFlinkSQLEngineLocal.scala
+++ b/externals/kyuubi-flink-sql-engine/src/test/scala/org/apache/kyuubi/engine/flink/WithFlinkSQLEngineLocal.scala
@@ -72,7 +72,7 @@ trait WithFlinkSQLEngineLocal extends KyuubiFunSuite with WithFlinkTestResources
     conf.set(HA_ADDRESSES, zkServer.getConnectString)
 
     val envs = scala.collection.mutable.Map[String, String]()
-    val kyuubiExternals = JavaJavaUtils.getCodeSourceLocation(getClass)
+    val kyuubiExternals = JavaUtils.getCodeSourceLocation(getClass)
       .split("externals").head
     val flinkHome = {
       val candidates = Paths.get(kyuubiExternals, "externals", "kyuubi-download", "target")

--- a/externals/kyuubi-flink-sql-engine/src/test/scala/org/apache/kyuubi/engine/flink/WithFlinkSQLEngineOnYarn.scala
+++ b/externals/kyuubi-flink-sql-engine/src/test/scala/org/apache/kyuubi/engine/flink/WithFlinkSQLEngineOnYarn.scala
@@ -34,6 +34,7 @@ import org.apache.kyuubi.{KYUUBI_VERSION, KyuubiFunSuite, SCALA_COMPILE_VERSION,
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.{ENGINE_FLINK_APPLICATION_JARS, KYUUBI_HOME}
 import org.apache.kyuubi.ha.HighAvailabilityConf.HA_ADDRESSES
+import org.apache.kyuubi.util.JavaUtils
 import org.apache.kyuubi.util.command.CommandLineUtils._
 import org.apache.kyuubi.zookeeper.EmbeddedZookeeper
 import org.apache.kyuubi.zookeeper.ZookeeperConf.{ZK_CLIENT_PORT, ZK_CLIENT_PORT_ADDRESS}

--- a/externals/kyuubi-flink-sql-engine/src/test/scala/org/apache/kyuubi/engine/flink/WithFlinkSQLEngineOnYarn.scala
+++ b/externals/kyuubi-flink-sql-engine/src/test/scala/org/apache/kyuubi/engine/flink/WithFlinkSQLEngineOnYarn.scala
@@ -131,7 +131,7 @@ trait WithFlinkSQLEngineOnYarn extends KyuubiFunSuite with WithFlinkTestResource
     writer.close()
 
     val envs = scala.collection.mutable.Map[String, String]()
-    val kyuubiExternals = Utils.getCodeSourceLocation(getClass)
+    val kyuubiExternals = JavaUtils.getCodeSourceLocation(getClass)
       .split("externals").head
     val flinkHome = {
       val candidates = Paths.get(kyuubiExternals, "externals", "kyuubi-download", "target")
@@ -239,7 +239,7 @@ trait WithFlinkSQLEngineOnYarn extends KyuubiFunSuite with WithFlinkTestResource
         .find(Files.exists(_)).map(_.toAbsolutePath.toFile.getCanonicalPath)
     }.orElse {
       // 3. get the main resource from dev environment
-      val cwd = Utils.getCodeSourceLocation(getClass).split("externals")
+      val cwd = JavaUtils.getCodeSourceLocation(getClass).split("externals")
       assert(cwd.length > 1)
       Option(Paths.get(cwd.head, "externals", module, "target", jarName))
         .map(_.toAbsolutePath.toFile.getCanonicalPath)

--- a/externals/kyuubi-hive-sql-engine/src/test/scala/org/apache/kyuubi/engine/hive/deploy/HiveYarnModeSubmitterSuite.scala
+++ b/externals/kyuubi-hive-sql-engine/src/test/scala/org/apache/kyuubi/engine/hive/deploy/HiveYarnModeSubmitterSuite.scala
@@ -20,7 +20,8 @@ import java.io.File
 
 import scala.collection.mutable.ListBuffer
 
-import org.apache.kyuubi.{KYUUBI_VERSION, KyuubiFunSuite, SCALA_COMPILE_VERSION, Utils}
+import org.apache.kyuubi.{KYUUBI_VERSION, KyuubiFunSuite, SCALA_COMPILE_VERSION}
+import org.apache.kyuubi.util.JavaUtils
 
 class HiveYarnModeSubmitterSuite extends KyuubiFunSuite {
   val hiveEngineHome: String = JavaUtils.getCodeSourceLocation(getClass).split("/target")(0)

--- a/externals/kyuubi-hive-sql-engine/src/test/scala/org/apache/kyuubi/engine/hive/deploy/HiveYarnModeSubmitterSuite.scala
+++ b/externals/kyuubi-hive-sql-engine/src/test/scala/org/apache/kyuubi/engine/hive/deploy/HiveYarnModeSubmitterSuite.scala
@@ -23,7 +23,7 @@ import scala.collection.mutable.ListBuffer
 import org.apache.kyuubi.{KYUUBI_VERSION, KyuubiFunSuite, SCALA_COMPILE_VERSION, Utils}
 
 class HiveYarnModeSubmitterSuite extends KyuubiFunSuite {
-  val hiveEngineHome: String = Utils.getCodeSourceLocation(getClass).split("/target")(0)
+  val hiveEngineHome: String = JavaUtils.getCodeSourceLocation(getClass).split("/target")(0)
 
   test("hadoop class path") {
     val jars = new ListBuffer[File]

--- a/externals/kyuubi-hive-sql-engine/src/test/scala/org/apache/kyuubi/engine/hive/udf/KyuubiDefinedFunctionSuite.scala
+++ b/externals/kyuubi-hive-sql-engine/src/test/scala/org/apache/kyuubi/engine/hive/udf/KyuubiDefinedFunctionSuite.scala
@@ -38,7 +38,7 @@ import org.apache.kyuubi.util.GoldenFileUtils._
  */
 class KyuubiDefinedFunctionSuite extends KyuubiFunSuite {
 
-  private val kyuubiHome: String = Utils.getCodeSourceLocation(getClass)
+  private val kyuubiHome: String = JavaUtils.getCodeSourceLocation(getClass)
     .split("kyuubi-hive-sql-engine")(0)
   private val markdown =
     Paths.get(kyuubiHome, "..", "docs", "extensions", "engines", "hive", "functions.md")

--- a/externals/kyuubi-hive-sql-engine/src/test/scala/org/apache/kyuubi/engine/hive/udf/KyuubiDefinedFunctionSuite.scala
+++ b/externals/kyuubi-hive-sql-engine/src/test/scala/org/apache/kyuubi/engine/hive/udf/KyuubiDefinedFunctionSuite.scala
@@ -19,8 +19,9 @@ package org.apache.kyuubi.engine.hive.udf
 
 import java.nio.file.Paths
 
-import org.apache.kyuubi.{KyuubiFunSuite, MarkdownBuilder, Utils}
+import org.apache.kyuubi.{KyuubiFunSuite, MarkdownBuilder}
 import org.apache.kyuubi.util.GoldenFileUtils._
+import org.apache.kyuubi.util.JavaUtils
 
 /**
  * End-to-end test cases for configuration doc file

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/udf/KyuubiDefinedFunctionSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/udf/KyuubiDefinedFunctionSuite.scala
@@ -19,8 +19,9 @@ package org.apache.kyuubi.engine.spark.udf
 
 import java.nio.file.Paths
 
-import org.apache.kyuubi.{KyuubiFunSuite, MarkdownBuilder, Utils}
+import org.apache.kyuubi.{KyuubiFunSuite, MarkdownBuilder}
 import org.apache.kyuubi.util.GoldenFileUtils._
+import org.apache.kyuubi.util.JavaUtils
 
 /**
  * End-to-end test cases for configuration doc file

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/udf/KyuubiDefinedFunctionSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/udf/KyuubiDefinedFunctionSuite.scala
@@ -38,7 +38,7 @@ import org.apache.kyuubi.util.GoldenFileUtils._
  */
 class KyuubiDefinedFunctionSuite extends KyuubiFunSuite {
 
-  private val kyuubiHome: String = Utils.getCodeSourceLocation(getClass)
+  private val kyuubiHome: String = JavaUtils.getCodeSourceLocation(getClass)
     .split("kyuubi-spark-sql-engine")(0)
   private val markdown =
     Paths.get(kyuubiHome, "..", "docs", "extensions", "engines", "spark", "functions.md")

--- a/integration-tests/kyuubi-flink-it/src/test/scala/org/apache/kyuubi/it/flink/WithKyuubiServerAndFlinkMiniCluster.scala
+++ b/integration-tests/kyuubi-flink-it/src/test/scala/org/apache/kyuubi/it/flink/WithKyuubiServerAndFlinkMiniCluster.scala
@@ -20,7 +20,8 @@ package org.apache.kyuubi.it.flink
 import org.apache.flink.configuration.{Configuration, RestOptions}
 import org.apache.flink.runtime.minicluster.{MiniCluster, MiniClusterConfiguration}
 
-import org.apache.kyuubi.{Utils, WithKyuubiServer}
+import org.apache.kyuubi.WithKyuubiServer
+import org.apache.kyuubi.util.JavaUtils
 
 trait WithKyuubiServerAndFlinkMiniCluster extends WithKyuubiServer {
 

--- a/integration-tests/kyuubi-flink-it/src/test/scala/org/apache/kyuubi/it/flink/WithKyuubiServerAndFlinkMiniCluster.scala
+++ b/integration-tests/kyuubi-flink-it/src/test/scala/org/apache/kyuubi/it/flink/WithKyuubiServerAndFlinkMiniCluster.scala
@@ -24,7 +24,7 @@ import org.apache.kyuubi.{Utils, WithKyuubiServer}
 
 trait WithKyuubiServerAndFlinkMiniCluster extends WithKyuubiServer {
 
-  val kyuubiHome: String = Utils.getCodeSourceLocation(getClass).split("integration-tests").head
+  val kyuubiHome: String = JavaUtils.getCodeSourceLocation(getClass).split("integration-tests").head
 
   protected lazy val flinkConfig = new Configuration()
   protected var miniCluster: MiniCluster = _

--- a/integration-tests/kyuubi-flink-it/src/test/scala/org/apache/kyuubi/it/flink/WithKyuubiServerAndYarnMiniCluster.scala
+++ b/integration-tests/kyuubi-flink-it/src/test/scala/org/apache/kyuubi/it/flink/WithKyuubiServerAndYarnMiniCluster.scala
@@ -29,7 +29,7 @@ import org.apache.kyuubi.server.{MiniDFSService, MiniYarnService}
 
 trait WithKyuubiServerAndYarnMiniCluster extends KyuubiFunSuite with WithKyuubiServer {
 
-  val kyuubiHome: String = Utils.getCodeSourceLocation(getClass).split("integration-tests").head
+  val kyuubiHome: String = JavaUtils.getCodeSourceLocation(getClass).split("integration-tests").head
 
   override protected val conf: KyuubiConf = new KyuubiConf(false)
 

--- a/integration-tests/kyuubi-flink-it/src/test/scala/org/apache/kyuubi/it/flink/WithKyuubiServerAndYarnMiniCluster.scala
+++ b/integration-tests/kyuubi-flink-it/src/test/scala/org/apache/kyuubi/it/flink/WithKyuubiServerAndYarnMiniCluster.scala
@@ -26,6 +26,7 @@ import org.apache.kyuubi.{KyuubiFunSuite, Utils, WithKyuubiServer}
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.KYUUBI_ENGINE_ENV_PREFIX
 import org.apache.kyuubi.server.{MiniDFSService, MiniYarnService}
+import org.apache.kyuubi.util.JavaUtils
 
 trait WithKyuubiServerAndYarnMiniCluster extends KyuubiFunSuite with WithKyuubiServer {
 

--- a/integration-tests/kyuubi-hive-it/src/test/scala/org/apache/kyuubi/it/hive/operation/KyuubiOperationHiveEnginePerConnectionSuite.scala
+++ b/integration-tests/kyuubi-hive-it/src/test/scala/org/apache/kyuubi/it/hive/operation/KyuubiOperationHiveEnginePerConnectionSuite.scala
@@ -23,6 +23,7 @@ import org.apache.kyuubi.{Utils, WithKyuubiServer}
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf._
 import org.apache.kyuubi.operation.HiveJDBCTestHelper
+import org.apache.kyuubi.util.JavaUtils
 
 class KyuubiOperationHiveEnginePerConnectionSuite extends WithKyuubiServer with HiveJDBCTestHelper {
 

--- a/integration-tests/kyuubi-hive-it/src/test/scala/org/apache/kyuubi/it/hive/operation/KyuubiOperationHiveEnginePerConnectionSuite.scala
+++ b/integration-tests/kyuubi-hive-it/src/test/scala/org/apache/kyuubi/it/hive/operation/KyuubiOperationHiveEnginePerConnectionSuite.scala
@@ -26,7 +26,7 @@ import org.apache.kyuubi.operation.HiveJDBCTestHelper
 
 class KyuubiOperationHiveEnginePerConnectionSuite extends WithKyuubiServer with HiveJDBCTestHelper {
 
-  val kyuubiHome: String = Utils.getCodeSourceLocation(getClass).split("integration-tests").head
+  val kyuubiHome: String = JavaUtils.getCodeSourceLocation(getClass).split("integration-tests").head
 
   override protected val conf: KyuubiConf = {
     val metastore = Utils.createTempDir(prefix = getClass.getSimpleName)

--- a/integration-tests/kyuubi-hive-it/src/test/scala/org/apache/kyuubi/it/hive/operation/KyuubiOperationHiveEnginePerUserSuite.scala
+++ b/integration-tests/kyuubi-hive-it/src/test/scala/org/apache/kyuubi/it/hive/operation/KyuubiOperationHiveEnginePerUserSuite.scala
@@ -24,7 +24,7 @@ import org.apache.kyuubi.shaded.hive.service.rpc.thrift.{TGetInfoReq, TGetInfoTy
 
 class KyuubiOperationHiveEnginePerUserSuite extends WithKyuubiServer with HiveEngineTests {
 
-  val kyuubiHome: String = Utils.getCodeSourceLocation(getClass).split("integration-tests").head
+  val kyuubiHome: String = JavaUtils.getCodeSourceLocation(getClass).split("integration-tests").head
 
   override protected val conf: KyuubiConf = {
     val metastore = Utils.createTempDir(prefix = getClass.getSimpleName)

--- a/integration-tests/kyuubi-hive-it/src/test/scala/org/apache/kyuubi/it/hive/operation/KyuubiOperationHiveEnginePerUserSuite.scala
+++ b/integration-tests/kyuubi-hive-it/src/test/scala/org/apache/kyuubi/it/hive/operation/KyuubiOperationHiveEnginePerUserSuite.scala
@@ -21,6 +21,7 @@ import org.apache.kyuubi.{HiveEngineTests, Utils, WithKyuubiServer}
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf._
 import org.apache.kyuubi.shaded.hive.service.rpc.thrift.{TGetInfoReq, TGetInfoType}
+import org.apache.kyuubi.util.JavaUtils
 
 class KyuubiOperationHiveEnginePerUserSuite extends WithKyuubiServer with HiveEngineTests {
 

--- a/integration-tests/kyuubi-jdbc-it/src/test/scala/org/apache/kyuubi/it/jdbc/doris/WithKyuubiServerAndDorisContainer.scala
+++ b/integration-tests/kyuubi-jdbc-it/src/test/scala/org/apache/kyuubi/it/jdbc/doris/WithKyuubiServerAndDorisContainer.scala
@@ -23,11 +23,12 @@ import org.apache.kyuubi.{Utils, WithKyuubiServer}
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.{ENGINE_JDBC_EXTRA_CLASSPATH, KYUUBI_ENGINE_ENV_PREFIX, KYUUBI_HOME}
 import org.apache.kyuubi.engine.jdbc.doris.WithDorisEngine
+import org.apache.kyuubi.util.JavaUtils
 
 trait WithKyuubiServerAndDorisContainer extends WithKyuubiServer with WithDorisEngine {
 
-  private val kyuubiHome: String = Utils
-    .getCodeSourceLocation(getClass).split("integration-tests").head
+  private val kyuubiHome: String =
+    JavaUtils.getCodeSourceLocation(getClass).split("integration-tests").head
 
   private val mysqlJdbcConnectorPath: String = {
     val keyword = "mysql-connector"

--- a/integration-tests/kyuubi-jdbc-it/src/test/scala/org/apache/kyuubi/it/jdbc/doris/WithKyuubiServerAndDorisContainer.scala
+++ b/integration-tests/kyuubi-jdbc-it/src/test/scala/org/apache/kyuubi/it/jdbc/doris/WithKyuubiServerAndDorisContainer.scala
@@ -19,7 +19,7 @@ package org.apache.kyuubi.it.jdbc.doris
 
 import java.nio.file.{Files, Path, Paths}
 
-import org.apache.kyuubi.{Utils, WithKyuubiServer}
+import org.apache.kyuubi.WithKyuubiServer
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.{ENGINE_JDBC_EXTRA_CLASSPATH, KYUUBI_ENGINE_ENV_PREFIX, KYUUBI_HOME}
 import org.apache.kyuubi.engine.jdbc.doris.WithDorisEngine

--- a/integration-tests/kyuubi-jdbc-it/src/test/scala/org/apache/kyuubi/it/jdbc/impala/WithKyuubiServerAndImpalaContainer.scala
+++ b/integration-tests/kyuubi-jdbc-it/src/test/scala/org/apache/kyuubi/it/jdbc/impala/WithKyuubiServerAndImpalaContainer.scala
@@ -19,15 +19,16 @@ package org.apache.kyuubi.it.jdbc.impala
 
 import java.nio.file.{Files, Path, Paths}
 
-import org.apache.kyuubi.{Utils, WithKyuubiServer}
+import org.apache.kyuubi.WithKyuubiServer
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.{ENGINE_JDBC_EXTRA_CLASSPATH, KYUUBI_ENGINE_ENV_PREFIX, KYUUBI_HOME}
 import org.apache.kyuubi.engine.jdbc.impala.WithImpalaEngine
+import org.apache.kyuubi.util.JavaUtils
 
 trait WithKyuubiServerAndImpalaContainer extends WithKyuubiServer with WithImpalaEngine {
 
-  private val kyuubiHome: String = Utils
-    .getCodeSourceLocation(getClass).split("integration-tests").head
+  private val kyuubiHome: String =
+    JavaUtils.getCodeSourceLocation(getClass).split("integration-tests").head
 
   private val hiveJdbcConnectorPath: String = {
     val keyword = "kyuubi-hive-jdbc-shaded"

--- a/integration-tests/kyuubi-jdbc-it/src/test/scala/org/apache/kyuubi/it/jdbc/mysql/WithKyuubiServerAndMySQLContainer.scala
+++ b/integration-tests/kyuubi-jdbc-it/src/test/scala/org/apache/kyuubi/it/jdbc/mysql/WithKyuubiServerAndMySQLContainer.scala
@@ -19,15 +19,16 @@ package org.apache.kyuubi.it.jdbc.mysql
 
 import java.nio.file.{Files, Path, Paths}
 
-import org.apache.kyuubi.{Utils, WithKyuubiServer}
+import org.apache.kyuubi.WithKyuubiServer
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.{ENGINE_JDBC_EXTRA_CLASSPATH, KYUUBI_ENGINE_ENV_PREFIX, KYUUBI_HOME}
 import org.apache.kyuubi.engine.jdbc.mysql.WithMySQLEngine
+import org.apache.kyuubi.util.JavaUtils
 
 trait WithKyuubiServerAndMySQLContainer extends WithKyuubiServer with WithMySQLEngine {
 
-  private val kyuubiHome: String = Utils
-    .getCodeSourceLocation(getClass).split("integration-tests").head
+  private val kyuubiHome: String =
+    JavaUtils.getCodeSourceLocation(getClass).split("integration-tests").head
 
   private val mysqlJdbcConnectorPath: String = {
     val keyword = "mysql-connector"

--- a/integration-tests/kyuubi-jdbc-it/src/test/scala/org/apache/kyuubi/it/jdbc/phoenix/WithKyuubiServerAndPhoenixContainer.scala
+++ b/integration-tests/kyuubi-jdbc-it/src/test/scala/org/apache/kyuubi/it/jdbc/phoenix/WithKyuubiServerAndPhoenixContainer.scala
@@ -19,15 +19,16 @@ package org.apache.kyuubi.it.jdbc.phoenix
 import java.nio.file.{Files, Path, Paths}
 import java.time.Duration
 
-import org.apache.kyuubi.{Utils, WithKyuubiServer}
+import org.apache.kyuubi.WithKyuubiServer
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.{ENGINE_IDLE_TIMEOUT, ENGINE_JDBC_EXTRA_CLASSPATH, KYUUBI_ENGINE_ENV_PREFIX, KYUUBI_HOME}
 import org.apache.kyuubi.engine.jdbc.phoenix.WithPhoenixEngine
+import org.apache.kyuubi.util.JavaUtils
 
 trait WithKyuubiServerAndPhoenixContainer extends WithKyuubiServer with WithPhoenixEngine {
 
-  private val kyuubiHome: String = Utils
-    .getCodeSourceLocation(getClass).split("integration-tests").head
+  private val kyuubiHome: String =
+    JavaUtils.getCodeSourceLocation(getClass).split("integration-tests").head
 
   private val phoenixJdbcConnectorPath: String = {
     val keyword = "phoenix-queryserver"

--- a/integration-tests/kyuubi-jdbc-it/src/test/scala/org/apache/kyuubi/it/jdbc/postgresql/WithKyuubiServerAndPostgreSQLContainer.scala
+++ b/integration-tests/kyuubi-jdbc-it/src/test/scala/org/apache/kyuubi/it/jdbc/postgresql/WithKyuubiServerAndPostgreSQLContainer.scala
@@ -19,15 +19,16 @@ package org.apache.kyuubi.it.jdbc.postgresql
 import java.nio.file.{Files, Path, Paths}
 import java.time.Duration
 
-import org.apache.kyuubi.{Utils, WithKyuubiServer}
+import org.apache.kyuubi.WithKyuubiServer
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.{ENGINE_IDLE_TIMEOUT, ENGINE_JDBC_EXTRA_CLASSPATH, KYUUBI_ENGINE_ENV_PREFIX, KYUUBI_HOME}
 import org.apache.kyuubi.engine.jdbc.postgresql.WithPostgreSQLEngine
+import org.apache.kyuubi.util.JavaUtils
 
 trait WithKyuubiServerAndPostgreSQLContainer extends WithKyuubiServer with WithPostgreSQLEngine {
 
-  private val kyuubiHome: String = Utils
-    .getCodeSourceLocation(getClass).split("integration-tests").head
+  private val kyuubiHome: String =
+    JavaUtils.getCodeSourceLocation(getClass).split("integration-tests").head
 
   private val postgresqlJdbcConnectorPath: String = {
     val keyword = "postgresql"

--- a/integration-tests/kyuubi-trino-it/src/test/scala/org/apache/kyuubi/it/trino/WithKyuubiServerAndTrinoContainer.scala
+++ b/integration-tests/kyuubi-trino-it/src/test/scala/org/apache/kyuubi/it/trino/WithKyuubiServerAndTrinoContainer.scala
@@ -20,9 +20,10 @@ package org.apache.kyuubi.it.trino
 import com.dimafeng.testcontainers.TrinoContainer
 import com.dimafeng.testcontainers.scalatest.TestContainerForAll
 
-import org.apache.kyuubi.{Utils, WithKyuubiServer}
+import org.apache.kyuubi.WithKyuubiServer
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf._
+import org.apache.kyuubi.util.JavaUtils
 
 trait WithKyuubiServerAndTrinoContainer extends WithKyuubiServer with TestContainerForAll {
 

--- a/integration-tests/kyuubi-trino-it/src/test/scala/org/apache/kyuubi/it/trino/WithKyuubiServerAndTrinoContainer.scala
+++ b/integration-tests/kyuubi-trino-it/src/test/scala/org/apache/kyuubi/it/trino/WithKyuubiServerAndTrinoContainer.scala
@@ -26,7 +26,7 @@ import org.apache.kyuubi.config.KyuubiConf._
 
 trait WithKyuubiServerAndTrinoContainer extends WithKyuubiServer with TestContainerForAll {
 
-  val kyuubiHome: String = Utils.getCodeSourceLocation(getClass).split("integration-tests").head
+  val kyuubiHome: String = JavaUtils.getCodeSourceLocation(getClass).split("integration-tests").head
 
   final val IMAGE_VERSION = 411
   final val DOCKER_IMAGE_NAME = s"trinodb/trino:$IMAGE_VERSION"

--- a/integration-tests/kyuubi-trino-it/src/test/scala/org/apache/kyuubi/it/trino/server/TrinoFrontendSuite.scala
+++ b/integration-tests/kyuubi-trino-it/src/test/scala/org/apache/kyuubi/it/trino/server/TrinoFrontendSuite.scala
@@ -19,10 +19,11 @@ package org.apache.kyuubi.it.trino.server
 
 import scala.util.control.NonFatal
 
-import org.apache.kyuubi.{Utils, WithKyuubiServer}
+import org.apache.kyuubi.WithKyuubiServer
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.{KYUUBI_ENGINE_ENV_PREFIX, KYUUBI_HOME}
 import org.apache.kyuubi.operation.SparkMetadataTests
+import org.apache.kyuubi.util.JavaUtils
 
 /**
  * This test is for Trino jdbc driver with Kyuubi Server and Spark engine:

--- a/integration-tests/kyuubi-trino-it/src/test/scala/org/apache/kyuubi/it/trino/server/TrinoFrontendSuite.scala
+++ b/integration-tests/kyuubi-trino-it/src/test/scala/org/apache/kyuubi/it/trino/server/TrinoFrontendSuite.scala
@@ -54,7 +54,7 @@ class TrinoFrontendSuite extends WithKyuubiServer with SparkMetadataTests {
     }
   }
 
-  val kyuubiHome: String = Utils.getCodeSourceLocation(getClass).split("integration-tests").head
+  val kyuubiHome: String = JavaUtils.getCodeSourceLocation(getClass).split("integration-tests").head
 
   override protected val conf: KyuubiConf = {
     KyuubiConf()

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/Utils.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/Utils.scala
@@ -329,10 +329,6 @@ object Utils extends Logging {
     }
   }
 
-  def getCodeSourceLocation(clazz: Class[_]): String = {
-    new File(clazz.getProtectionDomain.getCodeSource.getLocation.toURI).getPath
-  }
-
   def fromCommandLineArgs(args: Array[String], conf: KyuubiConf): Unit = {
     require(args.length % 2 == 0, s"Illegal size of arguments.")
     for (i <- args.indices by 2) {

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/KerberizedTestHelper.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/KerberizedTestHelper.scala
@@ -36,7 +36,7 @@ import org.scalatest.time.SpanSugar._
 trait KerberizedTestHelper extends KyuubiFunSuite {
   val clientPrincipalUser = "client"
   val baseDir: File =
-    Utils.createTempDir("kyuubi-kdc", Utils.getCodeSourceLocation(getClass)).toFile
+    Utils.createTempDir("kyuubi-kdc", JavaUtils.getCodeSourceLocation(getClass)).toFile
   val kdcConf = MiniKdc.createConf()
   val hostName = "localhost"
   kdcConf.setProperty(MiniKdc.INSTANCE, this.getClass.getSimpleName)

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/KerberizedTestHelper.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/KerberizedTestHelper.scala
@@ -33,6 +33,8 @@ import org.apache.hadoop.security.UserGroupInformation
 import org.ietf.jgss.{GSSContext, GSSException, GSSManager, GSSName}
 import org.scalatest.time.SpanSugar._
 
+import org.apache.kyuubi.util.JavaUtils
+
 trait KerberizedTestHelper extends KyuubiFunSuite {
   val clientPrincipalUser = "client"
   val baseDir: File =

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/engine/deploy/yarn/EngineYarnModeSubmitterSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/engine/deploy/yarn/EngineYarnModeSubmitterSuite.scala
@@ -26,6 +26,7 @@ import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import org.apache.kyuubi.{KyuubiFunSuite, Utils}
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.engine.deploy.yarn.EngineYarnModeSubmitter.KYUUBI_ENGINE_DEPLOY_YARN_MODE_JARS_KEY
+import org.apache.kyuubi.util.JavaUtils
 
 class EngineYarnModeSubmitterSuite extends KyuubiFunSuite with Matchers {
 

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/engine/deploy/yarn/EngineYarnModeSubmitterSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/engine/deploy/yarn/EngineYarnModeSubmitterSuite.scala
@@ -29,7 +29,7 @@ import org.apache.kyuubi.engine.deploy.yarn.EngineYarnModeSubmitter.KYUUBI_ENGIN
 
 class EngineYarnModeSubmitterSuite extends KyuubiFunSuite with Matchers {
 
-  val kyuubiHome: String = Utils.getCodeSourceLocation(getClass).split("kyuubi-common").head
+  val kyuubiHome: String = JavaUtils.getCodeSourceLocation(getClass).split("kyuubi-common").head
 
   test("Classpath should contain engine jars dir and conf dir") {
     val kyuubiConf = new KyuubiConf()
@@ -56,7 +56,7 @@ class EngineYarnModeSubmitterSuite extends KyuubiFunSuite with Matchers {
   }
 
   test("distinct archive files") {
-    val targetJars: String = s"${Utils.getCodeSourceLocation(getClass)}"
+    val targetJars: String = s"${JavaUtils.getCodeSourceLocation(getClass)}"
     // double the jars to make sure the distinct works
     val archives = s"$targetJars,$targetJars"
     val files = MockEngineYarnModeSubmitter.listDistinctFiles(archives)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ProcBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ProcBuilder.scala
@@ -32,7 +32,7 @@ import org.apache.kyuubi._
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.KYUUBI_HOME
 import org.apache.kyuubi.operation.log.OperationLog
-import org.apache.kyuubi.util.NamedThreadFactory
+import org.apache.kyuubi.util.{JavaUtils, NamedThreadFactory}
 
 trait ProcBuilder {
 
@@ -83,7 +83,7 @@ trait ProcBuilder {
         .find(Files.exists(_)).map(_.toAbsolutePath.toFile.getCanonicalPath)
     }.orElse {
       // 3. get the main resource from dev environment
-      val cwd = Utils.getCodeSourceLocation(getClass).split("kyuubi-server")
+      val cwd = JavaUtils.getCodeSourceLocation(getClass).split("kyuubi-server")
       assert(cwd.length > 1)
       Option(Paths.get(cwd.head, "externals", module, "target", jarName))
         .map(_.toAbsolutePath.toFile.getCanonicalPath)
@@ -330,7 +330,7 @@ trait ProcBuilder {
         }.filter(Files.exists(_)).map(_.toAbsolutePath.toFile.getCanonicalPath)
       }.orElse {
         // 3. get from kyuubi-server/../externals/kyuubi-download/target
-        Utils.getCodeSourceLocation(getClass).split("kyuubi-server").flatMap { cwd =>
+        JavaUtils.getCodeSourceLocation(getClass).split("kyuubi-server").flatMap { cwd =>
           val candidates = Paths.get(cwd, "externals", "kyuubi-download", "target")
             .toFile.listFiles(engineHomeDirFilter)
           if (candidates == null) None else candidates.map(_.toPath).headOption

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/jdbc/JDBCMetadataStoreConf.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/jdbc/JDBCMetadataStoreConf.scala
@@ -19,9 +19,9 @@ package org.apache.kyuubi.server.metadata.jdbc
 
 import java.util.Properties
 
-import org.apache.kyuubi.Utils
 import org.apache.kyuubi.config.{ConfigEntry, KyuubiConf, OptionalConfigEntry}
 import org.apache.kyuubi.config.KyuubiConf.buildConf
+import org.apache.kyuubi.util.JavaUtils
 
 object JDBCMetadataStoreConf {
   final val METADATA_STORE_JDBC_DATASOURCE_PREFIX = "kyuubi.metadata.store.jdbc.datasource"
@@ -33,7 +33,7 @@ object JDBCMetadataStoreConf {
         "<KYUUBI_HOME>",
         sys.env.getOrElse(
           "KYUUBI_HOME",
-          Utils.getCodeSourceLocation(getClass).split("kyuubi-server").head))
+          JavaUtils.getCodeSourceLocation(getClass).split("kyuubi-server").head))
     } else {
       rawJdbcUrl
     }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/WithKyuubiServerAndHadoopMiniCluster.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/WithKyuubiServerAndHadoopMiniCluster.scala
@@ -26,7 +26,7 @@ import org.apache.kyuubi.server.{MiniDFSService, MiniYarnService}
 
 trait WithKyuubiServerAndHadoopMiniCluster extends KyuubiFunSuite with WithKyuubiServer {
 
-  val kyuubiHome: String = Utils.getCodeSourceLocation(getClass).split("integration-tests").head
+  val kyuubiHome: String = JavaUtils.getCodeSourceLocation(getClass).split("integration-tests").head
 
   override protected val conf: KyuubiConf = new KyuubiConf(false)
 

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/WithKyuubiServerAndHadoopMiniCluster.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/WithKyuubiServerAndHadoopMiniCluster.scala
@@ -23,6 +23,7 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.KYUUBI_ENGINE_ENV_PREFIX
 import org.apache.kyuubi.server.{MiniDFSService, MiniYarnService}
+import org.apache.kyuubi.util.JavaUtils
 
 trait WithKyuubiServerAndHadoopMiniCluster extends KyuubiFunSuite with WithKyuubiServer {
 

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/config/AllKyuubiConfiguration.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/config/AllKyuubiConfiguration.scala
@@ -44,7 +44,8 @@ import org.apache.kyuubi.zookeeper.ZookeeperConf
  * }}}
  */
 class AllKyuubiConfiguration extends KyuubiFunSuite {
-  private val kyuubiHome: String = Utils.getCodeSourceLocation(getClass).split("kyuubi-server")(0)
+  private val kyuubiHome: String =
+    JavaUtils.getCodeSourceLocation(getClass).split("kyuubi-server")(0)
   private val markdown = Paths.get(kyuubiHome, "docs", "configuration", "settings.md")
     .toAbsolutePath
 

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/config/AllKyuubiConfiguration.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/config/AllKyuubiConfiguration.scala
@@ -21,12 +21,13 @@ import java.nio.file.Paths
 
 import scala.collection.JavaConverters._
 
-import org.apache.kyuubi.{KyuubiFunSuite, MarkdownBuilder, Utils}
+import org.apache.kyuubi.{KyuubiFunSuite, MarkdownBuilder}
 import org.apache.kyuubi.ctl.CtlConf
 import org.apache.kyuubi.ha.HighAvailabilityConf
 import org.apache.kyuubi.metrics.MetricsConf
 import org.apache.kyuubi.server.metadata.jdbc.JDBCMetadataStoreConf
 import org.apache.kyuubi.util.GoldenFileUtils._
+import org.apache.kyuubi.util.JavaUtils
 import org.apache.kyuubi.zookeeper.ZookeeperConf
 
 /**

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/rest/client/BatchCliSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/rest/client/BatchCliSuite.scala
@@ -36,10 +36,11 @@ import org.apache.kyuubi.metrics.{MetricsConstants, MetricsSystem}
 import org.apache.kyuubi.server.metadata.api.MetadataFilter
 import org.apache.kyuubi.session.KyuubiSessionManager
 import org.apache.kyuubi.shaded.hive.service.rpc.thrift.TProtocolVersion
+import org.apache.kyuubi.util.JavaUtils
 
 class BatchCliSuite extends RestClientTestHelper with TestPrematureExit with BatchTestHelper {
 
-  val basePath: String = Utils.getCodeSourceLocation(getClass)
+  val basePath: String = JavaUtils.getCodeSourceLocation(getClass)
   val batchFile: String = s"${basePath}/batch.yaml"
   val longTimeBatchFile: String = s"${basePath}/batch_long_time.yaml"
 

--- a/kyuubi-util/src/main/java/org/apache/kyuubi/util/JavaUtils.java
+++ b/kyuubi-util/src/main/java/org/apache/kyuubi/util/JavaUtils.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.kyuubi.util;
+
+import java.io.File;
+import java.net.URISyntaxException;
+
+public class JavaUtils {
+
+  public static String getCodeSourceLocation(Class<?> clazz) {
+    try {
+      return new File(clazz.getProtectionDomain().getCodeSource().getLocation().toURI()).getPath();
+    } catch (URISyntaxException rethrow) {
+      throw new RuntimeException(rethrow);
+    }
+  }
+}


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

The `getCodeSourceLocation` lives on `kyuubi-common`, which is not reachable for modules like `kyuubi-hive-beeline`.

## Describe Your Solution 🔧

Move it to `kyuubi-util`.

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

Pass GA.

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
