### PR TITLE
Deprecate Flink 1.16

### DIFF
--- a/docs/deployment/migration-guide.md
+++ b/docs/deployment/migration-guide.md
@@ -24,6 +24,7 @@
 * Since Kyuubi 1.9.0, the support of Spark SQL engine for Spark 3.1 is deprecated, and will be removed in the future.
 * Since Kyuubi 1.9.0, the support of Spark extensions for Spark 3.1 is removed, please use Spark 3.2 or higher versions.
 * Since Kyuubi 1.9.0, `kyuubi.frontend.login.timeout`, `kyuubi.frontend.thrift.login.timeout`, `kyuubi.frontend.backoff.slot.length`, `kyuubi.frontend.thrift.backoff.slot.length` are removed.
+* Since Kyuubi 1.9.0, the support of Flink engine for Flink 1.16 is deprecated, and will be removed in the future.
 
 ## Upgrading from Kyuubi 1.8.0 to 1.8.1
 

--- a/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/FlinkEngineUtils.scala
+++ b/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/FlinkEngineUtils.scala
@@ -56,6 +56,9 @@ object FlinkEngineUtils extends Logging {
     val flinkVersion = EnvironmentInformation.getVersion
     if (SUPPORTED_FLINK_VERSIONS.contains(FLINK_RUNTIME_VERSION)) {
       info(s"The current Flink version is $flinkVersion")
+      if (FlinkEngineUtils.FLINK_RUNTIME_VERSION === "1.16") {
+        warn("The support for Flink 1.16 is deprecated, and will be removed in the next version.")
+      }
     } else {
       throw new UnsupportedOperationException(
         s"You are using unsupported Flink version $flinkVersion, " +


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
This pull request add a message to tell users that Flink 1.16 is deprecated.

Disscusion: https://lists.apache.org/thread/fmq7462vcfm8l3m38xh4b4jjgd4smzn7

## Describe Your Solution 🔧
Add a message to tell users that Flink 1.16 is deprecated.

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
