### PR TITLE
[KYUUBI #6152] Remove useless variable

### DIFF
--- a/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/session/FlinkSQLSessionManager.scala
+++ b/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/session/FlinkSQLSessionManager.scala
@@ -61,8 +61,6 @@ class FlinkSQLSessionManager(engineContext: DefaultContext)
           .setSessionEndpointVersion(SqlGatewayRestAPIVersion.V1)
           .addSessionConfig(mapAsJavaMap(conf))
           .build)
-      val sessionConfig = flinkInternalSession.getSessionConfig
-      sessionConfig.putAll(conf.asJava)
       val session = new FlinkSessionImpl(
         protocol,
         user,


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #6152

## Describe Your Solution 🔧

`flinkInternalSession.getSessionConfig` returns a new map, and the `sessionConfig` variable is never used, so we can remove it.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
