### PR TITLE
Fix beeline test KyuubiBeeLineTest.testKyuubiBeelineComment

### DIFF
--- a/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/BeeLine.java
+++ b/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/BeeLine.java
@@ -134,7 +134,7 @@ public class BeeLine implements Closeable {
   private final BeeLineOpts opts = new BeeLineOpts(this, System.getProperties());
   private String lastProgress = null;
   private final Map<SQLWarning, Date> seenWarnings = new HashMap<SQLWarning, Date>();
-  private final Commands commands = new Commands(this);
+  private Commands commands = new Commands(this);
   private OutputFile scriptOutputFile = null;
   private OutputFile recordOutputFile = null;
   private PrintStream outputStream = new PrintStream(System.out, true);
@@ -2381,5 +2381,9 @@ public class BeeLine implements Closeable {
 
   boolean isTestMode() {
     return isTestMode;
+  }
+
+  protected void setCommands(Commands commands) {
+    this.commands = commands;
   }
 }

--- a/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/KyuubiBeeLine.java
+++ b/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/KyuubiBeeLine.java
@@ -48,7 +48,6 @@ public class KyuubiBeeLine extends BeeLine {
 
   public static final String KYUUBI_BEELINE_DEFAULT_JDBC_DRIVER =
       "org.apache.kyuubi.jdbc.KyuubiHiveDriver";
-  protected KyuubiCommands commands = new KyuubiCommands(this);
   private Driver defaultDriver;
 
   // copied from org.apache.hive.beeline.BeeLine
@@ -66,11 +65,7 @@ public class KyuubiBeeLine extends BeeLine {
   @SuppressWarnings("deprecation")
   public KyuubiBeeLine(boolean isBeeLine) {
     super(isBeeLine);
-    try {
-      DynFields.builder().hiddenImpl(BeeLine.class, "commands").buildChecked(this).set(commands);
-    } catch (Throwable t) {
-      throw new ExceptionInInitializerError("Failed to inject kyuubi commands");
-    }
+    setCommands(new KyuubiCommands(this));
     try {
       defaultDriver =
           DynConstructors.builder()

--- a/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/KyuubiBeeLineTest.java
+++ b/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/KyuubiBeeLineTest.java
@@ -89,8 +89,8 @@ public class KyuubiBeeLineTest {
   }
 
   @Test
-  public void testKyuubiBeelineComment() throws NoSuchFieldException {
-    KyuubiBeeLine kyuubiBeeLine =
+  public void testKyuubiBeelineComment() {
+    KyuubiBeeLine interceptedKyuubiBeeLine =
         new KyuubiBeeLine() {
           @Override
           boolean dispatch(String line) {
@@ -103,26 +103,28 @@ public class KyuubiBeeLineTest {
         };
 
     String[] cmd = new String[] {""};
-    KyuubiCommands commands =
-        new KyuubiCommands(kyuubiBeeLine) {
+    KyuubiCommands interceptedCommands =
+        new KyuubiCommands(interceptedKyuubiBeeLine) {
           @Override
           public boolean sql(String line, boolean entireLineAsCommand) {
             cmd[0] = line;
             return true;
           }
         };
-    kyuubiBeeLine.setCommands(commands);
+    interceptedKyuubiBeeLine.setCommands(interceptedCommands);
 
-    kyuubiBeeLine.initArgs(new String[] {"-u", "dummy_url", "-e", "--comment show database;"});
+    interceptedKyuubiBeeLine.initArgs(
+        new String[] {"-u", "dummy_url", "-e", "--comment show database;"});
     assertEquals(0, cmd[0].length());
 
     // Beeline#exit must be false to execute sql
-    kyuubiBeeLine.setExit(false);
-    kyuubiBeeLine.initArgs(new String[] {"-u", "dummy_url", "-e", "--comment\n show database;"});
+    interceptedKyuubiBeeLine.setExit(false);
+    interceptedKyuubiBeeLine.initArgs(
+        new String[] {"-u", "dummy_url", "-e", "--comment\n show database;"});
     assertEquals("show database;", cmd[0]);
 
-    kyuubiBeeLine.setExit(false);
-    kyuubiBeeLine.initArgs(
+    interceptedKyuubiBeeLine.setExit(false);
+    interceptedKyuubiBeeLine.initArgs(
         new String[] {
           "-u", "dummy_url", "-e", "--comment line 1 \n    --comment line 2 \n show database;"
         });

--- a/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/KyuubiBeeLineTest.java
+++ b/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/KyuubiBeeLineTest.java
@@ -26,8 +26,13 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import org.apache.kyuubi.util.reflect.DynFields;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class KyuubiBeeLineTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(KyuubiBeeLineTest.class);
+
   @Test
   public void testKyuubiBeelineWithoutArgs() {
     KyuubiBeeLine kyuubiBeeLine = new KyuubiBeeLine();
@@ -94,8 +99,8 @@ public class KyuubiBeeLineTest {
         new KyuubiBeeLine() {
           @Override
           boolean dispatch(String line) {
-            // Pretend connection is established
             if (line != null && line.startsWith("!connect")) {
+              LOG.info("Return true for command: {} to pretend connection is established.", line);
               return true;
             }
             return super.dispatch(line);
@@ -107,6 +112,7 @@ public class KyuubiBeeLineTest {
         new KyuubiCommands(interceptedKyuubiBeeLine) {
           @Override
           public boolean sql(String line, boolean entireLineAsCommand) {
+            LOG.info("Return true for sql {} to pretend sql is executed successfully.", line);
             cmd[0] = line;
             return true;
           }

--- a/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/KyuubiBeeLineTest.java
+++ b/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/KyuubiBeeLineTest.java
@@ -111,10 +111,7 @@ public class KyuubiBeeLineTest {
             return true;
           }
         };
-    DynFields.builder()
-        .hiddenImpl(BeeLine.class, "commands")
-        .buildChecked(kyuubiBeeLine)
-        .set(commands);
+    kyuubiBeeLine.setCommands(commands);
 
     kyuubiBeeLine.initArgs(new String[] {"-u", "dummy_url", "-e", "--comment show database;"});
     assertEquals(0, cmd[0].length());


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗

Shell command `beeline` uses `KyuubiBeeline#initArgs`, and never uses `KyuubiBeeline#initArgsFromCliVars`.
We should replace `KyuubiBeeline#initArgsFromCliVars` with `KyuubiBeeline#initArgs` in test `KyuubiBeeLineTest#testKyuubiBeelineComment`.


## Describe Your Solution 🔧


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
