### PR TITLE
[MINOR] Fix wrong copy path about SPARK_HOME in docker

### DIFF
--- a/bin/docker-image-tool.sh
+++ b/bin/docker-image-tool.sh
@@ -110,7 +110,7 @@ function build {
         error "Cannot found dir SPARK_HOME $SPARK_HOME, you must configure SPARK_HOME correct."
       fi
     fi
-    cp -r "$SPARK_HOME/" "$KYUUBI_ROOT/spark-binary/"
+    cp -r "$SPARK_HOME/." "$KYUUBI_ROOT/spark-binary/"
   fi
 
   # Verify that the Docker image content directory is present


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #

## Describe Your Solution 🔧

After running `build/dist`, the old structure is like `dist/spark-binary/spark-3.4.2-bin-hadoop3/xxx`.
In `Dockerfile`, after the command `ONBUILD COPY spark-binary ${SPARK_HOME}` takes effect. The path in the container is `/opt/spark/spark-3.4.2-bin-hadoop3`. So I suggest only copy the content of the origin spark binary, making the structure looks like `dist/spark-binary/xxx`. Finally, the path in the container (`/opt/spark/xxx`) should be correct.

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
