### PR TITLE
[KYUUBI #6168] Check if forcedMaxOutputRows is negative

### DIFF
--- a/extensions/spark/kyuubi-extension-spark-3-4/src/main/scala/org/apache/kyuubi/sql/watchdog/ForcedMaxOutputRowsBase.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-4/src/main/scala/org/apache/kyuubi/sql/watchdog/ForcedMaxOutputRowsBase.scala
@@ -71,9 +71,9 @@ trait ForcedMaxOutputRowsBase extends Rule[LogicalPlan] {
 
   protected def canInsertLimit(p: LogicalPlan, maxOutputRowsOpt: Option[Int]): Boolean = {
     maxOutputRowsOpt match {
-      case Some(forcedMaxOutputRows) => canInsertLimitInner(p) &&
+      case Some(forcedMaxOutputRows) if forcedMaxOutputRows >= 0 => canInsertLimitInner(p) &&
         !p.maxRows.exists(_ <= forcedMaxOutputRows)
-      case None => false
+      case _ => false
     }
   }
 

--- a/extensions/spark/kyuubi-extension-spark-3-4/src/main/scala/org/apache/kyuubi/sql/watchdog/ForcedMaxOutputRowsBase.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-4/src/main/scala/org/apache/kyuubi/sql/watchdog/ForcedMaxOutputRowsBase.scala
@@ -71,8 +71,8 @@ trait ForcedMaxOutputRowsBase extends Rule[LogicalPlan] {
 
   protected def canInsertLimit(p: LogicalPlan, maxOutputRowsOpt: Option[Int]): Boolean = {
     maxOutputRowsOpt match {
-      case Some(forcedMaxOutputRows) if forcedMaxOutputRows >= 0 => canInsertLimitInner(p) &&
-        !p.maxRows.exists(_ <= forcedMaxOutputRows)
+      case Some(forcedMaxOutputRows) if forcedMaxOutputRows >= 0 =>
+        canInsertLimitInner(p) && !p.maxRows.exists(_ <= forcedMaxOutputRows)
       case _ => false
     }
   }

--- a/extensions/spark/kyuubi-extension-spark-3-5/src/main/scala/org/apache/kyuubi/sql/watchdog/ForcedMaxOutputRowsBase.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-5/src/main/scala/org/apache/kyuubi/sql/watchdog/ForcedMaxOutputRowsBase.scala
@@ -71,9 +71,9 @@ trait ForcedMaxOutputRowsBase extends Rule[LogicalPlan] {
 
   protected def canInsertLimit(p: LogicalPlan, maxOutputRowsOpt: Option[Int]): Boolean = {
     maxOutputRowsOpt match {
-      case Some(forcedMaxOutputRows) => canInsertLimitInner(p) &&
+      case Some(forcedMaxOutputRows) if forcedMaxOutputRows >= 0 => canInsertLimitInner(p) &&
         !p.maxRows.exists(_ <= forcedMaxOutputRows)
-      case None => false
+      case _ => false
     }
   }
 

--- a/extensions/spark/kyuubi-extension-spark-3-5/src/main/scala/org/apache/kyuubi/sql/watchdog/ForcedMaxOutputRowsBase.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-5/src/main/scala/org/apache/kyuubi/sql/watchdog/ForcedMaxOutputRowsBase.scala
@@ -71,8 +71,8 @@ trait ForcedMaxOutputRowsBase extends Rule[LogicalPlan] {
 
   protected def canInsertLimit(p: LogicalPlan, maxOutputRowsOpt: Option[Int]): Boolean = {
     maxOutputRowsOpt match {
-      case Some(forcedMaxOutputRows) if forcedMaxOutputRows >= 0 => canInsertLimitInner(p) &&
-        !p.maxRows.exists(_ <= forcedMaxOutputRows)
+      case Some(forcedMaxOutputRows) if forcedMaxOutputRows >= 0 =>
+        canInsertLimitInner(p) && !p.maxRows.exists(_ <= forcedMaxOutputRows)
       case _ => false
     }
   }

--- a/extensions/spark/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/watchdog/ForcedMaxOutputRowsBase.scala
+++ b/extensions/spark/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/watchdog/ForcedMaxOutputRowsBase.scala
@@ -71,9 +71,9 @@ trait ForcedMaxOutputRowsBase extends Rule[LogicalPlan] {
 
   protected def canInsertLimit(p: LogicalPlan, maxOutputRowsOpt: Option[Int]): Boolean = {
     maxOutputRowsOpt match {
-      case Some(forcedMaxOutputRows) => canInsertLimitInner(p) &&
+      case Some(forcedMaxOutputRows) if forcedMaxOutputRows >= 0 => canInsertLimitInner(p) &&
         !p.maxRows.exists(_ <= forcedMaxOutputRows)
-      case None => false
+      case _ => false
     }
   }
 

--- a/extensions/spark/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/watchdog/ForcedMaxOutputRowsBase.scala
+++ b/extensions/spark/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/watchdog/ForcedMaxOutputRowsBase.scala
@@ -71,8 +71,8 @@ trait ForcedMaxOutputRowsBase extends Rule[LogicalPlan] {
 
   protected def canInsertLimit(p: LogicalPlan, maxOutputRowsOpt: Option[Int]): Boolean = {
     maxOutputRowsOpt match {
-      case Some(forcedMaxOutputRows) if forcedMaxOutputRows >= 0 => canInsertLimitInner(p) &&
-        !p.maxRows.exists(_ <= forcedMaxOutputRows)
+      case Some(forcedMaxOutputRows) if forcedMaxOutputRows >= 0 =>
+        canInsertLimitInner(p) && !p.maxRows.exists(_ <= forcedMaxOutputRows)
       case _ => false
     }
   }


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #6168

## Describe Your Solution 🔧

Check if forcedMaxOutputRows is negative.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
