### PR TITLE
[KYUUBI #6171][FOLLOWUP] Restore flink-1.16 profile to recover Flink IT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2316,6 +2316,13 @@
         </profile>
 
         <profile>
+            <id>flink-1.16</id>
+            <properties>
+                <flink.version>1.16.3</flink.version>
+            </properties>
+        </profile>
+
+        <profile>
             <id>flink-1.17</id>
             <properties>
                 <flink.version>1.17.2</flink.version>


### PR DESCRIPTION
# :mag: Description

I forgot the Flink cross-version verification integration tests require using the target Flink version to bootstrap a Flink Mini Cluster, this PR restores `flink-1.16` profile to recover Flink IT

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

Pass GA.

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
