### PR TITLE
AuthZ shaded should include ranger-plugins-cred

### DIFF
--- a/extensions/spark/kyuubi-spark-authz-shaded/pom.xml
+++ b/extensions/spark/kyuubi-spark-authz-shaded/pom.xml
@@ -237,6 +237,7 @@
                             <include>org.apache.kyuubi:kyuubi-util</include>
                             <include>org.apache.ranger:ranger-plugins-common</include>
                             <include>org.apache.ranger:ranger-plugins-audit</include>
+                            <include>org.apache.ranger:ranger-plugins-cred</include>
                             <include>org.codehaus.jackson:jackson-jaxrs</include>
                             <include>org.codehaus.jackson:jackson-core-asl</include>
                             <include>org.codehaus.jackson:jackson-mapper-asl</include>


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes a class not found issue.

```
Caused by: java.lang.ClassNotFoundException: org.apache.ranger.authorization.hadoop.utils.RangerCredentialProvider
  ...
```

## Describe Your Solution 🔧

`org.apache.ranger:ranger-plugins-cred` was missing in include list.

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

Manual test.

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
