### PR TITLE
[KYUUBI #6316] Support switching jdbc dialect based on session conf

### DIFF
--- a/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/operation/JdbcOperation.scala
+++ b/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/operation/JdbcOperation.scala
@@ -20,6 +20,7 @@ import org.apache.kyuubi.{KyuubiSQLException, Utils}
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.engine.jdbc.dialect.{JdbcDialect, JdbcDialects}
 import org.apache.kyuubi.engine.jdbc.schema.{Row, Schema}
+import org.apache.kyuubi.engine.jdbc.session.JdbcSessionImpl
 import org.apache.kyuubi.operation.{AbstractOperation, FetchIterator, OperationState}
 import org.apache.kyuubi.operation.FetchOrientation.{FETCH_FIRST, FETCH_NEXT, FETCH_PRIOR, FetchOrientation}
 import org.apache.kyuubi.session.Session
@@ -31,7 +32,7 @@ abstract class JdbcOperation(session: Session) extends AbstractOperation(session
 
   protected var iter: FetchIterator[Row] = _
 
-  protected lazy val conf: KyuubiConf = session.sessionManager.getConf
+  protected lazy val conf: KyuubiConf = session.asInstanceOf[JdbcSessionImpl].sessionConf
 
   protected lazy val dialect: JdbcDialect = JdbcDialects.get(conf)
 

--- a/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/session/JdbcSessionImpl.scala
+++ b/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/session/JdbcSessionImpl.scala
@@ -45,7 +45,7 @@ class JdbcSessionImpl(
 
   private var databaseMetaData: DatabaseMetaData = _
 
-  private val kyuubiConf: KyuubiConf = normalizeConf
+  val sessionConf: KyuubiConf = normalizeConf
 
   private def normalizeConf: KyuubiConf = {
     val kyuubiConf = sessionManager.getConf.clone
@@ -60,13 +60,13 @@ class JdbcSessionImpl(
   override def open(): Unit = {
     info(s"Starting to open jdbc session.")
     if (sessionConnection == null) {
-      sessionConnection = ConnectionProvider.create(kyuubiConf)
+      sessionConnection = ConnectionProvider.create(sessionConf)
       databaseMetaData = sessionConnection.getMetaData
     }
     KyuubiJdbcUtils.initializeJdbcSession(
-      kyuubiConf,
+      sessionConf,
       sessionConnection,
-      kyuubiConf.get(ENGINE_JDBC_SESSION_INITIALIZE_SQL))
+      sessionConf.get(ENGINE_JDBC_SESSION_INITIALIZE_SQL))
     super.open()
     info(s"The jdbc session is started.")
   }


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->
This pull request fixes #6316

## Describe Your Solution 🔧

Now JDBC engine using the overlay conf as session conf,  The ConnectionProvider will switch depending on the session conf. Therefore, we should also select the JDBC dialect based on the session conf.



## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
