### PR TITLE
Update comments for job group id of Spark broadcast jobs

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkOperation.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkOperation.scala
@@ -184,6 +184,8 @@ abstract class SparkOperation(session: Session)
     // We should use Throwable instead of Exception since `java.lang.NoClassDefFoundError`
     // could be thrown.
     case e: Throwable =>
+      // Prior SPARK-43952 (3.5.0), broadcast jobs uses a different group id, so we can
+      // cancel those broadcast jobs. See more details in SPARK-20774 (3.0.0)
       if (cancel && !spark.sparkContext.isStopped) spark.sparkContext.cancelJobGroup(statementId)
       withLockRequired {
         val errMsg = Utils.stringifyException(e)

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkOperation.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkOperation.scala
@@ -184,7 +184,7 @@ abstract class SparkOperation(session: Session)
     // We should use Throwable instead of Exception since `java.lang.NoClassDefFoundError`
     // could be thrown.
     case e: Throwable =>
-      // Prior SPARK-43952 (3.5.0), broadcast jobs uses a different group id, so we can
+      // Prior SPARK-43952 (3.5.0), broadcast jobs uses a different group id, so we can not
       // cancel those broadcast jobs. See more details in SPARK-20774 (3.0.0)
       if (cancel && !spark.sparkContext.isStopped) spark.sparkContext.cancelJobGroup(statementId)
       withLockRequired {

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SQLOperationListener.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SQLOperationListener.scala
@@ -72,10 +72,8 @@ class SQLOperationListener(
 
   def getExecutionId: Option[Long] = executionId
 
-  // For broadcast, Spark will introduce a new runId as SPARK_JOB_GROUP_ID, see:
-  // https://github.com/apache/spark/pull/24595, So we will miss these logs.
-  // TODO: Fix this until the below ticket resolved
-  // https://issues.apache.org/jira/browse/SPARK-34064
+  // Prior SPARK-43952 (3.5.0), broadcast jobs uses a different group id, so we will
+  // miss those logs. See more details in SPARK-20774 (3.0.0)
   private def sameGroupId(properties: Properties): Boolean = {
     properties != null && properties.getProperty(KYUUBI_STATEMENT_ID_KEY) == operationId
   }


### PR DESCRIPTION
# :mag: Description

Prior SPARK-43952 (3.5.0), broadcast jobs uses a different group id, so we can cancel those broadcast jobs. See more details in SPARK-20774 (3.0.0)


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

Only touch comment, review is sufficient.

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
