### PR TITLE
[KYUUBI #6212] Added audit handler shutdown to the shutdown hook

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPlugin.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPlugin.scala
@@ -78,10 +78,7 @@ object SparkRangerAdminPlugin extends RangerBasePlugin("spark", "sparkSql")
         if (plugin != null) {
           LOG.info(s"clean up ranger plugin, appId: ${plugin.getAppId}")
           plugin.cleanup()
-          val auditProviderFactory = plugin.getAuditProviderFactory
-          if (auditProviderFactory != null) {
-            auditProviderFactory.shutdown()
-          }
+          plugin.getAuditProviderFactory.shutdown()
         }
       },
       Integer.MAX_VALUE)

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPlugin.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPlugin.scala
@@ -21,7 +21,6 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable.{ArrayBuffer, LinkedHashMap}
 
 import org.apache.hadoop.util.ShutdownHookManager
-import org.apache.ranger.audit.provider.AuditProviderFactory
 import org.apache.ranger.plugin.policyengine.RangerAccessRequest
 import org.apache.ranger.plugin.service.RangerBasePlugin
 import org.slf4j.LoggerFactory

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPlugin.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPlugin.scala
@@ -21,6 +21,7 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable.{ArrayBuffer, LinkedHashMap}
 
 import org.apache.hadoop.util.ShutdownHookManager
+import org.apache.ranger.audit.provider.AuditProviderFactory
 import org.apache.ranger.plugin.policyengine.RangerAccessRequest
 import org.apache.ranger.plugin.service.RangerBasePlugin
 import org.slf4j.LoggerFactory
@@ -78,6 +79,10 @@ object SparkRangerAdminPlugin extends RangerBasePlugin("spark", "sparkSql")
         if (plugin != null) {
           LOG.info(s"clean up ranger plugin, appId: ${plugin.getAppId}")
           plugin.cleanup()
+          val auditProviderFactory = plugin.getAuditProviderFactory
+          if (auditProviderFactory != null) {
+            auditProviderFactory.shutdown()
+          }
         }
       },
       Integer.MAX_VALUE)


### PR DESCRIPTION
# :mag: Description

This pull request fixes #6212

When Kyuubi cleans up Ranger related threads like PolicyRefresher, it should also shutdown the audit threads that include SolrZkClient. Otherwise Spark Driver keeps on running since SolrZkClient is a non-daemon thread. Added the cleanup as part of the shutdown hook that Kyuubi registers.

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
