### PR TITLE
[KYUUBI #6223] Fix Scala interpreter can not access spark.jars issue

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala-2.12/org/apache/kyuubi/engine/spark/repl/KyuubiSparkILoop.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala-2.12/org/apache/kyuubi/engine/spark/repl/KyuubiSparkILoop.scala
@@ -93,10 +93,7 @@ private[spark] case class KyuubiSparkILoop private (
       classLoader match {
         case loader: MutableURLClassLoader =>
           allJars = loader.getURLs.filter { u =>
-            val file = new File(u.getPath)
-            u.getProtocol == "file" && file.isFile &&
-            // Some bad spark packages depend on the wrong version of scala-reflect. Blacklist it.
-            !file.getName.contains("scala-lang_scala-reflect")
+            u.getProtocol == "file" && new File(u.getPath).isFile
           }
           classLoader = null
         case _ =>

--- a/externals/kyuubi-spark-sql-engine/src/main/scala-2.12/org/apache/kyuubi/engine/spark/repl/KyuubiSparkILoop.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala-2.12/org/apache/kyuubi/engine/spark/repl/KyuubiSparkILoop.scala
@@ -28,12 +28,12 @@ import org.apache.spark.repl.SparkILoop
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.util.MutableURLClassLoader
 
-import org.apache.kyuubi.Utils
+import org.apache.kyuubi.{Logging, Utils}
 
 private[spark] case class KyuubiSparkILoop private (
     spark: SparkSession,
     output: ByteArrayOutputStream)
-  extends SparkILoop(None, new PrintWriter(output)) {
+  extends SparkILoop(None, new PrintWriter(output)) with Logging {
   import KyuubiSparkILoop._
 
   val result = new DataFrameHolder(spark)
@@ -60,8 +60,9 @@ private[spark] case class KyuubiSparkILoop private (
             val allJars = loader.getURLs.filter { u =>
               val file = new File(u.getPath)
               u.getProtocol == "file" && file.isFile &&
-              file.getName.contains("scala-lang_scala-reflect")
+              !file.getName.contains("scala-lang_scala-reflect")
             }
+            debug(s"Adding jars to Scala interpreter's class path: $allJars")
             this.addUrlsToClassPath(allJars: _*)
             classLoader = null
           case _ =>

--- a/externals/kyuubi-spark-sql-engine/src/main/scala-2.12/org/apache/kyuubi/engine/spark/repl/KyuubiSparkILoop.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala-2.12/org/apache/kyuubi/engine/spark/repl/KyuubiSparkILoop.scala
@@ -63,7 +63,8 @@ private[spark] case class KyuubiSparkILoop private (
               // Some bad spark packages depend on the wrong version of scala-reflect. Blacklist it.
               !file.getName.contains("scala-lang_scala-reflect")
             }
-            debug(s"Adding jars to Scala interpreter's class path: $allJars")
+            info(s"Adding jars to Scala interpreter's class path: " +
+              allJars.mkString(File.pathSeparator))
             this.addUrlsToClassPath(allJars: _*)
             classLoader = null
           case _ =>

--- a/externals/kyuubi-spark-sql-engine/src/main/scala-2.12/org/apache/kyuubi/engine/spark/repl/KyuubiSparkILoop.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala-2.12/org/apache/kyuubi/engine/spark/repl/KyuubiSparkILoop.scala
@@ -60,6 +60,7 @@ private[spark] case class KyuubiSparkILoop private (
             val allJars = loader.getURLs.filter { u =>
               val file = new File(u.getPath)
               u.getProtocol == "file" && file.isFile &&
+              // Some bad spark packages depend on the wrong version of scala-reflect. Blacklist it.
               !file.getName.contains("scala-lang_scala-reflect")
             }
             debug(s"Adding jars to Scala interpreter's class path: $allJars")

--- a/externals/kyuubi-spark-sql-engine/src/main/scala-2.12/org/apache/kyuubi/engine/spark/repl/KyuubiSparkILoop.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala-2.12/org/apache/kyuubi/engine/spark/repl/KyuubiSparkILoop.scala
@@ -93,6 +93,7 @@ private[spark] case class KyuubiSparkILoop private (
       classLoader match {
         case loader: MutableURLClassLoader =>
           allJars = loader.getURLs.filter { u =>
+            // TODO: handle SPARK-47475 since Spark 4.0.0 in the future
             u.getProtocol == "file" && new File(u.getPath).isFile
           }
           classLoader = null

--- a/externals/kyuubi-spark-sql-engine/src/main/scala-2.12/org/apache/kyuubi/engine/spark/repl/KyuubiSparkILoop.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala-2.12/org/apache/kyuubi/engine/spark/repl/KyuubiSparkILoop.scala
@@ -41,15 +41,15 @@ private[spark] case class KyuubiSparkILoop private (
 
   private def initialize(): Unit = withLockRequired {
     val currentClassLoader = Thread.currentThread().getContextClassLoader
-    val allJars = getAllJars(currentClassLoader)
-    info(s"Adding jars to Scala interpreter's class path: ${allJars.mkString(File.pathSeparator)}")
+    val interpreterClasspath = getAllJars(currentClassLoader).mkString(File.pathSeparator)
+    info(s"Adding jars to Scala interpreter's class path: $interpreterClasspath")
     settings = new Settings
     val interpArguments = List(
       "-Yrepl-class-based",
       "-Yrepl-outdir",
       s"${spark.sparkContext.getConf.get("spark.repl.class.outputDir")}",
       "-classpath",
-      allJars.mkString(File.pathSeparator))
+      interpreterClasspath)
     settings.processArguments(interpArguments, processAll = true)
     settings.usejavacp.value = true
     settings.embeddedDefaults(currentClassLoader)

--- a/externals/kyuubi-spark-sql-engine/src/main/scala-2.13/org/apache/kyuubi/engine/spark/repl/KyuubiSparkILoop.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala-2.13/org/apache/kyuubi/engine/spark/repl/KyuubiSparkILoop.scala
@@ -18,6 +18,7 @@
 package org.apache.kyuubi.engine.spark.repl
 
 import java.io.{ByteArrayOutputStream, File, PrintWriter}
+import java.net.URL
 import java.util.concurrent.locks.ReentrantLock
 
 import scala.tools.nsc.Settings
@@ -28,25 +29,29 @@ import org.apache.spark.repl.SparkILoop
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.util.MutableURLClassLoader
 
-import org.apache.kyuubi.Utils
+import org.apache.kyuubi.{Logging, Utils}
 
 private[spark] case class KyuubiSparkILoop private (
     spark: SparkSession,
     output: ByteArrayOutputStream)
-  extends SparkILoop(null, new PrintWriter(output)) {
+  extends SparkILoop(null, new PrintWriter(output)) with Logging {
   import KyuubiSparkILoop._
 
   val result = new DataFrameHolder(spark)
 
   private def initialize(): Unit = withLockRequired {
+    val currentClassLoader = Thread.currentThread().getContextClassLoader
+    val interpreterClasspath = getAllJars(currentClassLoader).mkString(File.pathSeparator)
+    info(s"Adding jars to Scala interpreter's class path: $interpreterClasspath")
     val settings = new Settings
     val interpArguments = List(
       "-Yrepl-class-based",
       "-Yrepl-outdir",
-      s"${spark.sparkContext.getConf.get("spark.repl.class.outputDir")}")
+      s"${spark.sparkContext.getConf.get("spark.repl.class.outputDir")}",
+      "-classpath",
+      interpreterClasspath)
     settings.processArguments(interpArguments, processAll = true)
     settings.usejavacp.value = true
-    val currentClassLoader = Thread.currentThread().getContextClassLoader
     settings.embeddedDefaults(currentClassLoader)
     this.createInterpreter(settings)
     val iMain = this.intp.asInstanceOf[IMain]
@@ -54,22 +59,6 @@ private[spark] case class KyuubiSparkILoop private (
     try {
       this.compilerClasspath
       iMain.ensureClassLoader()
-      var classLoader: ClassLoader = Thread.currentThread().getContextClassLoader
-      while (classLoader != null) {
-        classLoader match {
-          case loader: MutableURLClassLoader =>
-            val allJars = loader.getURLs.filter { u =>
-              val file = new File(u.getPath)
-              u.getProtocol == "file" && file.isFile &&
-              file.getName.contains("scala-lang_scala-reflect")
-            }
-            this.addUrlsToClassPath(allJars: _*)
-            classLoader = null
-          case _ =>
-            classLoader = classLoader.getParent
-        }
-      }
-
       this.addUrlsToClassPath(
         classOf[DataFrameHolder].getProtectionDomain.getCodeSource.getLocation)
     } finally {
@@ -96,6 +85,23 @@ private[spark] case class KyuubiSparkILoop private (
         classOf[DataFrameHolder].getCanonicalName,
         result)
     }
+  }
+
+  private def getAllJars(currentClassLoader: ClassLoader): Array[URL] = {
+    var classLoader: ClassLoader = currentClassLoader
+    var allJars = Array.empty[URL]
+    while (classLoader != null) {
+      classLoader match {
+        case loader: MutableURLClassLoader =>
+          allJars = loader.getURLs.filter { u =>
+            u.getProtocol == "file" && new File(u.getPath).isFile
+          }
+          classLoader = null
+        case _ =>
+          classLoader = classLoader.getParent
+      }
+    }
+    allJars
   }
 
   def getResult(statementId: String): DataFrame = result.get(statementId)

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteScala.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteScala.scala
@@ -89,7 +89,7 @@ class ExecuteScala(
         if (legacyOutput.nonEmpty) {
           warn(s"Clearing legacy output from last interpreting:\n $legacyOutput")
         }
-        val replUrls = repl.classLoader.getParent.asInstanceOf[URLClassLoader].getURLs
+        val replUrls = repl.global.classPath.asURLs
         spark.sharedState.jarClassLoader.getURLs.filterNot(replUrls.contains).foreach { jar =>
           try {
             if ("file".equals(jar.toURI.getScheme)) {

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteScala.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteScala.scala
@@ -20,7 +20,6 @@ package org.apache.kyuubi.engine.spark.operation
 import java.io.File
 import java.util.concurrent.RejectedExecutionException
 
-import scala.reflect.internal.util.ScalaClassLoader.URLClassLoader
 import scala.tools.nsc.interpreter.Results.{Error, Incomplete, Success}
 
 import org.apache.hadoop.fs.Path

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteScala.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteScala.scala
@@ -20,6 +20,7 @@ package org.apache.kyuubi.engine.spark.operation
 import java.io.File
 import java.util.concurrent.RejectedExecutionException
 
+import scala.reflect.internal.util.ScalaClassLoader.URLClassLoader
 import scala.tools.nsc.interpreter.Results.{Error, Incomplete, Success}
 
 import org.apache.hadoop.fs.Path
@@ -88,7 +89,7 @@ class ExecuteScala(
         if (legacyOutput.nonEmpty) {
           warn(s"Clearing legacy output from last interpreting:\n $legacyOutput")
         }
-        val replUrls = repl.global.classPath.asURLs
+        val replUrls = repl.classLoader.getParent.asInstanceOf[URLClassLoader].getURLs
         spark.sharedState.jarClassLoader.getURLs.filterNot(replUrls.contains).foreach { jar =>
           try {
             if ("file".equals(jar.toURI.getScheme)) {

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteScala.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteScala.scala
@@ -20,7 +20,6 @@ package org.apache.kyuubi.engine.spark.operation
 import java.io.File
 import java.util.concurrent.RejectedExecutionException
 
-import scala.reflect.internal.util.ScalaClassLoader.URLClassLoader
 import scala.tools.nsc.interpreter.Results.{Error, Incomplete, Success}
 
 import org.apache.hadoop.fs.Path
@@ -89,7 +88,7 @@ class ExecuteScala(
         if (legacyOutput.nonEmpty) {
           warn(s"Clearing legacy output from last interpreting:\n $legacyOutput")
         }
-        val replUrls = repl.classLoader.getParent.asInstanceOf[URLClassLoader].getURLs
+        val replUrls = repl.global.classPath.asURLs
         spark.sharedState.jarClassLoader.getURLs.filterNot(replUrls.contains).foreach { jar =>
           try {
             if ("file".equals(jar.toURI.getScheme)) {

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
@@ -365,7 +365,7 @@ class KyuubiOperationPerConnectionSuite extends WithKyuubiServer with HiveJDBCTe
       s"test-function-${UUID.randomUUID}.jar",
       jarDir.toString)
     val localPath = new Path(jarFile.getAbsolutePath)
-    withSessionConf(Map("spark.jars" -> localPath.toString))(Map.empty)() {
+    withSessionConf()(Map("spark.jars" -> localPath.toString))() {
       withJdbcStatement() { statement =>
         val kyuubiStatement = statement.asInstanceOf[KyuubiStatement]
         kyuubiStatement.executeScala("import test.utils.{Math => TMath}")

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
@@ -19,18 +19,19 @@ package org.apache.kyuubi.operation
 
 import java.sql.SQLException
 import java.util
-import java.util.Properties
+import java.util.{Properties, UUID}
 
 import scala.collection.JavaConverters._
 
+import org.apache.hadoop.fs.Path
 import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
 
-import org.apache.kyuubi.{KYUUBI_VERSION, WithKyuubiServer}
+import org.apache.kyuubi.{KYUUBI_VERSION, Utils, WithKyuubiServer}
 import org.apache.kyuubi.config.{KyuubiConf, KyuubiReservedKeys}
 import org.apache.kyuubi.config.KyuubiConf.SESSION_CONF_ADVISOR
 import org.apache.kyuubi.engine.{ApplicationManagerInfo, ApplicationState}
 import org.apache.kyuubi.jdbc.KyuubiHiveDriver
-import org.apache.kyuubi.jdbc.hive.{KyuubiConnection, KyuubiSQLException}
+import org.apache.kyuubi.jdbc.hive.{KyuubiConnection, KyuubiSQLException, KyuubiStatement}
 import org.apache.kyuubi.metrics.{MetricsConstants, MetricsSystem}
 import org.apache.kyuubi.plugin.SessionConfAdvisor
 import org.apache.kyuubi.session.{KyuubiSessionImpl, KyuubiSessionManager, SessionHandle, SessionType}
@@ -343,6 +344,34 @@ class KyuubiOperationPerConnectionSuite extends WithKyuubiServer with HiveJDBCTe
         eventually(timeout(3.seconds)) {
           assert(session.client.asyncRequestInterrupted)
         }
+      }
+    }
+  }
+
+  test("Scala REPL should see jars added by spark.jars") {
+    val jarDir = Utils.createTempDir().toFile
+    val udfCode =
+      """
+        |package test.utils
+        |
+        |object Math {
+        |  def add(x: Int, y: Int): Int = x + y
+        |}
+        |
+        |""".stripMargin
+    val jarFile = UserJarTestUtils.createJarFile(
+      udfCode,
+      "test",
+      s"test-function-${UUID.randomUUID}.jar",
+      jarDir.toString)
+    val localPath = new Path(jarFile.getAbsolutePath)
+    withSessionConf(Map("spark.jars" -> localPath.toString))(Map.empty)() {
+      withJdbcStatement() { statement =>
+        val kyuubiStatement = statement.asInstanceOf[KyuubiStatement]
+        kyuubiStatement.executeScala("import test.utils.{Math => TMath }")
+        val rs = kyuubiStatement.executeScala("println(TMath.add(1,2))")
+        rs.next()
+        assert(rs.getString(1) === "3")
       }
     }
   }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
@@ -368,7 +368,7 @@ class KyuubiOperationPerConnectionSuite extends WithKyuubiServer with HiveJDBCTe
     withSessionConf(Map("spark.jars" -> localPath.toString))(Map.empty)() {
       withJdbcStatement() { statement =>
         val kyuubiStatement = statement.asInstanceOf[KyuubiStatement]
-        kyuubiStatement.executeScala("import test.utils.{Math => TMath }")
+        kyuubiStatement.executeScala("import test.utils.{Math => TMath}")
         val rs = kyuubiStatement.executeScala("println(TMath.add(1,2))")
         rs.next()
         assert(rs.getString(1) === "3")


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #6223

Even the user specify `spark.jars`, but they can not access the classes in jars with Scala code.

## Describe Your Solution 🔧

Add the jars into repl classpath.

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests
UT.

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
