### PR TITLE
Specify logDir for RollingFile filePattern

### DIFF
--- a/conf/log4j2.xml.template
+++ b/conf/log4j2.xml.template
@@ -34,7 +34,7 @@
             <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %p %tn %c: %m%n%ex"/>
         </Console>
         <RollingFile name="restAudit" fileName="${sys:logDir}/${sys:restAuditLogPath}"
-                     filePattern="${sys:restAuditLogFilePattern}">
+                     filePattern="${sys:logDir}/${sys:restAuditLogFilePattern}">
             <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %p %c{1}: %m%n%ex"/>
             <Policies>
                 <SizeBasedTriggeringPolicy size="51200KB" />
@@ -42,7 +42,7 @@
             <DefaultRolloverStrategy max="10"/>
         </RollingFile>
         <RollingFile name="k8sAudit" fileName="${sys:logDir}/${sys:k8sAuditLogPath}"
-                     filePattern="${sys:k8sAuditLogFilePattern}">
+                     filePattern="${sys:logDir}/${sys:k8sAuditLogFilePattern}">
             <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %p %c{1}: %m%n%ex"/>
             <Policies>
                 <SizeBasedTriggeringPolicy size="51200KB" />
@@ -50,7 +50,7 @@
             <DefaultRolloverStrategy max="10"/>
         </RollingFile>
         <RollingFile name="opAudit" fileName="${sys:logDir}/${sys:opAuditLogPath}"
-                     filePattern="${sys:opAuditLogFilePattern}">
+                     filePattern="${sys:logDir}/${sys:opAuditLogFilePattern}">
             <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %p %c{1}: %m%n%ex"/>
             <Policies>
                 <SizeBasedTriggeringPolicy size="51200KB" />


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #

## Describe Your Solution 🔧

We should specify `sys:logDir` for RollingFile filePattern, otherwise the log will be rolled to kyuubi work directory.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
