### PR TITLE
[KYUUBI #6248] Web SQL Editor supports run SQL snippets

### DIFF
--- a/kyuubi-server/web-ui/src/components/monaco-editor/index.vue
+++ b/kyuubi-server/web-ui/src/components/monaco-editor/index.vue
@@ -105,6 +105,17 @@
     })
     emit('editorMounted', editor)
   }
+  const getSelectValue = () => {
+    const selection: any = editor.getSelection()
+    const range: any = {
+      startLineNumber: selection.selectionStartLineNumber,
+      startColumn: selection.selectionStartColumn,
+      endLineNumber: selection.positionLineNumber,
+      endColumn: selection.positionColumn
+    }
+    const model: any = editor.getModel()
+    return model.getValueInRange(range)
+  }
   watch(
     () => props.modelValue,
     (newValue) => {
@@ -145,5 +156,8 @@
   })
   onMounted(() => {
     init()
+  })
+  defineExpose({
+    getSelectValue
   })
 </script>

--- a/kyuubi-server/web-ui/src/components/monaco-editor/index.vue
+++ b/kyuubi-server/web-ui/src/components/monaco-editor/index.vue
@@ -106,15 +106,18 @@
     emit('editorMounted', editor)
   }
   const getSelectValue = () => {
-    const selection: any = editor.getSelection()
-    const range: any = {
+    const selection = editor.getSelection()
+    if (!selection) {
+      return ''
+    }
+    const range = {
       startLineNumber: selection.selectionStartLineNumber,
       startColumn: selection.selectionStartColumn,
       endLineNumber: selection.positionLineNumber,
       endColumn: selection.positionColumn
     }
-    const model: any = editor.getModel()
-    return model.getValueInRange(range)
+    const model = editor.getModel()
+    return model?.getValueInRange(range)
   }
   watch(
     () => props.modelValue,

--- a/kyuubi-server/web-ui/src/views/editor/components/Editor.vue
+++ b/kyuubi-server/web-ui/src/views/editor/components/Editor.vue
@@ -55,6 +55,7 @@
     </el-space>
     <section>
       <MonacoEditor
+        ref="monacoEditor"
         v-model="editorVariables.content"
         :language="editorVariables.language"
         :theme="theme"
@@ -113,6 +114,7 @@
   })
   const limit = ref(10)
   const sqlResult: Ref<any[] | null> = ref(null)
+  const monacoEditor = ref()
   const sqlLog = ref('')
   const activeTab = ref('result')
   const resultLoading = ref(false)
@@ -156,10 +158,10 @@
       if (!openSessionResponse) return
       sessionIdentifier.value = openSessionResponse.identifier
     }
-
+    const selectValue = monacoEditor.value.getSelectValue()
     const runSqlResponse: IResponse = await runSql(
       {
-        statement: editorVariables.content,
+        statement: selectValue || editorVariables.content,
         runAsync: false
       },
       sessionIdentifier.value


### PR DESCRIPTION
# :mag: Description
when some text is selected, only send the selected text.
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #6248 

## Describe Your Solution 🔧
The Monaco Editor API is called to get the selected SQL statement, and without any other dependency.
<img width="581" alt="image" src="https://github.com/apache/kyuubi/assets/34719039/ce6ac5ae-b1fc-4778-a57e-dfda9ad51275">



## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
