### PR TITLE
[KYUUBI #6251] Improve kyuubi-beeline help message

### DIFF
--- a/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/KyuubiBeeLine.java
+++ b/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/KyuubiBeeLine.java
@@ -79,7 +79,7 @@ public class KyuubiBeeLine extends BeeLine {
 
   @Override
   void usage() {
-    output(loc("kyuubi-beeline-usage"));
+    super.usage();
   }
 
   public boolean isPythonMode() {

--- a/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/KyuubiBeeLine.java
+++ b/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/KyuubiBeeLine.java
@@ -77,11 +77,6 @@ public class KyuubiBeeLine extends BeeLine {
     }
   }
 
-  @Override
-  void usage() {
-    super.usage();
-  }
-
   public boolean isPythonMode() {
     return pythonMode;
   }

--- a/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/KyuubiBeeLine.java
+++ b/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/KyuubiBeeLine.java
@@ -79,9 +79,7 @@ public class KyuubiBeeLine extends BeeLine {
 
   @Override
   void usage() {
-    super.usage();
-    output("Usage: java " + KyuubiBeeLine.class.getCanonicalName());
-    output("   --python-mode                   Execute python code/script.");
+    output(loc("kyuubi-beeline-usage"));
   }
 
   public boolean isPythonMode() {

--- a/kyuubi-hive-beeline/src/main/resources/BeeLine.properties
+++ b/kyuubi-hive-beeline/src/main/resources/BeeLine.properties
@@ -155,75 +155,79 @@ hs2-unexpected-error: Unexpected HS2 error when communicating with the Thrift se
 interrupt-ctrl-c: Interrupting... Please be patient this may take some time.
 
 cmd-usage: Usage: kyuubi-beeline <options>. \n\n\
-Options:\n \
-\  -u <database url>                 The JDBC URL to connect to.\n \
-\  -c <named url>                    The named JDBC URL to connect to,\n \
-\                                    which should be present in beeline-site.xml\n \
-\                                    as the value of beeline.kyuubi.jdbc.url.<namedUrl>.\n\n \
-\  -r                                Reconnect to last saved connect url (in conjunction with !save).\n \
-\  -n <username>                     The username to connect as.\n \
-\  -p <password>                     The password to connect as.\n \
-\  -d <driver class>                 The driver class to use.\n \
-\  -i <init file>                    Script file for initialization.\n \
-\  -e <query>                        Query that should be executed.\n \
-\  -f <exec file>                    Script file that should be executed.\n \
-\  -w, --password-file <file>        The password file to read password from.\n \
-\  --hiveconf property=value         Use value for given property.\n \
-\  --hivevar name=value              Hive variable name and value.\n \
-\                                    This is Hive specific settings in which variables\n \
-\                                    can be set at session level and referenced in Hive\n \
-\                                    commands or queries.\n\n \
-\  --property-file=<property-file>   The file to read connection properties (url, driver, user, password) from.\n \
-\  --color=[true|false]              Control whether color is used for display.\n \
-\  --showHeader=[true|false]         Show column names in query results.\n \
-\  --escapeCRLF=[true|false]         Show carriage return and line feeds in query results as escaped \\r and \\n. \n \
-\  --headerInterval=ROWS;            The interval between which heades are displayed.\n \
-\  --fastConnect=[true|false]        Skip building table/column list for tab-completion.\n \
-\  --autoCommit=[true|false]         Enable/disable automatic transaction commit.\n \
-\  --verbose=[true|false]            Show verbose error messages and debug info.\n \
-\  --showWarnings=[true|false]       Display connection warnings.\n \
-\  --showDbInPrompt=[true|false]     Display the current database name in the prompt.\n \
-\  --showNestedErrs=[true|false]     Display nested errors.\n \
-\  --numberFormat=[pattern]          Format numbers using DecimalFormat pattern.\n \
-\  --force=[true|false]              Continue running script even after errors.\n \
-\  --maxWidth=MAXWIDTH               The maximum width of the terminal.\n \
-\  --maxColumnWidth=MAXCOLWIDTH      The maximum width to use when displaying columns.\n \
-\  --silent=[true|false]             Be more silent.\n \
-\  --autosave=[true|false]           Automatically save preferences.\n \
-\  --outputformat=<format mode>      Format mode for result display.\n \
-\                                    The available options ars [table|vertical|csv2|tsv2|dsv|csv|tsv|json|jsonfile]. \n \
-\                                    Note that csv, and tsv are deprecated, use csv2, tsv2 instead.\n\n \
-\  --incremental=[true|false]        Defaults to false. When set to false, the entire result set\n \
-\                                    is fetched and buffered before being displayed, yielding optimal\n \
-\                                    display column sizing. When set to true, result rows are displayed\n \
-\                                    immediately as they are fetched, yielding lower latency and\n \
-\                                    memory usage at the price of extra display column padding.\n \
-\                                    Setting --incremental=true is recommended if you encounter an OutOfMemory\n \
-\                                    on the client side (due to the fetched result set size being large).\n \
-\                                    Only applicable if --outputformat=table.\n\n \
-\  --incrementalBufferRows=NUMROWS   The number of rows to buffer when printing rows on stdout,\n \
-\                                    defaults to 1000; only applicable if --incremental=true\n \
-\                                    and --outputformat=table.\n\n \
-\  --truncateTable=[true|false]      Truncate table column when it exceeds length.\n \
-\  --delimiterForDSV=DELIMITER       Specify the delimiter for delimiter-separated values output format (default: |).\n \
-\  --isolation=LEVEL                 Set the transaction isolation level.\n \
-\  --nullemptystring=[true|false]    Set to true to get historic behavior of printing null as empty string.\n \
-\  --maxHistoryRows=MAXHISTORYROWS   The maximum number of rows to store beeline history.\n \
-\  --delimiter=DELIMITER             Set the query delimiter; multi-char delimiters are allowed, but quotation\n \
-\                                    marks, slashes, and -- are not allowed; defaults to ;\n\n \
-\  --convertBinaryArrayToString=[true|false]\n \
-\                                    Display binary column data as string or as byte array.\n\n \
-\  --python-mode                     Execute python code/script.\n \
-\  --help                            Display this message.\n \
-\n \
-\  Example:\n \
-\   1. Connect using simple authentication to KyuubiServer on localhost:10009\n \
-\   $ kyuubi-beeline -u jdbc:kyuubi://localhost:10009 username password\n\n \
-\   2. Connect using simple authentication to KyuubiServer on kyuubi.local:10009 using -n for username and -p for password\n \
-\   $ kyuubi-beeline -n username -p password -u jdbc:kyuubi://kyuubi.local:10009\n\n \
-\   3. Connect using Kerberos authentication with hive/localhost@mydomain.com as KyuubiServer principal\n \
-\   $ kyuubi-beeline -u "jdbc:kyuubi://kyuubi.local:10009/default;principal=hive/localhost@mydomain.com"\n\n \
-\   4. Connect using SSL connection to KyuubiServer on localhost at 10009\n \
-\   $ kyuubi-beeline "jdbc:kyuubi://localhost:10009/default;ssl=true;sslTrustStore=/usr/local/truststore;trustStorePassword=mytruststorepassword"\n\n \
-\   5. Connect using LDAP authentication\n \
-\   $ kyuubi-beeline -u jdbc:kyuubi://kyuubi.local:10009/default <ldap-username> <ldap-password>
+Options:\n\
+\  -u <database url>               The JDBC URL to connect to.\n\
+\  -c <named url>                  The named JDBC URL to connect to,\n\
+\                                  which should be present in beeline-site.xml\n\
+\                                  as the value of beeline.kyuubi.jdbc.url.<namedUrl>.\n\n\
+\  -r                              Reconnect to last saved connect url (in conjunction with !save).\n\
+\  -n <username>                   The username to connect as.\n\
+\  -p <password>                   The password to connect as.\n\
+\  -d <driver class>               The driver class to use.\n\
+\  -i <init file>                  Script file for initialization.\n\
+\  -e <query>                      Query that should be executed.\n\
+\  -f <exec file>                  Script file that should be executed.\n\
+\  -w, --password-file <file>      The password file to read password from.\n\
+\  --hiveconf property=value       Use value for given property.\n\
+\  --hivevar name=value            Hive variable name and value.\n\
+\                                  This is Hive specific settings in which variables\n\
+\                                  can be set at session level and referenced in Hive\n\
+\                                  commands or queries.\n\n\
+\  --property-file=<property file> The file to read connection properties (url, driver, user, password) from.\n\
+\  --color=[true|false]            Control whether color is used for display.\n\
+\  --showHeader=[true|false]       Show column names in query results.\n\
+\  --escapeCRLF=[true|false]       Show carriage return and line feeds in query results as escaped \\r and \\n. \n\
+\  --headerInterval=ROWS;          The interval between which heades are displayed.\n\
+\  --fastConnect=[true|false]      Skip building table/column list for tab-completion.\n\
+\  --autoCommit=[true|false]       Enable/disable automatic transaction commit.\n\
+\  --verbose=[true|false]          Show verbose error messages and debug info.\n\
+\  --showWarnings=[true|false]     Display connection warnings.\n\
+\  --showDbInPrompt=[true|false]   Display the current database name in the prompt.\n\
+\  --showNestedErrs=[true|false]   Display nested errors.\n\
+\  --numberFormat=[pattern]        Format numbers using DecimalFormat pattern.\n\
+\  --force=[true|false]            Continue running script even after errors.\n\
+\  --maxWidth=MAXWIDTH             The maximum width of the terminal.\n\
+\  --maxColumnWidth=MAXCOLWIDTH    The maximum width to use when displaying columns.\n\
+\  --silent=[true|false]           Be more silent.\n\
+\  --autosave=[true|false]         Automatically save preferences.\n\
+\  --outputformat=<format mode>    Format mode for result display.\n\
+\                                  The available options ars [table|vertical|csv2|tsv2|dsv|csv|tsv|json|jsonfile]. \n\
+\                                  Note that csv, and tsv are deprecated, use csv2, tsv2 instead.\n\n\
+\  --incremental=[true|false]      Defaults to false. When set to false, the entire result set\n\
+\                                  is fetched and buffered before being displayed, yielding optimal\n\
+\                                  display column sizing. When set to true, result rows are displayed\n\
+\                                  immediately as they are fetched, yielding lower latency and\n\
+\                                  memory usage at the price of extra display column padding.\n\
+\                                  Setting --incremental=true is recommended if you encounter an OutOfMemory\n\
+\                                  on the client side (due to the fetched result set size being large).\n\
+\                                  Only applicable if --outputformat=table.\n\n\
+\  --incrementalBufferRows=NUMROWS The number of rows to buffer when printing rows on stdout,\n\
+\                                  defaults to 1000; only applicable if --incremental=true\n\
+\                                  and --outputformat=table.\n\n\
+\  --truncateTable=[true|false]    Truncate table column when it exceeds length.\n\
+\  --delimiterForDSV=DELIMITER     Specify the delimiter for delimiter-separated values output format (default: |).\n\
+\  --isolation=LEVEL               Set the transaction isolation level.\n\
+\  --nullemptystring=[true|false]  Set to true to get historic behavior of printing null as empty string.\n\
+\  --maxHistoryRows=MAXHISTORYROWS The maximum number of rows to store beeline history.\n\
+\  --delimiter=DELIMITER           Set the query delimiter; multi-char delimiters are allowed, but quotation\n\
+\                                  marks, slashes, and -- are not allowed; defaults to ;\n\n\
+\  --convertBinaryArrayToString=[true|false]\n\
+\                                  Display binary column data as string or as byte array.\n\n\
+\  --python-mode                   Execute python code/script.\n\
+\  -h, --help                      Display this message.\n\
+\n\
+Examples:\n\
+\  1. Connect using simple authentication to Kyuubi Server on localhost:10009.\n\
+\  $ kyuubi-beeline -u jdbc:kyuubi://localhost:10009 <username> <password>\n\n\
+\  2. Connect using simple authentication to Kyuubi Server on kyuubi.local:10009 using -n for username and -p for password.\n\
+\  $ kyuubi-beeline -n username -p password -u jdbc:kyuubi://kyuubi.local:10009\n\n\
+\  3. Connect using Kerberos authentication with kyuubi/localhost@mydomain.com as Kyuubi Server principal(kinit is required before connection).\n\
+\  $ kyuubi-beeline -u "jdbc:kyuubi://kyuubi.local:10009/default;kyuubiServerPrincipal=kyuubi/localhost@mydomain.com"\n\n\
+\  4. Connect using Kerberos authentication using principal and keytab directly.\n\
+\  $ kyuubi-beeline -u "jdbc:kyuubi://kyuubi.local:10009/default;kyuubiClientPrincipal=user@mydomain.com;kyuubiClientKeytab=/local/path/client.keytab;kyuubiServerPrincipal=kyuubi/localhost@mydomain.com"\n\n\
+\  5. Connect using SSL connection to Kyuubi Server on localhost:10009.\n\
+\  $ kyuubi-beeline -u "jdbc:kyuubi://localhost:10009/default;ssl=true;sslTrustStore=/usr/local/truststore;trustStorePassword=mytruststorepassword"\n\n\
+\  6. Connect using LDAP authentication.\n\
+\  $ kyuubi-beeline -u jdbc:kyuubi://kyuubi.local:10009/default -n ldap-username -p ldap-password\n\n\
+\  7. Connect using the ZooKeeper address to Kyuubi HA Server on localhost:2181.\n\
+\  $ kyuubi-beeline -u "jdbc:kyuubi://localhost:2181/;serviceDiscoveryMode=zooKeeper;zooKeeperNamespace=kyuubi" -n username

--- a/kyuubi-hive-beeline/src/main/resources/BeeLine.properties
+++ b/kyuubi-hive-beeline/src/main/resources/BeeLine.properties
@@ -218,7 +218,7 @@ Options:\n\
 \n\
 Examples:\n\
 \  1. Connect using simple authentication to Kyuubi Server on localhost:10009.\n\
-\  $ kyuubi-beeline -u jdbc:kyuubi://localhost:10009 <username> <password>\n\n\
+\  $ kyuubi-beeline -u jdbc:kyuubi://localhost:10009 -n username\n\n\
 \  2. Connect using simple authentication to Kyuubi Server on kyuubi.local:10009 using -n for username and -p for password.\n\
 \  $ kyuubi-beeline -n username -p password -u jdbc:kyuubi://kyuubi.local:10009\n\n\
 \  3. Connect using Kerberos authentication with kyuubi/localhost@mydomain.com as Kyuubi Server principal(kinit is required before connection).\n\
@@ -229,5 +229,5 @@ Examples:\n\
 \  $ kyuubi-beeline -u "jdbc:kyuubi://localhost:10009/default;ssl=true;sslTrustStore=/usr/local/truststore;trustStorePassword=mytruststorepassword"\n\n\
 \  6. Connect using LDAP authentication.\n\
 \  $ kyuubi-beeline -u jdbc:kyuubi://kyuubi.local:10009/default -n ldap-username -p ldap-password\n\n\
-\  7. Connect using the ZooKeeper address to Kyuubi HA Server on localhost:2181.\n\
-\  $ kyuubi-beeline -u "jdbc:kyuubi://localhost:2181/;serviceDiscoveryMode=zooKeeper;zooKeeperNamespace=kyuubi" -n username
+\  7. Connect using the ZooKeeper address to Kyuubi HA cluster.\n\
+\  $ kyuubi-beeline -u "jdbc:kyuubi://zk1:2181,zk2:2181,zk3:2181/;serviceDiscoveryMode=zooKeeper;zooKeeperNamespace=kyuubi" -n username

--- a/kyuubi-hive-beeline/src/main/resources/BeeLine.properties
+++ b/kyuubi-hive-beeline/src/main/resources/BeeLine.properties
@@ -154,78 +154,7 @@ hs2-unknown-connection-problem: Unknown HS2 problem when communicating with Thri
 hs2-unexpected-error: Unexpected HS2 error when communicating with the Thrift server.
 interrupt-ctrl-c: Interrupting... Please be patient this may take some time.
 
-
-cmd-usage: Usage: java org.apache.hive.cli.beeline.BeeLine \n \
-\  -u <database url>               the JDBC URL to connect to\n \
-\  -c <named url>                  the named JDBC URL to connect to,\n \
-\                                  which should be present in beeline-site.xml\n \
-\                                  as the value of beeline.hs2.jdbc.url.<namedUrl>\n \
-\  -r                              reconnect to last saved connect url (in conjunction with !save)\n \
-\  -n <username>                   the username to connect as\n \
-\  -p <password>                   the password to connect as\n \
-\  -d <driver class>               the driver class to use\n \
-\  -i <init file>                  script file for initialization\n \
-\  -e <query>                      query that should be executed\n \
-\  -f <exec file>                  script file that should be executed\n \
-\  -w (or) --password-file <password file>  the password file to read password from\n \
-\  --hiveconf property=value       Use value for given property\n \
-\  --hivevar name=value            hive variable name and value\n \
-\                                  This is Hive specific settings in which variables\n \
-\                                  can be set at session level and referenced in Hive\n \
-\                                  commands or queries.\n \
-\  --property-file=<property-file> the file to read connection properties (url, driver, user, password) from\n \
-\  --color=[true/false]            control whether color is used for display\n \
-\  --showHeader=[true/false]       show column names in query results\n \
-\  --escapeCRLF=[true/false]       show carriage return and line feeds in query results as escaped \\r and \\n \n \
-\  --headerInterval=ROWS;          the interval between which heades are displayed\n \
-\  --fastConnect=[true/false]      skip building table/column list for tab-completion\n \
-\  --autoCommit=[true/false]       enable/disable automatic transaction commit\n \
-\  --verbose=[true/false]          show verbose error messages and debug info\n \
-\  --showWarnings=[true/false]     display connection warnings\n \
-\  --showDbInPrompt=[true/false]   display the current database name in the prompt\n \
-\  --showNestedErrs=[true/false]   display nested errors\n \
-\  --numberFormat=[pattern]        format numbers using DecimalFormat pattern\n \
-\  --force=[true/false]            continue running script even after errors\n \
-\  --maxWidth=MAXWIDTH             the maximum width of the terminal\n \
-\  --maxColumnWidth=MAXCOLWIDTH    the maximum width to use when displaying columns\n \
-\  --silent=[true/false]           be more silent\n \
-\  --autosave=[true/false]         automatically save preferences\n \
-\  --outputformat=[table/vertical/csv2/tsv2/dsv/csv/tsv/json/jsonfile]  format mode for result display\n \
-\                                  Note that csv, and tsv are deprecated - use csv2, tsv2 instead\n \
-\  --incremental=[true/false]      Defaults to false. When set to false, the entire result set\n \
-\                                  is fetched and buffered before being displayed, yielding optimal\n \
-\                                  display column sizing. When set to true, result rows are displayed\n \
-\                                  immediately as they are fetched, yielding lower latency and\n \
-\                                  memory usage at the price of extra display column padding.\n \
-\                                  Setting --incremental=true is recommended if you encounter an OutOfMemory\n \
-\                                  on the client side (due to the fetched result set size being large).\n \
-\                                  Only applicable if --outputformat=table.\n \
-\  --incrementalBufferRows=NUMROWS the number of rows to buffer when printing rows on stdout,\n \
-\                                  defaults to 1000; only applicable if --incremental=true\n \
-\                                  and --outputformat=table\n \
-\  --truncateTable=[true/false]    truncate table column when it exceeds length\n \
-\  --delimiterForDSV=DELIMITER     specify the delimiter for delimiter-separated values output format (default: |)\n \
-\  --isolation=LEVEL               set the transaction isolation level\n \
-\  --nullemptystring=[true/false]  set to true to get historic behavior of printing null as empty string\n \
-\  --maxHistoryRows=MAXHISTORYROWS The maximum number of rows to store beeline history.\n \
-\  --delimiter=DELIMITER           set the query delimiter; multi-char delimiters are allowed, but quotation\n \
-\                                  marks, slashes, and -- are not allowed; defaults to ;\n \
-\  --convertBinaryArrayToString=[true/false]    display binary column data as string or as byte array \n \
-\  --help                          display this message\n \
-\n \
-\  Example:\n \
-\   1. Connect using simple authentication to HiveServer2 on localhost:10000\n \
-\   $ beeline -u jdbc:hive2://localhost:10000 username password\n\n \
-\   2. Connect using simple authentication to HiveServer2 on hs.local:10000 using -n for username and -p for password\n \
-\   $ beeline -n username -p password -u jdbc:hive2://hs2.local:10012\n\n \
-\   3. Connect using Kerberos authentication with hive/localhost@mydomain.com as HiveServer2 principal\n \
-\   $ beeline -u "jdbc:hive2://hs2.local:10013/default;principal=hive/localhost@mydomain.com"\n\n \
-\   4. Connect using SSL connection to HiveServer2 on localhost at 10000\n \
-\   $ beeline "jdbc:hive2://localhost:10000/default;ssl=true;sslTrustStore=/usr/local/truststore;trustStorePassword=mytruststorepassword"\n\n \
-\   5. Connect using LDAP authentication\n \
-\   $ beeline -u jdbc:hive2://hs2.local:10013/default <ldap-username> <ldap-password>\n 
-
-kyuubi-beeline-usage: Usage: java org.apache.hive.cli.beeline.BeeLine. \n \
+cmd-usage: Usage: java org.apache.hive.cli.beeline.BeeLine. \n \
 \  -u <database url>                 The JDBC URL to connect to.\n \
 \  -c <named url>                    The named JDBC URL to connect to,\n \
 \                                    which should be present in beeline-site.xml\n \

--- a/kyuubi-hive-beeline/src/main/resources/BeeLine.properties
+++ b/kyuubi-hive-beeline/src/main/resources/BeeLine.properties
@@ -210,7 +210,7 @@ Options:\n\
 \  --nullemptystring=[true|false]  Set to true to get historic behavior of printing null as empty string.\n\
 \  --maxHistoryRows=MAXHISTORYROWS The maximum number of rows to store beeline history.\n\
 \  --delimiter=DELIMITER           Set the query delimiter; multi-char delimiters are allowed, but quotation\n\
-\                                  marks, slashes, and -- are not allowed; defaults to ;\n\n\
+\                                  marks, slashes, and -- are not allowed (default: ;).\n\n\
 \  --convertBinaryArrayToString=[true|false]\n\
 \                                  Display binary column data as string or as byte array.\n\n\
 \  --python-mode                   Execute python code/script.\n\

--- a/kyuubi-hive-beeline/src/main/resources/BeeLine.properties
+++ b/kyuubi-hive-beeline/src/main/resources/BeeLine.properties
@@ -223,4 +223,78 @@ cmd-usage: Usage: java org.apache.hive.cli.beeline.BeeLine \n \
 \   4. Connect using SSL connection to HiveServer2 on localhost at 10000\n \
 \   $ beeline "jdbc:hive2://localhost:10000/default;ssl=true;sslTrustStore=/usr/local/truststore;trustStorePassword=mytruststorepassword"\n\n \
 \   5. Connect using LDAP authentication\n \
-\   $ beeline -u jdbc:hive2://hs2.local:10013/default <ldap-username> <ldap-password>\n \
+\   $ beeline -u jdbc:hive2://hs2.local:10013/default <ldap-username> <ldap-password>\n 
+
+kyuubi-beeline-usage: Usage: java org.apache.hive.cli.beeline.BeeLine. \n \
+\  -u <database url>                 The JDBC URL to connect to.\n \
+\  -c <named url>                    The named JDBC URL to connect to,\n \
+\                                    which should be present in beeline-site.xml\n \
+\                                    as the value of beeline.kyuubi.jdbc.url.<namedUrl>.\n \
+\  -r                                Reconnect to last saved connect url (in conjunction with !save).\n \
+\  -n <username>                     The username to connect as.\n \
+\  -p <password>                     The password to connect as.\n \
+\  -d <driver class>                 The driver class to use.\n \
+\  -i <init file>                    Script file for initialization.\n \
+\  -e <query>                        Query that should be executed.\n \
+\  -f <exec file>                    Script file that should be executed.\n \
+\  -w, --password-file <password file>\n \
+\                                    The password file to read password from.\n \
+\  --hiveconf property=value         Use value for given property.\n \
+\  --hivevar name=value              Hive variable name and value.\n \
+\                                    This is Hive specific settings in which variables\n \
+\                                    can be set at session level and referenced in Hive\n \
+\                                    commands or queries.\n \
+\  --property-file=<property-file>   The file to read connection properties (url, driver, user, password) from.\n \
+\  --color=[true|false]              Control whether color is used for display.\n \
+\  --showHeader=[true|false]         Show column names in query results.\n \
+\  --escapeCRLF=[true|false]         Show carriage return and line feeds in query results as escaped \\r and \\n. \n \
+\  --headerInterval=ROWS;            The interval between which heades are displayed.\n \
+\  --fastConnect=[true|false]        Skip building table/column list for tab-completion.\n \
+\  --autoCommit=[true|false]         Enable/disable automatic transaction commit.\n \
+\  --verbose=[true|false]            Show verbose error messages and debug info.\n \
+\  --showWarnings=[true|false]       Display connection warnings.\n \
+\  --showDbInPrompt=[true|false]     Display the current database name in the prompt.\n \
+\  --showNestedErrs=[true|false]     Display nested errors.\n \
+\  --numberFormat=[pattern]          Format numbers using DecimalFormat pattern.\n \
+\  --force=[true|false]              Continue running script even after errors.\n \
+\  --maxWidth=MAXWIDTH               The maximum width of the terminal.\n \
+\  --maxColumnWidth=MAXCOLWIDTH      The maximum width to use when displaying columns.\n \
+\  --silent=[true|false]             Be more silent.\n \
+\  --autosave=[true|false]           Automatically save preferences.\n \
+\  --outputformat=[table|vertical|csv2|tsv2|dsv|csv|tsv|json|jsonfile]\n \
+\                                    Format mode for result display.\n \
+\                                    Note that csv, and tsv are deprecated - use csv2, tsv2 instead.\n \
+\  --incremental=[true|false]        Defaults to false. When set to false, the entire result set\n \
+\                                    is fetched and buffered before being displayed, yielding optimal\n \
+\                                    display column sizing. When set to true, result rows are displayed\n \
+\                                    immediately as they are fetched, yielding lower latency and\n \
+\                                    memory usage at the price of extra display column padding.\n \
+\                                    Setting --incremental=true is recommended if you encounter an OutOfMemory\n \
+\                                    on the client side (due to the fetched result set size being large).\n \
+\                                    Only applicable if --outputformat=table.\n \
+\  --incrementalBufferRows=NUMROWS   The number of rows to buffer when printing rows on stdout,\n \
+\                                    defaults to 1000; only applicable if --incremental=true\n \
+\                                    and --outputformat=table.\n \
+\  --truncateTable=[true|false]      Truncate table column when it exceeds length.\n \
+\  --delimiterForDSV=DELIMITER       Specify the delimiter for delimiter-separated values output format (default: |).\n \
+\  --isolation=LEVEL                 Set the transaction isolation level.\n \
+\  --nullemptystring=[true|false]    Set to true to get historic behavior of printing null as empty string.\n \
+\  --maxHistoryRows=MAXHISTORYROWS   The maximum number of rows to store beeline history.\n \
+\  --delimiter=DELIMITER             Set the query delimiter; multi-char delimiters are allowed, but quotation\n \
+\                                    marks, slashes, and -- are not allowed; defaults to ;\n \
+\  --convertBinaryArrayToString=[true|false]\n \
+\                                    Display binary column data as string or as byte array.\n \
+\  --python-mode                     Execute python code/script.\n \
+\  --help                            Display this message.\n \
+\n \
+\  Example:\n \
+\   1. Connect using simple authentication to KyuubiServer on localhost:10009\n \
+\   $ kyuubi-beeline -u jdbc:kyuubi://localhost:10009 username password\n\n \
+\   2. Connect using simple authentication to KyuubiServer on kyuubi.local:10009 using -n for username and -p for password\n \
+\   $ kyuubi-beeline -n username -p password -u jdbc:kyuubi://kyuubi.local:10009\n\n \
+\   3. Connect using Kerberos authentication with hive/localhost@mydomain.com as KyuubiServer principal\n \
+\   $ kyuubi-beeline -u "jdbc:kyuubi://kyuubi.local:10009/default;principal=hive/localhost@mydomain.com"\n\n \
+\   4. Connect using SSL connection to KyuubiServer on localhost at 10009\n \
+\   $ kyuubi-beeline "jdbc:kyuubi://localhost:10009/default;ssl=true;sslTrustStore=/usr/local/truststore;trustStorePassword=mytruststorepassword"\n\n \
+\   5. Connect using LDAP authentication\n \
+\   $ kyuubi-beeline -u jdbc:kyuubi://kyuubi.local:10009/default <ldap-username> <ldap-password>

--- a/kyuubi-hive-beeline/src/main/resources/BeeLine.properties
+++ b/kyuubi-hive-beeline/src/main/resources/BeeLine.properties
@@ -154,11 +154,12 @@ hs2-unknown-connection-problem: Unknown HS2 problem when communicating with Thri
 hs2-unexpected-error: Unexpected HS2 error when communicating with the Thrift server.
 interrupt-ctrl-c: Interrupting... Please be patient this may take some time.
 
-cmd-usage: Usage: java org.apache.hive.cli.beeline.BeeLine. \n \
+cmd-usage: Usage: kyuubi-beeline <options>. \n\n\
+Options:\n \
 \  -u <database url>                 The JDBC URL to connect to.\n \
 \  -c <named url>                    The named JDBC URL to connect to,\n \
 \                                    which should be present in beeline-site.xml\n \
-\                                    as the value of beeline.kyuubi.jdbc.url.<namedUrl>.\n \
+\                                    as the value of beeline.kyuubi.jdbc.url.<namedUrl>.\n\n \
 \  -r                                Reconnect to last saved connect url (in conjunction with !save).\n \
 \  -n <username>                     The username to connect as.\n \
 \  -p <password>                     The password to connect as.\n \
@@ -166,13 +167,12 @@ cmd-usage: Usage: java org.apache.hive.cli.beeline.BeeLine. \n \
 \  -i <init file>                    Script file for initialization.\n \
 \  -e <query>                        Query that should be executed.\n \
 \  -f <exec file>                    Script file that should be executed.\n \
-\  -w, --password-file <password file>\n \
-\                                    The password file to read password from.\n \
+\  -w, --password-file <file>        The password file to read password from.\n \
 \  --hiveconf property=value         Use value for given property.\n \
 \  --hivevar name=value              Hive variable name and value.\n \
 \                                    This is Hive specific settings in which variables\n \
 \                                    can be set at session level and referenced in Hive\n \
-\                                    commands or queries.\n \
+\                                    commands or queries.\n\n \
 \  --property-file=<property-file>   The file to read connection properties (url, driver, user, password) from.\n \
 \  --color=[true|false]              Control whether color is used for display.\n \
 \  --showHeader=[true|false]         Show column names in query results.\n \
@@ -190,9 +190,9 @@ cmd-usage: Usage: java org.apache.hive.cli.beeline.BeeLine. \n \
 \  --maxColumnWidth=MAXCOLWIDTH      The maximum width to use when displaying columns.\n \
 \  --silent=[true|false]             Be more silent.\n \
 \  --autosave=[true|false]           Automatically save preferences.\n \
-\  --outputformat=[table|vertical|csv2|tsv2|dsv|csv|tsv|json|jsonfile]\n \
-\                                    Format mode for result display.\n \
-\                                    Note that csv, and tsv are deprecated - use csv2, tsv2 instead.\n \
+\  --outputformat=<format mode>      Format mode for result display.\n \
+\                                    The available options ars [table|vertical|csv2|tsv2|dsv|csv|tsv|json|jsonfile]. \n \
+\                                    Note that csv, and tsv are deprecated, use csv2, tsv2 instead.\n\n \
 \  --incremental=[true|false]        Defaults to false. When set to false, the entire result set\n \
 \                                    is fetched and buffered before being displayed, yielding optimal\n \
 \                                    display column sizing. When set to true, result rows are displayed\n \
@@ -200,19 +200,19 @@ cmd-usage: Usage: java org.apache.hive.cli.beeline.BeeLine. \n \
 \                                    memory usage at the price of extra display column padding.\n \
 \                                    Setting --incremental=true is recommended if you encounter an OutOfMemory\n \
 \                                    on the client side (due to the fetched result set size being large).\n \
-\                                    Only applicable if --outputformat=table.\n \
+\                                    Only applicable if --outputformat=table.\n\n \
 \  --incrementalBufferRows=NUMROWS   The number of rows to buffer when printing rows on stdout,\n \
 \                                    defaults to 1000; only applicable if --incremental=true\n \
-\                                    and --outputformat=table.\n \
+\                                    and --outputformat=table.\n\n \
 \  --truncateTable=[true|false]      Truncate table column when it exceeds length.\n \
 \  --delimiterForDSV=DELIMITER       Specify the delimiter for delimiter-separated values output format (default: |).\n \
 \  --isolation=LEVEL                 Set the transaction isolation level.\n \
 \  --nullemptystring=[true|false]    Set to true to get historic behavior of printing null as empty string.\n \
 \  --maxHistoryRows=MAXHISTORYROWS   The maximum number of rows to store beeline history.\n \
 \  --delimiter=DELIMITER             Set the query delimiter; multi-char delimiters are allowed, but quotation\n \
-\                                    marks, slashes, and -- are not allowed; defaults to ;\n \
+\                                    marks, slashes, and -- are not allowed; defaults to ;\n\n \
 \  --convertBinaryArrayToString=[true|false]\n \
-\                                    Display binary column data as string or as byte array.\n \
+\                                    Display binary column data as string or as byte array.\n\n \
 \  --python-mode                     Execute python code/script.\n \
 \  --help                            Display this message.\n \
 \n \


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #6251

## Describe Your Solution 🔧
As `kyuubi-beeline` is derived from Hive `beeline`, I haven't made extensive modifications to its help message, only adjusting some formatting to enhance its appearance. Below are the specific changes:
1. Replace `jdbc:hive2//` with `jdbc:kyuubi//`.
2. Replace `beeline` with `kyuubi-beeline`.
3. Capitalize the first letter.
4. If the comment for a parameter spans multiple lines, add an additional `\n` at the end of the comment to separate it from the following line.
5. Append the help information for `--python-mode` to the front of `--help`.
6. Add some examples.
7. Improved letter indentation.

Here is the whole help message:
```
$ ./bin/kyuubi-beeline --help
Usage: kyuubi-beeline <options>. 

Options:
  -u <database url>               The JDBC URL to connect to.
  -c <named url>                  The named JDBC URL to connect to,
                                  which should be present in beeline-site.xml
                                  as the value of beeline.kyuubi.jdbc.url.<namedUrl>.

  -r                              Reconnect to last saved connect url (in conjunction with !save).
  -n <username>                   The username to connect as.
  -p <password>                   The password to connect as.
  -d <driver class>               The driver class to use.
  -i <init file>                  Script file for initialization.
  -e <query>                      Query that should be executed.
  -f <exec file>                  Script file that should be executed.
  -w, --password-file <file>      The password file to read password from.
  --hiveconf property=value       Use value for given property.
  --hivevar name=value            Hive variable name and value.
                                  This is Hive specific settings in which variables
                                  can be set at session level and referenced in Hive
                                  commands or queries.

  --property-file=<property file> The file to read connection properties (url, driver, user, password) from.
  --color=[true|false]            Control whether color is used for display.
  --showHeader=[true|false]       Show column names in query results.
  --escapeCRLF=[true|false]       Show carriage return and line feeds in query results as escaped \r and \n. 
  --headerInterval=ROWS;          The interval between which heades are displayed.
  --fastConnect=[true|false]      Skip building table/column list for tab-completion.
  --autoCommit=[true|false]       Enable/disable automatic transaction commit.
  --verbose=[true|false]          Show verbose error messages and debug info.
  --showWarnings=[true|false]     Display connection warnings.
  --showDbInPrompt=[true|false]   Display the current database name in the prompt.
  --showNestedErrs=[true|false]   Display nested errors.
  --numberFormat=[pattern]        Format numbers using DecimalFormat pattern.
  --force=[true|false]            Continue running script even after errors.
  --maxWidth=MAXWIDTH             The maximum width of the terminal.
  --maxColumnWidth=MAXCOLWIDTH    The maximum width to use when displaying columns.
  --silent=[true|false]           Be more silent.
  --autosave=[true|false]         Automatically save preferences.
  --outputformat=<format mode>    Format mode for result display.
                                  The available options ars [table|vertical|csv2|tsv2|dsv|csv|tsv|json|jsonfile]. 
                                  Note that csv, and tsv are deprecated, use csv2, tsv2 instead.

  --incremental=[true|false]      Defaults to false. When set to false, the entire result set
                                  is fetched and buffered before being displayed, yielding optimal
                                  display column sizing. When set to true, result rows are displayed
                                  immediately as they are fetched, yielding lower latency and
                                  memory usage at the price of extra display column padding.
                                  Setting --incremental=true is recommended if you encounter an OutOfMemory
                                  on the client side (due to the fetched result set size being large).
                                  Only applicable if --outputformat=table.

  --incrementalBufferRows=NUMROWS The number of rows to buffer when printing rows on stdout,
                                  defaults to 1000; only applicable if --incremental=true
                                  and --outputformat=table.

  --truncateTable=[true|false]    Truncate table column when it exceeds length.
  --delimiterForDSV=DELIMITER     Specify the delimiter for delimiter-separated values output format (default: |).
  --isolation=LEVEL               Set the transaction isolation level.
  --nullemptystring=[true|false]  Set to true to get historic behavior of printing null as empty string.
  --maxHistoryRows=MAXHISTORYROWS The maximum number of rows to store beeline history.
  --delimiter=DELIMITER           Set the query delimiter; multi-char delimiters are allowed, but quotation
                                  marks, slashes, and -- are not allowed (default: ;).

  --convertBinaryArrayToString=[true|false]
                                  Display binary column data as string or as byte array.

  --python-mode                   Execute python code/script.
  -h, --help                      Display this message.

Examples:
  1. Connect using simple authentication to Kyuubi Server on localhost:10009.
  $ kyuubi-beeline -u jdbc:kyuubi://localhost:10009 -n username

  2. Connect using simple authentication to Kyuubi Server on kyuubi.local:10009 using -n for username and -p for password.
  $ kyuubi-beeline -n username -p password -u jdbc:kyuubi://kyuubi.local:10009

  3. Connect using Kerberos authentication with kyuubi/localhost@mydomain.com as Kyuubi Server principal(kinit is required before connection).
  $ kyuubi-beeline -u "jdbc:kyuubi://kyuubi.local:10009/default;kyuubiServerPrincipal=kyuubi/localhost@mydomain.com"

  4. Connect using Kerberos authentication using principal and keytab directly.
  $ kyuubi-beeline -u "jdbc:kyuubi://kyuubi.local:10009/default;kyuubiClientPrincipal=user@mydomain.com;kyuubiClientKeytab=/local/path/client.keytab;kyuubiServerPrincipal=kyuubi/localhost@mydomain.com"

  5. Connect using SSL connection to Kyuubi Server on localhost:10009.
  $ kyuubi-beeline -u "jdbc:kyuubi://localhost:10009/default;ssl=true;sslTrustStore=/usr/local/truststore;trustStorePassword=mytruststorepassword"

  6. Connect using LDAP authentication.
  $ kyuubi-beeline -u jdbc:kyuubi://kyuubi.local:10009/default -n ldap-username -p ldap-password

  7. Connect using the ZooKeeper address to Kyuubi HA cluster.
  $ kyuubi-beeline -u "jdbc:kyuubi://zk1:2181,zk2:2181,zk3:2181/;serviceDiscoveryMode=zooKeeper;zooKeeperNamespace=kyuubi" -n username
```
If you have any suggested revisions, I will promptly respond and make the necessary adjustments.

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
