### PR TITLE
[KYUUBI #6298][HELM] Make ServiceMonitor use selector labels

### DIFF
--- a/charts/kyuubi/templates/kyuubi-servicemonitor.yaml
+++ b/charts/kyuubi/templates/kyuubi-servicemonitor.yaml
@@ -28,7 +28,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: {{ .Release.Name }}
+      {{- include "kyuubi.selectorLabels" $ | nindent 6 }}
   endpoints:
     {{- toYaml .Values.serviceMonitor.endpoints | nindent 4 }}
 {{- end }}

--- a/charts/kyuubi/templates/kyuubi-servicemonitor.yaml
+++ b/charts/kyuubi/templates/kyuubi-servicemonitor.yaml
@@ -28,7 +28,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      {{- include "kyuubi.selectorLabels" $ | nindent 6 }}
+      {{- include "kyuubi.selectorLabels" . | nindent 6 }}
   endpoints:
     {{- toYaml .Values.serviceMonitor.endpoints | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #6298 

## Describe Your Solution 🔧

Change matchlabels field to use template `selectorLabels`


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:

ServiceMonitor is not able to match kyuubi service

#### Related Unit Tests

Ran `helm template` and produced yaml files as expected

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
