### PR TITLE
[KYUUBI #6297] Package Spark SQL engine both Scala 2.12 and 2.13

### DIFF
--- a/build/dist
+++ b/build/dist
@@ -250,16 +250,16 @@ echo -e "\$ ${BUILD_COMMAND[@]}\n"
 
 # shellcheck disable=SC2050
 if [ "$SCALA_VERSION" = "2.12" ]; then
-  EXTRA_BUILD_COMMAND=("$MVN" install $MVN_DIST_OPT $@  -Pscala-2.13 -pl :kyuubi-spark-sql-engine_2.13 )
+  EXTRA_SPARK_ENGINE_BUILD_COMMAND=("$MVN" install $MVN_DIST_OPT $@ -Pscala-2.13 -pl :kyuubi-spark-sql-engine_2.13 -am)
 else
-  EXTRA_BUILD_COMMAND=("$MVN" install $MVN_DIST_OPT $@  -Pscala-2.12 -pl :kyuubi-spark-sql-engine_2.12 )
+  EXTRA_SPARK_ENGINE_BUILD_COMMAND=("$MVN" install $MVN_DIST_OPT -pl :kyuubi-spark-sql-engine_2.12 -am)
 fi
 
 # shellcheck disable=SC2145
-echo -e "\$ ${EXTRA_BUILD_COMMAND[@]}\n"
+echo -e "\$ ${EXTRA_SPARK_ENGINE_BUILD_COMMAND[@]}\n"
 
 "${BUILD_COMMAND[@]}"
-"${EXTRA_BUILD_COMMAND[@]}"
+"${EXTRA_SPARK_ENGINE_BUILD_COMMAND}"
 
 # Make directories
 rm -rf "$DISTDIR"
@@ -307,8 +307,8 @@ done
 cp "$KYUUBI_HOME/externals/kyuubi-flink-sql-engine/target/kyuubi-flink-sql-engine_${SCALA_VERSION}-${VERSION}.jar" "$DISTDIR/externals/engines/flink/"
 
 # Copy spark engines
-for SUPPORT_VERSION in 2.12 2.13; do
-  cp "$KYUUBI_HOME/externals/kyuubi-spark-sql-engine/target/kyuubi-spark-sql-engine_${SUPPORT_VERSION}-${VERSION}.jar" "$DISTDIR/externals/engines/spark/"
+for scala_version in 2.12 2.13; do
+  cp "$KYUUBI_HOME/externals/kyuubi-spark-sql-engine/target/kyuubi-spark-sql-engine_${scala_version}-${VERSION}.jar" "$DISTDIR/externals/engines/spark/"
 done
 
 # Copy trino engines

--- a/build/dist
+++ b/build/dist
@@ -252,14 +252,14 @@ echo -e "\$ ${BUILD_COMMAND[@]}\n"
 if [ "$SCALA_VERSION" = "2.12" ]; then
   EXTRA_SPARK_ENGINE_BUILD_COMMAND=("$MVN" install $MVN_DIST_OPT $@ -Pscala-2.13 -pl :kyuubi-spark-sql-engine_2.13 -am)
 else
-  EXTRA_SPARK_ENGINE_BUILD_COMMAND=("$MVN" install $MVN_DIST_OPT -pl :kyuubi-spark-sql-engine_2.12 -am)
+  EXTRA_SPARK_ENGINE_BUILD_COMMAND=("$MVN" install $MVN_DIST_OPT $@ -Pscala-2.12 -pl :kyuubi-spark-sql-engine_2.12 -am)
 fi
 
 # shellcheck disable=SC2145
 echo -e "\$ ${EXTRA_SPARK_ENGINE_BUILD_COMMAND[@]}\n"
 
 "${BUILD_COMMAND[@]}"
-"${EXTRA_SPARK_ENGINE_BUILD_COMMAND}"
+"${EXTRA_SPARK_ENGINE_BUILD_COMMAND[@]}"
 
 # Make directories
 rm -rf "$DISTDIR"

--- a/build/dist
+++ b/build/dist
@@ -248,7 +248,18 @@ echo -e "\nBuilding with..."
 # shellcheck disable=SC2145
 echo -e "\$ ${BUILD_COMMAND[@]}\n"
 
+# shellcheck disable=SC2050
+if [ "$SCALA_VERSION" = "2.12" ]; then
+  EXTRA_BUILD_COMMAND=("$MVN" install $MVN_DIST_OPT $@  -Pscala-2.13 -pl :kyuubi-spark-sql-engine_2.13 )
+else
+  EXTRA_BUILD_COMMAND=("$MVN" install $MVN_DIST_OPT $@  -Pscala-2.12 -pl :kyuubi-spark-sql-engine_2.12 )
+fi
+
+# shellcheck disable=SC2145
+echo -e "\$ ${EXTRA_BUILD_COMMAND[@]}\n"
+
 "${BUILD_COMMAND[@]}"
+"${EXTRA_BUILD_COMMAND[@]}"
 
 # Make directories
 rm -rf "$DISTDIR"
@@ -296,7 +307,9 @@ done
 cp "$KYUUBI_HOME/externals/kyuubi-flink-sql-engine/target/kyuubi-flink-sql-engine_${SCALA_VERSION}-${VERSION}.jar" "$DISTDIR/externals/engines/flink/"
 
 # Copy spark engines
-cp "$KYUUBI_HOME/externals/kyuubi-spark-sql-engine/target/kyuubi-spark-sql-engine_${SCALA_VERSION}-${VERSION}.jar" "$DISTDIR/externals/engines/spark/"
+for SUPPORT_VERSION in 2.12 2.13; do
+  cp "$KYUUBI_HOME/externals/kyuubi-spark-sql-engine/target/kyuubi-spark-sql-engine_${SUPPORT_VERSION}-${VERSION}.jar" "$DISTDIR/externals/engines/spark/"
+done
 
 # Copy trino engines
 cp "$KYUUBI_HOME/externals/kyuubi-trino-engine/target/kyuubi-trino-engine_${SCALA_VERSION}-${VERSION}.jar" "$DISTDIR/externals/engines/trino/"


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #6297 

## Describe Your Solution 🔧

Here are my main modifications:
1. In the `build/dist` file, I added an additional packaging command that detects the version of `SCALA_VERSION`. If it is version 2.12, then it will additionally package version 2.13, otherwise it will package version 2.12
2. In the section of `# Copy spark engines`, the Jar packages of versions 2.12 and 2.13 will be moved to `$DISTDIR/externals/engines/spark/`

This is my first time submitting a PR, so there may be many unfamiliar areas, and I don't know if my changes meet the needs of the community. More guidance may be needed. When testing locally, it was able to be packaged successfully


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

![image](https://github.com/apache/kyuubi/assets/96274454/fb1981e0-dc3f-47a3-a497-2ae0d3161e6b)

![image](https://github.com/apache/kyuubi/assets/96274454/b7307738-7699-4c2c-b6ad-08b323539d90)


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
