### PR TITLE
[KYUUBI #6312][HELM] Allow attaching annotations to service account

### DIFF
--- a/charts/kyuubi/templates/kyuubi-serviceaccount.yaml
+++ b/charts/kyuubi/templates/kyuubi-serviceaccount.yaml
@@ -20,6 +20,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccount.name | default .Release.Name }}
+  annotations:
+    {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
   labels:
     {{- include "kyuubi.labels" . | nindent 4 }}
 {{- end }}

--- a/charts/kyuubi/values.yaml
+++ b/charts/kyuubi/values.yaml
@@ -55,6 +55,8 @@ serviceAccount:
   create: true
   # Specifies ServiceAccount name to be used (created if `create: true`)
   name: ~
+  # Annotations to add to the ServiceAccount
+  annotations: {}
 
 # priorityClass used for Kyuubi server pod
 priorityClass:


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #6312

## Describe Your Solution 🔧

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:
Not able to attach annotations to service account

#### Related Unit Tests
Ran `helm template` and rendered correctly as below image
<img width="428" alt="image" src="https://github.com/apache/kyuubi/assets/22145541/d439a846-152b-4939-8ec6-c4f0ba1a4eca">


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
