### PR TITLE
[KYUUBI #6320] Fix terminated application pods not deleted issue when kyuubi server restarted

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
@@ -265,7 +265,7 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
     enginePodInformers.clear()
 
     if (cleanupTerminatedAppInfoTrigger != null) {
-      cleanupTerminatedAppInfoTrigger.cleanUp()
+      cleanupTerminatedAppInfoTrigger.invalidateAll()
       cleanupTerminatedAppInfoTrigger = null
     }
 


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #

We found that some pods were not deleted if kyuubi server restarted

The root cause is that:
com.google.common.cache::cleanup will not trigger removalListener action, we shall use `invalidateAll` instead.

Testing:
Nothing print for below code:
```
import com.google.common.cache.{Cache, CacheBuilder, RemovalNotification}

var removed = 0
val cache: Cache[String, String] = CacheBuilder.newBuilder()
  .removalListener((notification: RemovalNotification[String, String]) => {
    removed += 1
    println("removed: " + removed)
  }).build()

(0 until 1000).foreach { i =>
  cache.put(i.toString, i.toString)
}

cache.cleanup()
```

Replacing `cache.cleanup()` with `cache.invalidateAll()`, the output is expected.

## Describe Your Solution 🔧

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
