### PR TITLE
[KYUUBI #6326] Load existing pods and services when initializing the k8s client

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
@@ -327,9 +327,7 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
     extends ResourceEventHandler[Service] {
 
     override def onAdd(svc: Service): Unit = {
-      if (isSparkEngineSvc(svc)) {
-        updateApplicationUrl(kubernetesInfo, svc)
-      }
+      updateService(kubernetesInfo, svc)
     }
 
     override def onUpdate(oldSvc: Service, newSvc: Service): Unit = {
@@ -344,6 +342,7 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
   private def updateService(kubernetesInfo: KubernetesInfo, svc: Service): Unit = {
     if (isSparkEngineSvc(svc)) {
       updateApplicationUrl(kubernetesInfo, svc)
+      KubernetesApplicationAuditLogger.audit(kubernetesInfo, svc)
     }
   }
 


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->
Close #6326 
Seems that the informer will ignore the existing resources if no add/update/deletion.

It is better to load it one time when initializing the server.

We also audit the engine service in this pr.
## Describe Your Solution 🔧

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
