### PR TITLE
[KYUUBI #6338] Support connecting Kyuubi using Hive JDBC driver 4.0

### DIFF
--- a/docs/configuration/settings.md
+++ b/docs/configuration/settings.md
@@ -444,6 +444,7 @@ You can configure the Kyuubi properties in `$KYUUBI_HOME/conf/kyuubi-defaults.co
 | kyuubi.server.name                                       | &lt;undefined&gt; | The name of Kyuubi Server.                                                                                                                                                                                                                                              | string   | 1.5.0 |
 | kyuubi.server.periodicGC.interval                        | PT30M             | How often to trigger a garbage collection.                                                                                                                                                                                                                              | duration | 1.7.0 |
 | kyuubi.server.redaction.regex                            | &lt;undefined&gt; | Regex to decide which Kyuubi contain sensitive information. When this regex matches a property key or value, the value is redacted from the various logs.                                                                                                                         || 1.6.0 |
+| kyuubi.server.thrift.resultset.default.fetch.size        | 1000              | The number of rows sent in one Fetch RPC call by the server to the client, if not specified by the client. Respect `hive.server2.thrift.resultset.default.fetch.size` hive conf.                                                                                        | int      | 1.9.1 |
 
 ### Session
 

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -3624,7 +3624,7 @@ object KyuubiConf {
   private val HIVE_SERVER2_THRIFT_RESULTSET_DEFAULT_FETCH_SIZE: ConfigEntry[Int] =
     buildConf("hive.server2.thrift.resultset.default.fetch.size")
       .doc("This is a hive server configuration used as a fallback conf" +
-        s" for `${KYUUBI_SERVER_THRIFT_RESULTSET_DEFAULT_FETCH_SIZE.key}`.")
+        s" for `kyuubi.server.thrift.resultset.default.fetch.size`.")
       .version("1.9.1")
       .internal
       .serverOnly

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -3620,4 +3620,20 @@ object KyuubiConf {
       .version("1.8.1")
       .booleanConf
       .createWithDefault(false)
+
+  private val HIVE_SERVER2_THRIFT_RESULTSET_DEFAULT_FETCH_SIZE: ConfigEntry[Int] =
+    buildConf("hive.server2.thrift.resultset.default.fetch.size")
+      .internal
+      .serverOnly
+      .intConf
+      .createWithDefault(1000)
+
+  val KYUUBI_SERVER_THRIFT_RESULTSET_DEFAULT_FETCH_SIZE: ConfigEntry[Int] =
+    buildConf("kyuubi.server.thrift.resultset.default.fetch.size")
+      .doc("The number of rows sent in one Fetch RPC call by the server to the client, if not" +
+        " specified by the client. Respect `hive.server2.thrift.resultset.default.fetch.size`" +
+        " hive conf.")
+      .version("1.9.1")
+      .serverOnly
+      .fallbackConf(HIVE_SERVER2_THRIFT_RESULTSET_DEFAULT_FETCH_SIZE)
 }

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -3623,6 +3623,8 @@ object KyuubiConf {
 
   private val HIVE_SERVER2_THRIFT_RESULTSET_DEFAULT_FETCH_SIZE: ConfigEntry[Int] =
     buildConf("hive.server2.thrift.resultset.default.fetch.size")
+      .doc("The number of rows sent in one Fetch RPC call by the server to the client, if not" +
+        " specified by the client. This is a hive server configuration.")
       .internal
       .serverOnly
       .intConf

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -3623,8 +3623,9 @@ object KyuubiConf {
 
   private val HIVE_SERVER2_THRIFT_RESULTSET_DEFAULT_FETCH_SIZE: ConfigEntry[Int] =
     buildConf("hive.server2.thrift.resultset.default.fetch.size")
-      .doc("The number of rows sent in one Fetch RPC call by the server to the client, if not" +
-        " specified by the client. This is a hive server configuration.")
+      .doc("This is a hive server configuration used as a fallback conf" +
+        s" for `${KYUUBI_SERVER_THRIFT_RESULTSET_DEFAULT_FETCH_SIZE.key}`.")
+      .version("1.9.1")
       .internal
       .serverOnly
       .intConf

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiTBinaryFrontendService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiTBinaryFrontendService.scala
@@ -24,6 +24,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.kyuubi.KyuubiSQLException
 import org.apache.kyuubi.cli.Handle
 import org.apache.kyuubi.config.KyuubiConf
+import org.apache.kyuubi.config.KyuubiConf.KYUUBI_SERVER_THRIFT_RESULTSET_DEFAULT_FETCH_SIZE
 import org.apache.kyuubi.config.KyuubiReservedKeys._
 import org.apache.kyuubi.ha.client.{KyuubiServiceDiscovery, ServiceDiscovery}
 import org.apache.kyuubi.metrics.MetricsConstants._
@@ -48,6 +49,8 @@ final class KyuubiTBinaryFrontendService(
       None
     }
   }
+
+  private lazy val defaultFetchSize = conf.get(KYUUBI_SERVER_THRIFT_RESULTSET_DEFAULT_FETCH_SIZE)
 
   override def initialize(conf: KyuubiConf): Unit = synchronized {
     super.initialize(conf)
@@ -93,6 +96,10 @@ final class KyuubiTBinaryFrontendService(
         Base64.getMimeEncoder.encodeToString(opHandleIdentifier.getSecret))
 
       respConfiguration.put(KYUUBI_SESSION_ENGINE_LAUNCH_SUPPORT_RESULT, true.toString)
+
+      // KYUUBI-6338: Set default fetch size
+      respConfiguration.put("hive.server2.thrift.resultset.default.fetch.size",
+        defaultFetchSize.toString)
 
       resp.setSessionHandle(sessionHandle.toTSessionHandle)
       resp.setConfiguration(respConfiguration)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiTBinaryFrontendService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiTBinaryFrontendService.scala
@@ -97,7 +97,7 @@ final class KyuubiTBinaryFrontendService(
 
       respConfiguration.put(KYUUBI_SESSION_ENGINE_LAUNCH_SUPPORT_RESULT, true.toString)
 
-      // After HIVE-23005, hive driver requires this conf
+      // HIVE-23005(4.0.0), Hive JDBC driver supposes that server always returns this conf
       respConfiguration.put(
         "hive.server2.thrift.resultset.default.fetch.size",
         defaultFetchSize.toString)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiTBinaryFrontendService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiTBinaryFrontendService.scala
@@ -97,8 +97,9 @@ final class KyuubiTBinaryFrontendService(
 
       respConfiguration.put(KYUUBI_SESSION_ENGINE_LAUNCH_SUPPORT_RESULT, true.toString)
 
-      // KYUUBI-6338: Set default fetch size
-      respConfiguration.put("hive.server2.thrift.resultset.default.fetch.size",
+      // After HIVE-23005, hive driver requires this conf
+      respConfiguration.put(
+        "hive.server2.thrift.resultset.default.fetch.size",
         defaultFetchSize.toString)
 
       resp.setSessionHandle(sessionHandle.toTSessionHandle)

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/KyuubiTBinaryFrontendServiceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/KyuubiTBinaryFrontendServiceSuite.scala
@@ -30,6 +30,7 @@ import org.apache.kyuubi.shaded.hive.service.rpc.thrift.{TOpenSessionReq, TSessi
 class KyuubiTBinaryFrontendServiceSuite extends WithKyuubiServer with KyuubiFunSuite {
 
   override protected val conf: KyuubiConf = KyuubiConf()
+    .set(KyuubiConf.KYUUBI_SERVER_THRIFT_RESULTSET_DEFAULT_FETCH_SIZE, 500)
 
   test("connection metrics") {
     val totalConnections =
@@ -115,5 +116,17 @@ class KyuubiTBinaryFrontendServiceSuite extends WithKyuubiServer with KyuubiFunS
     }
     Thread.sleep(3000L)
     assert(server.backendService.sessionManager.allSessions().size == sessionCount)
+  }
+
+  test("test kyuubi.server.thrift.resultset.default.fetch.size") {
+    TClientTestUtils.withThriftClient(server.frontendServices.head) {
+      client =>
+        val req = new TOpenSessionReq()
+        req.setUsername(Utils.currentUser)
+        req.setPassword("anonymous")
+        val resp = client.OpenSession(req)
+        assertResult("500")(
+          resp.getConfiguration.get("hive.server2.thrift.resultset.default.fetch.size"))
+    }
   }
 }


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #6338

## Describe Your Solution 🔧

Support `kyuubi.server.thrift.resultset.default.fetchsize` conf to respect `hive.server2.thrift.resultset.default.fetch.size` hive conf.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests
KyuubiTBinaryFrontendServiceSuite.test("test kyuubi.server.thrift.resultset.default.fetch.size")

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
