### PR TITLE
[KYUUBI #6295] Engine supports to bind only a specific range of ports

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -525,6 +525,18 @@ object KyuubiConf {
       .serverOnly
       .fallbackConf(FRONTEND_BIND_HOST)
 
+  private val validPortRange: Pattern = ("(\\d+-\\d+)").r.pattern
+
+  val FRONTEND_THRIFT_BINARY_BIND_PORT_RANGE: ConfigEntry[Option[String]] =
+    buildConf("kyuubi.frontend.thrift.binary.bind.port.range")
+      .doc("Range of ports of the machine on which to run the thrift frontend service.")
+      .version("1.10.0")
+      .serverOnly
+      .stringConf
+      .checkValue(validPortRange.matcher(_).matches(), "must be valid port range.")
+      .createOptional
+
+
   val FRONTEND_THRIFT_HTTP_BIND_PORT: ConfigEntry[Int] =
     buildConf("kyuubi.frontend.thrift.http.bind.port")
       .doc("Port of the machine on which to run the thrift frontend service via http protocol.")

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/service/TFrontendServiceSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/service/TFrontendServiceSuite.scala
@@ -588,4 +588,25 @@ class TFrontendServiceSuite extends KyuubiFunSuite {
     assert(conf.size === 1)
     assert(conf("session.check.interval") === "10000")
   }
+
+
+  test("specify server port with range") {
+    def newService: TBinaryFrontendService = {
+      new TBinaryFrontendService("DummyThriftBinaryFrontendService") {
+        override val serverable: Serverable = new NoopTBinaryFrontendServer
+        override val discoveryService: Option[Service] = None
+      }
+    }
+    val conf = new KyuubiConf()
+      .set(FRONTEND_THRIFT_BINARY_BIND_HOST.key, "127.0.0.1")
+      .set(FRONTEND_THRIFT_BINARY_BIND_PORT, 0)
+      .set(FRONTEND_THRIFT_BINARY_BIND_PORT_RANGE, Some("8000-8002"))
+    val service = newService
+    intercept[IllegalStateException](service.connectionUrl)
+
+    service.initialize(conf)
+    // use what user want
+    val actualPort = service.connectionUrl.split(":")(1).toInt
+    assert(actualPort >= 8000 && actualPort <= 8002)
+  }
 }


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #https://github.com/apache/kyuubi/issues/6295

## Describe Your Solution 🔧

Add config in `KyuubiConfig` for specific port range and randomly pick up a port as frontend service thrift binary port.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**