### PR TITLE
[KYUUBI #4515] Capturing process id for kyuubi server launched using run command

### DIFF
--- a/bin/kyuubi
+++ b/bin/kyuubi
@@ -117,6 +117,14 @@ cmd="${RUNNER} ${KYUUBI_JAVA_OPTS} -cp ${KYUUBI_CLASSPATH} $CLASS $@"
 
 pid="${KYUUBI_PID_DIR}/kyuubi-$USER-$CLASS.pid"
 
+function get_pid(){
+  run_pid="$(ps -ef | grep org.apache.kyuubi.server.KyuubiServer |
+  grep java | grep "$KYUUBI_CONF_DIR" | grep -v grep | awk '{print $2}')"
+  if [[ -n $run_pid ]]; then
+    echo "$run_pid" > "$pid"
+  fi
+}
+
 function start_kyuubi() {
   if [[ ! -w ${KYUUBI_PID_DIR} ]]; then
     echo "${USER} does not have 'w' permission to ${KYUUBI_PID_DIR}"
@@ -127,6 +135,8 @@ function start_kyuubi() {
     echo "${USER} does not have 'w' permission to ${KYUUBI_LOG_DIR}"
     exit 1
   fi
+
+  get_pid
 
   if [ -f "$pid" ]; then
     TARGET_ID="$(cat "$pid")"
@@ -167,6 +177,14 @@ function start_kyuubi() {
 }
 
 function run_kyuubi() {
+  if [ -f "$pid" ]; then
+    TARGET_ID="$(cat "$pid")"
+    if [[ $(ps -p "$TARGET_ID" -o comm=) =~ "java" ]]; then
+      echo "$CLASS running as process $TARGET_ID  Stop it first."
+      exit 1
+    fi
+  fi
+
   echo "Starting $CLASS"
   exec nice -n "${KYUUBI_NICENESS:-0}" ${cmd}
 }
@@ -229,6 +247,12 @@ function kill_kyuubi() {
 }
 
 function check_kyuubi() {
+  if [[ ! -w ${KYUUBI_PID_DIR} ]]; then
+    echo "${USER} does not have 'w' permission to ${KYUUBI_PID_DIR}"
+    exit 1
+  fi
+
+  get_pid
   if [[ -f ${pid} ]]; then
     TARGET_ID="$(cat "$pid")"
     if [[ $(ps -p "$TARGET_ID" -o comm=) =~ "java" ]]; then


### PR DESCRIPTION
…run command

# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes # https://github.com/apache/kyuubi/issues/4515

## Describe Your Solution 🔧

Currently, the process ID (PID) for a Kyuubi server launched using bin/kyuubi run is not being captured. This leads to the bin/kyuubi status command incorrectly reporting that the server is not running.
Furthermore, if the bin/kyuubi run command is initiated at the launch of a Docker container, subsequent attempts to run bin/kyuubi start will fail due to the error "ports already occupied".
To resolve these issues and ensure synchronization between the status of the Kyuubi server whether it's launched in the foreground with bin/kyuubi run or in the background with bin/kyuubi start, two changes have been made:
1. A get_pid function has been created to capture the PID of the process launched using the run command.
2. A check has been added before starting a Kyuubi server to ensure that it's not already running in a different mode.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:
bin/kyuubi run -> Launches kyuubi server
bin/kyuubi status -> Kyuubi is not running
bin/kyuubi start -> Fails with port already occupied

#### Behavior With This Pull Request :tada:
bin/kyuubi run -> Launches kyuubi server
bin/kyuubi status -> Kyuubi is running (PID)
bin/kyuubi start -> Kyuubi running as process PID. Stop it first.

#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
