### PR TITLE
[KYUUBI #6373] Add empty RowSet for OpertationLog

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/KyuubiOperationManager.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/KyuubiOperationManager.scala
@@ -25,11 +25,11 @@ import org.apache.kyuubi.config.KyuubiConf.OPERATION_QUERY_TIMEOUT
 import org.apache.kyuubi.metrics.MetricsConstants.OPERATION_OPEN
 import org.apache.kyuubi.metrics.MetricsSystem
 import org.apache.kyuubi.operation.FetchOrientation.FetchOrientation
+import org.apache.kyuubi.operation.log.OperationLog
 import org.apache.kyuubi.server.metadata.api.Metadata
 import org.apache.kyuubi.session.{KyuubiBatchSession, KyuubiSessionImpl, Session}
 import org.apache.kyuubi.shaded.hive.service.rpc.thrift.{TFetchResultsResp, TStatus, TStatusCode}
 import org.apache.kyuubi.sql.plan.command.RunnableCommand
-import org.apache.kyuubi.util.ThriftUtils
 
 class KyuubiOperationManager private (name: String) extends OperationManager(name) {
 
@@ -223,7 +223,7 @@ class KyuubiOperationManager private (name: String) extends OperationManager(nam
         if (remoteHandle != null) {
           client.fetchResults(remoteHandle, order, maxRows, fetchLog = true)
         } else {
-          ThriftUtils.EMPTY_ROW_SET
+          OperationLog.LOG_EMPTY_ROW_SET
         }
     }
     resp.setResults(rowSet)


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #6373

## Describe Your Solution 🔧

`ThriftUtils#EMPTY_ROW_SET` is not suitable for OperationLog , so I add a new `LOG_EMPTY_ROW_SET`


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
