### PR TITLE
Return engine name and engine url within KyuubiSessionEvent/SessionData

### DIFF
--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/api/v1/dto/KyuubiSessionEvent.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/api/v1/dto/KyuubiSessionEvent.java
@@ -33,6 +33,10 @@ public class KyuubiSessionEvent {
 
   private String engineId;
 
+  private String engineName;
+
+  private String engineUrl;
+
   private String user;
 
   private String clientIp;
@@ -62,6 +66,8 @@ public class KyuubiSessionEvent {
       String sessionName,
       String remoteSessionId,
       String engineId,
+      String engineName,
+      String engineUrl,
       String user,
       String clientIp,
       String serverIp,
@@ -78,6 +84,8 @@ public class KyuubiSessionEvent {
     this.sessionName = sessionName;
     this.remoteSessionId = remoteSessionId;
     this.engineId = engineId;
+    this.engineName = engineName;
+    this.engineUrl = engineUrl;
     this.user = user;
     this.clientIp = clientIp;
     this.serverIp = serverIp;
@@ -106,6 +114,10 @@ public class KyuubiSessionEvent {
     private String remoteSessionId;
 
     private String engineId;
+
+    private String engineName;
+
+    private String engineUrl;
 
     private String user;
 
@@ -157,6 +169,16 @@ public class KyuubiSessionEvent {
 
     public KyuubiSessionEvent.KyuubiSessionEventBuilder engineId(final String engineId) {
       this.engineId = engineId;
+      return this;
+    }
+
+    public KyuubiSessionEvent.KyuubiSessionEventBuilder engineName(final String engineName) {
+      this.engineName = engineName;
+      return this;
+    }
+
+    public KyuubiSessionEvent.KyuubiSessionEventBuilder engineUrl(final String engineUrl) {
+      this.engineUrl = engineUrl;
       return this;
     }
 
@@ -218,6 +240,8 @@ public class KyuubiSessionEvent {
           sessionName,
           remoteSessionId,
           engineId,
+          engineName,
+          engineUrl,
           user,
           clientIp,
           serverIp,
@@ -277,6 +301,22 @@ public class KyuubiSessionEvent {
 
   public void setEngineId(String engineId) {
     this.engineId = engineId;
+  }
+
+  public String getEngineName() {
+    return engineName;
+  }
+
+  public void setEngineName(String engineName) {
+    this.engineName = engineName;
+  }
+
+  public String getEngineUrl() {
+    return engineUrl;
+  }
+
+  public void setEngineUrl(String engineUrl) {
+    this.engineUrl = engineUrl;
   }
 
   public String getUser() {

--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/api/v1/dto/SessionData.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/api/v1/dto/SessionData.java
@@ -36,6 +36,8 @@ public class SessionData {
   private String sessionType;
   private String kyuubiInstance;
   private String engineId;
+  private String engineName;
+  private String engineUrl;
   private String sessionName;
   private Integer totalOperations;
 
@@ -54,6 +56,8 @@ public class SessionData {
       String sessionType,
       String kyuubiInstance,
       String engineId,
+      String engineName,
+      String engineUrl,
       String sessionName,
       Integer totalOperations) {
     this.identifier = identifier;
@@ -68,6 +72,8 @@ public class SessionData {
     this.sessionType = sessionType;
     this.kyuubiInstance = kyuubiInstance;
     this.engineId = engineId;
+    this.engineName = engineName;
+    this.engineUrl = engineUrl;
     this.sessionName = sessionName;
     this.totalOperations = totalOperations;
   }
@@ -169,6 +175,22 @@ public class SessionData {
 
   public void setEngineId(String engineId) {
     this.engineId = engineId;
+  }
+
+  public String getEngineName() {
+    return engineName;
+  }
+
+  public void setEngineName(String engineName) {
+    this.engineName = engineName;
+  }
+
+  public String getEngineUrl() {
+    return engineUrl;
+  }
+
+  public void setEngineUrl(String engineUrl) {
+    this.engineUrl = engineUrl;
   }
 
   public String getSessionName() {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/events/KyuubiSessionEvent.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/events/KyuubiSessionEvent.scala
@@ -52,6 +52,8 @@ case class KyuubiSessionEvent(
     startTime: Long,
     var remoteSessionId: String = "",
     var engineId: String = "",
+    var engineName: String = "",
+    var engineUrl: String = "",
     var openedTime: Long = -1L,
     var endTime: Long = -1L,
     var totalOperations: Int = 0,

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/ApiUtils.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/ApiUtils.scala
@@ -65,6 +65,8 @@ object ApiUtils extends Logging {
       session.sessionType.toString,
       session.connectionUrl,
       sessionEvent.map(_.engineId).getOrElse(""),
+      sessionEvent.map(_.engineName).getOrElse(""),
+      sessionEvent.map(_.engineUrl).getOrElse(""),
       session.name.getOrElse(""),
       sessionEvent.map(_.totalOperations).getOrElse(0): Int)
   }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/ApiUtils.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/ApiUtils.scala
@@ -41,6 +41,8 @@ object ApiUtils extends Logging {
         .conf(event.conf.asJava)
         .remoteSessionId(event.remoteSessionId)
         .engineId(event.engineId)
+        .engineName(event.engineName)
+        .engineUrl(event.engineUrl)
         .eventTime(event.eventTime)
         .openedTime(event.openedTime)
         .startTime(event.startTime)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
@@ -222,6 +222,8 @@ class KyuubiSessionImpl(
         sessionEvent.openedTime = System.currentTimeMillis()
         sessionEvent.remoteSessionId = _engineSessionHandle.identifier.toString
         _client.engineId.foreach(e => sessionEvent.engineId = e)
+        _client.engineName.foreach(e => sessionEvent.engineName = e)
+        _client.engineUrl.foreach(e => sessionEvent.engineUrl = e)
         EventBus.post(sessionEvent)
       }
     }


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

In this pr, engineName and engineUrl will return within KyuubiSessionEvent/SessionData, these information are helpful to get the session info straight forward.

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
