### PR TITLE
Bump Delta from 3.1.0 to 3.2.0 for Spark 3.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
         <commons-lang.version>2.6</commons-lang.version>
         <commons-lang3.version>3.13.0</commons-lang3.version>
         <delta.artifact>delta-spark</delta.artifact>
-        <delta.version>3.1.0</delta.version>
+        <delta.version>3.2.0</delta.version>
         <failsafe.verion>3.3.2</failsafe.verion>
         <fb303.version>0.9.3</fb303.version>
         <flexmark.version>0.62.2</flexmark.version>
@@ -2059,7 +2059,7 @@
             </modules>
             <properties>
                 <delta.artifact>delta-spark</delta.artifact>
-                <delta.version>3.1.0</delta.version>
+                <delta.version>3.2.0</delta.version>
                 <!-- Remove this when Hudi supports Spark 3.5 -->
                 <hudi.spark.binary.version>3.4</hudi.spark.binary.version>
                 <spark.version>3.5.1</spark.version>


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
[Delta 3.2.0](https://github.com/delta-io/delta/releases/tag/v3.2.0) is available, which is built on top of Spark 3.5.

## Describe Your Solution 🔧

Bump Delta from 3.1.0 to 3.2.0 for Spark 3.5.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪
Pass GA.


#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
