### PR TITLE
[KYUUBI #6396] Add caching for KerberosAuthentication using ticketCache key

### DIFF
--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/auth/KerberosAuthenticationManager.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/auth/KerberosAuthenticationManager.java
@@ -22,18 +22,19 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class KerberosAuthenticationManager {
 
-  private static CachingKerberosAuthentication GLOBAL_TGT_CACHE_AUTHENTICATION;
+  private static final Map<String, CachingKerberosAuthentication> TGT_CACHE_AUTHENTICATION_CACHE =
+      new ConcurrentHashMap<>();
 
   private static final Map<String, CachingKerberosAuthentication> KEYTAB_AUTHENTICATION_CACHE =
       new ConcurrentHashMap<>();
 
-  public static synchronized CachingKerberosAuthentication getTgtCacheAuthentication(
-      String ticketCache) {
-    if (GLOBAL_TGT_CACHE_AUTHENTICATION == null) {
-      KerberosAuthentication tgtCacheAuth = new KerberosAuthentication(ticketCache);
-      GLOBAL_TGT_CACHE_AUTHENTICATION = new CachingKerberosAuthentication(tgtCacheAuth);
-    }
-    return GLOBAL_TGT_CACHE_AUTHENTICATION;
+  public static CachingKerberosAuthentication getTgtCacheAuthentication(String ticketCache) {
+    return TGT_CACHE_AUTHENTICATION_CACHE.computeIfAbsent(
+        ticketCache,
+        key -> {
+          KerberosAuthentication tgtCacheAuth = new KerberosAuthentication(ticketCache);
+          return new CachingKerberosAuthentication(tgtCacheAuth);
+        });
   }
 
   public static CachingKerberosAuthentication getKeytabAuthentication(


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #6396 

## Describe Your Solution 🔧

By using a cache to store CachingKerberosAuthentication objects keyed by the ticket cache path, we ensure that each unique ticket cache path generates a distinct authentication object. 

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
