### PR TITLE
Change to Base64 RFC4648 for handle guid and credential

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/HadoopThriftAuthBridgeServer.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/HadoopThriftAuthBridgeServer.scala
@@ -196,7 +196,7 @@ object HadoopThriftAuthBridgeServer {
 
     def getPasswd(identifier: KyuubiDelegationTokenIdentifier): Array[Char] = {
       val passwd = secretMgr.retrievePassword(identifier)
-      Base64.getMimeEncoder.encodeToString(passwd).toCharArray
+      Base64.getEncoder.encodeToString(passwd).toCharArray
     }
 
     override def handle(callbacks: Array[Callback]): Unit = {

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/util/KyuubiHadoopUtils.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/util/KyuubiHadoopUtils.scala
@@ -60,11 +60,11 @@ object KyuubiHadoopUtils extends Logging {
     val byteStream = new ByteArrayOutputStream
     creds.writeTokenStorageToStream(new DataOutputStream(byteStream))
 
-    Base64.getMimeEncoder.encodeToString(byteStream.toByteArray)
+    Base64.getUrlEncoder.encodeToString(byteStream.toByteArray)
   }
 
   def decodeCredentials(newValue: String): Credentials = {
-    val decoded = Base64.getMimeDecoder.decode(newValue)
+    val decoded = Base64.getUrlDecoder.decode(newValue)
 
     val byteStream = new ByteArrayInputStream(decoded)
     val creds = new Credentials()

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/util/KyuubiHadoopUtils.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/util/KyuubiHadoopUtils.scala
@@ -60,11 +60,11 @@ object KyuubiHadoopUtils extends Logging {
     val byteStream = new ByteArrayOutputStream
     creds.writeTokenStorageToStream(new DataOutputStream(byteStream))
 
-    Base64.getUrlEncoder.encodeToString(byteStream.toByteArray)
+    Base64.getEncoder.encodeToString(byteStream.toByteArray)
   }
 
   def decodeCredentials(newValue: String): Credentials = {
-    val decoded = Base64.getUrlDecoder.decode(newValue)
+    val decoded = Base64.getDecoder.decode(newValue)
 
     val byteStream = new ByteArrayInputStream(decoded)
     val creds = new Credentials()

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/TClientTestUtils.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/TClientTestUtils.scala
@@ -127,8 +127,8 @@ object TClientTestUtils extends Logging {
       val launchOpHandleOpt =
         if (guid != null && secret != null) {
           val launchHandleId = new THandleIdentifier(
-            ByteBuffer.wrap(Base64.getUrlDecoder.decode(guid)),
-            ByteBuffer.wrap(Base64.getUrlDecoder.decode(secret)))
+            ByteBuffer.wrap(Base64.getDecoder.decode(guid)),
+            ByteBuffer.wrap(Base64.getDecoder.decode(secret)))
           Some(new TOperationHandle(launchHandleId, TOperationType.UNKNOWN, false))
         } else None
 

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/TClientTestUtils.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/TClientTestUtils.scala
@@ -127,8 +127,8 @@ object TClientTestUtils extends Logging {
       val launchOpHandleOpt =
         if (guid != null && secret != null) {
           val launchHandleId = new THandleIdentifier(
-            ByteBuffer.wrap(Base64.getMimeDecoder.decode(guid)),
-            ByteBuffer.wrap(Base64.getMimeDecoder.decode(secret)))
+            ByteBuffer.wrap(Base64.getUrlDecoder.decode(guid)),
+            ByteBuffer.wrap(Base64.getUrlDecoder.decode(secret)))
           Some(new TOperationHandle(launchHandleId, TOperationType.UNKNOWN, false))
         } else None
 

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
@@ -797,8 +797,8 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
 
       if (launchEngineOpHandleGuid != null && launchEngineOpHandleSecret != null) {
         try {
-          byte[] guidBytes = Base64.getMimeDecoder().decode(launchEngineOpHandleGuid);
-          byte[] secretBytes = Base64.getMimeDecoder().decode(launchEngineOpHandleSecret);
+          byte[] guidBytes = Base64.getUrlDecoder().decode(launchEngineOpHandleGuid);
+          byte[] secretBytes = Base64.getUrlDecoder().decode(launchEngineOpHandleSecret);
           THandleIdentifier handleIdentifier =
               new THandleIdentifier(ByteBuffer.wrap(guidBytes), ByteBuffer.wrap(secretBytes));
           launchEngineOpHandle =

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
@@ -797,8 +797,8 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
 
       if (launchEngineOpHandleGuid != null && launchEngineOpHandleSecret != null) {
         try {
-          byte[] guidBytes = Base64.getUrlDecoder().decode(launchEngineOpHandleGuid);
-          byte[] secretBytes = Base64.getUrlDecoder().decode(launchEngineOpHandleSecret);
+          byte[] guidBytes = Base64.getDecoder().decode(launchEngineOpHandleGuid);
+          byte[] secretBytes = Base64.getDecoder().decode(launchEngineOpHandleSecret);
           THandleIdentifier handleIdentifier =
               new THandleIdentifier(ByteBuffer.wrap(guidBytes), ByteBuffer.wrap(secretBytes));
           launchEngineOpHandle =

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiTBinaryFrontendService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiTBinaryFrontendService.scala
@@ -90,10 +90,10 @@ final class KyuubiTBinaryFrontendService(
       val opHandleIdentifier = Handle.toTHandleIdentifier(launchEngineOp.getHandle.identifier)
       respConfiguration.put(
         KYUUBI_SESSION_ENGINE_LAUNCH_HANDLE_GUID,
-        Base64.getUrlEncoder.encodeToString(opHandleIdentifier.getGuid))
+        Base64.getEncoder.encodeToString(opHandleIdentifier.getGuid))
       respConfiguration.put(
         KYUUBI_SESSION_ENGINE_LAUNCH_HANDLE_SECRET,
-        Base64.getUrlEncoder.encodeToString(opHandleIdentifier.getSecret))
+        Base64.getEncoder.encodeToString(opHandleIdentifier.getSecret))
 
       respConfiguration.put(KYUUBI_SESSION_ENGINE_LAUNCH_SUPPORT_RESULT, true.toString)
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiTBinaryFrontendService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiTBinaryFrontendService.scala
@@ -90,10 +90,10 @@ final class KyuubiTBinaryFrontendService(
       val opHandleIdentifier = Handle.toTHandleIdentifier(launchEngineOp.getHandle.identifier)
       respConfiguration.put(
         KYUUBI_SESSION_ENGINE_LAUNCH_HANDLE_GUID,
-        Base64.getMimeEncoder.encodeToString(opHandleIdentifier.getGuid))
+        Base64.getUrlEncoder.encodeToString(opHandleIdentifier.getGuid))
       respConfiguration.put(
         KYUUBI_SESSION_ENGINE_LAUNCH_HANDLE_SECRET,
-        Base64.getMimeEncoder.encodeToString(opHandleIdentifier.getSecret))
+        Base64.getUrlEncoder.encodeToString(opHandleIdentifier.getSecret))
 
       respConfiguration.put(KYUUBI_SESSION_ENGINE_LAUNCH_SUPPORT_RESULT, true.toString)
 


### PR DESCRIPTION
# :mag: Description

`Base64.getMimeEncoder`(RFC2045) might generate newline when encoded chars exceed 76, so I changed it to `Base64.getEncoder`(RFC4648).
## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

Use the changed BeeLine to connect to Kyuubi Server 1.9.0, everything goes well.

```
$ bin/beeline -u 'jdbc:kyuubi://0.0.0.0:10009/'
...
Connected to: Spark SQL (version 3.4.1)
Driver: Kyuubi Project Hive JDBC Client (version 1.10.0-SNAPSHOT)
Beeline version 1.10.0-SNAPSHOT by Apache Kyuubi
0: jdbc:kyuubi://0.0.0.0:10009/>
```

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
