### PR TITLE
[KYUUBI #6410] Check if asyncRequestExecutor is initialized before shutdown

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/client/KyuubiSyncThriftClient.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/client/KyuubiSyncThriftClient.scala
@@ -69,9 +69,12 @@ class KyuubiSyncThriftClient private (
   private var engineAliveThreadPool: ScheduledExecutorService = _
   @volatile private var engineLastAlive: Long = _
 
-  private lazy val asyncRequestExecutor: ExecutorService =
+  @volatile private var asyncRequestExecutorInitialized: Boolean = false
+  private lazy val asyncRequestExecutor: ExecutorService = {
+    asyncRequestExecutorInitialized = true
     ThreadUtils.newDaemonSingleThreadScheduledExecutor(
       "async-request-executor-" + SessionHandle(_remoteSessionHandle))
+  }
 
   @VisibleForTesting
   @volatile private[kyuubi] var asyncRequestInterrupted: Boolean = false
@@ -80,7 +83,9 @@ class KyuubiSyncThriftClient private (
   private[kyuubi] def getEngineAliveProbeProtocol: Option[TProtocol] = engineAliveProbeProtocol
 
   private def shutdownAsyncRequestExecutor(): Unit = {
-    Option(asyncRequestExecutor).filterNot(_.isShutdown).foreach(ThreadUtils.shutdown(_))
+    if (asyncRequestExecutorInitialized) {
+      Option(asyncRequestExecutor).filterNot(_.isShutdown).foreach(ThreadUtils.shutdown(_))
+    }
     asyncRequestInterrupted = true
   }
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/client/KyuubiSyncThriftClient.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/client/KyuubiSyncThriftClient.scala
@@ -83,8 +83,8 @@ class KyuubiSyncThriftClient private (
   private[kyuubi] def getEngineAliveProbeProtocol: Option[TProtocol] = engineAliveProbeProtocol
 
   private def shutdownAsyncRequestExecutor(): Unit = {
-    if (asyncRequestExecutorInitialized) {
-      Option(asyncRequestExecutor).filterNot(_.isShutdown).foreach(ThreadUtils.shutdown(_))
+    if (asyncRequestExecutorInitialized && !asyncRequestExecutor.isShutdown) {
+      ThreadUtils.shutdown(asyncRequestExecutor)
     }
     asyncRequestInterrupted = true
   }


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #6410

## Describe Your Solution 🔧

Check if asyncRequestExecutor is initialized before shutdown to avoid NPE.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
