### PR TITLE
Generate flattened POM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ spark-warehouse/
 metastore_db
 derby.log
 rest-audit.log
+**/.flattened-pom.xml
 **/dependency-reduced-pom.xml
 metrics/
 /kyuubi-ha/embedded_zookeeper/

--- a/pom.xml
+++ b/pom.xml
@@ -227,6 +227,7 @@
         <maven.plugin.download.version>1.8.1</maven.plugin.download.version>
         <maven.plugin.download.cache.path></maven.plugin.download.cache.path>
         <maven.plugin.enforcer.mojo.rules.version>1.6.1</maven.plugin.enforcer.mojo.rules.version>
+        <maven.plugin.flatten.version>1.6.0</maven.plugin.flatten.version>
         <maven.plugin.frontend.version>1.12.1</maven.plugin.frontend.version>
         <maven.plugin.scala.version>4.8.0</maven.plugin.scala.version>
         <maven.plugin.scalatest.version>2.2.0</maven.plugin.scalatest.version>
@@ -1578,6 +1579,21 @@
                 </plugin>
 
                 <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>flatten-maven-plugin</artifactId>
+                    <version>${maven.plugin.flatten.version}</version>
+                    <executions>
+                        <execution>
+                            <id>flatten</id>
+                            <goals>
+                                <goal>flatten</goal>
+                            </goals>
+                            <phase>process-resources</phase>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
                     <executions>
@@ -1817,6 +1833,11 @@
         </pluginManagement>
 
         <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+            </plugin>
+
             <!-- dump test classpath into a folder -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
# :mag: Description

Leverage [Flatten Maven Plugin](https://www.mojohaus.org/flatten-maven-plugin/) to generate resolved `pom.xml`.

This recovers a dev case for Scala 2.13.

We usually perform `clean install` with `-am` and `-DskipTests` one time and perform `test` after changing code on specific modules, e.g.
```
build/mvn -Pscala-2.13 -pl externals/kyuubi-spark-sql-engine clean install -am -DskipTests
build/mvn -Pscala-2.13 -pl externals/kyuubi-spark-sql-engine test
```

Currently, the second step wrongly resolves to `*_2.12` dependencies due to the installed `pom.xml` referring to `*_${scala.binary.version}` while the default value of `scala.binary.version` is `2.12`.

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

This change is verified locally by the above case.

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
