### PR TITLE
Remove scala compile args -Yno-adapted-args

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1420,7 +1420,6 @@
                             <arg>-deprecation</arg>
                             <arg>-feature</arg>
                             <arg>-explaintypes</arg>
-                            <arg>-Yno-adapted-args</arg>
                             <arg>-P:silencer:globalFilters=.*deprecated.*</arg>
                             <arg>-P:silencer:globalFilters=.*Could not find any member to link for.*</arg>
                             <arg>-P:silencer:globalFilters=.*undefined in comment for class.*</arg>


### PR DESCRIPTION
# :mag: Description

IDEA complains when enabling `scala-2.13` profile.
```
scala: bad option: '-Yno-adapted-args'
```

<img width="1728" alt="image" src="https://github.com/apache/kyuubi/assets/26535726/5e350028-489b-4764-be7b-2cde2fcc522d">

I also found Spark removes it in SPARK-29413

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

Pass GHA, and verify locally with IDEA.

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
