### PR TITLE
Add footnote about pyhive origin

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -33,3 +33,6 @@ the following copyright notice:
 
 Apache Spark
 Copyright 2014 and onwards The Apache Software Foundation.
+
+PyHive
+This project includes code from PyHive originally developed by Dropbox and was donated to Apache/Kyuubi in 2024


### PR DESCRIPTION
Small notice change to include that pyhive was originally developed at Dropbox.