### PR TITLE
[KYUUBI #6247] Make KSHC binary compatible with multiple Spark versions

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -186,6 +186,7 @@ jobs:
             - '3.5'
         spark-runtime:
             - '3.4'
+            - '3.3'
         comment: [ "normal" ]
     env:
       SPARK_LOCAL_IP: localhost
@@ -218,10 +219,9 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v3
         with:
-          name: >-
-            unit-tests-log-java-${{ matrix.java }}-scala-${{ matrix.scala }}
-            -spark-compile-${{ matrix.spark-compile }}-spark-runtime-${{ matrix.spark-runtime }}
-            -${{ matrix.comment }}
+          name: "unit-tests-log-java-${{ matrix.java }}-scala-${{ matrix.scala }}\
+            -spark-compile-${{ matrix.spark-compile }}-spark-runtime-${{ matrix.spark-runtime }}\
+            -${{ matrix.comment }}"
           path: |
             **/target/unit-tests.log
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -171,14 +171,17 @@ jobs:
             **/kyuubi-hive-sql-engine.log*
 
   spark-connector-cross-version-test:
-    name: Kyuubi Spark Connector Cross Version Test
+    name: Spark Connector Cross Version Test
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
-      max-parallel: 6
+      max-parallel: 1
       matrix:
         java:
-          - 8
+          - 17
+        scala:
+          - '2.12'
+          - '2.13'
         spark-compile:
             - '3.5'
         spark-runtime:
@@ -204,11 +207,13 @@ jobs:
       - name: Build Kyuubi Spark Hive Connector with Spark-${{ matrix.spark-compile }}
         run: |
           ./build/mvn clean install ${MVN_OPT} -pl extensions/spark/kyuubi-spark-connector-hive -am \
-          -Pjava-${{ matrix.java }} -Pspark-${{ matrix.spark-compile }} -DskipTests
+          -Pjava-${{ matrix.java }} -Pscala-${{ matrix.scala }} -Pspark-${{ matrix.spark-compile }} \
+          -DskipTests
       - name: Test Kyuubi Spark Hive Connector with Spark-${{ matrix.spark-runtime }}
         run: |
           ./build/mvn test ${MVN_OPT} -pl extensions/spark/kyuubi-spark-connector-hive \
-          -Pjava-${{ matrix.java }} -Pspark-${{ matrix.spark-runtime }} -Pcross-version-test
+          -Pjava-${{ matrix.java }} -Pscala-${{ matrix.scala }} -Pspark-${{ matrix.spark-runtime }} \
+          -Pcross-version-test
       - name: Upload test logs
         if: failure()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -218,7 +218,8 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v3
         with:
-          name: unit-tests-log-java-${{ matrix.java }}-scala-${{ matrix.scala }}\
+          name: |
+            unit-tests-log-java-${{ matrix.java }}-scala-${{ matrix.scala }}\
             -spark-compile-${{ matrix.spark-compile }}-spark-runtime-${{ matrix.spark-runtime }}\
             -${{ matrix.comment }}
           path: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -218,8 +218,9 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v3
         with:
-          name: unit-tests-log-java-${{ matrix.java }}-spark-compile-${{ matrix.spark-compile }}\
-            spark-runtime-${{ matrix.spark-runtime }}-${{ matrix.comment }}
+          name: unit-tests-log-java-${{ matrix.java }}-scala-${{ matrix.scala }}\
+            -spark-compile-${{ matrix.spark-compile }}-spark-runtime-${{ matrix.spark-runtime }}\
+            -${{ matrix.comment }}
           path: |
             **/target/unit-tests.log
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -218,9 +218,9 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v3
         with:
-          name: |
-            unit-tests-log-java-${{ matrix.java }}-scala-${{ matrix.scala }}\
-            -spark-compile-${{ matrix.spark-compile }}-spark-runtime-${{ matrix.spark-runtime }}\
+          name: >-
+            unit-tests-log-java-${{ matrix.java }}-scala-${{ matrix.scala }}
+            -spark-compile-${{ matrix.spark-compile }}-spark-runtime-${{ matrix.spark-runtime }}
             -${{ matrix.comment }}
           path: |
             **/target/unit-tests.log

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -170,6 +170,54 @@ jobs:
             **/kyuubi-jdbc-engine.log*
             **/kyuubi-hive-sql-engine.log*
 
+  spark-connector-cross-version-test:
+    name: Kyuubi Spark Connector Cross Version Test
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      max-parallel: 6
+      matrix:
+        java:
+          - 8
+        spark-compile:
+            - '3.5'
+        spark-runtime:
+            - '3.4'
+        comment: [ "normal" ]
+    env:
+      SPARK_LOCAL_IP: localhost
+    steps:
+      - uses: actions/checkout@v4
+      - name: Free up disk space
+        run: ./.github/scripts/free_disk_space.sh
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+      - name: Setup JDK ${{ matrix.java }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java }}
+          cache: 'maven'
+          check-latest: false
+      - name: Setup Maven
+        uses: ./.github/actions/setup-maven
+      - name: Build Kyuubi Spark Hive Connector with Spark-${{ matrix.spark-compile }}
+        run: |
+          ./build/mvn clean install ${MVN_OPT} -pl extensions/spark/kyuubi-spark-connector-hive -am \
+          -Pjava-${{ matrix.java }} -Pspark-${{ matrix.spark-compile }} -DskipTests
+      - name: Test Kyuubi Spark Hive Connector with Spark-${{ matrix.spark-runtime }}
+        run: |
+          ./build/mvn test ${MVN_OPT} -pl extensions/spark/kyuubi-spark-connector-hive \
+          -Pjava-${{ matrix.java }} -Pspark-${{ matrix.spark-runtime }} -Pcross-version-test
+      - name: Upload test logs
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: unit-tests-log-java-${{ matrix.java }}-spark-compile-${{ matrix.spark-compile }}\
+            spark-runtime-${{ matrix.spark-runtime }}-${{ matrix.comment }}
+          path: |
+            **/target/unit-tests.log
+
   flink-it:
     name: Flink Test
     runs-on: ubuntu-22.04

--- a/extensions/spark/kyuubi-spark-connector-hive/pom.xml
+++ b/extensions/spark/kyuubi-spark-connector-hive/pom.xml
@@ -182,4 +182,45 @@
         <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
         <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
     </build>
+
+    <profiles>
+        <profile>
+            <id>cross-version-test</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.kyuubi</groupId>
+                    <artifactId>kyuubi-spark-connector-hive-local_${scala.binary.version}</artifactId>
+                    <version>${project.version}</version>
+                    <scope>system</scope>
+                    <systemPath>${project.basedir}/target/kyuubi-spark-connector-hive_${scala.binary.version}-${project.version}.jar</systemPath>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-clean-plugin</artifactId>
+                        <configuration>
+                            <excludeDefaultDirectories>true</excludeDefaultDirectories>
+                            <filesets>
+                                <fileset>
+                                    <directory>target/scala-${scala.binary.version}/classes</directory>
+                                    <includes>**/*.*</includes>
+                                </fileset>
+                            </filesets>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>clean target/scala-${scala.binary.version}/classes</id>
+                                <goals>
+                                    <goal>clean</goal>
+                                </goals>
+                                <phase>process-test-classes</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/read/HiveScan.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/read/HiveScan.scala
@@ -103,8 +103,8 @@ case class HiveScan(
         } else {
           partition.values
         }
-      partition.files.flatMap { file =>
-        val filePath = file.getPath
+      partition.files.asInstanceOf[Seq[AnyRef]].flatMap { file =>
+        val filePath = HiveConnectorUtils.getPartitionFilePath(file)
         val partFiles = HiveConnectorUtils.splitFiles(
           sparkSession = sparkSession,
           file = file,


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request closes #6247

This also closes #6431

## Describe Your Solution 🔧
Add a job `spark-connector-cross-version-test` in GitHub Actions to:
1. Build KSHC package with maven opt `-Pspark-3.5`
2. Run KSHC tests with maven opt `-Pspark-3.3` and `-Pspark-3.4` and KSHC package built in step 1
3. Fix the binary-compatible issue via reflection.

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

Pass GHA.

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
