### PR TITLE
Fix casing in kubectl commands for serviceaccount creation

### DIFF
--- a/docs/deployment/kyuubi_on_kubernetes.md
+++ b/docs/deployment/kyuubi_on_kubernetes.md
@@ -77,8 +77,8 @@ You should create your ServiceAccount(or reuse account with the appropriate priv
 For example, you can create ServiceAccount by following command:
 
 ```shell
-kubectl create serviceAccount kyuubi -n <your namespace>
-kubectl create rolebinding kyuubi-role --role=edit --serviceAccount=<your namespace>:kyuubi --namespace=<your namespace>
+kubectl create serviceaccount kyuubi -n <your namespace>
+kubectl create rolebinding kyuubi-role --role=edit --serviceaccount=<your namespace>:kyuubi --namespace=<your namespace>
 ```
 
 See more related details in [Using RBAC Authorization](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) and [Configure Service Accounts for Pods](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/).


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes the issue related to incorrect casing in `kubectl` commands used for creating `serviceaccount`.


## Describe Your Solution 🔧

This PR corrects the casing for the Kubernetes `serviceaccount` creation and rolebinding command to ensure compatibility with `kubectl`. Previously, the commands used incorrect casing (`serviceAccount`), which could potentially lead to execution errors or compatibility issues with Kubernetes API expectations.
Reference: [Kubernetes Official Documentation for Creating a ServiceAccount](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_create/kubectl_create_serviceaccount/)

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
