### PR TITLE
[KYUUBI #6447] Use static regex Pattern instances in JavaUtils.timeStringAs and JavaUtils.byteStringAs 

### DIFF
--- a/extensions/spark/kyuubi-spark-connector-common/src/main/java/org/apache/kyuubi/spark/connector/common/JavaUtils.java
+++ b/extensions/spark/kyuubi-spark-connector-common/src/main/java/org/apache/kyuubi/spark/connector/common/JavaUtils.java
@@ -58,6 +58,8 @@ public class JavaUtils {
     byteSuffixes.put("pb", ByteUnit.PiB);
   }
 
+  private static final Pattern TIME_STRING_PATTERN = Pattern.compile("(-?[0-9]+)([a-z]+)?");
+
   /**
    * Convert a passed time string (e.g. 50s, 100ms, or 250us) to a time count in the given unit. The
    * unit is also considered the default if the given string does not specify a unit.
@@ -66,7 +68,7 @@ public class JavaUtils {
     String lower = str.toLowerCase(Locale.ROOT).trim();
 
     try {
-      Matcher m = Pattern.compile("(-?[0-9]+)([a-z]+)?").matcher(lower);
+      Matcher m = TIME_STRING_PATTERN.matcher(lower);
       if (!m.matches()) {
         throw new NumberFormatException("Failed to parse time string: " + str);
       }
@@ -107,6 +109,10 @@ public class JavaUtils {
     return timeStringAs(str, TimeUnit.SECONDS);
   }
 
+  private static final Pattern BYTE_STRING_PATTERN = Pattern.compile("([0-9]+)([a-z]+)?");
+  private static final Pattern BYTE_STRING_FRACTION_PATTERN =
+      Pattern.compile("([0-9]+\\.[0-9]+)([a-z]+)?");
+
   /**
    * Convert a passed byte string (e.g. 50b, 100kb, or 250mb) to the given. If no suffix is
    * provided, a direct conversion to the provided unit is attempted.
@@ -115,8 +121,8 @@ public class JavaUtils {
     String lower = str.toLowerCase(Locale.ROOT).trim();
 
     try {
-      Matcher m = Pattern.compile("([0-9]+)([a-z]+)?").matcher(lower);
-      Matcher fractionMatcher = Pattern.compile("([0-9]+\\.[0-9]+)([a-z]+)?").matcher(lower);
+      Matcher m = BYTE_STRING_PATTERN.matcher(lower);
+      Matcher fractionMatcher = BYTE_STRING_FRACTION_PATTERN.matcher(lower);
 
       if (m.matches()) {
         long val = Long.parseLong(m.group(1));


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #6447

## Describe Your Solution 🔧
Use static regex Pattern instances in JavaUtils.timeStringAs and JavaUtils.byteStringAs 



## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
