### PR TITLE
[KYUUBI #6445] Normalize extra name for optional Python distribution dependencies

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -46,7 +46,7 @@ setup(
         'presto': ['requests>=1.0.0'],
         'trino': ['requests>=1.0.0'],
         'hive': ['sasl>=0.2.1', 'thrift>=0.10.0', 'thrift_sasl>=0.1.0'],
-        'hive_pure_sasl': ['pure-sasl>=0.6.2', 'thrift>=0.10.0', 'thrift_sasl>=0.1.0'],
+        'hive-pure-sasl': ['pure-sasl>=0.6.2', 'thrift>=0.10.0', 'thrift_sasl>=0.1.0'],
         'sqlalchemy': ['sqlalchemy>=1.3.0'],
         'kerberos': ['requests_kerberos>=0.12.0'],
     },


### PR DESCRIPTION
…pendencies

# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #6445

## Describe Your Solution 🔧

use `hive-pure-sasl` instead of `hive_pure_sasl` for extra name for optional distribution dependencies.

this avoid potential `WARNING: pyhive x.y.z does not provide the extra 'hive-pure-sasl'` and missing dependencies when a package depends on `pyhive[hive_pure_sasl]` and python build system choose to normalize it to `pyhive[hive-pure-saal]`.

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:

a package depends on `pyhive[hive_pure_sasl]` may complain `WARNING: pyhive x.y.z does not provide the extra 'hive-pure-sasl'` and missing dependencies to support hive feature.

#### Behavior With This Pull Request :tada:

based on my test on our internal pypi, users use `pyhive[hive_pure_sasl]` are not affected by this change. But we should update README when we release a new version of pyhive.

#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
