### PR TITLE
[KYUUBI #6476] Fix incomplete app events deserialization in SHS

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/events/SparkOperationEvent.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/events/SparkOperationEvent.scala
@@ -67,7 +67,9 @@ case class SparkOperationEvent(
     sessionId: String,
     sessionUser: String,
     executionId: Option[Long],
+    @JsonDeserialize(contentAs = classOf[java.lang.Long])
     operationRunTime: Option[Long],
+    @JsonDeserialize(contentAs = classOf[java.lang.Long])
     operationCpuTime: Option[Long]) extends KyuubiEvent with SparkListenerEvent {
 
   override def partitions: Seq[(String, String)] =

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/events/SparkOperationEvent.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/events/SparkOperationEvent.scala
@@ -66,6 +66,7 @@ case class SparkOperationEvent(
     exception: Option[Throwable],
     sessionId: String,
     sessionUser: String,
+    @JsonDeserialize(contentAs = classOf[java.lang.Long])
     executionId: Option[Long],
     @JsonDeserialize(contentAs = classOf[java.lang.Long])
     operationRunTime: Option[Long],

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EnginePage.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EnginePage.scala
@@ -539,8 +539,8 @@ private class StatementStatsPagedTable(
       <td >
         {formatDuration(event.duration)}
       </td>
-      <td> {formatDuration(event.operationRunTime.getOrElse(0L).toString.toLong)} </td>
-      <td> {formatDuration(event.operationCpuTime.getOrElse(0L).toString.toLong / 1000000)} </td>
+      <td> {formatDuration(event.operationRunTime.getOrElse(0L))} </td>
+      <td> {formatDuration(event.operationCpuTime.getOrElse(0L) / 1000000)} </td>
       <td>
         <span class="description-input">
           {event.statement}

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EnginePage.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EnginePage.scala
@@ -539,8 +539,8 @@ private class StatementStatsPagedTable(
       <td >
         {formatDuration(event.duration)}
       </td>
-      <td> {formatDuration(event.operationRunTime.getOrElse(0L))} </td>
-      <td> {formatDuration(event.operationCpuTime.getOrElse(0L) / 1000000)} </td>
+      <td> {formatDuration(event.operationRunTime.getOrElse(0L).toString.toLong)} </td>
+      <td> {formatDuration(event.operationCpuTime.getOrElse(0L).toString.toLong / 1000000)} </td>
       <td>
         <span class="description-input">
           {event.statement}


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #6476 : spark historyserver -> Show incomplete applications -> kyuubi query engine ui error（java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.Long）.

The reason:
it's related to https://github.com/FasterXML/jackson-module-scala/issues/62

## Describe Your Solution 🔧

add @JsonDeserialize(contentAs = classOf[java.lang.Long]) annotation

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
