### PR TITLE
[KYUUBI apache#6486] enabling both KERBEROS and LDAP functions simultaneously is not available

### DIFF
--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/zookeeper/ZookeeperDiscoveryClient.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/zookeeper/ZookeeperDiscoveryClient.scala
@@ -329,7 +329,7 @@ class ZookeeperDiscoveryClient(conf: KyuubiConf) extends DiscoveryClient {
     // Auth specific confs
     val authenticationMethod = conf.get(KyuubiConf.AUTHENTICATION_METHOD).mkString(",")
     confsToPublish += ("hive.server2.authentication" -> authenticationMethod)
-    if (authenticationMethod.equalsIgnoreCase("KERBEROS")) {
+    if (authenticationMethod.contains("KERBEROS")) {
       confsToPublish += ("hive.server2.authentication.kerberos.principal" ->
         conf.get(KyuubiConf.SERVER_PRINCIPAL).getOrElse(""))
     }

--- a/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/hs2connection/HiveSiteHS2ConnectionFileParser.java
+++ b/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/hs2connection/HiveSiteHS2ConnectionFileParser.java
@@ -148,7 +148,7 @@ public class HiveSiteHS2ConnectionFileParser implements HS2ConnectionFileParser 
   }
 
   private void addKerberos(Properties props) {
-    if ("KERBEROS".equals(conf.get("hive.server2.authentication", "NONE"))) {
+    if (conf.get("hive.server2.authentication", "NONE").contains("KERBEROS")) {
       props.setProperty(
           "principal", conf.get("hive.server2.authentication.kerberos.principal", ""));
     }


### PR DESCRIPTION

# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #6486 
To enable both authentication methods(kerberos and ldap) simultaneously.
kyuubi server set kyuubi.authentication=KERBEROS,LDAP
Other relevant authentication parameters have been correctly configured.
reproducible:

kint user01
beeline -u 'jdbc:hive2://felixzh:2181/;serviceDiscoveryMode=zooKeeper;zooKeeperNamespace=kyuubi1.9.1'
ERROR as follows:
ERROR hive.Utils Unable to read HiveServer2 configs from Zookeeper
Unknown HS2 problem when communication with Thrift server.
Error: Could not open client transport for any of the Server URI's in Zookeeper: Peer indicated failure: javax.security.sasl.AuthenticationException: Error validating LDAP user: uid=anonymous,..........
## Describe Your Solution 🔧

ZookeeperDiscoveryClient.scala addConfsToPublish() correctly set hive.server2.authentication.kerberos.principal
HiveSiteHS2ConnectionFileParser.java addKerberos() correctly set principal


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
