### PR TITLE
[KYUUBI #6489] [PYTHON] PyKyuubi get_table_names also supports Spark SQL dialect

### DIFF
--- a/python/pyhive/sqlalchemy_hive.py
+++ b/python/pyhive/sqlalchemy_hive.py
@@ -377,7 +377,17 @@ class HiveDialect(default.DefaultDialect):
         query = 'SHOW TABLES'
         if schema:
             query += ' IN ' + self.identifier_preparer.quote_identifier(schema)
-        return [row[1] for row in connection.execute(text(query))]
+
+        table_names = []
+
+        for row in connection.execute(text(query)):
+            # Hive returns 1 columns
+            if len(row) == 1:
+                table_names.append(row[0])
+            # Kyuubi returns 3 columns
+            elif len(row) == 3:
+                table_names.append(row[1])
+        return table_names
 
     def do_rollback(self, dbapi_connection):
         # No transactions for Hive

--- a/python/pyhive/sqlalchemy_hive.py
+++ b/python/pyhive/sqlalchemy_hive.py
@@ -10,6 +10,7 @@ from __future__ import unicode_literals
 
 import datetime
 import decimal
+import logging
 
 import re
 from sqlalchemy import exc
@@ -39,6 +40,7 @@ from pyhive.common import UniversalSet
 from dateutil.parser import parse
 from decimal import Decimal
 
+_logger = logging.getLogger(__name__)
 
 class HiveStringTypeBase(types.TypeDecorator):
     """Translates strings returned by Thrift into something else"""
@@ -384,9 +386,13 @@ class HiveDialect(default.DefaultDialect):
             # Hive returns 1 columns
             if len(row) == 1:
                 table_names.append(row[0])
-            # Kyuubi returns 3 columns
+            # Spark SQL returns 3 columns
             elif len(row) == 3:
                 table_names.append(row[1])
+            else:
+                _logger.warning("Unexpected number of columns in SHOW TABLES result: {}".format(len(row)))
+                table_names.append('UNKNOWN')
+
         return table_names
 
     def do_rollback(self, dbapi_connection):

--- a/python/pyhive/sqlalchemy_hive.py
+++ b/python/pyhive/sqlalchemy_hive.py
@@ -377,7 +377,7 @@ class HiveDialect(default.DefaultDialect):
         query = 'SHOW TABLES'
         if schema:
             query += ' IN ' + self.identifier_preparer.quote_identifier(schema)
-        return [row[0] for row in connection.execute(text(query))]
+        return [row[1] for row in connection.execute(text(query))]
 
     def do_rollback(self, dbapi_connection):
         # No transactions for Hive


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #6489

## Describe Your Solution 🔧

After my investigation, I found the bug and solution.
The function get_table_names returns an incorrect value when I used Superset to connect to Kyuubi for Spark SQL.
[get_table_names](https://github.com/apache/kyuubi/blob/master/python/pyhive/sqlalchemy_hive.py#L380)

The following code is used to connect to hive directly.
`return [row[0] for row in connection.execute(text(query))]` 

Because The following value is returned when the Hive is connected.

show tables in default :
[('student',), ('student_scores',)]

The following code is used to connect to Kyuubi.
`return [row[1] for row in connection.execute(text(query))]` 

Because The following value is returned when the Kyuubi is connected.

show tables in default :
[('default', 'employees', False), ('default', 'student', False), ('default', 'student_scores', False)]

So, for the difference in return value, I modified the code.

And I test them in Superset. The code works.

Hive
<img width="1214" alt="image" src="https://github.com/apache/kyuubi/assets/29974394/9048b21d-053e-4b5d-be35-ba29d3bd6848">

Kyuubi
<img width="1085" alt="image" src="https://github.com/apache/kyuubi/assets/29974394/d600dfed-1127-41ea-a0bf-ca662a5487df">

Spark SQL also works properly.
<img width="1199" alt="image" src="https://github.com/apache/kyuubi/assets/29974394/7026e39e-6d63-473d-9e43-eeab580719ea">


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
