### PR TITLE
[K8S][HELM] Align Helm templates with formatting approach

### DIFF
--- a/charts/kyuubi/templates/kyuubi-alert.yaml
+++ b/charts/kyuubi/templates/kyuubi-alert.yaml
@@ -20,9 +20,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ .Release.Name }}
-  labels:
-    {{- include "kyuubi.labels" . | nindent 4 }}
+  labels: {{- include "kyuubi.labels" . | nindent 4 }}
 spec:
-  groups:
-    {{- toYaml .Values.prometheusRule.groups | nindent 4 }}
+  groups: {{- toYaml .Values.prometheusRule.groups | nindent 4 }}
 {{- end }}

--- a/charts/kyuubi/templates/kyuubi-configmap.yaml
+++ b/charts/kyuubi/templates/kyuubi-configmap.yaml
@@ -19,8 +19,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}
-  labels:
-    {{- include "kyuubi.labels" . | nindent 4 }}
+  labels: {{- include "kyuubi.labels" . | nindent 4 }}
 data:
   {{- with .Values.kyuubiConf.kyuubiEnv }}
   kyuubi-env.sh: |

--- a/charts/kyuubi/templates/kyuubi-headless-service.yaml
+++ b/charts/kyuubi/templates/kyuubi-headless-service.yaml
@@ -19,8 +19,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-headless
-  labels:
-    {{- include "kyuubi.labels" $ | nindent 4 }}
+  labels: {{- include "kyuubi.labels" $ | nindent 4 }}
 spec:
   type: ClusterIP
   clusterIP: None
@@ -35,6 +34,4 @@ spec:
       port: {{ .Values.monitoring.prometheus.port }}
       targetPort: {{ .Values.monitoring.prometheus.port }}
     {{- end }}
-  selector:
-    {{- include "kyuubi.selectorLabels" $ | nindent 4 }}
-
+  selector: {{- include "kyuubi.selectorLabels" $ | nindent 4 }}

--- a/charts/kyuubi/templates/kyuubi-podmonitor.yaml
+++ b/charts/kyuubi/templates/kyuubi-podmonitor.yaml
@@ -20,12 +20,10 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: {{ .Release.Name }}
-  labels:
-    {{- include "kyuubi.labels" . | nindent 4 }}
+  labels: {{- include "kyuubi.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
       app: {{ .Release.Name }}
-  podMetricsEndpoints:
-    {{- toYaml .Values.podMonitor.podMetricsEndpoint | nindent 4 }}
+  podMetricsEndpoints: {{- toYaml .Values.podMonitor.podMetricsEndpoint | nindent 4 }}
 {{- end }}

--- a/charts/kyuubi/templates/kyuubi-priorityclass.yaml
+++ b/charts/kyuubi/templates/kyuubi-priorityclass.yaml
@@ -20,7 +20,6 @@ apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: {{ .Values.priorityClass.name | default .Release.Name }}
-  labels:
-    {{- include "kyuubi.labels" . | nindent 4 }}
+  labels: {{- include "kyuubi.labels" . | nindent 4 }}
 value: {{ .Values.priorityClass.value }}
 {{- end }}

--- a/charts/kyuubi/templates/kyuubi-role.yaml
+++ b/charts/kyuubi/templates/kyuubi-role.yaml
@@ -20,7 +20,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ .Release.Name }}
-  labels:
-    {{- include "kyuubi.labels" . | nindent 4 }}
+  labels: {{- include "kyuubi.labels" . | nindent 4 }}
 rules: {{- toYaml .Values.rbac.rules | nindent 2 }}
 {{- end }}

--- a/charts/kyuubi/templates/kyuubi-rolebinding.yaml
+++ b/charts/kyuubi/templates/kyuubi-rolebinding.yaml
@@ -20,8 +20,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ .Release.Name }}
-  labels:
-    {{- include "kyuubi.labels" . | nindent 4 }}
+  labels: {{- include "kyuubi.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.serviceAccount.name | default .Release.Name }}

--- a/charts/kyuubi/templates/kyuubi-service.yaml
+++ b/charts/kyuubi/templates/kyuubi-service.yaml
@@ -21,8 +21,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ $.Release.Name }}-{{ $name | kebabcase }}
-  labels:
-    {{- include "kyuubi.labels" $ | nindent 4 }}
+  labels: {{- include "kyuubi.labels" $ | nindent 4 }}
   {{- with $frontend.service.annotations }}
   annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -35,8 +34,7 @@ spec:
       {{- if and (eq $frontend.service.type "NodePort") ($frontend.service.nodePort) }}
       nodePort: {{ $frontend.service.nodePort }}
       {{- end }}
-  selector:
-    {{- include "kyuubi.selectorLabels" $ | nindent 4 }}
+  selector: {{- include "kyuubi.selectorLabels" $ | nindent 4 }}
   {{- if ($frontend.service.sessionAffinity) }}
   sessionAffinity: {{ $frontend.service.sessionAffinity }}
   {{- end }}

--- a/charts/kyuubi/templates/kyuubi-serviceaccount.yaml
+++ b/charts/kyuubi/templates/kyuubi-serviceaccount.yaml
@@ -20,8 +20,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccount.name | default .Release.Name }}
-  annotations:
-    {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
-  labels:
-    {{- include "kyuubi.labels" . | nindent 4 }}
+  annotations: {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+  labels: {{- include "kyuubi.labels" . | nindent 4 }}
 {{- end }}

--- a/charts/kyuubi/templates/kyuubi-servicemonitor.yaml
+++ b/charts/kyuubi/templates/kyuubi-servicemonitor.yaml
@@ -23,12 +23,10 @@ metadata:
   labels:
     {{- include "kyuubi.labels" . | nindent 4 }}
     {{- if .Values.serviceMonitor.labels }}
-    {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
+      {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
     {{- end }}
 spec:
   selector:
-    matchLabels:
-      {{- include "kyuubi.selectorLabels" . | nindent 6 }}
-  endpoints:
-    {{- toYaml .Values.serviceMonitor.endpoints | nindent 4 }}
+    matchLabels: {{- include "kyuubi.selectorLabels" . | nindent 6 }}
+  endpoints: {{- toYaml .Values.serviceMonitor.endpoints | nindent 4 }}
 {{- end }}

--- a/charts/kyuubi/templates/kyuubi-spark-configmap.yaml
+++ b/charts/kyuubi/templates/kyuubi-spark-configmap.yaml
@@ -19,8 +19,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-spark
-  labels:
-    {{- include "kyuubi.labels" . | nindent 4 }}
+  labels: {{- include "kyuubi.labels" . | nindent 4 }}
 data:
   {{- with .Values.sparkConf.sparkEnv }}
   spark-env.sh: |

--- a/charts/kyuubi/templates/kyuubi-statefulset.yaml
+++ b/charts/kyuubi/templates/kyuubi-statefulset.yaml
@@ -19,12 +19,10 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ .Release.Name }}
-  labels:
-    {{- include "kyuubi.labels" . | nindent 4 }}
+  labels: {{- include "kyuubi.labels" . | nindent 4 }}
 spec:
   selector:
-    matchLabels:
-      {{- include "kyuubi.selectorLabels" . | nindent 6 }}
+    matchLabels: {{- include "kyuubi.selectorLabels" . | nindent 6 }}
   serviceName: {{ .Release.Name }}-headless
   minReadySeconds: {{ .Values.minReadySeconds }}
   replicas: {{ .Values.replicaCount }}
@@ -35,8 +33,7 @@ spec:
   {{- end }}
   template:
     metadata:
-      labels:
-        {{- include "kyuubi.selectorLabels" . | nindent 8 }}
+      labels: {{- include "kyuubi.selectorLabels" . | nindent 8 }}
       annotations:
         checksum/conf: {{ include (print $.Template.BasePath "/kyuubi-configmap.yaml") . | sha256sum }}
     spec:


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
There are few formatting misalignments in the Helm chart.

## Describe Your Solution 🔧
The PR aligns the chart templates formatting without any functional changes.

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Test 1
All templates (and rendered `labels`) are correct with default chart values:
```sh
helm template --debug charts/kyuubi
```

#### Test 2
Templates `kyuubi-alert.yaml`, `kyuubi-podmonitor.yaml` and `kyuubi-servicemonitor.yaml` are correct with additionally provided values:
```sh
helm template --debug charts/kyuubi -f values-monitoring.yaml -s templates/kyuubi-alert.yaml -s templates/kyuubi-podmonitor.yaml -s templates/kyuubi-servicemonitor.yaml
```
File `values-monitoring.yaml` used for testing
```yaml
metricsReporters: PROMETHEUS

podMonitor:
  enabled: true
  podMetricsEndpoint:
    - port: web

serviceMonitor:
  enabled: true
  endpoints:
    - port: web
  labels:
    first: label1
    second: label2

prometheusRule:
  enabled: true
  groups:
    - name: ./example.rules
      rules:
        - alert: ExampleAlert
          expr: vector(1)

```


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
