### PR TITLE
[K8S][HELM] Update default Kyuubi version to 1.9.1

### DIFF
--- a/charts/kyuubi/Chart.yaml
+++ b/charts/kyuubi/Chart.yaml
@@ -20,7 +20,7 @@ name: kyuubi
 description: A Helm chart for Kyuubi server
 type: application
 version: 0.1.0
-appVersion: 1.9.0
+appVersion: 1.9.1
 home: https://kyuubi.apache.org
 icon: https://raw.githubusercontent.com/apache/kyuubi/master/docs/imgs/logo.png
 sources:


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗

Default Kyuubi version in the chart is not up to date with the latest release version.

## Describe Your Solution 🔧

Upgrade default version to the latest 1.9.1 to be up to date with the release version.

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### The chart deploys Kyuubi 1.9.1
Install the chart:
```sh
helm install kyuubi charts/kyuubi
```
Check version:
```sh
kubectl exec kyuubi-0 -- cat /opt/kyuubi/RELEASE
Kyuubi 1.9.1 (git revision c232a4b) built for
Java 1.8.0_412
Scala 2.12
Flink 1.17.2
Spark 3.5.1
Kyuubi Hadoop 3.3.6
Hive 3.1.3
Build flags:
```


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
