### PR TITLE
Correct Kyuubi BeeLine help message for incremental

### DIFF
--- a/kyuubi-hive-beeline/src/main/resources/BeeLine.properties
+++ b/kyuubi-hive-beeline/src/main/resources/BeeLine.properties
@@ -193,7 +193,7 @@ Options:\n\
 \  --outputformat=<format mode>    Format mode for result display.\n\
 \                                  The available options ars [table|vertical|csv2|tsv2|dsv|csv|tsv|json|jsonfile]. \n\
 \                                  Note that csv, and tsv are deprecated, use csv2, tsv2 instead.\n\n\
-\  --incremental=[true|false]      Defaults to false. When set to false, the entire result set\n\
+\  --incremental=[true|false]      Defaults to true. When set to false, the entire result set\n\
 \                                  is fetched and buffered before being displayed, yielding optimal\n\
 \                                  display column sizing. When set to true, result rows are displayed\n\
 \                                  immediately as they are fetched, yielding lower latency and\n\


### PR DESCRIPTION
# :mag: Description

Hive 2.3.0 (HIVE-7224) turns it on by default, while Kyuubi BeeLine is a fork from Hive BeeLine 3.1.3, we should update the help message to reflect the change.

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

Pass GHA.

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
