### PR TITLE
[KYUUBI #6508] Add the key-value pairs in optimizedConf to session conf

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiBatchSession.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiBatchSession.scala
@@ -93,6 +93,10 @@ class KyuubiBatchSession(
     }
   }
 
+  optimizedConf.foreach {
+    case (key, value) => sessionConf.set(key, value)
+  }
+
   override lazy val name: Option[String] =
     batchName.filterNot(_.trim.isEmpty).orElse(optimizedConf.get(KyuubiConf.SESSION_NAME.key))
 


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #6508

## Describe Your Solution 🔧

Add the key-value pairs in optimizedConf to session conf，to make the Kyuubi.env.SPARK_HOME take effect


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:
When I configure the following parameters in kyuubi-env.sh
![image](https://github.com/apache/kyuubi/assets/14961757/98e8ac2b-ccdd-493c-9dff-171667b58b53)
Then submit a spark batch task through the restful interface and pass the kyuubi.engineEnv.SPARK_HOME parameter to change the default value
```curl -H "Content-Type: application/json" -X POST -d '{"batchType": "SPARK", "resource":"xxxx/spark-examples_2.12-3.3.2.jar",  "name": "Spark-PI", "conf": {"spark.master":"yarn","hive.server2.proxy.user":"XXXX","kyuubi.engineEnv.SPARK_HOME":"XXXXX/cluster114/spark","kyuubi.engineEnv.HADOOP_CONF_DIR":"XXXXX/conf"}, "args": [10],"className": "org.apache.spark.examples.SparkPi"}' http://XXXXX:XXXX/api/v1/batches```
Observe the log and find that SPARK_HOME is not set and takes effect. It still uses the value in kyuubi-env.sh.
![image](https://github.com/apache/kyuubi/assets/14961757/37a60b10-1f7f-4c69-8495-c96596d9bfb1)


#### Behavior With This Pull Request :tada:
![image](https://github.com/apache/kyuubi/assets/14961757/c86cae46-55c6-4e7d-ac1e-c04eb600d932)
After this PR, the update was successful

#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
