### PR TITLE
Add link to Github Issues on Contributing Documentation page

### DIFF
--- a/docs/contributing/doc/get_started.rst
+++ b/docs/contributing/doc/get_started.rst
@@ -18,6 +18,7 @@ Get Started
 
 .. image:: https://img.shields.io/github/issues/apache/kyuubi/kind:documentation?color=green&logo=gfi&logoColor=red&style=for-the-badge
    :alt: GitHub issues by-label
+   :target: `Documentation Issues`_
 
 
 Trivial Fixes
@@ -115,3 +116,4 @@ If you don't have time to fix the doc issue and submit a pull request on your ow
 .. _Build and verify: build.html
 .. _Create A Pull Request: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request
 .. _reporting a document issue: https://github.com/apache/kyuubi/issues/new/choose
+.. _Documentation Issues: https://github.com/apache/kyuubi/issues?q=is%3Aopen+is%3Aissue+label%3Akind%3Adocumentation


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

[Good First Issues](https://kyuubi.readthedocs.io/en/master/contributing/code/get_started.html) image links to the Github issues page while the image on [Contributing Documentation](https://kyuubi.readthedocs.io/en/master/contributing/doc/get_started.html) does not.

## Describe Your Solution 🔧

Added a link to https://github.com/apache/kyuubi/issues?q=is%3Aopen+is%3Aissue+label%3Akind%3Adocumentation to match the behaviour from good first issues

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
