### PR TITLE
Kyuubi BeeLine wrongly process JDBC URL that contains `--`

### DIFF
--- a/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/KyuubiBeeLine.java
+++ b/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/KyuubiBeeLine.java
@@ -218,7 +218,7 @@ public class KyuubiBeeLine extends BeeLine {
     if (!commands.isEmpty()) {
       for (String command : commands) {
         debug(loc("executing-command", command));
-        if (!dispatch(command)) {
+        if (!removeCommentsDispatch(command)) {
           code++;
         }
       }
@@ -282,9 +282,8 @@ public class KyuubiBeeLine extends BeeLine {
     return executionResult;
   }
 
-  // see HIVE-15820: comment at the head of beeline -e
-  @Override
-  boolean dispatch(String line) {
+  // see HIVE-15820: comment at the head of beeline -e only dispatch commands
+  boolean removeCommentsDispatch(String line) {
     return super.dispatch(isPythonMode() ? line : HiveStringUtils.removeComments(line));
   }
 

--- a/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/KyuubiBeeLineTest.java
+++ b/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/KyuubiBeeLineTest.java
@@ -95,12 +95,14 @@ public class KyuubiBeeLineTest {
 
   @Test
   public void testKyuubiBeelineComment() {
+    String[] url = new String[] {""};
     KyuubiBeeLine interceptedKyuubiBeeLine =
         new KyuubiBeeLine() {
           @Override
           boolean dispatch(String line) {
             if (line != null && line.startsWith("!connect")) {
               LOG.info("Return true for command: {} to pretend connection is established.", line);
+              url[0] = line;
               return true;
             }
             return super.dispatch(line);
@@ -122,12 +124,14 @@ public class KyuubiBeeLineTest {
     interceptedKyuubiBeeLine.initArgs(
         new String[] {"-u", "dummy_url", "-e", "--comment show database;"});
     assertEquals(0, cmd[0].length());
+    assertEquals("!connect dummy_url '' '' ", url[0]);
 
     // Beeline#exit must be false to execute sql
     interceptedKyuubiBeeLine.setExit(false);
     interceptedKyuubiBeeLine.initArgs(
         new String[] {"-u", "dummy_url", "-e", "--comment\n show database;"});
     assertEquals("show database;", cmd[0]);
+    assertEquals("!connect dummy_url '' '' ", url[0]);
 
     interceptedKyuubiBeeLine.setExit(false);
     interceptedKyuubiBeeLine.initArgs(
@@ -135,6 +139,12 @@ public class KyuubiBeeLineTest {
           "-u", "dummy_url", "-e", "--comment line 1 \n    --comment line 2 \n show database;"
         });
     assertEquals("show database;", cmd[0]);
+
+    interceptedKyuubiBeeLine.setExit(false);
+    interceptedKyuubiBeeLine.initArgs(
+        new String[] {"-u", "dummy--url", "-e", "--comment\n show database;"});
+    assertEquals("show database;", cmd[0]);
+    assertEquals("!connect dummy--url '' '' ", url[0]);
   }
 
   static class BufferPrintStream extends PrintStream {


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes https://github.com/apache/kyuubi/issues/6522

## Describe Your Solution 🔧

Remove comments in dispatch commands only execute command

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
