### PR TITLE
KyuubiBatchService should wait for HTTP server started before picking jobs

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiBatchService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiBatchService.scala
@@ -23,7 +23,7 @@ import org.apache.kyuubi.config.KyuubiConf.BATCH_SUBMITTER_THREADS
 import org.apache.kyuubi.engine.ApplicationState
 import org.apache.kyuubi.operation.OperationState
 import org.apache.kyuubi.server.metadata.MetadataManager
-import org.apache.kyuubi.service.{AbstractService, Serverable}
+import org.apache.kyuubi.service.{AbstractService, Serverable, ServiceState}
 import org.apache.kyuubi.session.KyuubiSessionManager
 import org.apache.kyuubi.util.ThreadUtils
 
@@ -34,7 +34,7 @@ class KyuubiBatchService(
 
   private lazy val restFrontend = server.frontendServices
     .filter(_.isInstanceOf[KyuubiRestFrontendService])
-    .head
+    .head.asInstanceOf[KyuubiRestFrontendService]
 
   private def kyuubiInstance: String = restFrontend.connectionUrl
 
@@ -66,6 +66,7 @@ class KyuubiBatchService(
   override def start(): Unit = {
     assert(running.compareAndSet(false, true))
     val submitTask: Runnable = () => {
+      restFrontend.waitForServerStarted()
       while (running.get) {
         metadataManager.pickBatchForSubmitting(kyuubiInstance) match {
           case None => Thread.sleep(1000)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiBatchService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiBatchService.scala
@@ -23,7 +23,7 @@ import org.apache.kyuubi.config.KyuubiConf.BATCH_SUBMITTER_THREADS
 import org.apache.kyuubi.engine.ApplicationState
 import org.apache.kyuubi.operation.OperationState
 import org.apache.kyuubi.server.metadata.MetadataManager
-import org.apache.kyuubi.service.{AbstractService, Serverable, ServiceState}
+import org.apache.kyuubi.service.{AbstractService, Serverable}
 import org.apache.kyuubi.session.KyuubiSessionManager
 import org.apache.kyuubi.util.ThreadUtils
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/ui/JettyServer.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/ui/JettyServer.scala
@@ -24,7 +24,7 @@ import org.eclipse.jetty.util.thread.{QueuedThreadPool, ScheduledExecutorSchedul
 
 import org.apache.kyuubi.util.JavaUtils
 
-private[kyuubi] case class JettyServer(
+private[kyuubi] class JettyServer(
     server: Server,
     connector: ServerConnector,
     rootHandler: ContextHandlerCollection) {
@@ -68,7 +68,7 @@ private[kyuubi] case class JettyServer(
     addHandler(JettyUtils.createRedirectHandler(src, dest))
   }
 
-  def getState: String = server.getState
+  def isStarted: Boolean = server.isStarted
 }
 
 object JettyServer {


### PR DESCRIPTION
# :mag: Description

This is similar to https://github.com/apache/kyuubi/pull/5310.

We need to wait for Jetty Server started before picking jobs, otherwise, it may get the wrong local HTTP server port -1.

This only affects Batch V2

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

Tested in internal workloads.

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
