### PR TITLE
[KYUUBI #6541] [AUTHZ] Fix DataSourceV2RelationTableExtractor can't get the 'database' attribute if it's a Paimon plan.

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/test/gen/scala/org/apache/kyuubi/plugin/spark/authz/gen/PolicyJsonFileGenerator.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/gen/scala/org/apache/kyuubi/plugin/spark/authz/gen/PolicyJsonFileGenerator.scala
@@ -173,7 +173,7 @@ class PolicyJsonFileGenerator extends AnyFunSuite {
     name = "all - database, udf",
     description = "Policy for all - database, udf",
     resources = Map(
-      databaseRes(defaultDb, sparkCatalog, icebergNamespace, namespace1),
+      databaseRes(defaultDb, sparkCatalog, icebergNamespace, namespace1, paimonNamespace),
       allTableRes,
       allColumnRes),
     policyItems = List(

--- a/extensions/spark/kyuubi-spark-authz/src/test/resources/sparkSql_hive_jenkins.json
+++ b/extensions/spark/kyuubi-spark-authz/src/test/resources/sparkSql_hive_jenkins.json
@@ -229,7 +229,7 @@
     "isAuditEnabled" : true,
     "resources" : {
       "database" : {
-        "values" : [ "default", "spark_catalog", "iceberg_ns", "ns1" ],
+        "values" : [ "default", "spark_catalog", "iceberg_ns", "ns1", "paimon_ns"],
         "isExcludes" : false,
         "isRecursive" : false
       },

--- a/extensions/spark/kyuubi-spark-authz/src/test/resources/sparkSql_hive_jenkins.json
+++ b/extensions/spark/kyuubi-spark-authz/src/test/resources/sparkSql_hive_jenkins.json
@@ -229,7 +229,7 @@
     "isAuditEnabled" : true,
     "resources" : {
       "database" : {
-        "values" : [ "default", "spark_catalog", "iceberg_ns", "ns1", "paimon_ns"],
+        "values" : [ "default", "spark_catalog", "iceberg_ns", "ns1", "paimon_ns" ],
         "isExcludes" : false,
         "isRecursive" : false
       },

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/RangerTestResources.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/RangerTestResources.scala
@@ -42,6 +42,7 @@ object RangerTestNamespace {
   val sparkCatalog = "spark_catalog"
   val icebergNamespace = "iceberg_ns"
   val hudiNamespace = "hudi_ns"
+  val paimonNamespace = "paimon_ns"
   val deltaNamespace = "delta_ns"
   val namespace1 = "ns1"
   val namespace2 = "ns2"

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/PaimonCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/PaimonCatalogRangerSparkExtensionSuite.scala
@@ -99,10 +99,10 @@ class PaimonCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
             .foreach(i => sql(s"INSERT INTO $catalogV2.$namespace1.$table1 VALUES ($i, 'name_$i')"))
         })
 
-      doAs(bob, sql(s"SELECT id FROM $catalogV2.$namespace1.$table1").show)
+      doAs(bob, sql(s"SELECT id FROM $catalogV2.$namespace1.$table1").collect())
 
       interceptEndsWith[AccessControlException] {
-        doAs(someone, sql(s"SELECT id FROM $catalogV2.$namespace1.$table1").show)
+        doAs(someone, sql(s"SELECT id FROM $catalogV2.$namespace1.$table1").collect())
       }(s"does not have [select] privilege on [$namespace1/$table1/id]")
     }
   }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/PaimonCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/PaimonCatalogRangerSparkExtensionSuite.scala
@@ -99,9 +99,11 @@ class PaimonCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
             .foreach(i => sql(s"INSERT INTO $catalogV2.$namespace1.$table1 VALUES ($i, 'name_$i')"))
         })
 
+      doAs(bob, sql(s"SELECT id FROM $catalogV2.$namespace1.$table1").show)
+
       interceptEndsWith[AccessControlException] {
-        doAs(bob, sql(s"SELECT * FROM $catalogV2.$namespace1.$table1").show)
-      }(s"does not have [select] privilege on [$namespace1/$table1]")
+        doAs(someone, sql(s"SELECT id FROM $catalogV2.$namespace1.$table1").show)
+      }(s"does not have [select] privilege on [$namespace1/$table1/id]")
     }
   }
 }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/PaimonCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/PaimonCatalogRangerSparkExtensionSuite.scala
@@ -86,14 +86,14 @@ class PaimonCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
     withCleanTmpResources(Seq((s"$catalogV2.$namespace1.$table1", "table"))) {
       doAs(
         bob, {
-          sql( s"""
-                  |CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table1
-                  |(id int, name string)
-                  |USING paimon
-                  |OPTIONS (
-                  | primaryKey = 'id'
-                  |)
-                  |""".stripMargin)
+          sql(s"""
+                 |CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table1
+                 |(id int, name string)
+                 |USING paimon
+                 |OPTIONS (
+                 | primaryKey = 'id'
+                 |)
+                 |""".stripMargin)
           // insert 2 data files
           (0 until 2)
             .foreach(i => sql(s"INSERT INTO $catalogV2.$namespace1.$table1 VALUES ($i, 'name_$i')"))


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #6541

## Describe Your Solution 🔧
Fix an issue where DataSourceV2RelationTableExtractor#table could not fetch the ‘database’ attribute causing the Ranger checks to fail when using the Paimon Catalog.
If the database attribute is not resolved, use DataSourceV2RelationTableExtractor#identifier to complete it.

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
