### PR TITLE
Delete `updateStrategy.rollingUpdate.maxUnavailable` because it is alpha feature

### DIFF
--- a/charts/kyuubi/values.yaml
+++ b/charts/kyuubi/values.yaml
@@ -39,7 +39,6 @@ revisionHistoryLimit: 10
 updateStrategy:
   type: RollingUpdate
   rollingUpdate:
-    maxUnavailable: 1
     partition: 0
 
 image:


### PR DESCRIPTION
# :mag: Description

StatefulSet's `updateStrategy.rollingUpdate.maxUnavailable` is being used, but this feature is still in the alpha stage. It should not be used by default.

https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-alpha-or-beta-features:~:text=%E2%80%93-,MaxUnavailableStatefulSet,-false

https://kubernetes.io/blog/2022/05/27/maxunavailable-for-statefulset/

## Issue References 🔗

None

## Describe Your Solution 🔧

I simply removed it. The behavior should not change even after the removal.

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
