### PR TITLE
[KYUUBI #6567] Fix compatibility of pyhive with setuptools==72.0.0

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -1,22 +1,7 @@
 #!/usr/bin/env python
 
 from setuptools import setup
-from setuptools.command.test import test as TestCommand
 import pyhive
-import sys
-
-
-class PyTest(TestCommand):
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        # import here, cause outside the eggs aren't loaded
-        import pytest
-        errno = pytest.main(self.test_args)
-        sys.exit(errno)
 
 
 with open('README.rst') as readme:
@@ -62,7 +47,6 @@ setup(
         'sqlalchemy>=1.3.0',
         'thrift>=0.10.0',
     ],
-    cmdclass={'test': PyTest},
     package_data={
         '': ['*.rst'],
     },


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
This pull request fixes #6567

## Describe Your Solution 🔧
With `setuptools==72.0.0`, the `test` command was removed after being deprecated for a long time.
This completely breaks the installation of any packages using the `test` command, including PyHive.
This PR fixes PyHive to be compatible with `setuptools` 72+ again.
It seems that `setup.py test` wasn't used anywhere at all, which is why I just removed it.

## Types of changes :bookmark:
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:
```
$ pip install -e .
Obtaining file:///home/localstack/Repos/kyuubi/python
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [6 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/home/localstack/Repos/kyuubi/python/setup.py", line 4, in <module>
          from setuptools.command.test import test as TestCommand
      ModuleNotFoundError: No module named 'setuptools.command.test'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details
```

#### Behavior With This Pull Request :tada:
```
$ pip install --upgrade setuptools
Requirement already satisfied: setuptools in .../.pyenv/versions/3.11.5/lib/python3.11/site-packages (72.0.0)
$ pip install -e .
Obtaining file:///home/.../repos/kyuubi/python
  Preparing metadata (setup.py) ... done
Collecting future (from PyHive==0.7.0)
  Obtaining dependency information for future from https://files.pythonhosted.org/packages/da/71/ae30dadffc90b9006d77af76b393cb9dfbfc9629f339fc1574a1c52e6806/future-1.0.0-py3-none-any.whl.metadata
  Using cached future-1.0.0-py3-none-any.whl.metadata (4.0 kB)
Requirement already satisfied: python-dateutil in /home/.../.pyenv/versions/3.11.5/lib/python3.11/site-packages (from PyHive==0.7.0) (2.8.2)
Requirement already satisfied: six>=1.5 in /home/.../.pyenv/versions/3.11.5/lib/python3.11/site-packages (from python-dateutil->PyHive==0.7.0) (1.16.0)
Using cached future-1.0.0-py3-none-any.whl (491 kB)
Installing collected packages: future, PyHive
  Running setup.py develop for PyHive
Successfully installed PyHive-0.7.0 future-1.0.0

[notice] A new release of pip is available: 23.2.1 -> 24.1.2
[notice] To update, run: pip install --upgrade pip
```

#### Related Unit Tests
None

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
