### PR TITLE
Show kyuubi batch app details on app state change

### DIFF
--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/util/Render.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/util/Render.scala
@@ -122,7 +122,7 @@ private[ctl] object Render {
         millisToDateString(batch.getEndTime, "yyyy-MM-dd HH:mm:ss")).mkString("\n~\n"))
   }
 
-  private def buildBatchAppInfo(batch: Batch, showDiagnostic: Boolean = true): List[String] = {
+  def buildBatchAppInfo(batch: Batch, showDiagnostic: Boolean = true): List[String] = {
     val batchAppInfo = ListBuffer[String]()
     batch.getBatchInfo.asScala.foreach { case (key, value) =>
       batchAppInfo += s"$key: $value"


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pr enhance the kyuubi batch logs for spark on k8s with kyuubi-ctl.
## Describe Your Solution 🔧

For spark on k8s, before, it does not show the app detail info until the log batch command finished.

In this PR, it will show the batch app details in app state change.

Especially show the app URL info.

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests
<img width="1326" alt="image" src="https://github.com/user-attachments/assets/2356af83-4422-4dfc-812c-d90b809ea724">


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
