### PR TITLE
Get effective USER if env var is unavailable

### DIFF
--- a/bin/kyuubi
+++ b/bin/kyuubi
@@ -35,6 +35,11 @@ if [[ "$*" = *--help ]] || [[ "$*" = *-h ]]; then
   exit 0
 fi
 
+# if for some reason the shell doesn't have $USER defined
+# (e.g., ssh'd in to execute a command)
+# let's get the effective username and use that
+USER=${USER:-$(id -nu)}
+
 function kyuubi_logo() {
   source ${KYUUBI_HOME}/bin/kyuubi-logo
 }

--- a/build/kyuubi-build-info
+++ b/build/kyuubi-build-info
@@ -30,7 +30,10 @@ echo_build_properties() {
   echo kyuubi_hadoop_version="$7"
   echo kyuubi_flink_version="$8"
   echo kyuubi_trino_version="$9"
-  echo user="$USER"
+  # if for some reason the shell doesn't have $USER defined
+  # (e.g., ssh'd in to execute a command)
+  # let's get the effective username and use that
+  echo user="${USER:-$(id -nu)}"
   echo revision=$(git rev-parse HEAD)
   echo revision_time=$(git show -s --format=%ci HEAD)
   echo branch=$(git rev-parse --abbrev-ref HEAD)


### PR DESCRIPTION
# :mag: Description

In some cases, env var USER is unavailable, for example, docker container, we should evaluate it via `id -nu`

ref: https://github.com/apache/hadoop/blob/rel/release-3.4.0/hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh#L893-L896

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

```
$ docker run -t -i ubuntu:latest
root@1dbeaefd6cd4:/# echo $USER

root@1dbeaefd6cd4:/# id -nu
root
root@1dbeaefd6cd4:/# exit
```

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
