### PR TITLE
Add uploadWorkDir into local dir allow list and do not skip check for resource uploaded use case

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KyuubiApplicationManager.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KyuubiApplicationManager.scala
@@ -133,9 +133,9 @@ object KyuubiApplicationManager {
   }
 
   private[kyuubi] def checkApplicationAccessPath(path: String, conf: KyuubiConf): Unit = {
-    val localDirAllowList =
-      conf.get(KyuubiConf.SESSION_LOCAL_DIR_ALLOW_LIST) ++ Seq(uploadWorkDir.toUri.getPath)
+    var localDirAllowList: Set[String] = conf.get(KyuubiConf.SESSION_LOCAL_DIR_ALLOW_LIST)
     if (localDirAllowList.nonEmpty) {
+      localDirAllowList ++= Set(uploadWorkDir.toUri.getPath)
       val uri =
         try {
           new URI(path)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KyuubiApplicationManager.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KyuubiApplicationManager.scala
@@ -133,7 +133,8 @@ object KyuubiApplicationManager {
   }
 
   private[kyuubi] def checkApplicationAccessPath(path: String, conf: KyuubiConf): Unit = {
-    val localDirAllowList = conf.get(KyuubiConf.SESSION_LOCAL_DIR_ALLOW_LIST)
+    val localDirAllowList =
+      conf.get(KyuubiConf.SESSION_LOCAL_DIR_ALLOW_LIST) ++ Seq(uploadWorkDir.toUri.getPath)
     if (localDirAllowList.nonEmpty) {
       val uri =
         try {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiBatchSession.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiBatchSession.scala
@@ -144,7 +144,7 @@ class KyuubiBatchSession(
       batchType,
       optimizedConf,
       sessionManager.getConf)
-    if (resource != SparkProcessBuilder.INTERNAL_RESOURCE && !isResourceUploaded) {
+    if (resource != SparkProcessBuilder.INTERNAL_RESOURCE) {
       KyuubiApplicationManager.checkApplicationAccessPath(resource, sessionManager.getConf)
     }
   }


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

As title, for security concern. 

Before, it skips to check the local dir access for resource upload use case, which is not expected.
## Describe Your Solution 🔧

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
