### PR TITLE
[KYUUBI #5314] Support JDK 21

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -55,7 +55,7 @@ jobs:
         exclude-tags: [""]
         comment: ["normal"]
         include:
-          - java: 17
+          - java: 21
             spark: '4.0'
             spark-archive: '-Pscala-2.13'
             exclude-tags: ''

--- a/pom.xml
+++ b/pom.xml
@@ -1939,29 +1939,13 @@
                 <maven.compiler.source></maven.compiler.source>
                 <maven.compiler.target></maven.compiler.target>
                 <maven.compiler.release>${java.version}</maven.compiler.release>
+                <!-- TODO: The current version of spotless(2.30.0) and google-java-format(1.7)
+                           does not support Java 21, but new version produces different outputs.
+                           Re-evaluate once we dropped support for Java 8. -->
+                <maven.plugin.spotless.version>2.43.0</maven.plugin.spotless.version>
+                <spotless.check.skip>true</spotless.check.skip>
+                <spotless.java.googlejavaformat.version>1.22.0</spotless.java.googlejavaformat.version>
             </properties>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>com.diffplug.spotless</groupId>
-                            <artifactId>spotless-maven-plugin</artifactId>
-                            <version>2.43.0</version>
-                            <configuration>
-                                <java>
-                                    <googleJavaFormat>
-                                        <version>1.22.0</version>
-                                    </googleJavaFormat>
-                                </java>
-                                <!-- TODO: The current version of spotless(2.30.0) and google-java-format(1.7) does not match with Java 21.
-                                     To build with Java 21, the spotless.check.skip needs to set to `true`.
-                                     Re-evaluate once we dropped support for Java 8. -->
-                                <skip>true</skip>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
         </profile>
 
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -236,6 +236,7 @@
         <maven.plugin.scalatest.exclude.tags>org.scalatest.tags.Slow</maven.plugin.scalatest.exclude.tags>
         <maven.plugin.scalatest.include.tags></maven.plugin.scalatest.include.tags>
         <maven.plugin.scalatest.debug.enabled>false</maven.plugin.scalatest.debug.enabled>
+        <!-- TODO: Once we drop support for Java 8, we can consider upgrade spotless.version to 2.43.0. -->
         <maven.plugin.spotless.version>2.30.0</maven.plugin.spotless.version>
         <maven.plugin.surefire.version>3.2.1</maven.plugin.surefire.version>
         <maven.plugin.jacoco.version>0.8.11</maven.plugin.jacoco.version>
@@ -255,7 +256,8 @@
         <!-- Package to use when relocating shaded classes. -->
         <kyuubi.shade.packageName>org.apache.kyuubi.shade</kyuubi.shade.packageName>
 
-        <!-- Needed for Spotless style check-->
+        <!-- Needed for Spotless style check.
+             TODO: Once we drop support for Java 8, we can consider upgrade googlejavaformat.version to 1.22.0 or above. -->
         <spotless.java.googlejavaformat.version>1.7</spotless.java.googlejavaformat.version>
         <spotless.python.includes></spotless.python.includes>
         <spotless.python.black.version>22.3.0</spotless.python.black.version>
@@ -1925,6 +1927,41 @@
                 <maven.compiler.release>${java.version}</maven.compiler.release>
                 <minimalJavaBuildVersion>${java.version}</minimalJavaBuildVersion>
             </properties>
+        </profile>
+
+        <profile>
+            <id>java-21</id>
+            <activation>
+                <jdk>21</jdk>
+            </activation>
+            <properties>
+                <java.version>21</java.version>
+                <maven.compiler.source></maven.compiler.source>
+                <maven.compiler.target></maven.compiler.target>
+                <maven.compiler.release>${java.version}</maven.compiler.release>
+            </properties>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>com.diffplug.spotless</groupId>
+                            <artifactId>spotless-maven-plugin</artifactId>
+                            <version>2.43.0</version>
+                            <configuration>
+                                <java>
+                                    <googleJavaFormat>
+                                        <version>1.22.0</version>
+                                    </googleJavaFormat>
+                                </java>
+                                <!-- TODO: The current version of spotless(2.30.0) and google-java-format(1.7) does not match with Java 21.
+                                     To build with Java 21, the spotless.check.skip needs to set to `true`.
+                                     Re-evaluate once we dropped support for Java 8. -->
+                                <skip>true</skip>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
         </profile>
 
         <profile>


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
This pull request fixes #5314

## Describe Your Solution 🔧
To support Java 21, some dependency packages need to be upgraded.Here is the detailed explanation.
1. To build with Java 21, Scala binary version needs to be upgraded to 2.13.11 or above.
2. The versions of `spotless` and `googlejavaformat` need to be upgraded to higher versions. However, this will lose support for Java 8. In order to continue supporting Java 8, code style checks will be ignored in the Java 21 profile.
3. Since the Flink engine does not support Scala 2.13, the Scala version of the Flink module is fixed at 2.12.


Previous discussions were at https://github.com/apache/kyuubi/pull/6306.

---
## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

---

**Be nice. Be informative.**
