### PR TITLE
Flink engine module supports building with Scala 2.13

### DIFF
--- a/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/FlinkSQLEngine.scala
+++ b/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/FlinkSQLEngine.scala
@@ -91,6 +91,7 @@ object FlinkSQLEngine extends Logging {
       val flinkConfFromArgs =
         kyuubiConf.getAll.filterKeys(_.startsWith("flink."))
           .map { case (k, v) => (k.stripPrefix("flink."), v) }
+          .toMap
       flinkConf.addAll(Configuration.fromMap(flinkConfFromArgs.asJava))
 
       val executionTarget = flinkConf.getString(DeploymentOptions.TARGET)

--- a/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/GetFunctions.scala
+++ b/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/GetFunctions.scala
@@ -57,9 +57,9 @@ class GetFunctions(
         .filter { c => StringUtils.isEmpty(catalogName) || c == catalogName }
         .flatMap { c =>
           val catalog = catalogManager.getCatalog(c).get()
-          filterPattern(catalog.listDatabases().asScala, schemaPattern)
+          filterPattern(catalog.listDatabases().asScala.toSeq, schemaPattern)
             .flatMap { d =>
-              filterPattern(catalog.listFunctions(d).asScala, functionPattern)
+              filterPattern(catalog.listFunctions(d).asScala.toSeq, functionPattern)
                 .map { f =>
                   Row.of(
                     c,

--- a/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/GetSchemas.scala
+++ b/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/GetSchemas.scala
@@ -41,7 +41,7 @@ class GetSchemas(session: Session, catalogName: String, schema: String)
         .filter { c => StringUtils.isEmpty(catalogName) || c == catalogName }
         .flatMap { c =>
           val catalog = catalogManager.getCatalog(c).get()
-          filterPattern(catalog.listDatabases().asScala, schemaPattern)
+          filterPattern(catalog.listDatabases().asScala.toSeq, schemaPattern)
             .map { d => Row.of(d, c) }
         }.toArray
       resultSet = ResultSet.builder.resultKind(ResultKind.SUCCESS_WITH_CONTENT)


### PR DESCRIPTION
# :mag: Description

This PR makes `kyuubi-flink-sql-engine` compile success with Scala 2.13.

Note: As of Flink 1.20, it does not support Scala 2.13, so won't expect the Flink engine to work with Scala 2.13 for now. It would be helpful in the future after Flink removes Scala dependencies(planed in 2.0) then we can use any version of Scala.

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

```
$ build/mvn clean install -DskipTests -Pscala-2.13
...
[INFO] Reactor Summary for Kyuubi Project Parent 1.10.0-SNAPSHOT:
[INFO] 
[INFO] Kyuubi Project Parent .............................. SUCCESS [  9.031 s]
[INFO] Kyuubi Project Util ................................ SUCCESS [  3.998 s]
[INFO] Kyuubi Project Util Scala .......................... SUCCESS [  8.579 s]
[INFO] Kyuubi Project Common .............................. SUCCESS [ 26.006 s]
[INFO] Kyuubi Project Embedded Zookeeper .................. SUCCESS [  6.573 s]
[INFO] Kyuubi Project High Availability ................... SUCCESS [ 12.360 s]
[INFO] Kyuubi Project Rest Client ......................... SUCCESS [  5.799 s]
[INFO] Kyuubi Project Control ............................. SUCCESS [ 12.345 s]
[INFO] Kyuubi Project Events .............................. SUCCESS [ 11.447 s]
[INFO] Kyuubi Dev Spark Lineage Extension ................. SUCCESS [ 13.327 s]
[INFO] Kyuubi Project Metrics ............................. SUCCESS [  7.326 s]
[INFO] Kyuubi Project Hive JDBC Client .................... SUCCESS [  7.492 s]
[INFO] Kyuubi Project Server Plugin ....................... SUCCESS [  1.428 s]
[INFO] Kyuubi Project Download Externals .................. SUCCESS [  7.132 s]
[INFO] Kyuubi Project Engine Spark SQL .................... SUCCESS [01:11 min]
[INFO] Kyuubi Project Server .............................. SUCCESS [ 35.930 s]
[INFO] Kyuubi Project Hive Beeline ........................ SUCCESS [  6.833 s]
[INFO] Kyuubi Spark Connector Common ...................... SUCCESS [ 10.399 s]
[INFO] Kyuubi Spark TPC-DS Connector ...................... SUCCESS [ 13.854 s]
[INFO] Kyuubi Spark TPC-H Connector ....................... SUCCESS [ 10.407 s]
[INFO] Kyuubi Dev Code Coverage ........................... SUCCESS [  1.701 s]
[INFO] Kyuubi Spark JDBC Dialect plugin ................... SUCCESS [  6.881 s]
[INFO] Kyuubi Dev Spark Authorization Extension ........... SUCCESS [ 21.508 s]
[INFO] Kyuubi Dev Spark Authorization Extension Shaded .... SUCCESS [  0.627 s]
[INFO] Kyuubi Project Engine Chat ......................... SUCCESS [ 10.577 s]
[INFO] Kyuubi Project Engine Flink SQL .................... SUCCESS [ 22.605 s]
[INFO] Kyuubi Project Engine Hive SQL ..................... SUCCESS [ 17.021 s]
[INFO] Kyuubi Project Engine JDBC ......................... SUCCESS [ 13.871 s]
[INFO] Kyuubi Project Engine Trino ........................ SUCCESS [ 14.339 s]
[INFO] Kyuubi Test Integration Tests ...................... SUCCESS [  0.122 s]
[INFO] Kyuubi Test Flink SQL IT ........................... SUCCESS [  4.563 s]
[INFO] Kyuubi Test Hive IT ................................ SUCCESS [  4.123 s]
[INFO] Kyuubi Test Trino IT ............................... SUCCESS [  3.992 s]
[INFO] Kyuubi Project Hive JDBC Shaded Client ............. SUCCESS [ 10.347 s]
[INFO] Kyuubi Test Jdbc IT ................................ SUCCESS [  4.597 s]
[INFO] Kyuubi Test Zookeeper IT ........................... SUCCESS [  2.907 s]
[INFO] Kyuubi Project Assembly ............................ SUCCESS [  1.346 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  07:03 min
[INFO] Finished at: 2024-08-09T11:38:13+08:00
[INFO] ------------------------------------------------------------------------
```

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
