### PR TITLE
Correct usage of `maven.scaladoc.skip`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1934,48 +1934,6 @@
                 <scala.version>2.13.8</scala.version>
                 <spark.archive.scala.suffix>-scala${scala.binary.version}</spark.archive.scala.suffix>
             </properties>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>net.alchim31.maven</groupId>
-                            <artifactId>scala-maven-plugin</artifactId>
-                            <configuration>
-                                <scalaVersion>${scala.version}</scalaVersion>
-                                <recompileMode>incremental</recompileMode>
-                                <args>
-                                    <arg>-unchecked</arg>
-                                    <arg>-deprecation</arg>
-                                    <arg>-feature</arg>
-                                    <arg>-explaintypes</arg>
-                                    <arg>-P:silencer:globalFilters=.*deprecated.*</arg>
-                                    <arg>-P:silencer:globalFilters=.*Could not find any member to link for.*</arg>
-                                    <arg>-P:silencer:globalFilters=.*undefined in comment for class.*</arg>
-                                    <arg>-Xfatal-warnings</arg>
-                                    <arg>-Ywarn-unused:imports</arg>
-                                </args>
-                                <jvmArgs>
-                                    <jvmArg>-Xms1024m</jvmArg>
-                                    <jvmArg>-Xmx1024m</jvmArg>
-                                    <jvmArg>-XX:ReservedCodeCacheSize=512M</jvmArg>
-                                </jvmArgs>
-                                <javacArgs>
-                                    <javacArg>-Xlint:all,-serial,-path,-try,-processing</javacArg>
-                                </javacArgs>
-                                <compilerPlugins>
-                                    <compilerPlugin>
-                                        <groupId>com.github.ghik</groupId>
-                                        <artifactId>silencer-plugin_${scala.version}</artifactId>
-                                        <version>${maven.plugin.silencer.version}</version>
-                                    </compilerPlugin>
-                                </compilerPlugins>
-                                <!-- only skipping `scala:doc-jar` -->
-                                <skip>${maven.scaladoc.skip}</skip>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
         </profile>
 
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -1397,8 +1397,6 @@
                                 <version>${maven.plugin.silencer.version}</version>
                             </compilerPlugin>
                         </compilerPlugins>
-                        <!-- only skipping `scala:doc-jar` -->
-                        <skip>${maven.scaladoc.skip}</skip>
                     </configuration>
                     <executions>
                         <execution>
@@ -1425,6 +1423,9 @@
                                 <goal>doc-jar</goal>
                             </goals>
                             <phase>verify</phase>
+                            <configuration>
+                                <skip>${maven.scaladoc.skip}</skip>
+                            </configuration>
                         </execution>
                     </executions>
                 </plugin>


### PR DESCRIPTION
# :mag: Description

It was wrong applied to all goals previously, which caused all `test-compile`s are skipped.

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

Let's monitor what CI happens

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
