### PR TITLE
Upgrade Scala version from 2.13.8 to 2.13.14

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -162,6 +162,7 @@ jobs:
         run: |
           TEST_MODULES="!externals/kyuubi-flink-sql-engine,!integration-tests/kyuubi-flink-it"
           ./build/mvn clean install ${MVN_OPT} -pl ${TEST_MODULES} -am \
+          -Dmaven.plugin.scalatest.exclude.tags=org.scalatest.tags.Slow,org.apache.kyuubi.tags.SparkLocalClusterTest \
           -Pscala-${{ matrix.scala }} -Pjava-${{ matrix.java }} -Pspark-${{ matrix.spark }}
       - name: Upload test logs
         if: failure()

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/jdbc/JDBCMetadataStore.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/jdbc/JDBCMetadataStore.scala
@@ -80,7 +80,8 @@ class JDBCMetadataStore(conf: KyuubiConf) extends MetadataStore with Logging {
   hikariConfig.setPoolName("jdbc-metadata-store-pool")
 
   @VisibleForTesting
-  implicit private[kyuubi] val hikariDataSource = new HikariDataSource(hikariConfig)
+  implicit private[kyuubi] val hikariDataSource: HikariDataSource =
+    new HikariDataSource(hikariConfig)
   private val mapper = new ObjectMapper().registerModule(DefaultScalaModule)
 
   private val terminalStates = OperationState.terminalStates.map(x => s"'$x'").mkString(", ")

--- a/pom.xml
+++ b/pom.xml
@@ -1931,8 +1931,7 @@
             <id>scala-2.13</id>
             <properties>
                 <scala.binary.version>2.13</scala.binary.version>
-                <!-- Scala version above 2.13.11 support Java 21. -->
-                <scala.version>2.13.11</scala.version>
+                <scala.version>2.13.14</scala.version>
                 <spark.archive.scala.suffix>-scala${scala.binary.version}</spark.archive.scala.suffix>
             </properties>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -1853,7 +1853,6 @@
                                 <enforceBytecodeVersion>
                                     <maxJdkVersion>${java.version}</maxJdkVersion>
                                     <ignoredScopes>test</ignoredScopes>
-                                    <ignoredScopes>provided</ignoredScopes>
                                     <ignoreClasses>
                                         <ignoreClass>org.jline.terminal.impl.ffm.*</ignoreClass>
                                     </ignoreClasses>

--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,7 @@
         <maven.plugin.jacoco.version>0.8.11</maven.plugin.jacoco.version>
         <maven.plugin.scalastyle.version>1.0.0</maven.plugin.scalastyle.version>
         <maven.plugin.shade.version>3.5.2</maven.plugin.shade.version>
-        <maven.plugin.silencer.version>1.7.13</maven.plugin.silencer.version>
+        <maven.plugin.silencer.version>1.7.17</maven.plugin.silencer.version>
         <!-- MSOURCES-121 breaks creating source artifacts for shaded modules,
              we should skip upgrading until MSOURCES-141 gets fixed. -->
         <maven.plugin.source.version>3.2.1</maven.plugin.source.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1853,6 +1853,10 @@
                                 <enforceBytecodeVersion>
                                     <maxJdkVersion>${java.version}</maxJdkVersion>
                                     <ignoredScopes>test</ignoredScopes>
+                                    <ignoredScopes>provided</ignoredScopes>
+                                    <ignoreClasses>
+                                        <ignoreClass>org.jline.terminal.impl.ffm.*</ignoreClass>
+                                    </ignoreClasses>
                                 </enforceBytecodeVersion>
                             </rules>
                             <fail>true</fail>

--- a/pom.xml
+++ b/pom.xml
@@ -1854,6 +1854,11 @@
                                     <maxJdkVersion>${java.version}</maxJdkVersion>
                                     <ignoredScopes>test</ignoredScopes>
                                     <ignoreClasses>
+                                        <!--
+                                          The package `org.jline.terminal.impl.ffm.*` contains some class files
+                                          that are not compatible with JDK17 (only JDK21 is supported).
+                                          However, it will not cause problems for use. See: https://github.com/scala/bug/issues/12994
+                                        -->
                                         <ignoreClass>org.jline.terminal.impl.ffm.*</ignoreClass>
                                     </ignoreClasses>
                                 </enforceBytecodeVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -1931,7 +1931,8 @@
             <id>scala-2.13</id>
             <properties>
                 <scala.binary.version>2.13</scala.binary.version>
-                <scala.version>2.13.8</scala.version>
+                <!-- Scala version above 2.13.11 support Java 21. -->
+                <scala.version>2.13.11</scala.version>
                 <spark.archive.scala.suffix>-scala${scala.binary.version}</spark.archive.scala.suffix>
             </properties>
         </profile>


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗

To support Java 21, the Scala version needs to be upgraded to 2.13.11 or above.





## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
