### PR TITLE
[KYUUBI #6485] Fix the Presto TABLE NOT FOUND error message that failed to match

### DIFF
--- a/python/pyhive/sqlalchemy_presto.py
+++ b/python/pyhive/sqlalchemy_presto.py
@@ -143,7 +143,7 @@ class PrestoDialect(default.DefaultDialect):
                 else None
             )
             regex = r"Table\ \'.*{}\'\ does\ not\ exist".format(re.escape(table_name))
-            if msg and re.search(regex, msg):
+            if msg and re.search(regex, msg, re.IGNORECASE):
                 raise exc.NoSuchTableError(table_name)
             else:
                 raise

--- a/python/pyhive/tests/test_sqlalchemy_presto.py
+++ b/python/pyhive/tests/test_sqlalchemy_presto.py
@@ -1,6 +1,11 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+
+import re
 from builtins import str
+
+import sqlalchemy
+
 from pyhive.tests.sqlalchemy_test_case import SqlAlchemyTestCase
 from pyhive.tests.sqlalchemy_test_case import with_engine_connection
 from sqlalchemy import types
@@ -87,3 +92,12 @@ class TestSqlAlchemyPresto(unittest.TestCase, SqlAlchemyTestCase):
         self.assertIn('"current_timestamp"', query)
         self.assertNotIn('`select`', query)
         self.assertNotIn('`current_timestamp`', query)
+
+    @with_engine_connection
+    def test_hash_table(self, engine, connection):
+        sqlalchemy_version = float(re.search(r"^([\d]+\.[\d]+)\..+", sqlalchemy.__version__).group(1))
+        if sqlalchemy_version >= 1.4:
+            insp = sqlalchemy.inspect(engine)
+            self.assertFalse(insp.has_table("THIS_TABLE_DOSE_NOT_EXIST"))
+        else:
+            self.assertFalse(Table('THIS_TABLE_DOSE_NOT_EXIST', MetaData(bind=engine)).exists())

--- a/python/pyhive/tests/test_sqlalchemy_presto.py
+++ b/python/pyhive/tests/test_sqlalchemy_presto.py
@@ -99,5 +99,7 @@ class TestSqlAlchemyPresto(unittest.TestCase, SqlAlchemyTestCase):
         if sqlalchemy_version >= 1.4:
             insp = sqlalchemy.inspect(engine)
             self.assertFalse(insp.has_table("THIS_TABLE_DOSE_NOT_EXIST"))
+            self.assertFalse(insp.has_table("THIS_TABLE_DOSE_dot_exist"))
         else:
             self.assertFalse(Table('THIS_TABLE_DOSE_NOT_EXIST', MetaData(bind=engine)).exists())
+            self.assertFalse(Table('THIS_TABLE_DOSE_dot_exits', MetaData(bind=engine)).exists())

--- a/python/pyhive/tests/test_sqlalchemy_presto.py
+++ b/python/pyhive/tests/test_sqlalchemy_presto.py
@@ -99,7 +99,7 @@ class TestSqlAlchemyPresto(unittest.TestCase, SqlAlchemyTestCase):
         if sqlalchemy_version >= 1.4:
             insp = sqlalchemy.inspect(engine)
             self.assertFalse(insp.has_table("THIS_TABLE_DOSE_NOT_EXIST"))
-            self.assertFalse(insp.has_table("THIS_TABLE_DOSE_dot_exist"))
+            self.assertFalse(insp.has_table("THIS_TABLE_DOSE_not_exist"))
         else:
             self.assertFalse(Table('THIS_TABLE_DOSE_NOT_EXIST', MetaData(bind=engine)).exists())
-            self.assertFalse(Table('THIS_TABLE_DOSE_dot_exits', MetaData(bind=engine)).exists())
+            self.assertFalse(Table('THIS_TABLE_DOSE_not_exits', MetaData(bind=engine)).exists())


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #6485 

## Describe Your Solution 🔧

Ignore uppercase and lowercase letters in table names when using regular expressions to match.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

Added unit tests when table names have capital letters.

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
