### PR TITLE
`build/mvn` checks project local downloaded binary ahead

### DIFF
--- a/build/mvn
+++ b/build/mvn
@@ -45,59 +45,58 @@ install_app() {
   curl_opts="--progress-bar ${curl_opts}"
   wget_opts="--progress=bar:force ${wget_opts}"
 
-  if [ -z "$3" -o ! -f "$binary" ]; then
-    # check if we already have the tarball
-    # check if we have curl installed
-    # download application
-    [ ! -f "${local_tarball}" ] && [ $(command -v curl) ] && \
-      echo "exec: curl ${curl_opts} ${remote_tarball}" 1>&2 && \
-      curl ${curl_opts} "${remote_tarball}" > "${local_tarball}"
-    # if the file still doesn't exist, lets try `wget` and cross our fingers
-    [ ! -f "${local_tarball}" ] && [ $(command -v wget) ] && \
-      echo "exec: wget ${wget_opts} ${remote_tarball}" 1>&2 && \
-      wget ${wget_opts} -O "${local_tarball}" "${remote_tarball}"
-    # if both were unsuccessful, exit
-    [ ! -f "${local_tarball}" ] && \
-      echo -n "ERROR: Cannot download $2 with cURL or wget; " && \
-      echo "please install manually and try again." && \
-      exit 2
-    cd "${_DIR}" && tar -xzf "$2"
-    rm -rf "$local_tarball"
-  fi
+  # check if we already have the tarball
+  # check if we have curl installed
+  # download application
+  [ ! -f "${local_tarball}" ] && [ $(command -v curl) ] && \
+    echo "exec: curl ${curl_opts} ${remote_tarball}" 1>&2 && \
+    curl ${curl_opts} "${remote_tarball}" > "${local_tarball}"
+  # if the file still doesn't exist, lets try `wget` and cross our fingers
+  [ ! -f "${local_tarball}" ] && [ $(command -v wget) ] && \
+    echo "exec: wget ${wget_opts} ${remote_tarball}" 1>&2 && \
+    wget ${wget_opts} -O "${local_tarball}" "${remote_tarball}"
+  # if both were unsuccessful, exit
+  [ ! -f "${local_tarball}" ] && \
+    echo -n "ERROR: Cannot download $2 with cURL or wget; " && \
+    echo "please install manually and try again." && \
+    exit 2
+  cd "${_DIR}" && tar -xzf "$2"
+  rm -rf "$local_tarball"
 }
 
 # Determine the Maven version from the root pom.xml file and
 # install maven under the build/ folder if needed.
 install_mvn() {
   local MVN_VERSION=`grep "<maven.version>" "${_DIR}/../pom.xml" | head -n1 | awk -F '[<>]' '{print $3}'`
-  MVN_BIN="$(command -v mvn)"
-  if [ "$MVN_BIN" ]; then
-    local MVN_DETECTED_VERSION="$(mvn --version | head -n1 | awk '{print $3}')"
-  fi
-  # See simple version normalization: http://stackoverflow.com/questions/16989598/bash-comparing-version-numbers
-  function version { echo "$@" | awk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }'; }
-  if [ $(version $MVN_DETECTED_VERSION) -ne $(version $MVN_VERSION) ]; then
-    local APACHE_MIRROR=${APACHE_MIRROR:-'https://www.apache.org/dyn/closer.lua'}
-    local MIRROR_URL_QUERY="?action=download"
-    local MVN_TARBALL="apache-maven-${MVN_VERSION}-bin.tar.gz"
-    local FILE_PATH="maven/maven-3/${MVN_VERSION}/binaries"
-
-    if [ $(command -v curl) ]; then
-      if ! curl -L --output /dev/null --silent --head --fail "${APACHE_MIRROR}/${FILE_PATH}/${MVN_TARBALL}${MIRROR_URL_QUERY}" ; then
-        # Fall back to archive.apache.org for older Maven
-        echo "Falling back to archive.apache.org to download Maven"
-        APACHE_MIRROR="https://archive.apache.org/dist"
-        MIRROR_URL_QUERY=""
-      fi
+  MVN_BIN="${_DIR}/apache-maven-${MVN_VERSION}/bin/mvn"
+  if [ ! -f "$MVN_BIN" ]; then
+    MVN_BIN="$(command -v mvn)"
+    if [ "$MVN_BIN" ]; then
+      local MVN_DETECTED_VERSION="$(mvn --version | head -n1 | awk '{print $3}')"
     fi
+    if [ $MVN_DETECTED_VERSION != $MVN_VERSION ]; then
+      local APACHE_MIRROR=${APACHE_MIRROR:-'https://www.apache.org/dyn/closer.lua'}
+      local MIRROR_URL_QUERY="?action=download"
+      local MVN_TARBALL="apache-maven-${MVN_VERSION}-bin.tar.gz"
+      local FILE_PATH="maven/maven-3/${MVN_VERSION}/binaries"
 
-    install_app \
-      "${APACHE_MIRROR}/${FILE_PATH}" \
-      "${MVN_TARBALL}" \
-      "apache-maven-${MVN_VERSION}/bin/mvn" \
-      "${MIRROR_URL_QUERY}"
+      if [ $(command -v curl) ]; then
+        if ! curl -L --output /dev/null --silent --head --fail "${APACHE_MIRROR}/${FILE_PATH}/${MVN_TARBALL}${MIRROR_URL_QUERY}" ; then
+          # Fall back to archive.apache.org for older Maven
+          echo "Falling back to archive.apache.org to download Maven"
+          APACHE_MIRROR="https://archive.apache.org/dist"
+          MIRROR_URL_QUERY=""
+        fi
+      fi
 
-    MVN_BIN="${_DIR}/apache-maven-${MVN_VERSION}/bin/mvn"
+      install_app \
+        "${APACHE_MIRROR}/${FILE_PATH}" \
+        "${MVN_TARBALL}" \
+        "apache-maven-${MVN_VERSION}/bin/mvn" \
+        "${MIRROR_URL_QUERY}"
+
+      MVN_BIN="${_DIR}/apache-maven-${MVN_VERSION}/bin/mvn"
+    fi
   fi
 }
 

--- a/build/mvn
+++ b/build/mvn
@@ -28,16 +28,13 @@ if [ "$CI" ]; then
   export MAVEN_CLI_OPTS="--no-transfer-progress --errors --fail-fast"
 fi
 
-# Installs any application tarball given a URL, the expected tarball name,
-# and, optionally, a checkable binary path to determine if the binary has
-# already been installed
+# Installs any application tarball given a URL, the expected tarball name
 ## Arg1 - URL
 ## Arg2 - Tarball Name
-## Arg3 - Checkable Binary
+## Arg3 - URL query string
 install_app() {
-  local remote_tarball="$1/$2$4"
+  local remote_tarball="$1/$2$3"
   local local_tarball="${_DIR}/$2"
-  local binary="${_DIR}/$3"
 
   # setup `curl` and `wget` silent options if we're running on Jenkins
   local curl_opts="-L"
@@ -92,7 +89,6 @@ install_mvn() {
       install_app \
         "${APACHE_MIRROR}/${FILE_PATH}" \
         "${MVN_TARBALL}" \
-        "apache-maven-${MVN_VERSION}/bin/mvn" \
         "${MIRROR_URL_QUERY}"
 
       MVN_BIN="${_DIR}/apache-maven-${MVN_VERSION}/bin/mvn"


### PR DESCRIPTION
# :mag: Description

I found sometimes `build/mvn -version` is pretty slow even `build/apache-maven-${MVN_VERSION}` is already cached, and I found it may stuck at the following call when network quality is not good.

https://github.com/apache/kyuubi/blob/bdd91f45396ab20b6dfe0a266fb8bfe340d99192/build/mvn#L86

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

Tested `build/mvn -version` in the following cases:
1. when `build/apache-maven-${MVN_VERSION}/bin/mvn` is available, the command always finishes quickly.
2. when `build/apache-maven-${MVN_VERSION}/bin/mvn` is unavailable but global installed `mvn` version matches `maven.version` defined in root `pom.xml`, the command always finishes quickly too.
3. otherwise, it automatically downloads the maven binary tarball from network.

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
