### PR TITLE
[KYUUBI #6606][FOLLOWUP] Restore shell compatibility for `build/mvn`

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -418,7 +418,7 @@ jobs:
           # passthrough CI into build container
           build-args: |
             CI=${CI}
-            MVN_ARG=--flink-provided --hive-provided -Dmaven.javadoc.skip=true -Drat.skip=true -Dscalastyle.skip=true -Dspotless.check.skip -DskipTests
+            MVN_ARG=--flink-provided --hive-provided
           context: .
           file: build/Dockerfile.CI
           load: true

--- a/build/mvn
+++ b/build/mvn
@@ -61,38 +61,42 @@ install_app() {
   rm -rf "$local_tarball"
 }
 
+# See simple version normalization: http://stackoverflow.com/questions/16989598/bash-comparing-version-numbers
+function version { echo "$@" | awk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }'; }
+
 # Determine the Maven version from the root pom.xml file and
 # install maven under the build/ folder if needed.
 install_mvn() {
   local MVN_VERSION=`grep "<maven.version>" "${_DIR}/../pom.xml" | head -n1 | awk -F '[<>]' '{print $3}'`
   MVN_BIN="${_DIR}/apache-maven-${MVN_VERSION}/bin/mvn"
-  if [ ! -f "$MVN_BIN" ]; then
-    MVN_BIN="$(command -v mvn)"
-    if [ "$MVN_BIN" ]; then
-      local MVN_DETECTED_VERSION="$(mvn --version | head -n1 | awk '{print $3}')"
-    fi
-    if [ $MVN_DETECTED_VERSION != $MVN_VERSION ]; then
-      local APACHE_MIRROR=${APACHE_MIRROR:-'https://www.apache.org/dyn/closer.lua'}
-      local MIRROR_URL_QUERY="?action=download"
-      local MVN_TARBALL="apache-maven-${MVN_VERSION}-bin.tar.gz"
-      local FILE_PATH="maven/maven-3/${MVN_VERSION}/binaries"
+  if [ -f "$MVN_BIN" ]; then
+    return
+  fi
+  MVN_BIN="$(command -v mvn)"
+  if [ "$MVN_BIN" ]; then
+    local MVN_DETECTED_VERSION="$(mvn --version | head -n1 | awk '{print $3}')"
+  fi
+  if [ $(version $MVN_DETECTED_VERSION) -ne $(version $MVN_VERSION) ]; then
+    local APACHE_MIRROR=${APACHE_MIRROR:-'https://www.apache.org/dyn/closer.lua'}
+    local MIRROR_URL_QUERY="?action=download"
+    local MVN_TARBALL="apache-maven-${MVN_VERSION}-bin.tar.gz"
+    local FILE_PATH="maven/maven-3/${MVN_VERSION}/binaries"
 
-      if [ $(command -v curl) ]; then
-        if ! curl -L --output /dev/null --silent --head --fail "${APACHE_MIRROR}/${FILE_PATH}/${MVN_TARBALL}${MIRROR_URL_QUERY}" ; then
-          # Fall back to archive.apache.org for older Maven
-          echo "Falling back to archive.apache.org to download Maven"
-          APACHE_MIRROR="https://archive.apache.org/dist"
-          MIRROR_URL_QUERY=""
-        fi
+    if [ $(command -v curl) ]; then
+      if ! curl -L --output /dev/null --silent --head --fail "${APACHE_MIRROR}/${FILE_PATH}/${MVN_TARBALL}${MIRROR_URL_QUERY}" ; then
+        # Fall back to archive.apache.org for older Maven
+        echo "Falling back to archive.apache.org to download Maven"
+        APACHE_MIRROR="https://archive.apache.org/dist"
+        MIRROR_URL_QUERY=""
       fi
-
-      install_app \
-        "${APACHE_MIRROR}/${FILE_PATH}" \
-        "${MVN_TARBALL}" \
-        "${MIRROR_URL_QUERY}"
-
-      MVN_BIN="${_DIR}/apache-maven-${MVN_VERSION}/bin/mvn"
     fi
+
+    install_app \
+      "${APACHE_MIRROR}/${FILE_PATH}" \
+      "${MVN_TARBALL}" \
+      "${MIRROR_URL_QUERY}"
+
+    MVN_BIN="${_DIR}/apache-maven-${MVN_VERSION}/bin/mvn"
   fi
 }
 


### PR DESCRIPTION
# :mag: Description

I found the [previous change](https://github.com/apache/kyuubi/pull/6606) breaks compatibility in some shell interpreters, for example `[ ! -f "$MVN_BIN" ]`, `[ $MVN_DETECTED_VERSION != $MVN_VERSION ]` are not supported in ubuntu dash, which fails the CI https://github.com/apache/kyuubi/actions/runs/10347069575/job/28636666290

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

This change should recover the CI.

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
