### PR TITLE
Fix NPE for EnginePage in Spark history server

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EnginePage.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EnginePage.scala
@@ -563,7 +563,11 @@ private class StatementStatsPagedTable(
     }
       </td>
       {
-      if (event.exception.isDefined) errorMessageCell(event.exception.get.getMessage) else <td></td>
+      event.exception match {
+        case Some(e) =>
+          errorMessageCell(Option(e.getMessage).getOrElse(Utils.stringifyException(e)))
+        case _ => <td></td>
+      }
     }
     </tr>
   }


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

Meet NPE when rendering the kyuubi UI page in spark history server.
```
HTTP ERROR 500 java.lang.NullPointerException
URI:	/history/application_1723088988367_478456/1/kyuubi/
STATUS:	500
MESSAGE:	java.lang.NullPointerException
SERVLET:	org.apache.spark.ui.JettyUtils$$anon$1-eeb2a50
CAUSED BY:	java.lang.NullPointerException
Caused by:
java.lang.NullPointerException
	at org.apache.spark.ui.StatementStatsPagedTable.errorMessageCell(EnginePage.scala:407)
	at org.apache.spark.ui.StatementStatsPagedTable.row(EnginePage.scala:401)
	at org.apache.spark.ui.StatementStatsPagedTable.row(EnginePage.scala:299)
	at org.apache.spark.ui.PagedTable.$anonfun$table$1(PagedTable.scala:127)
	at scala.collection.immutable.Stream.$anonfun$map$1(Stream.scala:418)
	at scala.collection.immutable.Stream$Cons.tail(Stream.scala:1173)
	at scala.collection.immutable.Stream$Cons.tail(Stream.scala:1163)
	at scala.collection.immutable.StreamIterator.$anonfun$next$1(Stream.scala:1061)
	at scala.collection.immutable.StreamIterator$LazyCell.v$lzycompute(Stream.scala:1050)
	at scala.collection.immutable.StreamIterator$LazyCell.v(Stream.scala:1050)
	at scala.collection.immutable.StreamIterator.hasNext(Stream.scala:1055)
	at scala.collection.Iterator.foreach(Iterator.scala:943)
	at scala.collection.Iterator.foreach$(Iterator.scala:943)
	at scala.collection.AbstractIterator.foreach(Iterator.scala:1431)
```
## Describe Your Solution 🔧

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests

Integration testing, after this PR, it works fine.

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
