### PR TITLE
[KYUUBI #6584] Upgrade flip-tables from 1.0.2 to 1.1.1

### DIFF
--- a/dev/dependencyList
+++ b/dev/dependencyList
@@ -35,7 +35,7 @@ error_prone_annotations/2.23.0//error_prone_annotations-2.23.0.jar
 failsafe/3.3.2//failsafe-3.3.2.jar
 failureaccess/1.0.2//failureaccess-1.0.2.jar
 flatbuffers-java/23.5.26//flatbuffers-java-23.5.26.jar
-fliptables/1.0.2//fliptables-1.0.2.jar
+fliptables/1.1.1//fliptables-1.1.1.jar
 grpc-api/1.65.1//grpc-api-1.65.1.jar
 grpc-context/1.65.1//grpc-context-1.65.1.jar
 grpc-core/1.65.1//grpc-core-1.65.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
         <guava.failureaccess.version>1.0.2</guava.failureaccess.version>
         <hadoop.version>3.3.6</hadoop.version>
         <hikaricp.version>4.0.3</hikaricp.version>
-        <fliptables.verion>1.0.2</fliptables.verion>
+        <fliptables.verion>1.1.1</fliptables.verion>
         <hive.version>3.1.3</hive.version>
         <hive.archive.name>apache-hive-${hive.version}-bin.tar.gz</hive.archive.name>
         <hive.archive.mirror>${apache.archive.dist}/hive/hive-${hive.version}</hive.archive.mirror>


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #6584

## Describe Your Solution 🔧
It involves bumping the version from 1.0.2 to 1.1.1 for flip-tables

## Test Plan 🧪
Build locally

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
