### PR TITLE
Fix operation never expired issue with periodical listOperations api calls

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/events/KyuubiOperationEvent.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/events/KyuubiOperationEvent.scala
@@ -18,8 +18,6 @@
 package org.apache.kyuubi.events
 
 import org.apache.kyuubi.Utils
-import org.apache.kyuubi.operation.{KyuubiOperation, OperationHandle}
-import org.apache.kyuubi.session.KyuubiSession
 
 /**
  * A [[KyuubiOperationEvent]] used to tracker the lifecycle of an operation at server side.
@@ -45,7 +43,7 @@ import org.apache.kyuubi.session.KyuubiSession
  * @param kyuubiInstance the parent session connection url
  * @param metrics the operation metrics
  */
-case class KyuubiOperationEvent private (
+case class KyuubiOperationEvent(
     statementId: String,
     remoteId: String,
     statement: String,
@@ -66,31 +64,4 @@ case class KyuubiOperationEvent private (
   // created.
   override def partitions: Seq[(String, String)] =
     ("day", Utils.getDateFromTimestamp(createTime)) :: Nil
-}
-
-object KyuubiOperationEvent {
-
-  /**
-   * Shorthand for instantiating a operation event with a [[KyuubiOperation]] instance
-   */
-  def apply(operation: KyuubiOperation): KyuubiOperationEvent = {
-    val session = operation.getSession.asInstanceOf[KyuubiSession]
-    val status = operation.getStatus
-    new KyuubiOperationEvent(
-      operation.statementId,
-      Option(operation.remoteOpHandle()).map(OperationHandle(_).identifier.toString).orNull,
-      operation.statement,
-      operation.shouldRunAsync,
-      status.state.name(),
-      status.lastModified,
-      status.create,
-      status.start,
-      status.completed,
-      status.exception,
-      session.handle.identifier.toString,
-      session.user,
-      session.sessionType.toString,
-      session.connectionUrl,
-      operation.metrics)
-  }
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/ApiUtils.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/ApiUtils.scala
@@ -22,7 +22,6 @@ import scala.collection.JavaConverters._
 import org.apache.kyuubi.{Logging, Utils}
 import org.apache.kyuubi.client.api.v1.dto
 import org.apache.kyuubi.client.api.v1.dto.{OperationData, OperationProgress, ServerData, SessionData}
-import org.apache.kyuubi.events.KyuubiOperationEvent
 import org.apache.kyuubi.ha.client.ServiceNodeInfo
 import org.apache.kyuubi.operation.KyuubiOperation
 import org.apache.kyuubi.session.KyuubiSession
@@ -86,7 +85,7 @@ object ApiUtils extends Logging {
   }
 
   def operationEvent(operation: KyuubiOperation): dto.KyuubiOperationEvent = {
-    val opEvent = KyuubiOperationEvent(operation)
+    val opEvent = operation.getOperationEvent
     dto.KyuubiOperationEvent.builder()
       .statementId(opEvent.statementId)
       .remoteId(opEvent.remoteId)
@@ -108,7 +107,7 @@ object ApiUtils extends Logging {
   }
 
   def operationData(operation: KyuubiOperation): OperationData = {
-    val opEvent = KyuubiOperationEvent(operation)
+    val opEvent = operation.getOperationEvent
     new OperationData(
       opEvent.statementId,
       opEvent.remoteId,


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes operation never expired issue.
I found that, some Kyuubi operations never expired.

After investigation, the root cause:
1. our kyuubi console lookup the operations periodically
2. it retrieves the kyuubi operation events
3. the KyuubiOperationEvent::apply will get the operation status and update the operation the last access time, https://github.com/apache/kyuubi/pull/2452 
4. then the operation never expired.
## Describe Your Solution 🔧

Just get the operation event without updating the operation last access time.

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
