### PR TITLE
Using concurrent collections for session operation handle set

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/OperationManager.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/OperationManager.scala
@@ -17,6 +17,8 @@
 
 package org.apache.kyuubi.operation
 
+import java.util.concurrent.ConcurrentHashMap
+
 import scala.collection.JavaConverters._
 
 import org.apache.kyuubi.KyuubiSQLException
@@ -36,7 +38,7 @@ import org.apache.kyuubi.shaded.hive.service.rpc.thrift._
  */
 abstract class OperationManager(name: String) extends AbstractService(name) {
 
-  final private val handleToOperation = new java.util.HashMap[OperationHandle, Operation]()
+  final private val handleToOperation = new ConcurrentHashMap[OperationHandle, Operation]()
 
   protected def skipOperationLog: Boolean = false
 

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/OperationManager.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/OperationManager.scala
@@ -17,8 +17,6 @@
 
 package org.apache.kyuubi.operation
 
-import java.util.concurrent.ConcurrentHashMap
-
 import scala.collection.JavaConverters._
 
 import org.apache.kyuubi.KyuubiSQLException
@@ -38,7 +36,7 @@ import org.apache.kyuubi.shaded.hive.service.rpc.thrift._
  */
 abstract class OperationManager(name: String) extends AbstractService(name) {
 
-  final private val handleToOperation = new ConcurrentHashMap[OperationHandle, Operation]()
+  final private val handleToOperation = new java.util.HashMap[OperationHandle, Operation]()
 
   protected def skipOperationLog: Boolean = false
 

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/session/AbstractSession.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/session/AbstractSession.scala
@@ -17,6 +17,8 @@
 
 package org.apache.kyuubi.session
 
+import java.util.concurrent.ConcurrentHashMap
+
 import scala.collection.JavaConverters._
 
 import org.apache.kyuubi.{KyuubiSQLException, Logging}
@@ -59,7 +61,7 @@ abstract class AbstractSession(
 
   override lazy val name: Option[String] = normalizedConf.get(SESSION_NAME.key)
 
-  final private val opHandleSet = new java.util.HashSet[OperationHandle]
+  final private val opHandleSet = ConcurrentHashMap.newKeySet[OperationHandle]()
 
   private def acquire(userAccess: Boolean): Unit = synchronized {
     if (userAccess) {


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->


As mentioned in https://github.com/apache/kyuubi/pull/6626, the operation never idle because of periodical get operation status, but in my opinion, the operations should be closed after session closed, but it did not.

Currently, for session operation handles set, it does not use concurrent collections, I wonder there is concurrent update issue.

## Describe Your Solution 🔧

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests
Not needed.

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
