### PR TITLE
[KYUUBI #6633][Bug] Running with paimon failed with class not found exception

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/serde/tableExtractors.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/serde/tableExtractors.scala
@@ -52,10 +52,15 @@ object TableExtractor {
    * @return owner
    */
   def getOwner(v: AnyRef): Option[String] = {
-    // org.apache.spark.sql.connector.catalog.Table
-    val table = invokeAs[AnyRef](v, "table")
-    val properties = invokeAs[JMap[String, String]](table, "properties").asScala
-    properties.get("owner")
+    try {
+
+      // org.apache.spark.sql.connector.catalog.Table
+      val table = invokeAs[AnyRef](v, "table")
+      val properties = invokeAs[JMap[String, String]](table, "properties").asScala
+      properties.get("owner")
+    } catch {
+      case _: Throwable => None
+    }
   }
 
   def getOwner(spark: SparkSession, catalogName: String, tableIdent: AnyRef): Option[String] = {
@@ -69,7 +74,7 @@ object TableExtractor {
       getOwner(table)
     } catch {
       // Exception may occur due to invalid reflection or table not found
-      case _: Exception => None
+      case _: Throwable => None
     }
   }
 }
@@ -88,7 +93,7 @@ class TableIdentifierTableExtractor extends TableExtractor {
           val catalogTable = spark.sessionState.catalog.getTableMetadata(identifier)
           Option(catalogTable.owner).filter(_.nonEmpty)
         } catch {
-          case _: Exception => None
+          case _: Throwable => None
         }
       Some(Table(None, identifier.database, identifier.table, owner))
     }


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #
Running spark + auth + paimon extension throw below exception
```
java.lang.NoClassDefFoundError: [Lorg/apache/spark/sql/connector/catalog/Column;
	at java.lang.Class.getDeclaredMethods0(Native Method)
	at java.lang.Class.privateGetDeclaredMethods(Class.java:2701)
	at java.lang.Class.privateGetMethodRecursive(Class.java:3048)
	at java.lang.Class.getMethod0(Class.java:3018)
	at java.lang.Class.getMethod(Class.java:1784)
	at org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils$.invoke(AuthZUtils.scala:63)
	at org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils$.invokeAs(AuthZUtils.scala:77)
	at org.apache.kyuubi.plugin.spark.authz.serde.TableExtractor$.getOwner(tableExtractors.scala:52)
	at org.apache.kyuubi.plugin.spark.authz.serde.DataSourceV2RelationTableExtractor.$anonfun$apply$8(tableExtractors.scala:142)
	at scala.Option.flatMap(Option.scala:271)
	at org.apache.kyuubi.plugin.spark.authz.serde.DataSourceV2RelationTableExtractor.apply(tableExtractors.scala:140)
	at org.apache.kyuubi.plugin.spark.authz.serde.DataSourceV2RelationTableExtractor.apply(tableExtractors.scala:129)
	at org.apache.kyuubi.plugin.spark.authz.serde.ScanDesc.extract(Descriptor.scala:307)
	at org.apache.kyuubi.plugin.spark.authz.serde.ScanSpec.$anonfun$tables$2(CommandSpec.scala:102)
	at scala.collection.immutable.List.flatMap(List.scala:366)
	at org.apache.kyuubi.plugin.spark.authz.serde.ScanSpec.$anonfun$tables$1(CommandSpec.scala:100)
	at org.apache.kyuubi.plugin.spark.authz.ram.RamPrivilegesBuilder$.buildQuery(RamPrivilegesBuilder.scala:164)
```
Caused by paomin low version extension jar SparkTable will carry high version spark class

## Describe Your Solution 🔧

Make the extract process more robust


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
