### PR TITLE
[KYUUBI #6661] Improve perf for column-based TRowSet generation

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/engine/result/TColumnGenerator.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/engine/result/TColumnGenerator.scala
@@ -34,8 +34,7 @@ trait TColumnGenerator[RowT] extends TRowSetColumnGetter[RowT] {
     val ret = new JArrayList[T](rowSize)
     val nulls = new JBitSet()
     var idx = 0
-    while (idx < rowSize) {
-      val row = rows(idx)
+    rows.foreach { row =>
       val isNull = isColumnNullAt(row, ordinal)
       if (isNull) {
         nulls.set(idx, true)


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #6661 

## Describe Your Solution 🔧

TColumnGenerator.getColumnToList should not access to non-IndexedSeq with Seq.apply(i), which will cause performance reduce, convert it to foreach loop will be good. see https://issues.apache.org/jira/browse/SPARK-47085 for more details.

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
