### PR TITLE
Improve the display of sql editor and query result

### DIFF
--- a/kyuubi-server/web-ui/src/views/editor/components/Editor.vue
+++ b/kyuubi-server/web-ui/src/views/editor/components/Editor.vue
@@ -53,29 +53,51 @@
           :value="item" />
       </el-select>
     </el-space>
-    <section>
-      <MonacoEditor
-        ref="monacoEditor"
-        v-model="editorVariables.content"
-        :language="editorVariables.language"
-        :theme="theme"
-        @editor-mounted="editorMounted"
-        @change="handleContentChange"
-        @editor-save="editorSave" />
-    </section>
-    <el-tabs v-model="activeTab" type="card" class="result-el-tabs">
-      <el-tab-pane
-        v-loading="resultLoading"
-        :label="`${$t('result')}${
-          sqlResult?.length ? ` (${sqlResult?.length})` : ''
-        }`"
-        name="result">
-        <Result :data="sqlResult" :error-messages="errorMessages" />
-      </el-tab-pane>
-      <el-tab-pane v-loading="logLoading" :label="$t('log')" name="log">
-        <Log :data="sqlLog" />
-      </el-tab-pane>
-    </el-tabs>
+    <div ref="box" class="box">
+      <div ref="sqlEditor" class="sqlEditor">
+        <MonacoEditor
+          ref="monacoEditor"
+          v-model="editorVariables.content"
+          :language="editorVariables.language"
+          :theme="theme"
+          @editor-mounted="editorMounted"
+          @change="handleContentChange"
+          @editor-save="editorSave" />
+      </div>
+      <div ref="resizer" class="resizer"></div>
+      <div ref="queryResult" class="queryResult">
+        <el-tabs
+          v-model="activeTab"
+          type="card"
+          class="result-el-tabs"
+          :class="{ 'hide-query-detail': !showQueryDetail.valueOf() }">
+          <el-tab-pane
+            v-loading="resultLoading"
+            :label="`${$t('result')}${
+              sqlResult?.length ? ` (${sqlResult?.length})` : ''
+            }`"
+            name="result">
+            <Result :data="sqlResult" :error-messages="errorMessages" />
+          </el-tab-pane>
+          <el-tab-pane v-loading="logLoading" :label="$t('log')" name="log">
+            <Log :data="sqlLog" />
+          </el-tab-pane>
+        </el-tabs>
+
+        <div style="position: absolute; right: 0; top: 0">
+          <div class="el-tabs__item" @click="minimizeQueryResultTab">
+            <el-icon>
+              <ArrowDown />
+            </el-icon>
+          </div>
+          <div class="el-tabs__item" @click="maximizeQueryResultTab">
+            <el-icon>
+              <ArrowUp />
+            </el-icon>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -83,7 +105,7 @@
   import MonacoEditor from '@/components/monaco-editor/index.vue'
   import Result from './Result.vue'
   import Log from './Log.vue'
-  import { ref, reactive, onUnmounted, toRaw } from 'vue'
+  import { ref, reactive, onUnmounted, toRaw, onMounted } from 'vue'
   import type { Ref } from 'vue'
   import * as monaco from 'monaco-editor'
   import { format } from 'sql-formatter'
@@ -128,6 +150,86 @@
     content: '',
     options: {}
   })
+
+  const sqlEditor = ref()
+  const queryResult = ref()
+  const box = ref()
+  const resizer = ref()
+
+  const showQueryDetail = ref(true)
+  const sqlEditorMinHeight = 64
+  const resizerHeight = 10
+  const queryResultHiddenThreshold = 210
+
+  onMounted(() => {
+    handleResizerDrag()
+  })
+
+  // 设置 SQL 编辑器和查询结果区域的高度
+  function setEditorAndResultHeights(
+    sqlEditorHeight: number,
+    queryResultHeight: number
+  ): void {
+    sqlEditor.value.style.height = `${sqlEditorHeight}px`
+    queryResult.value.style.height = `${queryResultHeight}px`
+  }
+
+  // 最大化查询结果区域
+  function maximizeQueryResultTab(): void {
+    showQueryDetail.value = true
+    const sqlEditorHeight = sqlEditorMinHeight
+    const queryResultHeight =
+      box.value.clientHeight - sqlEditorMinHeight - resizerHeight
+    setEditorAndResultHeights(sqlEditorHeight, queryResultHeight)
+  }
+
+  // 最小化查询结果区域
+  function minimizeQueryResultTab(): void {
+    showQueryDetail.value = false
+    const sqlEditorHeight =
+      box.value.clientHeight - resizerHeight - sqlEditorMinHeight
+    setEditorAndResultHeights(sqlEditorHeight, 0)
+  }
+
+  // 处理分隔条的拖动事件
+  function handleResizerDrag(): void {
+    const onMouseDown = (event: MouseEvent): void => {
+      const initialMouseY = event.clientY
+      const initialResizerTop = resizer.value.offsetTop
+
+      const onMouseMove = (moveEvent: MouseEvent): void => {
+        const currentMouseY = moveEvent.clientY
+        const distanceMoved =
+          initialResizerTop + (currentMouseY - initialMouseY)
+        const newSqlEditorHeight = Math.max(distanceMoved, sqlEditorMinHeight)
+        const newQueryResultHeight =
+          box.value.clientHeight - distanceMoved - resizerHeight
+        if (newQueryResultHeight < queryResultHiddenThreshold) {
+          minimizeQueryResultTab()
+        } else {
+          showQueryDetail.value = true
+          resizer.value.style.top = `${distanceMoved}px`
+          setEditorAndResultHeights(newSqlEditorHeight, newQueryResultHeight)
+        }
+      }
+
+      const onMouseUp = (): void => {
+        document.removeEventListener('mousemove', onMouseMove)
+        document.removeEventListener('mouseup', onMouseUp)
+        if (resizer.value.releaseCapture) {
+          resizer.value.releaseCapture()
+        }
+      }
+
+      document.addEventListener('mousemove', onMouseMove)
+      document.addEventListener('mouseup', onMouseUp)
+      if (resizer.value.setCapture) {
+        resizer.value.setCapture()
+      }
+      event.preventDefault()
+    }
+    resizer.value.addEventListener('mousedown', onMouseDown)
+  }
 
   const editorMounted = (editor: monaco.editor.IStandaloneCodeEditor) => {
     editorVariables.editor = editor
@@ -284,9 +386,40 @@
       }
     }
 
-    > section {
-      height: 180px;
-      border: 1px solid #e0e0e0;
+    .box {
+      height: calc(100vh - 190px);
+    }
+
+    .sqlEditor {
+      width: 100%;
+      height: calc(60% - 10px);
+      background: #ffffff;
+      float: left;
+      box-sizing: border-box;
+    }
+
+    .resizer {
+      cursor: row-resize;
+      float: left;
+      width: 100%;
+      height: 2px;
+      background-color: #e4e7ed;
+      margin-top: 6px;
+      margin-bottom: 6px;
+    }
+
+    .queryResult {
+      position: relative;
+      float: left;
+      width: 100%;
+      height: calc(32% - 10px);
+      box-sizing: border-box;
+    }
+  }
+
+  :deep(.hide-query-detail) {
+    .el-tabs__content {
+      display: none;
     }
   }
 </style>

--- a/kyuubi-server/web-ui/src/views/editor/components/Editor.vue
+++ b/kyuubi-server/web-ui/src/views/editor/components/Editor.vue
@@ -165,7 +165,6 @@
     handleResizerDrag()
   })
 
-  // 设置 SQL 编辑器和查询结果区域的高度
   function setEditorAndResultHeights(
     sqlEditorHeight: number,
     queryResultHeight: number
@@ -174,7 +173,6 @@
     queryResult.value.style.height = `${queryResultHeight}px`
   }
 
-  // 最大化查询结果区域
   function maximizeQueryResultTab(): void {
     showQueryDetail.value = true
     const sqlEditorHeight = sqlEditorMinHeight
@@ -183,7 +181,6 @@
     setEditorAndResultHeights(sqlEditorHeight, queryResultHeight)
   }
 
-  // 最小化查询结果区域
   function minimizeQueryResultTab(): void {
     showQueryDetail.value = false
     const sqlEditorHeight =
@@ -191,7 +188,6 @@
     setEditorAndResultHeights(sqlEditorHeight, 0)
   }
 
-  // 处理分隔条的拖动事件
   function handleResizerDrag(): void {
     const onMouseDown = (event: MouseEvent): void => {
       const initialMouseY = event.clientY


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗

This pull request fixes #6660

## Describe Your Solution 🔧

### Pull Request Description

This pull request improves the drag-and-resize functionality between the SQL Editor and the Result/Log panel. The updates ensure smoother resizing and better management of UI constraints, including the automatic adjustment of the Result/Log panel and the option to minimize/maximize it.

> drag-to-resize

![resizing](https://github.com/user-attachments/assets/212ffb31-053c-448d-aa57-29f179e7d228)

> minimize

![minimize](https://github.com/user-attachments/assets/a0d301ac-a8e7-4414-83fc-bd27d7ffcfb0)

> maximize 

![maximize ](https://github.com/user-attachments/assets/0a911511-5631-43dc-b331-4f15a9d05ad9)



## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
