### PR TITLE
Bump Scalafmt to 3.9.x

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 3.7.5
+version = 3.8.6
 runner.dialect=scala212
 project.git=true
 
@@ -11,7 +11,7 @@ assumeStandardLibraryStripMargin = true
 danglingParentheses.preset = false
 docstrings.style = Asterisk
 docstrings.wrap = no
-importSelectors = singleLine
+binPack.importSelectors = singleLine
 indent.extendSite = 2
 literals.hexDigits = Upper
 maxColumn = 100

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 3.8.6
+version = 3.9.0
 runner.dialect=scala212
 project.git=true
 

--- a/kyuubi-util-scala/src/test/scala/org/apache/kyuubi/util/AssertionUtils.scala
+++ b/kyuubi-util-scala/src/test/scala/org/apache/kyuubi/util/AssertionUtils.scala
@@ -76,9 +76,8 @@ object AssertionUtils {
       path: Path,
       expectedLines: Traversable[String],
       regenScript: String,
-      splitFirstExpectedLine: Boolean = false)(implicit
-      prettifier: Prettifier,
-      pos: Position): Unit = {
+      splitFirstExpectedLine: Boolean =
+        false)(implicit prettifier: Prettifier, pos: Position): Unit = {
     val fileSource = Source.fromFile(path.toUri, StandardCharsets.UTF_8.name())
     try {
       def expectedLinesIter = if (splitFirstExpectedLine) {

--- a/pom.xml
+++ b/pom.xml
@@ -266,7 +266,7 @@
         <spotless.python.includes></spotless.python.includes>
         <spotless.python.black.version>22.3.0</spotless.python.black.version>
         <!-- Please also update .scalafmt.conf when you change it here -->
-        <spotless.scala.scalafmt.version>3.7.5</spotless.scala.scalafmt.version>
+        <spotless.scala.scalafmt.version>3.8.6</spotless.scala.scalafmt.version>
 
         <distMgmtReleaseId>apache.releases.https</distMgmtReleaseId>
         <distMgmtReleaseName>Apache Release Distribution Repository</distMgmtReleaseName>

--- a/pom.xml
+++ b/pom.xml
@@ -266,7 +266,7 @@
         <spotless.python.includes></spotless.python.includes>
         <spotless.python.black.version>22.3.0</spotless.python.black.version>
         <!-- Please also update .scalafmt.conf when you change it here -->
-        <spotless.scala.scalafmt.version>3.8.6</spotless.scala.scalafmt.version>
+        <spotless.scala.scalafmt.version>3.9.0</spotless.scala.scalafmt.version>
 
         <distMgmtReleaseId>apache.releases.https</distMgmtReleaseId>
         <distMgmtReleaseName>Apache Release Distribution Repository</distMgmtReleaseName>


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #

## Describe Your Solution 🔧

Without this PR:
- use and conform Scalafmt 3.7.x
- forcing all the imports from the same parent package, which is even violation the max length of the line

With this PR:
- use and conform Scalafmt 3.9.x
- Scalafmt 3.8.2 changes the binpack style: https://github.com/scalameta/scalafmt/releases/tag/v3.8.2
- change to `binPack.importSelectors=singleLine`, minimizing the impacts to existed code


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
