### PR TITLE
Bump scala-collection-compat to 2.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <scala.version>2.12.18</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
-        <scala-collection-compat.version>2.8.1</scala-collection-compat.version>
+        <scala-collection-compat.version>2.12.0</scala-collection-compat.version>
 
         <arrow.version>16.0.0</arrow.version>
         <!-- Please don't upgrade the version to 4.10+, it depends on JDK 11 -->


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->


## Describe Your Solution 🔧
-   Bump `scala-collection-compat` to 2.12.0 
    - `scala-collection-compat` is used by the authz plugin testing Iceberg
    - Currently Iceberg 1.6.1 uses `scala-collection-compat` 2.12.0,
according to: https://github.com/apache/iceberg/blob/apache-iceberg-1.6.1/gradle/libs.versions.toml#L78
    -  release note: https://github.com/scala/scala-collection-compat/releases/tag/v2.12.0


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests
- pass the Authz tests

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
