### PR TITLE
[KYUUBI #6689] Extract kyuubiClientPrincipal/kyuubiClientKeytab/kyuubiServerPrincipal/principal from JDBC connection properties

### DIFF
--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/Utils.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/Utils.java
@@ -348,6 +348,36 @@ public class Utils {
       }
     }
 
+    if (!connParams.getSessionVars().containsKey(AUTH_KYUUBI_CLIENT_PRINCIPAL)) {
+      if (info.containsKey(AUTH_KYUUBI_CLIENT_PRINCIPAL)) {
+        connParams
+            .getSessionVars()
+            .put(AUTH_KYUUBI_CLIENT_PRINCIPAL, info.getProperty(AUTH_KYUUBI_CLIENT_PRINCIPAL));
+      }
+    }
+
+    if (!connParams.getSessionVars().containsKey(AUTH_KYUUBI_CLIENT_KEYTAB)) {
+      if (info.containsKey(AUTH_KYUUBI_CLIENT_KEYTAB)) {
+        connParams
+            .getSessionVars()
+            .put(AUTH_KYUUBI_CLIENT_KEYTAB, info.getProperty(AUTH_KYUUBI_CLIENT_KEYTAB));
+      }
+    }
+
+    if (!connParams.getSessionVars().containsKey(AUTH_KYUUBI_SERVER_PRINCIPAL)) {
+      if (info.containsKey(AUTH_KYUUBI_SERVER_PRINCIPAL)) {
+        connParams
+            .getSessionVars()
+            .put(AUTH_KYUUBI_SERVER_PRINCIPAL, info.getProperty(AUTH_KYUUBI_SERVER_PRINCIPAL));
+      }
+    }
+
+    if (!connParams.getSessionVars().containsKey(AUTH_PRINCIPAL)) {
+      if (info.containsKey(AUTH_PRINCIPAL)) {
+        connParams.getSessionVars().put(AUTH_PRINCIPAL, info.getProperty(AUTH_PRINCIPAL));
+      }
+    }
+
     if (info.containsKey(AUTH_TYPE)) {
       connParams.getSessionVars().put(AUTH_TYPE, info.getProperty(AUTH_TYPE));
     }


### PR DESCRIPTION
…ab from JDBC connection properties

# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #6689 

## Describe Your Solution 🔧

It extracts the values of AUTH_KYUUBI_CLIENT_PRINCIPAL, AUTH_KYUUBI_CLIENT_KEYTAB, AUTH_KYUUBI_SERVER_PRINCIPAL  and AUTH_PRINCIPAL, then passes it to connParams , to be used for establishing connections.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
