### PR TITLE
Fix Trino Status Printer to Prevent Thread Leak

### DIFF
--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/TrinoStatement.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/TrinoStatement.scala
@@ -63,7 +63,6 @@ class TrinoStatement(
     ThreadUtils.newDaemonSingleThreadScheduledExecutor("Trino-Status-Printer", false)
   private var lastStats: OptionalDouble = OptionalDouble.empty()
 
-
   implicit val ec: ExecutionContext =
     ExecutionContext.fromExecutor(Executors.newFixedThreadPool(dataProcessingPoolSize))
 

--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/TrinoStatement.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/TrinoStatement.scala
@@ -17,8 +17,8 @@
 
 package org.apache.kyuubi.engine.trino
 
-import java.util.{Timer, TimerTask}
-import java.util.concurrent.Executors
+import java.util.OptionalDouble
+import java.util.concurrent.{Executors, TimeUnit}
 
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
@@ -38,6 +38,7 @@ import org.apache.kyuubi.config.KyuubiConf.ENGINE_TRINO_SHOW_PROGRESS
 import org.apache.kyuubi.config.KyuubiConf.ENGINE_TRINO_SHOW_PROGRESS_DEBUG
 import org.apache.kyuubi.engine.trino.TrinoConf.DATA_PROCESSING_POOL_SIZE
 import org.apache.kyuubi.operation.log.OperationLog
+import org.apache.kyuubi.util.ThreadUtils
 
 /**
  * Trino client communicate with trino cluster.
@@ -58,7 +59,10 @@ class TrinoStatement(
   private lazy val showProcess = kyuubiConf.get(ENGINE_TRINO_SHOW_PROGRESS)
   private lazy val showDebug = kyuubiConf.get(ENGINE_TRINO_SHOW_PROGRESS_DEBUG)
 
-  private lazy val timer = new Timer("refresh status info", true)
+  private val timer =
+    ThreadUtils.newDaemonSingleThreadScheduledExecutor("Trino-Status-Printer", false)
+  private var lastStats: OptionalDouble = OptionalDouble.empty()
+
 
   implicit val ec: ExecutionContext =
     ExecutionContext.fromExecutor(Executors.newFixedThreadPool(dataProcessingPoolSize))
@@ -105,7 +109,7 @@ class TrinoStatement(
             getData()
           }
         } else {
-          timer.cancel()
+          timer.shutdown()
           Verify.verify(trino.isFinished)
           if (operationLog.isDefined && showProcess) {
             TrinoStatusPrinter.printStatusInfo(trino, operationLog.get, showDebug)
@@ -153,17 +157,21 @@ class TrinoStatement(
   }
   def printStatusInfo(): Unit = {
     if (operationLog.isDefined && showProcess) {
-      timer.schedule(
-        new TimerTask {
-          override def run(): Unit = {
-            if (trino.isRunning) {
-              TrinoStatusPrinter.printStatusInfo(trino, operationLog.get, showDebug)
-            }
+      timer.scheduleWithFixedDelay(
+        () => {
+          if (trino.isRunning) {
+            lastStats =
+              TrinoStatusPrinter.printStatusInfo(trino, operationLog.get, showDebug, lastStats)
           }
         },
         500L,
-        kyuubiConf.get(KyuubiConf.ENGINE_TRINO_SHOW_PROGRESS_UPDATE_INTERVAL))
+        kyuubiConf.get(KyuubiConf.ENGINE_TRINO_SHOW_PROGRESS_UPDATE_INTERVAL),
+        TimeUnit.MILLISECONDS)
     }
+  }
+
+  def stopPrinter(): Unit = {
+    timer.shutdown()
   }
 }
 

--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/ExecuteStatement.scala
@@ -127,6 +127,7 @@ class ExecuteStatement(
     } catch {
       onError(cancel = true)
     } finally {
+      trinoStatement.stopPrinter()
       shutdownTimeoutMonitor()
     }
   }


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->


## Describe Your Solution 🔧

- use `newDaemonSingleThreadScheduledExecutor` avoid `timer` thread leak
- reduce same status info out


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
