### PR TITLE
[KYUUBI #6681][FOLLOWUP] Log the kill batch request before closeSession and during closeOperation

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
@@ -349,51 +349,55 @@ class BatchJobSubmission(
     if (!isClosedOrCanceled) {
       MetricsSystem.tracing(_.decCount(MetricRegistry.name(OPERATION_OPEN, opType)))
 
-      // fast fail
-      if (isTerminalState(state)) {
-        killMessage = (false, s"batch $batchId is already terminal so can not kill it.")
-        builder.close(true)
-        cleanupUploadedResourceIfNeeded()
-        return
-      }
-
       try {
-        killMessage = killBatchApplication()
-        builder.close(true)
-        cleanupUploadedResourceIfNeeded()
-      } finally {
-        if (state == OperationState.INITIALIZED) {
-          // if state is INITIALIZED, it means that the batch submission has not started to run, set
-          // the state to CANCELED manually and regardless of kill result
-          setState(OperationState.CANCELED)
-          updateBatchMetadata()
-        } else {
-          if (killMessage._1 && !isTerminalState(state)) {
-            // kill success and we can change state safely
-            // note that, the batch operation state should never be closed
+        // fast fail
+        if (isTerminalState(state)) {
+          killMessage = (false, s"batch $batchId is already terminal so can not kill it.")
+          builder.close(true)
+          cleanupUploadedResourceIfNeeded()
+          return
+        }
+
+        try {
+          killMessage = killBatchApplication()
+          builder.close(true)
+          cleanupUploadedResourceIfNeeded()
+        } finally {
+          if (state == OperationState.INITIALIZED) {
+            // if state is INITIALIZED, it means that the batch submission has not started to run,
+            // set the state to CANCELED manually and regardless of kill result
             setState(OperationState.CANCELED)
             updateBatchMetadata()
-          } else if (killMessage._1) {
-            // we can not change state safely
-            killMessage = (false, s"batch $batchId is already terminal so can not kill it.")
-          } else if (!isTerminalState(state)) {
-            _applicationInfo = currentApplicationInfo()
-            _applicationInfo.map(_.state) match {
-              case Some(ApplicationState.FINISHED) =>
-                setState(OperationState.FINISHED)
-                updateBatchMetadata()
-              case Some(ApplicationState.FAILED) =>
-                setState(OperationState.ERROR)
-                updateBatchMetadata()
-              case Some(ApplicationState.UNKNOWN) |
-                  Some(ApplicationState.NOT_FOUND) |
-                  Some(ApplicationState.KILLED) =>
-                setState(OperationState.CANCELED)
-                updateBatchMetadata()
-              case _ => // failed to kill, the kill message is enough
+          } else {
+            if (killMessage._1 && !isTerminalState(state)) {
+              // kill success and we can change state safely
+              // note that, the batch operation state should never be closed
+              setState(OperationState.CANCELED)
+              updateBatchMetadata()
+            } else if (killMessage._1) {
+              // we can not change state safely
+              killMessage = (false, s"batch $batchId is already terminal so can not kill it.")
+            } else if (!isTerminalState(state)) {
+              _applicationInfo = currentApplicationInfo()
+              _applicationInfo.map(_.state) match {
+                case Some(ApplicationState.FINISHED) =>
+                  setState(OperationState.FINISHED)
+                  updateBatchMetadata()
+                case Some(ApplicationState.FAILED) =>
+                  setState(OperationState.ERROR)
+                  updateBatchMetadata()
+                case Some(ApplicationState.UNKNOWN) |
+                    Some(ApplicationState.NOT_FOUND) |
+                    Some(ApplicationState.KILLED) =>
+                  setState(OperationState.CANCELED)
+                  updateBatchMetadata()
+                case _ => // failed to kill, the kill message is enough
+              }
             }
           }
         }
+      } finally {
+        withOperationLog(warn(s"Kill batch response: $killMessage."))
       }
     }
   })

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
@@ -501,12 +501,11 @@ private[v1] class BatchesResource extends ApiRequestContext with Logging {
     sessionManager.getBatchSession(sessionHandle).map { batchSession =>
       val userName = fe.getSessionUser(batchSession.user)
       val ipAddress = fe.getIpAddress
-      sessionManager.closeSession(batchSession.handle)
-      val (killed, msg) = batchSession.batchJobSubmissionOp.getKillMessage
       batchSession.batchJobSubmissionOp.withOperationLog {
         warn(s"Received kill batch request from $userName/$ipAddress")
-        warn(s"Kill batch response: killed: $killed, msg: $msg.")
       }
+      sessionManager.closeSession(batchSession.handle)
+      val (killed, msg) = batchSession.batchJobSubmissionOp.getKillMessage
       new CloseBatchResponse(killed, msg)
     }.getOrElse {
       sessionManager.getBatchMetadata(batchId).map { metadata =>


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

Followup for #6681

We shall log the kill batch request before or inside `closeSession`, as it will close the operation log.
## Describe Your Solution 🔧

1. log the kill batch request before `closeSession`.
2. log the kill batch response in BatchJobSubmission::close.

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests

<img width="1571" alt="image" src="https://github.com/user-attachments/assets/dbb4049a-6cf3-4ae5-a2a7-4decba67cd76">

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
