### PR TITLE
spark-sql-engine's classes should not be visible in server module

### DIFF
--- a/kyuubi-server/pom.xml
+++ b/kyuubi-server/pom.xml
@@ -77,7 +77,7 @@
 
         <dependency>
             <groupId>org.apache.kyuubi</groupId>
-            <artifactId>kyuubi-hive-jdbc</artifactId>
+            <artifactId>${hive.jdbc.artifact}</artifactId>
             <version>${project.version}</version>
         </dependency>
 
@@ -269,17 +269,21 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.apache.kyuubi</groupId>
-            <artifactId>${hive.jdbc.artifact}</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-
+        <!--
+          The server module does not consume the spark-sql-engine classes, but it supposes that
+          spark-sql-engine's jar existed on the target folder, so here we declare it as a dependency
+          to make sure that Maven always process spark-sql-engine module before the server module.
+          IntelliJ IDEA 2024.1 fixed the IDEA-93855, thus the relocated classes inside the
+          spark-sql-engine's shaded jar are visible in the server module in IDEA, for example,
+          `org.apache.kyuubi.shaded.spark.connect.proto.ExecutePlanRequest`, which silently breaks
+          the IDEA code analysis and jumping capabilities. This seems could be workaround by changing
+          the dependency type from `jar`(default value) to `pom`.
+         -->
         <dependency>
             <groupId>org.apache.kyuubi</groupId>
             <artifactId>kyuubi-spark-sql-engine_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
+            <type>pom</type>
             <scope>test</scope>
         </dependency>
 

--- a/kyuubi-server/pom.xml
+++ b/kyuubi-server/pom.xml
@@ -77,7 +77,7 @@
 
         <dependency>
             <groupId>org.apache.kyuubi</groupId>
-            <artifactId>${hive.jdbc.artifact}</artifactId>
+            <artifactId>kyuubi-hive-jdbc</artifactId>
             <version>${project.version}</version>
         </dependency>
 
@@ -266,6 +266,13 @@
             <artifactId>kyuubi-download</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.kyuubi</groupId>
+            <artifactId>${hive.jdbc.artifact}</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/kyuubi-server/pom.xml
+++ b/kyuubi-server/pom.xml
@@ -270,13 +270,13 @@
         </dependency>
 
         <!--
-          The server module does not consume the spark-sql-engine classes, but it supposes that
-          spark-sql-engine's jar existed on the target folder, so here we declare it as a dependency
-          to make sure that Maven always process spark-sql-engine module before the server module.
+          The server module does not consume the `spark-sql-engine` classes, but it supposes that
+          `spark-sql-engine`'s jar existed on the target folder, so here we declare it as a dependency
+          to make sure that Maven always processes `spark-sql-engine` module before the server module.
           IntelliJ IDEA 2024.1 fixed the IDEA-93855, thus the relocated classes inside the
-          spark-sql-engine's shaded jar are visible in the server module in IDEA, for example,
+          `spark-sql-engine`'s shaded jar are visible in the server module in IDEA, for example,
           `org.apache.kyuubi.shaded.spark.connect.proto.ExecutePlanRequest`, which silently breaks
-          the IDEA code analysis and jumping capabilities. This seems could be workaround by changing
+          the IDEA code analysis and jumping capabilities. It seems to be a workaround by changing
           the dependency type from `jar`(default value) to `pom`.
          -->
         <dependency>


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

The server module does not consume the `spark-sql-engine` classes, but it supposes that
`spark-sql-engine`'s jar existed on the target folder, so here we declare it as a dependency
to make sure that Maven always processes `spark-sql-engine` module before the server module.
IntelliJ IDEA 2024.1 fixed the IDEA-93855, thus the relocated classes inside the
`spark-sql-engine`'s shaded jar are visible in the server module in IDEA, for example,
`org.apache.kyuubi.shaded.spark.connect.proto.ExecutePlanRequest`, which silently breaks
the IDEA code analysis and jumping capabilities.

## Describe Your Solution 🔧


Changing the dependency type from `jar`(default value) to `pom` seems to be a workaround.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

<img width="593" alt="image" src="https://github.com/user-attachments/assets/cc53709a-5f9d-4452-a24f-0c84e2342191">


#### Behavior Without This Pull Request :coffin:

<img width="1511" alt="image" src="https://github.com/user-attachments/assets/1c547c6d-a603-4c9d-92b4-8e2059b35fac">


#### Behavior With This Pull Request :tada:

<img width="1509" alt="image" src="https://github.com/user-attachments/assets/55f9e6e5-b9ea-4959-9142-ab7db21ab9b1">


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
