### PR TITLE
[KYUUBI #6709] Fix seq and set equals check bug while check auth type in AuthenticationFilter.initAuthHandlers

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/http/authentication/AuthenticationFilter.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/http/authentication/AuthenticationFilter.scala
@@ -58,7 +58,7 @@ class AuthenticationFilter(conf: KyuubiConf) extends Filter with Logging {
     val authTypes = conf.get(AUTHENTICATION_METHOD).map(AuthTypes.withName)
     val spnegoKerberosEnabled = authTypes.contains(KERBEROS)
     val basicAuthTypeOpt = {
-      if (authTypes == Set(NOSASL)) {
+      if (authTypes.toSet == Set(NOSASL)) {
         authTypes.headOption
       } else {
         authTypes.filterNot(_.equals(KERBEROS)).filterNot(_.equals(NOSASL)).headOption


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #6709 

## Describe Your Solution 🔧

transfer the type of authTypes from seq to set before do equals check


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪
test in our produce kyuubi env
#### Behavior Without This Pull Request :coffin:
<img width="1431" alt="image" src="https://github.com/user-attachments/assets/6fd40d49-8d6b-446a-8feb-70df8c92604d">
<img width="603" alt="image" src="https://github.com/user-attachments/assets/637e5788-bfe0-4bab-a2a5-f6a79fb93fa6">

always hint to login  in all sub tabs of management tab in kyuubi web ui, but can not login in actually, while use confkyuubi.authentication NOSASL, and our java version is 1.8 scala version is 2.12.18
#### Behavior With This Pull Request :tada:
<img width="1422" alt="image" src="https://github.com/user-attachments/assets/211b76ee-d937-456b-bed4-f94dd41896f0">


#### Related Unit Tests

none, no need i think
---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
