### PR TITLE
Fix AppState when Engine connection is terminated

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
@@ -162,12 +162,13 @@ class BatchJobSubmission(
   }
 
   private def getAppState(
-      operState: OperationState,
+      opState: OperationState,
       appState: ApplicationState.ApplicationState): ApplicationState.ApplicationState = {
-    if (state == OperationState.ERROR && !ApplicationState.isTerminated(appState)) {
+    if (opState == OperationState.ERROR && !ApplicationState.isTerminated(appState)) {
       ApplicationState.UNKNOWN
+    } else {
+      appState
     }
-    appState
   }
 
   override def getOperationLog: Option[OperationLog] = Option(_operationLog)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
@@ -161,7 +161,9 @@ class BatchJobSubmission(
     }
   }
 
-  private def getAppState(operState: OperationState, appState: ApplicationState.ApplicationState): ApplicationState.ApplicationState = {
+  private def getAppState(
+      operState: OperationState,
+      appState: ApplicationState.ApplicationState): ApplicationState.ApplicationState = {
     if (state == OperationState.ERROR && !ApplicationState.isTerminated(appState)) {
       ApplicationState.UNKNOWN
     }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
@@ -154,11 +154,18 @@ class BatchJobSubmission(
         engineId = appInfo.id,
         engineName = appInfo.name,
         engineUrl = appInfo.url.orNull,
-        engineState = appInfo.state.toString,
+        engineState = getAppState(state, appInfo.state).toString,
         engineError = appInfo.error,
         endTime = endTime)
       session.sessionManager.updateMetadata(metadataToUpdate)
     }
+  }
+
+  private def getAppState(operState: OperationState, appState: ApplicationState): Unit = {
+    if (state == ERROR && appState != ApplicationState.FAILED) {
+      ApplicationState.UNKNOWN
+    }
+    appState
   }
 
   override def getOperationLog: Option[OperationLog] = Option(_operationLog)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
@@ -162,7 +162,7 @@ class BatchJobSubmission(
   }
 
   private def getAppState(operState: OperationState, appState: ApplicationState.ApplicationState): ApplicationState.ApplicationState = {
-    if (state == OperationState.ERROR && appState != ApplicationState.FAILED) {
+    if (state == OperationState.ERROR && !ApplicationState.isTerminated(appState)) {
       ApplicationState.UNKNOWN
     }
     appState

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
@@ -161,8 +161,8 @@ class BatchJobSubmission(
     }
   }
 
-  private def getAppState(operState: OperationState, appState: ApplicationState): Unit = {
-    if (state == ERROR && appState != ApplicationState.FAILED) {
+  private def getAppState(operState: OperationState, appState: ApplicationState.ApplicationState): ApplicationState.ApplicationState = {
+    if (state == OperationState.ERROR && appState != ApplicationState.FAILED) {
       ApplicationState.UNKNOWN
     }
     appState

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/WithKyuubiServerOnYarn.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/WithKyuubiServerOnYarn.scala
@@ -210,11 +210,4 @@ class KyuubiOperationYarnClusterSuite extends WithKyuubiServerOnYarn with HiveJD
       assert(exception.getMessage contains "Could not open client transport with JDBC Uri")
     }
   }
-
-  test("last application state is UNKNOWN if engine connection fail") {
-    val batchId = UUID.randomUUID().toString
-    // TODO Simulate connection fail
-    assert(sessionManager.getBatchMetadata(batchId).map(_.state).contains("ERROR"))
-    assert(sessionManager.getBatchMetadata(batchId).map(_.appState).contains("UNKNOWN"))
-  }
 }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/WithKyuubiServerOnYarn.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/WithKyuubiServerOnYarn.scala
@@ -32,6 +32,7 @@ import org.apache.kyuubi.operation.{FetchOrientation, HiveJDBCTestHelper, Operat
 import org.apache.kyuubi.operation.OperationState.ERROR
 import org.apache.kyuubi.server.MiniYarnService
 import org.apache.kyuubi.session.{KyuubiBatchSession, KyuubiSessionManager}
+import org.apache.hadoop.yarn.client.api.YarnClient
 
 /**
  * To developers:

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/WithKyuubiServerOnYarn.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/WithKyuubiServerOnYarn.scala
@@ -193,13 +193,14 @@ class KyuubiOperationYarnClusterSuite extends WithKyuubiServerOnYarn with HiveJD
   }
 
   test("fast fail the kyuubi connection on engine terminated") {
+    val batchId = UUID.randomUUID().toString
     withSessionConf(Map.empty)(Map(
       "spark.master" -> "yarn",
       "spark.submit.deployMode" -> "cluster",
       "spark.sql.defaultCatalog=spark_catalog" -> "spark_catalog",
       "spark.sql.catalog.spark_catalog.type" -> "invalid_type",
       ENGINE_INIT_TIMEOUT.key -> "PT10M",
-      KYUUBI_BATCH_ID_KEY -> UUID.randomUUID().toString))(Map.empty) {
+      KYUUBI_BATCH_ID_KEY -> batchId))(Map.empty) {
       val startTime = System.currentTimeMillis()
       val exception = intercept[Exception] {
         withJdbcStatement() { _ => }
@@ -207,6 +208,8 @@ class KyuubiOperationYarnClusterSuite extends WithKyuubiServerOnYarn with HiveJD
       val elapsedTime = System.currentTimeMillis() - startTime
       assert(elapsedTime < 60 * 1000)
       assert(exception.getMessage contains "Could not open client transport with JDBC Uri")
+      assert(sessionManager.getBatchMetadata(batchId).map(_.state).contains("ERROR"))
+      assert(sessionManager.getBatchMetadata(batchId).map(_.appState).contains("UNKNOWN"))
     }
   }
 }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/WithKyuubiServerOnYarn.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/WithKyuubiServerOnYarn.scala
@@ -32,7 +32,6 @@ import org.apache.kyuubi.operation.{FetchOrientation, HiveJDBCTestHelper, Operat
 import org.apache.kyuubi.operation.OperationState.ERROR
 import org.apache.kyuubi.server.MiniYarnService
 import org.apache.kyuubi.session.{KyuubiBatchSession, KyuubiSessionManager}
-import org.apache.hadoop.yarn.client.api.YarnClient
 
 /**
  * To developers:


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This issue was noticed a few times when the batch `state` was `set` to `ERROR`, but the `appState` kept the non-terminal state forever (e.g. `RUNNING`), even if the application was finished (in this case Yarn Application).

```json
{
"id": "********",
"user": "****",
"batchType": "SPARK",
"name": "*********",
"appStartTime": 0,
"appId": "********",
"appUrl": "********",
"appState": "RUNNING",
"appDiagnostic": "",
"kyuubiInstance": "*********",
"state": "ERROR",
"createTime": 1725343207318,
"endTime": 1725343300986,
"batchInfo": {}
}
```

It seems that this happens when there is some intermittent failure during the monitoring step and the batch ends with ERROR, leaving the application metadata without an update. This can lead to some misinterpretation that the application is still running. We need to set this to `UNKNOWN` state to avoid errors.

## Describe Your Solution 🔧

This is a simple fix that only checks if the batch state is `ERROR` and the appState is not in a terminal state and changes the `appState` to `UNKNOWN`, in these cases (during the batch metadata update).

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:

If there is some error between the Kyuubi and the Application request (e.g. YARN client), the batch is finished with `ERROR` state and the application keeps the last know state (e.g. RUNNING).

#### Behavior With This Pull Request :tada:

If there is some error between the Kyuubi and the Application request (e.g. YARN client), the batch is finished with `ERROR `state and the application has a non-terminal state, it is forced to `UNKNOWN` state.

#### Related Unit Tests

I've tried to implement a unit test to replicate this behavior but I didn't make it. We need to force an exception in the Engine Request (e.g. `YarnClient.getApplication`) but we need to wait for the application to be in the RUNNING state before raising this exception, or maybe block the connection between kyuubi and the engine.

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
