### PR TITLE
[KYUUBI #6638][FOLLOWUP] Authz shaded should include jsr311-api

### DIFF
--- a/extensions/spark/kyuubi-spark-authz-shaded/pom.xml
+++ b/extensions/spark/kyuubi-spark-authz-shaded/pom.xml
@@ -52,6 +52,7 @@
                             <include>org.codehaus.jackson:*</include>
                             <include>com.sun.jersey:*</include>
                             <include>com.kstruct:gethostname4j</include>
+                            <include>javax.ws.rs:jsr311-api</include>
                             <!-- JNA is the transitive dependency of gethostname4j -->
                             <include>net.java.dev.jna:jna</include>
                             <include>net.java.dev.jna:jna-platform</include>


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗

Fix a ClassNotFound issue.
```
java.lang.NoClassDefFoundError: org/apache/kyuubi/shade/javax/ws/rs/core/Cookie
```

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

Verified manually.

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
