### PR TITLE
[REST] Check all required extra resource files uploaded in creating batch request

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
@@ -202,12 +202,13 @@ private[v1] class BatchesResource extends ApiRequestContext with Logging {
       "batchRequest is required and please check the content type" +
         " of batchRequest is application/json")
 
-    val unsatisfiedFileNames =
+    val unUploadedExtraResourceFileNames =
       batchRequest.getExtraResourcesMap.values.asScala.flatMap(_.split(",")).toSet.diff(
-        formDataMultiPart.getFields.values().flatten.map(_.getContentDisposition.getFileName).toSet)
+        formDataMultiPart.getFields.values().flatten.map(_.getContentDisposition.getFileName)
+          .filter(StringUtils.isNotBlank(_)).toSet)
     require(
-      unsatisfiedFileNames.isEmpty,
-      f"required extra resource files [${unsatisfiedFileNames.mkString(",")}]" +
+      unUploadedExtraResourceFileNames.isEmpty,
+      f"required extra resource files [${unUploadedExtraResourceFileNames.mkString(",")}]" +
         f" are not uploaded in the multipart form data")
 
     openBatchSessionInternal(

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
@@ -202,13 +202,13 @@ private[v1] class BatchesResource extends ApiRequestContext with Logging {
       "batchRequest is required and please check the content type" +
         " of batchRequest is application/json")
 
-    val usedExtraResourcesFileNames =
-      batchRequest.getExtraResourcesMap.values.asScala.flatMap(_.split(",")).toSet
-    val fileNamesInMultiParts = formDataMultiPart.getFields.values().flatten
-      .map(_.getContentDisposition.getFileName).toSet
+    val unsatisfiedFileNames =
+      batchRequest.getExtraResourcesMap.values.asScala.flatMap(_.split(",")).toSet.diff(
+        formDataMultiPart.getFields.values().flatten.map(_.getContentDisposition.getFileName).toSet)
     require(
-      usedExtraResourcesFileNames.subsetOf(fileNamesInMultiParts),
-      "not all required extra resource files are uploaded")
+      unsatisfiedFileNames.isEmpty,
+      f"required extra resource files [${unsatisfiedFileNames.mkString(",")}]" +
+        f" are not uploaded in the multipart form data")
 
     openBatchSessionInternal(
       batchRequest,

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
@@ -203,12 +203,14 @@ private[v1] class BatchesResource extends ApiRequestContext with Logging {
         " of batchRequest is application/json")
 
     val unUploadedExtraResourceFileNames =
-      batchRequest.getExtraResourcesMap.values.asScala.flatMap(_.split(",")).toSet.diff(
-        formDataMultiPart.getFields.values().flatten.map(_.getContentDisposition.getFileName)
-          .filter(StringUtils.isNotBlank(_)).toSet)
+      batchRequest.getExtraResourcesMap.values.asScala
+        .flatMap(_.split(",")).filter(StringUtils.isNotBlank(_)).toSet.diff(
+          formDataMultiPart.getFields.values().flatten.map(_.getContentDisposition.getFileName)
+            .filter(StringUtils.isNotBlank(_)).toSet)
     require(
       unUploadedExtraResourceFileNames.isEmpty,
-      f"required extra resource files [${unUploadedExtraResourceFileNames.mkString(",")}]" +
+      f"required extra resource files " +
+        f"[${unUploadedExtraResourceFileNames.toList.sorted.mkString(",")}]" +
         f" are not uploaded in the multipart form data")
 
     openBatchSessionInternal(

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
@@ -203,10 +203,9 @@ private[v1] class BatchesResource extends ApiRequestContext with Logging {
         " of batchRequest is application/json")
 
     val unUploadedExtraResourceFileNames =
-      batchRequest.getExtraResourcesMap.values.asScala
-        .flatMap(_.split(",")).filter(StringUtils.isNotBlank(_)).toSet.diff(
-          formDataMultiPart.getFields.values().flatten.map(_.getContentDisposition.getFileName)
-            .filter(StringUtils.isNotBlank(_)).toSet)
+      batchRequest.getExtraResourcesMap.values.asScala.flatMap(_.split(",")).toSet.diff(
+        formDataMultiPart.getFields.values.flatten.map(_.getContentDisposition.getFileName).toSet)
+        .filter(StringUtils.isNotBlank(_))
     require(
       unUploadedExtraResourceFileNames.isEmpty,
       f"required extra resource files " +

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
@@ -26,6 +26,7 @@ import javax.ws.rs._
 import javax.ws.rs.core.MediaType
 
 import scala.collection.JavaConverters._
+import scala.collection.convert.ImplicitConversions.`collection AsScalaIterable`
 import scala.util.{Failure, Success, Try}
 import scala.util.control.NonFatal
 
@@ -200,6 +201,15 @@ private[v1] class BatchesResource extends ApiRequestContext with Logging {
       batchRequest != null,
       "batchRequest is required and please check the content type" +
         " of batchRequest is application/json")
+
+    val usedExtraResourcesFileNames =
+      batchRequest.getExtraResourcesMap.values.asScala.flatMap(_.split(",")).toSet
+    val fileNamesInMultiParts = formDataMultiPart.getFields.values().flatten
+      .map(_.getContentDisposition.getFileName).toSet
+    require(
+      usedExtraResourcesFileNames.subsetOf(fileNamesInMultiParts),
+      "not all required extra resource files are uploaded")
+
     openBatchSessionInternal(
       batchRequest,
       isResourceFromUpload = true,

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/rest/client/BatchRestApiSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/rest/client/BatchRestApiSuite.scala
@@ -23,6 +23,8 @@ import java.util.zip.{ZipEntry, ZipOutputStream}
 
 import scala.collection.JavaConverters._
 
+import com.github.dockerjava.zerodep.shaded.org.apache.hc.core5.http.HttpResponse
+import org.apache.http.client.HttpResponseException
 import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
 
 import org.apache.kyuubi.{BatchTestHelper, KYUUBI_VERSION, RestClientTestHelper}
@@ -32,6 +34,7 @@ import org.apache.kyuubi.client.exception.KyuubiRestException
 import org.apache.kyuubi.config.KyuubiReservedKeys
 import org.apache.kyuubi.metrics.{MetricsConstants, MetricsSystem}
 import org.apache.kyuubi.session.{KyuubiSession, SessionHandle}
+import org.apache.kyuubi.util.AssertionUtils.interceptCauseContains
 import org.apache.kyuubi.util.GoldenFileUtils.getCurrentModuleHome
 
 class BatchRestApiSuite extends RestClientTestHelper with BatchTestHelper {
@@ -179,6 +182,35 @@ class BatchRestApiSuite extends RestClientTestHelper with BatchTestHelper {
 
     } finally {
       Files.deleteIfExists(Paths.get(modulesZipFile))
+      basicKyuubiRestClient.close()
+    }
+  }
+
+  test("basic batch rest client with uploading resource and extra resources of unuploaded") {
+
+    val basicKyuubiRestClient: KyuubiRestClient =
+      KyuubiRestClient.builder(baseUri.toString)
+        .authHeaderMethod(KyuubiRestClient.AuthHeaderMethod.BASIC)
+        .username(ldapUser)
+        .password(ldapUserPasswd)
+        .socketTimeout(5 * 60 * 1000)
+        .build()
+    val batchRestApi: BatchRestApi = new BatchRestApi(basicKyuubiRestClient)
+
+    val pythonScriptsPath = s"${getCurrentModuleHome(this)}/src/test/resources/python/"
+    val appScriptFileName = "app.py"
+    val appScriptFile = Paths.get(pythonScriptsPath, appScriptFileName).toFile
+    val requestObj = newSparkBatchRequest(Map("spark.master" -> "local"))
+    requestObj.setBatchType("PYSPARK")
+    requestObj.setName("pyspark-test")
+    requestObj.setExtraResourcesMap(Map("spark.submit.pyFiles" -> "non-existed.zip").asJava)
+
+    try {
+      interceptCauseContains[KyuubiRestException, HttpResponseException] {
+        batchRestApi.createBatch(requestObj, appScriptFile, List().asJava)
+      }("required extra resource files [non-existed.zip] are not uploaded" +
+        " in the multipart form data")
+    } finally {
       basicKyuubiRestClient.close()
     }
   }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/rest/client/BatchRestApiSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/rest/client/BatchRestApiSuite.scala
@@ -162,10 +162,7 @@ class BatchRestApiSuite extends RestClientTestHelper with BatchTestHelper {
     val requestObj = newSparkBatchRequest(Map("spark.master" -> "local"))
     requestObj.setBatchType("PYSPARK")
     requestObj.setName("pyspark-test")
-    requestObj.setExtraResourcesMap(Map(
-      "spark.submit.pyFiles" -> modulesZipFileName,
-      "hahaha" -> "ok.file",
-    ).asJava)
+    requestObj.setExtraResourcesMap(Map("spark.submit.pyFiles" -> modulesZipFileName).asJava)
     val extraResources = List(modulesZipFile)
     val batch: Batch = batchRestApi.createBatch(requestObj, appScriptFile, extraResources.asJava)
 

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/rest/client/BatchRestApiSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/rest/client/BatchRestApiSuite.scala
@@ -206,8 +206,7 @@ class BatchRestApiSuite extends RestClientTestHelper with BatchTestHelper {
       "spark.submit.pyFiles" -> "non-existed-zip.zip",
       "spark.files" -> "non-existed-jar.jar",
       "spark.some.config1" -> "",
-      "spark.some.config2" -> " ",
-    ).asJava)
+      "spark.some.config2" -> " ").asJava)
 
     try {
       interceptCauseContains[KyuubiRestException, HttpResponseException] {

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/rest/client/BatchRestApiSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/rest/client/BatchRestApiSuite.scala
@@ -23,7 +23,6 @@ import java.util.zip.{ZipEntry, ZipOutputStream}
 
 import scala.collection.JavaConverters._
 
-import com.github.dockerjava.zerodep.shaded.org.apache.hc.core5.http.HttpResponse
 import org.apache.http.client.HttpResponseException
 import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
 
@@ -203,13 +202,18 @@ class BatchRestApiSuite extends RestClientTestHelper with BatchTestHelper {
     val requestObj = newSparkBatchRequest(Map("spark.master" -> "local"))
     requestObj.setBatchType("PYSPARK")
     requestObj.setName("pyspark-test")
-    requestObj.setExtraResourcesMap(Map("spark.submit.pyFiles" -> "non-existed.zip").asJava)
+    requestObj.setExtraResourcesMap(Map(
+      "spark.submit.pyFiles" -> "non-existed-zip.zip",
+      "spark.files" -> "non-existed-jar.jar",
+      "spark.some.config1" -> "",
+      "spark.some.config2" -> " ",
+    ).asJava)
 
     try {
       interceptCauseContains[KyuubiRestException, HttpResponseException] {
         batchRestApi.createBatch(requestObj, appScriptFile, List().asJava)
-      }("required extra resource files [non-existed.zip] are not uploaded" +
-        " in the multipart form data")
+      }("required extra resource files [non-existed-jar.jar,non-existed-zip.zip]" +
+        " are not uploaded in the multipart form data")
     } finally {
       basicKyuubiRestClient.close()
     }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/rest/client/BatchRestApiSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/rest/client/BatchRestApiSuite.scala
@@ -162,7 +162,10 @@ class BatchRestApiSuite extends RestClientTestHelper with BatchTestHelper {
     val requestObj = newSparkBatchRequest(Map("spark.master" -> "local"))
     requestObj.setBatchType("PYSPARK")
     requestObj.setName("pyspark-test")
-    requestObj.setExtraResourcesMap(Map("spark.submit.pyFiles" -> modulesZipFileName).asJava)
+    requestObj.setExtraResourcesMap(Map(
+      "spark.submit.pyFiles" -> modulesZipFileName,
+      "hahaha" -> "ok.file",
+    ).asJava)
     val extraResources = List(modulesZipFile)
     val batch: Batch = batchRestApi.createBatch(requestObj, appScriptFile, extraResources.asJava)
 

--- a/kyuubi-util-scala/src/test/scala/org/apache/kyuubi/util/AssertionUtils.scala
+++ b/kyuubi-util-scala/src/test/scala/org/apache/kyuubi/util/AssertionUtils.scala
@@ -193,4 +193,17 @@ object AssertionUtils {
     val exception = intercept[T](f)(classTag, pos)
     assert(exception.getMessage.endsWith(end))
   }
+
+  /**
+   * Asserts that the given function throws an exception of the given type T
+   * with a cause of type Q and with the cause message of the exception equals to expected string
+   */
+  def interceptCauseContains[T <: Exception, Q <: Throwable](f: => Any)(contained: String)(
+      implicit
+      classTag: ClassTag[T],
+      pos: Position): Unit = {
+    assert(contained != null)
+    val exception = intercept[T](f)(classTag, pos)
+    assert(exception.getCause.asInstanceOf[Q].getMessage.contains(contained))
+  }
 }


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #

## Describe Your Solution 🔧

- check all the required extra resource files are uploaded in POST multi-part request as expected, when creating batch with REST Batch API

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
