### PR TITLE
Bump vertx-grpc and vertx-core from 4.5.1 to 4.5.3

### DIFF
--- a/dev/dependencyList
+++ b/dev/dependencyList
@@ -182,7 +182,7 @@ swagger-jaxrs2/2.2.1//swagger-jaxrs2-2.2.1.jar
 swagger-models/2.2.1//swagger-models-2.2.1.jar
 trino-client/411//trino-client-411.jar
 units/1.7//units-1.7.jar
-vertx-core/4.5.1//vertx-core-4.5.1.jar
-vertx-grpc/4.5.1//vertx-grpc-4.5.1.jar
+vertx-core/4.5.3//vertx-core-4.5.3.jar
+vertx-grpc/4.5.3//vertx-grpc-4.5.3.jar
 zjsonpatch/0.3.0//zjsonpatch-0.3.0.jar
 zstd-jni/1.5.5-1//zstd-jni-1.5.5-1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,7 @@
         <trino.client.version>411</trino.client.version>
         <trino.tpcds.version>1.4</trino.tpcds.version>
         <trino.tpch.version>1.1</trino.tpch.version>
+        <vertx.version>4.5.3</vertx.version>
 
         <!-- webui -->
         <webui.skip>true</webui.skip>
@@ -907,6 +908,12 @@
                         <artifactId>snappy-java</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>io.vertx</groupId>
+                <artifactId>vertx-grpc</artifactId>
+                <version>${vertx.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
# :mag: Description

## Describe Your Solution 🔧

Bump vertx-core from 4.5.1 to 4.5.3 to fix CVE-2024-1300 and CVE-2024-1023

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪
Build and ran locally



---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
