### PR TITLE
[CI] Bump runner image from Ubuntu 22.04 to 24.04

### DIFF
--- a/.github/workflows/dep.yml
+++ b/.github/workflows/dep.yml
@@ -36,7 +36,7 @@ concurrency:
 jobs:
   dep:
     name: Dependency check
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: setup java

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   sphinx:
     name: sphinx-build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/gluten.yml
+++ b/.github/workflows/gluten.yml
@@ -27,7 +27,7 @@ env:
 jobs:
   gluten-build:
     name: Build Gluten
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Free up disk space
@@ -74,7 +74,7 @@ jobs:
   gluten-it:
     name: Gluten Integration TPC-H/DS Test
     needs: gluten-build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -22,7 +22,7 @@ on: issues
 
 jobs:
   greeting:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   triage:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/labeler@v5
       with:

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -32,7 +32,7 @@ concurrency:
 jobs:
   rat:
     name: License
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Setup JDK 8

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -39,7 +39,7 @@ env:
 jobs:
   default:
     name: Kyuubi and Spark Test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       max-parallel: 6
@@ -131,7 +131,7 @@ jobs:
 
   scala-test:
     name: Scala Test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -178,7 +178,7 @@ jobs:
 
   spark-connector-cross-version-test:
     name: Spark Connector Cross Version Test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       max-parallel: 1
@@ -240,7 +240,7 @@ jobs:
 
   flink-it:
     name: Flink Test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       max-parallel: 2
@@ -310,7 +310,7 @@ jobs:
 
   hive-it:
     name: Hive Test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       max-parallel: 1
@@ -372,7 +372,7 @@ jobs:
 
   jdbc-trino-tpc-it:
     name: JDBC Trino TPC Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -418,7 +418,7 @@ jobs:
 
   kyuubi-on-k8s-it:
     name: Kyuubi Server On Kubernetes Integration Test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Free up disk space
@@ -491,7 +491,7 @@ jobs:
 
   spark-on-k8s-it:
     name: Spark Engine On Kubernetes Integration Test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Free up disk space
@@ -534,7 +534,7 @@ jobs:
 
   zookeeper-it:
     name: Zookeeper Integration Test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       max-parallel: 1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,7 +25,7 @@ jobs:
   build:
     name: Build
     if: ${{ startsWith(github.repository, 'apache/') }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         profiles:

--- a/.github/workflows/publish-snapshot-docker.yml
+++ b/.github/workflows/publish-snapshot-docker.yml
@@ -25,7 +25,7 @@ jobs:
   push_to_registry:
     name: Push Snapshot Docker Image to Docker Hub
     if: ${{ startsWith(github.repository, 'apache/') }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Free up disk space

--- a/.github/workflows/publish-snapshot-nexus.yml
+++ b/.github/workflows/publish-snapshot-nexus.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   publish-snapshot:
     if: ${{ startsWith(github.repository, 'apache/') }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -33,7 +33,7 @@ concurrency:
 
 jobs:
   unit-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   linter:
     name: Style check
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         profiles:

--- a/.github/workflows/web-ui.yml
+++ b/.github/workflows/web-ui.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   web-ui:
     name: Kyuubi Web UI check
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #

## Describe Your Solution 🔧

- The Ubuntu 24.04 image for Actions is now generally available since Sep 2024 : https://github.blog/changelog/2024-09-25-actions-new-images-and-ubuntu-latest-changes/


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
