### PR TITLE
Bump okhttp from 3.12.12 to 4.12.0

### DIFF
--- a/dev/dependencyList
+++ b/dev/dependencyList
@@ -18,6 +18,7 @@
 HikariCP/4.0.3//HikariCP-4.0.3.jar
 ST4/4.3.4//ST4-4.3.4.jar
 animal-sniffer-annotations/1.23//animal-sniffer-annotations-1.23.jar
+annotations/13.0//annotations-13.0.jar
 annotations/4.1.1.4//annotations-4.1.1.4.jar
 antlr-runtime/3.5.3//antlr-runtime-3.5.3.jar
 antlr4-runtime/4.9.3//antlr4-runtime-4.9.3.jar
@@ -98,6 +99,10 @@ jetty-util/9.4.54.v20240208//jetty-util-9.4.54.v20240208.jar
 jline/2.14.6//jline-2.14.6.jar
 jul-to-slf4j/1.7.36//jul-to-slf4j-1.7.36.jar
 kafka-clients/3.5.2//kafka-clients-3.5.2.jar
+kotlin-stdlib-common/1.9.10//kotlin-stdlib-common-1.9.10.jar
+kotlin-stdlib-jdk7/1.8.21//kotlin-stdlib-jdk7-1.8.21.jar
+kotlin-stdlib-jdk8/1.8.21//kotlin-stdlib-jdk8-1.8.21.jar
+kotlin-stdlib/1.8.21//kotlin-stdlib-1.8.21.jar
 kubernetes-client-api/6.13.1//kubernetes-client-api-6.13.1.jar
 kubernetes-client/6.13.1//kubernetes-client-6.13.1.jar
 kubernetes-httpclient-okhttp/6.13.1//kubernetes-httpclient-okhttp-6.13.1.jar
@@ -151,8 +156,9 @@ netty-transport-native-epoll/4.1.108.Final/linux-x86_64/netty-transport-native-e
 netty-transport-native-unix-common/4.1.108.Final//netty-transport-native-unix-common-4.1.108.Final.jar
 netty-transport/4.1.108.Final//netty-transport-4.1.108.Final.jar
 okhttp-urlconnection/3.14.9//okhttp-urlconnection-3.14.9.jar
-okhttp/3.12.12//okhttp-3.12.12.jar
-okio/1.15.0//okio-1.15.0.jar
+okhttp/4.12.0//okhttp-4.12.0.jar
+okio-jvm/3.6.0//okio-jvm-3.6.0.jar
+okio/3.6.0//okio-3.6.0.jar
 osgi-resource-locator/1.0.3//osgi-resource-locator-1.0.3.jar
 paranamer/2.8//paranamer-2.8.jar
 perfmark-api/0.26.0//perfmark-api-0.26.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,7 @@
         <mysql.jdbc.version>8.0.32</mysql.jdbc.version>
         <mockito.version>4.11.0</mockito.version>
         <netty.version>4.1.108.Final</netty.version>
+        <okhttp.version>4.12.0</okhttp.version>
         <openai.java.version>0.12.0</openai.java.version>
         <retrofit.version>2.9.0</retrofit.version>
         <paimon.version>0.8.2</paimon.version>
@@ -609,6 +610,12 @@
                 for doing any customization to OkHttp clients.
                 https://github.com/fabric8io/kubernetes-client/blob/master/doc/MIGRATION-v6.md#okhttp-httpclient
             -->
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>okhttp</artifactId>
+                <version>${okhttp.version}</version>
+            </dependency>
+
             <dependency>
                 <groupId>io.fabric8</groupId>
                 <artifactId>kubernetes-httpclient-okhttp</artifactId>


### PR DESCRIPTION
# :mag: Description

## Describe Your Solution 🔧
This is to fix CVE-2023-0833 and CVE-2023-3635 (for okio)
As there is no breaking change from okhttp 3 to 4, seems feasible - https://github.com/square/okhttp/issues/4723 


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪
Build and ran locally
#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
