### PR TITLE
Set hadoop fs delegation token renewer to empty

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/credentials/HadoopFsDelegationTokenProvider.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/credentials/HadoopFsDelegationTokenProvider.scala
@@ -68,12 +68,10 @@ class HadoopFsDelegationTokenProvider extends HadoopDelegationTokenProvider with
       }.toMap
 
       try {
-        // Renewer is not needed. But setting a renewer can avoid potential NPE.
-        val renewer = UserGroupInformation.getCurrentUser.getUserName
         fileSystems.foreach { case (fs, uri) =>
           info(s"getting token owned by $owner for: $uri")
           try {
-            fs.addDelegationTokens(renewer, creds)
+            fs.addDelegationTokens("", creds)
           } catch {
             case e: Exception =>
               throw new KyuubiException(s"Failed to get token owned by $owner for: $uri", e)


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

Allow delegation tokens to be used and renewed by yarn resourcemanager. (used in proxy user mode of flink engine, address https://github.com/apache/kyuubi/pull/6383#discussion_r1635768060)

## Describe Your Solution 🔧

Set hadoop fs delegation token renewer to empty.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
