### PR TITLE
[KYUUBI #6754] Improve the performance of ranger access requests

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/pom.xml
+++ b/extensions/spark/kyuubi-spark-authz/pom.xml
@@ -380,6 +380,19 @@
             <artifactId>${hudi.artifact}</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.scalatestplus</groupId>
+            <artifactId>mockito-4-11_${scala.binary.version}</artifactId>
+            <version>${scalatestplus.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleAuthorizationSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleAuthorizationSuite.scala
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.plugin.spark.authz.ranger
+
+import java.io.File
+import java.nio.file.Files
+
+import scala.reflect.io.Path.jfile2path
+
+import org.apache.ranger.plugin.policyengine.RangerAccessRequest
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+// scalastyle:off
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.BeforeAndAfterAll
+
+import org.apache.kyuubi.plugin.spark.authz.SparkSessionProvider
+
+class RuleAuthorizationSuite extends AnyFunSuite
+  with SparkSessionProvider with BeforeAndAfterAll with MockitoSugar {
+  // scalastyle:on
+  override protected val catalogImpl: String = "hive"
+
+  private var tempDir: File = _
+
+  override def beforeAll(): Unit = {
+    tempDir = Files.createTempDirectory("kyuubi-test-").toFile
+  }
+
+
+  override def afterAll(): Unit = {
+    if (tempDir != null) {
+      tempDir.deleteRecursively()
+    }
+    spark.stop()
+    super.afterAll()
+  }
+
+  // scalastyle:on
+  test("KYUUBI #6754: improve the performance of ranger access requests") {
+    val outputPath = tempDir.getAbsolutePath + "/small_files"
+    spark.range(1, 1000, 1, 1000).write.parquet(outputPath)
+
+    val plugin = mock[SparkRangerAdminPlugin.type]
+    when(plugin.verify(Seq(any[RangerAccessRequest]), any[SparkRangerAuditHandler]))
+      .thenAnswer(_ => ())
+
+    val df = spark.read.parquet(outputPath + "/*.parquet")
+    val plan = df.queryExecution.optimizedPlan
+    val start = System.currentTimeMillis()
+    RuleAuthorization(spark).checkPrivileges(spark, plan)
+    val end = System.currentTimeMillis()
+    assert(end - start < 10000, "RuleAuthorization.checkPrivileges() timed out")
+  }
+}


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗

This pull request fixes #6754

## Describe Your Solution 🔧

Right now in RuleAuthorization we use an ArrayBuffer to collect access requests, which is very slow because each new PrivilegeObject needs to be compared with all access requests.


## Types of changes :bookmark:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:

![Before](https://github.com/user-attachments/assets/b8b76383-cced-4e8b-9116-9bf9694f32d6)

#### Behavior With This Pull Request :tada:

![After](https://github.com/user-attachments/assets/25859dee-0f4c-4f85-9c55-82378121ad30)


#### Related Unit Tests

Test with local 50000 files:
```java
test("KYUUBI #6754: improve the performance of ranger access requests") {
    val outputPath = "/private/var/folders/tr/scn8dgl13_l6_sh17bghtln1b35kn1/T/kyuubi-test-5492934124608743789/"
    println("output path: "+ outputPath)

    val plugin = mock[SparkRangerAdminPlugin.type]
    when(plugin.verify(Seq(any[RangerAccessRequest]), any[SparkRangerAuditHandler]))
      .thenAnswer(_ => ())

    val df = spark.read.parquet(outputPath + "/*/*.parquet")
    val plan = df.queryExecution.optimizedPlan
    val start = System.currentTimeMillis()
    RuleAuthorization(spark).checkPrivileges(spark, plan)
    val end = System.currentTimeMillis()
    println(s"Time elapsed : ${end - start} ms")
  }
```

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
