### PR TITLE
[BUILD] cleanup dockerfile warnings

### DIFF
--- a/build/Dockerfile.CI
+++ b/build/Dockerfile.CI
@@ -33,7 +33,7 @@
 # see: https://github.com/moby/moby/issues/38379
 ARG BASE_IMAGE=eclipse-temurin:8-jdk-focal
 
-FROM eclipse-temurin:8-jdk-focal as builder
+FROM eclipse-temurin:8-jdk-focal AS builder
 
 ARG MVN_ARG
 
@@ -43,7 +43,7 @@ ARG MVN_ARG
 # an environment variable `CI` in runners, and we detect this variable to run some
 # specific actions, e.g. run `mvn` in batch mode to suppress noisy logs.
 ARG CI
-ENV CI ${CI}
+ENV CI=${CI}
 
 ADD . /workspace/kyuubi
 WORKDIR /workspace/kyuubi
@@ -64,10 +64,10 @@ ARG kyuubi_uid=10009
 
 USER root
 
-ENV KYUUBI_HOME /opt/kyuubi
-ENV KYUUBI_LOG_DIR ${KYUUBI_HOME}/logs
-ENV KYUUBI_PID_DIR ${KYUUBI_HOME}/pid
-ENV KYUUBI_WORK_DIR_ROOT ${KYUUBI_HOME}/work
+ENV KYUUBI_HOME=/opt/kyuubi
+ENV KYUUBI_LOG_DIR=${KYUUBI_HOME}/logs
+ENV KYUUBI_PID_DIR=${KYUUBI_HOME}/pid
+ENV KYUUBI_WORK_DIR_ROOT=${KYUUBI_HOME}/work
 
 COPY --from=builder /opt/kyuubi ${KYUUBI_HOME}
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,10 +40,10 @@ FROM builder_${spark_provided}
 ARG kyuubi_uid=10009
 USER root
 
-ENV KYUUBI_HOME /opt/kyuubi
-ENV KYUUBI_LOG_DIR ${KYUUBI_HOME}/logs
-ENV KYUUBI_PID_DIR ${KYUUBI_HOME}/pid
-ENV KYUUBI_WORK_DIR_ROOT ${KYUUBI_HOME}/work
+ENV KYUUBI_HOME=/opt/kyuubi
+ENV KYUUBI_LOG_DIR=${KYUUBI_HOME}/logs
+ENV KYUUBI_PID_DIR=${KYUUBI_HOME}/pid
+ENV KYUUBI_WORK_DIR_ROOT=${KYUUBI_HOME}/work
 
 RUN set -ex && \
     sed -i 's/http:\/\/deb.\(.*\)/https:\/\/deb.\1/g' /etc/apt/sources.list && \


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #

## Describe Your Solution 🔧

- fix the dockerfile warning reported by `GitHub Actions
/ Kyuubi Server On Kubernetes Integration Test` :
  - Legacy key/value format with whitespace separator should not be used
LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format
More info: https://docs.docker.com/go/dockerfile/rule/legacy-key-value-format/

  - The 'as' keyword should match the case of the 'from' keyword
FromAsCasing: 'as' and 'FROM' keywords' casing do not match
More info: https://docs.docker.com/go/dockerfile/rule/from-as-casing/

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
