### PR TITLE
[CI] Specify JDK 11 for spark engine on kubernetes IT

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -498,6 +498,13 @@ jobs:
         run: ./.github/scripts/free_disk_space.sh
       - name: Cache Engine Archives
         uses: ./.github/actions/cache-engine-archives
+      - name: Setup JDK 11
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 11
+          cache: 'maven'
+          check-latest: false
       - name: Setup Minikube
         run: |
           # https://minikube.sigs.k8s.io/docs/start/


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗

`Spark Engine On Kubernetes Integration Test` always fails after #6739

The default java version of Ubuntu 24.04 is OpenJDK 21: https://discourse.ubuntu.com/t/ubuntu-24-04-lts-noble-numbat-release-notes/39890#openjdk , this is a version higher than that supported by spark 3.5.X.

## Describe Your Solution 🔧

Specify JDK 11 for spark engine on kubernetes it.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

test ga: https://github.com/wForget/kyuubi/actions/runs/11441231714/job/31828818049


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
