### PR TITLE
Bump log4j from 2.20.0 to 2.24.1

### DIFF
--- a/dev/dependencyList
+++ b/dev/dependencyList
@@ -123,10 +123,10 @@ kubernetes-model-rbac/6.13.1//kubernetes-model-rbac-6.13.1.jar
 kubernetes-model-resource/6.13.1//kubernetes-model-resource-6.13.1.jar
 kubernetes-model-scheduling/6.13.1//kubernetes-model-scheduling-6.13.1.jar
 kubernetes-model-storageclass/6.13.1//kubernetes-model-storageclass-6.13.1.jar
-log4j-1.2-api/2.20.0//log4j-1.2-api-2.20.0.jar
-log4j-api/2.20.0//log4j-api-2.20.0.jar
-log4j-core/2.20.0//log4j-core-2.20.0.jar
-log4j-slf4j-impl/2.20.0//log4j-slf4j-impl-2.20.0.jar
+log4j-1.2-api/2.24.1//log4j-1.2-api-2.24.1.jar
+log4j-api/2.24.1//log4j-api-2.24.1.jar
+log4j-core/2.24.1//log4j-core-2.24.1.jar
+log4j-slf4j-impl/2.24.1//log4j-slf4j-impl-2.24.1.jar
 logging-interceptor/3.12.12//logging-interceptor-3.12.12.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
 metrics-core/4.2.26//metrics-core-4.2.26.jar

--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
         <kyuubi-relocated.version>0.4.1</kyuubi-relocated.version>
         <kyuubi-relocated-zookeeper.artifacts>kyuubi-relocated-zookeeper-34</kyuubi-relocated-zookeeper.artifacts>
         <ldapsdk.version>6.0.5</ldapsdk.version>
-        <log4j.version>2.20.0</log4j.version>
+        <log4j.version>2.24.1</log4j.version>
         <mysql.jdbc.version>8.0.32</mysql.jdbc.version>
         <mockito.version>4.11.0</mockito.version>
         <netty.version>4.1.108.Final</netty.version>


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #

## Describe Your Solution 🔧

- bump log4j from 2.20.0(Feb 2023) to 2.24.1 (Sep 2024) : https://logging.apache.org/log4j/2.x/release-notes.html#release-notes-2-24-1


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
