### PR TITLE
Support save WithCTE for insertRepartitionBeforeWrite

### DIFF
--- a/extensions/spark/kyuubi-extension-spark-3-3/src/main/scala/org/apache/kyuubi/sql/RepartitionBeforeWritingBase.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-3/src/main/scala/org/apache/kyuubi/sql/RepartitionBeforeWritingBase.scala
@@ -128,6 +128,7 @@ trait RepartitionBeforeWriteHelper extends Rule[LogicalPlan] {
   def canInsertRepartitionByExpression(plan: LogicalPlan): Boolean = {
     def canInsert(p: LogicalPlan): Boolean = p match {
       case Project(_, child) => canInsert(child)
+      case WithCTE(plan, _) => canInsert(plan)
       case SubqueryAlias(_, child) => canInsert(child)
       case Limit(_, _) => false
       case _: Sort => false

--- a/extensions/spark/kyuubi-extension-spark-3-3/src/test/scala/org/apache/spark/sql/RebalanceBeforeWritingSuite.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-3/src/test/scala/org/apache/spark/sql/RebalanceBeforeWritingSuite.scala
@@ -93,39 +93,6 @@ class RebalanceBeforeWritingSuite extends KyuubiSparkSQLExtensionTest {
     }
   }
 
-  test("check rebalance does not exists for WithCTE") {
-    def check(df: DataFrame): Unit = {
-      assert(
-        df.queryExecution.analyzed.collect {
-          case r: RebalancePartitions => r
-        }.isEmpty)
-    }
-    withSQLConf(
-      KyuubiSQLConf.INSERT_REPARTITION_BEFORE_WRITE.key -> "true",
-      KyuubiSQLConf.INSERT_REPARTITION_BEFORE_WRITE_IF_NO_SHUFFLE.key -> "true") {
-      withTable("tmp1") {
-        spark.sql("CREATE TABLE tmp1 (id BIGINT,name BIGINT)")
-
-        val result = sql("with tmp_table as (select id, name from tmp1 group by id, name)" +
-          "select id, name from tmp_table order by id")
-
-        val colName = (0 until result.schema.size).map(x => "col" + x)
-        val renamedDf = result.toDF(colName: _*)
-
-        renamedDf.write
-          .option("compression", "zstd")
-          .format("orc")
-          .mode("overwrite")
-          .save("test")
-
-        // TODO
-        // This check will not take effect at this time
-        // because the execution plan associated with the write operation is not in the DF
-        check(renamedDf)
-      }
-    }
-  }
-
   test("check rebalance does not exists") {
     def check(df: DataFrame): Unit = {
       assert(

--- a/extensions/spark/kyuubi-extension-spark-3-4/src/main/scala/org/apache/kyuubi/sql/RepartitionBeforeWritingBase.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-4/src/main/scala/org/apache/kyuubi/sql/RepartitionBeforeWritingBase.scala
@@ -109,6 +109,7 @@ trait RepartitionBeforeWriteHelper extends Rule[LogicalPlan] {
   def canInsertRepartitionByExpression(plan: LogicalPlan): Boolean = {
     def canInsert(p: LogicalPlan): Boolean = p match {
       case Project(_, child) => canInsert(child)
+      case WithCTE(plan, _) => canInsert(plan)
       case SubqueryAlias(_, child) => canInsert(child)
       case Limit(_, _) => false
       case _: Sort => false

--- a/extensions/spark/kyuubi-extension-spark-3-5/src/main/scala/org/apache/kyuubi/sql/RepartitionBeforeWritingBase.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-5/src/main/scala/org/apache/kyuubi/sql/RepartitionBeforeWritingBase.scala
@@ -109,6 +109,7 @@ trait RepartitionBeforeWriteHelper extends Rule[LogicalPlan] {
   def canInsertRepartitionByExpression(plan: LogicalPlan): Boolean = {
     def canInsert(p: LogicalPlan): Boolean = p match {
       case Project(_, child) => canInsert(child)
+      case WithCTE(plan, _) => canInsert(plan)
       case SubqueryAlias(_, child) => canInsert(child)
       case Limit(_, _) => false
       case _: Sort => false

--- a/extensions/spark/kyuubi-extension-spark-3-5/src/test/scala/org/apache/spark/sql/KyuubiSparkSQLExtensionTest.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-5/src/test/scala/org/apache/spark/sql/KyuubiSparkSQLExtensionTest.scala
@@ -100,6 +100,10 @@ trait KyuubiSparkSQLExtensionTest extends QueryTest
   }
 
   def withListener(df: => DataFrame)(callback: DataWritingCommand => Unit): Unit = {
+    runWithListener(df.collect())(callback)
+  }
+
+  def runWithListener(func: => Unit)(callback: DataWritingCommand => Unit): Unit = {
     val listener = new QueryExecutionListener {
       override def onFailure(f: String, qe: QueryExecution, e: Exception): Unit = {}
 
@@ -112,7 +116,7 @@ trait KyuubiSparkSQLExtensionTest extends QueryTest
     }
     spark.listenerManager.register(listener)
     try {
-      df.collect()
+      func
       sparkContext.listenerBus.waitUntilEmpty()
     } finally {
       spark.listenerManager.unregister(listener)


### PR DESCRIPTION


# :mag: Description
## Issue References 🔗

<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

First, I'd like to thank @wForget for the help with this issue.

When using the "save to HDFS" feature, queries ending with an `ORDER BY` sometimes lose their sort order in the results. Upon investigating the code, I discovered that when using `WITH` statements and saving SQL results with `toDF.write.save`, a `WithCTE` node is generated after the Sort node. This causes the `canInsertRepartitionByExpression` check to fail, leading to an incorrect `Repartition` node insertion after the Sort node, which ultimately disrupts the sort order.

However, this issue does not occur when using `INSERT INTO TABLE` with `WithCTE` nodes.

The provided unit test can reproduce this issue, but after using `toDF.write.save`, I am unable to access the complete execution plan to assert whether a `Repartition` node is present. Therefore, the current test is ineffective. 

Hope someone can help figure out how to write this unit test.

## Describe Your Solution 🔧

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
