### PR TITLE
Shutdown the executor service in KubernetesApplicationOperation and prevent NPE

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
@@ -266,6 +266,7 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
 
     if (cleanupTerminatedAppInfoTrigger != null) {
       cleanupTerminatedAppInfoTrigger.invalidateAll()
+      ThreadUtils.shutdown(expireCleanUpTriggerCacheExecutor)
       cleanupTerminatedAppInfoTrigger = null
     }
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
@@ -151,11 +151,12 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
       expireCleanUpTriggerCacheExecutor,
       () => {
         try {
-          if (cleanupTerminatedAppInfoTrigger == null) return
-          cleanupTerminatedAppInfoTrigger.asMap().asScala.foreach {
-            case (key, _) =>
-              // do get to trigger cache eviction
-              cleanupTerminatedAppInfoTrigger.getIfPresent(key)
+          Option(cleanupTerminatedAppInfoTrigger).foreach { trigger =>
+            trigger.asMap().asScala.foreach {
+              case (key, _) =>
+                // do get to trigger cache eviction
+                trigger.getIfPresent(key)
+            }
           }
         } catch {
           case NonFatal(e) => error("Failed to evict clean up terminated app cache", e)


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

As title.

Fix NPE, because the cleanupTerminatedAppInfoTrigger will be set to `null`.
https://github.com/apache/kyuubi/blob/d3520ddbcea96ec55c525600126047c44c7adb35/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala#L269

Also shutdown the ExecutorService when KubernetesApplicationOperation stoped. 
## Describe Your Solution 🔧

Shutdown the thread executor service and check the null.
## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
