### PR TITLE
Improve the compatibility of queryTimeout in more version clients

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/AbstractOperation.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/AbstractOperation.scala
@@ -62,7 +62,19 @@ abstract class AbstractOperation(session: Session) extends Operation with Loggin
     if (queryTimeout > 0) {
       val timeoutExecutor =
         ThreadUtils.newDaemonSingleThreadScheduledExecutor("query-timeout-thread", false)
-      val action: Runnable = () => cleanup(OperationState.TIMEOUT)
+      val action: Runnable = () =>
+        // Clients less than version 2.1 have no HIVE-4924 Patch,
+        // no queryTimeout parameter and no TIMEOUT status.
+        // When the server enables kyuubi.operation.query.timeout,
+        // this will cause the client of the lower version to get stuck.
+        // Check thrift protocol version <= HIVE_CLI_SERVICE_PROTOCOL_V8(Hive 2.1.0),
+        // convert TIMEDOUT_STATE to CANCELED.
+        if (getProtocolVersion.getValue <=
+            TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V8.getValue) {
+          cleanup(OperationState.CANCELED)
+        } else {
+          cleanup(OperationState.TIMEOUT)
+        }
       timeoutExecutor.schedule(action, queryTimeout, TimeUnit.SECONDS)
       statementTimeoutCleaner = Some(timeoutExecutor)
     }

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/AbstractOperation.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/AbstractOperation.scala
@@ -69,8 +69,7 @@ abstract class AbstractOperation(session: Session) extends Operation with Loggin
         // this will cause the client of the lower version to get stuck.
         // Check thrift protocol version <= HIVE_CLI_SERVICE_PROTOCOL_V8(Hive 2.1.0),
         // convert TIMEDOUT_STATE to CANCELED.
-        if (getProtocolVersion.getValue <=
-            TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V8.getValue) {
+        if (isHive21OrLower) {
           cleanup(OperationState.CANCELED)
         } else {
           cleanup(OperationState.TIMEOUT)
@@ -286,5 +285,9 @@ abstract class AbstractOperation(session: Session) extends Operation with Loggin
         case e: IOException => error(e.getMessage, e)
       }
     }
+  }
+
+  protected def isHive21OrLower: Boolean = {
+    getProtocolVersion.getValue <= TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V8.getValue
   }
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/ExecuteStatement.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/ExecuteStatement.scala
@@ -28,7 +28,7 @@ import org.apache.kyuubi.metrics.{MetricsConstants, MetricsSystem}
 import org.apache.kyuubi.operation.FetchOrientation.FETCH_NEXT
 import org.apache.kyuubi.operation.log.OperationLog
 import org.apache.kyuubi.session.Session
-import org.apache.kyuubi.shaded.hive.service.rpc.thrift.{TGetOperationStatusResp, TOperationState, TProtocolVersion}
+import org.apache.kyuubi.shaded.hive.service.rpc.thrift.{TGetOperationStatusResp, TOperationState}
 import org.apache.kyuubi.shaded.hive.service.rpc.thrift.TOperationState._
 
 class ExecuteStatement(
@@ -124,9 +124,7 @@ class ExecuteStatement(
               // this will cause the client of the lower version to get stuck.
               // Check thrift protocol version <= HIVE_CLI_SERVICE_PROTOCOL_V8(Hive 2.1.0),
               // convert TIMEDOUT_STATE to CANCELED.
-              if getProtocolVersion.getValue <=
-                TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V8.getValue =>
-            setState(OperationState.CANCELED)
+              if isHive21OrLower => setState(OperationState.CANCELED)
 
           case TIMEDOUT_STATE =>
             setState(OperationState.TIMEOUT)


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #2112

## Describe Your Solution 🔧

Similar to #2113, the query-timeout-thread should verify the Thrift protocol version. For protocol versions <= HIVE_CLI_SERVICE_PROTOCOL_V8, it should convert TIMEDOUT_STATE to CANCELED.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
