### PR TITLE
Fix check write for spark 3.5 unit tests

### DIFF
--- a/extensions/spark/kyuubi-extension-spark-3-5/src/test/scala/org/apache/spark/sql/KyuubiSparkSQLExtensionTest.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-5/src/test/scala/org/apache/spark/sql/KyuubiSparkSQLExtensionTest.scala
@@ -122,6 +122,8 @@ trait KyuubiSparkSQLExtensionTest extends QueryTest
         collectWrite(qe.executedPlan)
       }
     }
+    // Make sure the listener is registered after all previous events have been processed
+    sparkContext.listenerBus.waitUntilEmpty()
     spark.listenerManager.register(listener)
     try {
       df.collect()

--- a/extensions/spark/kyuubi-extension-spark-3-5/src/test/scala/org/apache/spark/sql/KyuubiSparkSQLExtensionTest.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-5/src/test/scala/org/apache/spark/sql/KyuubiSparkSQLExtensionTest.scala
@@ -111,15 +111,15 @@ trait KyuubiSparkSQLExtensionTest extends QueryTest
       override def onFailure(f: String, qe: QueryExecution, e: Exception): Unit = {}
 
       override def onSuccess(funcName: String, qe: QueryExecution, duration: Long): Unit = {
-        def doCallback(plan: SparkPlan): Unit = {
+        def collectWrite(plan: SparkPlan): Unit = {
           plan match {
             case write: DataWritingCommandExec =>
               writes.add(write.cmd)
-            case a: AdaptiveSparkPlanExec => doCallback(a.executedPlan)
+            case a: AdaptiveSparkPlanExec => collectWrite(a.executedPlan)
             case _ =>
           }
         }
-        doCallback(qe.executedPlan)
+        collectWrite(qe.executedPlan)
       }
     }
     spark.listenerManager.register(listener)


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

`KyuubiSparkSQLExtensionTest#withListener`  in Spark 3.5  may not work, make the following adjustments:
+ skip `AdaptiveSparkPlanExec` when collecting writes
+ execute `callback` function in main thread to avoid assert failed not working
+ add `collectRebalancePartitions` methoad
+ fix unit tests

## Describe Your Solution 🔧


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
