### PR TITLE
[K8S][HELM] Update default Kyuubi version to 1.10.0

### DIFF
--- a/charts/kyuubi/Chart.yaml
+++ b/charts/kyuubi/Chart.yaml
@@ -20,7 +20,7 @@ name: kyuubi
 description: A Helm chart for Kyuubi server
 type: application
 version: 0.1.0
-appVersion: 1.9.2
+appVersion: 1.10.0
 home: https://kyuubi.apache.org
 icon: https://raw.githubusercontent.com/apache/kyuubi/master/docs/imgs/logo.png
 sources:


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
Default Kyuubi version in the chart is not up to date with the latest release version.

## Describe Your Solution 🔧

Upgrade default version to the latest 1.10.0 to be up to date with the release version.


## Types of changes :bookmark:
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

Check the chart deploys Kyuubi 1.10.0

Install the chart:
```shell
helm install kyuubi charts/kyuubi
```
Check Kyuubi version:
```shell
kubectl exec kyuubi-0 -- cat /opt/kyuubi/RELEASE
Kyuubi 1.10.0 (git revision bfcd1f1) built for
Java 1.8.0_432
Scala 2.12
Flink 1.20.0
Spark 3.5.2
Kyuubi Hadoop 3.3.6
Hive 3.1.3
Build flags:
```

---

# Checklist 📝
- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)
