### PR TITLE
[K8S][HELM] Headless service renders ports for enabled protocols only

### DIFF
--- a/charts/kyuubi/templates/kyuubi-headless-service.yaml
+++ b/charts/kyuubi/templates/kyuubi-headless-service.yaml
@@ -26,9 +26,11 @@ spec:
   clusterIP: None
   ports:
     {{- range $name, $frontend := .Values.server }}
+    {{- if $frontend.enabled }}
     - name: {{ $name | kebabcase }}
       port: {{ tpl $frontend.service.port $ }}
       targetPort: {{ $frontend.port }}
+    {{- end }}
     {{- end }}
     {{- if and .Values.metrics.enabled (.Values.metrics.reporters | nospace | splitList "," | has "PROMETHEUS") }}
     - name: prometheus


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗

Headless service exposes ports for all protocols (enabled and disabled).

## Describe Your Solution 🔧

Add condition to render ports for enabled protocols only.

## Types of changes :bookmark:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

> Note: `thrift-binary` and `rest` protocols are enabled by default

#### Behavior Without This Pull Request :coffin:
```shell
helm template kyuubi charts/kyuubi -s templates/kyuubi-headless-service.yaml
---
# Source: kyuubi/templates/kyuubi-headless-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: kyuubi-headless
  labels:
    helm.sh/chart: kyuubi-0.1.0
    app.kubernetes.io/name: kyuubi
    app.kubernetes.io/instance: kyuubi
    app.kubernetes.io/version: "1.9.2"
    app.kubernetes.io/managed-by: Helm
spec:
  type: ClusterIP
  clusterIP: None
  ports:
    - name: mysql
      port: 3309
      targetPort: 3309
    - name: rest
      port: 10099
      targetPort: 10099
    - name: thrift-binary
      port: 10009
      targetPort: 10009
    - name: thrift-http
      port: 10010
      targetPort: 10010
    - name: prometheus
      port: 10019
      targetPort: prometheus
  selector:
    app.kubernetes.io/name: kyuubi
    app.kubernetes.io/instance: kyuubi
```

#### Behavior With This Pull Request :tada:
```shell
helm template kyuubi charts/kyuubi -s templates/kyuubi-headless-service.yaml
---
# Source: kyuubi/templates/kyuubi-headless-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: kyuubi-headless
  labels:
    helm.sh/chart: kyuubi-0.1.0
    app.kubernetes.io/name: kyuubi
    app.kubernetes.io/instance: kyuubi
    app.kubernetes.io/version: "1.9.2"
    app.kubernetes.io/managed-by: Helm
spec:
  type: ClusterIP
  clusterIP: None
  ports:
    - name: rest
      port: 10099
      targetPort: 10099
    - name: thrift-binary
      port: 10009
      targetPort: 10009
    - name: prometheus
      port: 10019
      targetPort: prometheus
  selector:
    app.kubernetes.io/name: kyuubi
    app.kubernetes.io/instance: kyuubi
```

---

# Checklist 📝

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

