### PR TITLE
[KYUUBI #6263] Use HiveConf.getConfVars or Hive conf names directly

### DIFF
--- a/extensions/spark/kyuubi-extension-spark-3-3/src/test/scala/org/apache/spark/sql/KyuubiSparkSQLExtensionTest.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-3/src/test/scala/org/apache/spark/sql/KyuubiSparkSQLExtensionTest.scala
@@ -86,7 +86,7 @@ trait KyuubiSparkSQLExtensionTest extends QueryTest
       .set("spark.hadoop.hive.exec.dynamic.partition.mode", "nonstrict")
       .set("spark.hadoop.hive.metastore.client.capability.check", "false")
       .set(
-        ConfVars.METASTORECONNECTURLKEY.varname,
+        "javax.jdo.option.ConnectionURL",
         s"jdbc:derby:;databaseName=$metastorePath;create=true")
       .set(StaticSQLConf.WAREHOUSE_PATH, warehousePath)
       .set("spark.ui.enabled", "false")

--- a/extensions/spark/kyuubi-extension-spark-3-4/src/test/scala/org/apache/spark/sql/KyuubiSparkSQLExtensionTest.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-4/src/test/scala/org/apache/spark/sql/KyuubiSparkSQLExtensionTest.scala
@@ -89,7 +89,7 @@ trait KyuubiSparkSQLExtensionTest extends QueryTest
       .set("spark.hadoop.hive.exec.dynamic.partition.mode", "nonstrict")
       .set("spark.hadoop.hive.metastore.client.capability.check", "false")
       .set(
-        ConfVars.METASTORECONNECTURLKEY.varname,
+        "javax.jdo.option.ConnectionURL",
         s"jdbc:derby:;databaseName=$metastorePath;create=true")
       .set(StaticSQLConf.WAREHOUSE_PATH, warehousePath)
       .set("spark.ui.enabled", "false")

--- a/extensions/spark/kyuubi-extension-spark-3-5/src/test/scala/org/apache/spark/sql/KyuubiSparkSQLExtensionTest.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-5/src/test/scala/org/apache/spark/sql/KyuubiSparkSQLExtensionTest.scala
@@ -89,7 +89,7 @@ trait KyuubiSparkSQLExtensionTest extends QueryTest
       .set("spark.hadoop.hive.exec.dynamic.partition.mode", "nonstrict")
       .set("spark.hadoop.hive.metastore.client.capability.check", "false")
       .set(
-        ConfVars.METASTORECONNECTURLKEY.varname,
+        "javax.jdo.option.ConnectionURL",
         s"jdbc:derby:;databaseName=$metastorePath;create=true")
       .set(StaticSQLConf.WAREHOUSE_PATH, warehousePath)
       .set("spark.ui.enabled", "false")

--- a/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/write/HiveBatchWrite.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/write/HiveBatchWrite.scala
@@ -126,10 +126,10 @@ class HiveBatchWrite(
 
     if (overwrite && table.tableType == CatalogTableType.EXTERNAL) {
       val numWrittenParts = writtenParts.size
-      val maxDynamicPartitionsKey = HiveConf.ConfVars.DYNAMICPARTITIONMAXPARTS.varname
+      val maxDynamicPartitionsKey = "hive.exec.dynamic.partition.max.partitions"
       val maxDynamicPartitions = hadoopConf.getInt(
         maxDynamicPartitionsKey,
-        HiveConf.ConfVars.DYNAMICPARTITIONMAXPARTS.defaultIntVal)
+        HiveConf.getInt("hive.exec.dynamic.partition.max.partitions"))
       if (numWrittenParts > maxDynamicPartitions) {
         throw KyuubiHiveConnectorException(
           s"Number of dynamic partitions created is $numWrittenParts, " +

--- a/extensions/spark/kyuubi-spark-lineage/src/test/scala/org/apache/spark/sql/SparkListenerExtensionTest.scala
+++ b/extensions/spark/kyuubi-spark-lineage/src/test/scala/org/apache/spark/sql/SparkListenerExtensionTest.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql
 
-import org.apache.hadoop.hive.conf.HiveConf.ConfVars
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.internal.StaticSQLConf
 import org.apache.spark.util.Utils
@@ -35,7 +34,7 @@ trait SparkListenerExtensionTest {
       .master("local")
       .config("spark.ui.enabled", "false")
       .config(
-        ConfVars.METASTORECONNECTURLKEY.varname,
+        "javax.jdo.option.ConnectionURL",
         s"jdbc:derby:;databaseName=$metastorePath;create=true")
       .config("spark.sql.catalogImplementation", catalogImpl)
       .config(StaticSQLConf.WAREHOUSE_PATH.key, warehousePath)

--- a/externals/kyuubi-hive-sql-engine/src/main/scala/org/apache/kyuubi/engine/hive/operation/HiveOperationManager.scala
+++ b/externals/kyuubi-hive-sql-engine/src/main/scala/org/apache/kyuubi/engine/hive/operation/HiveOperationManager.scala
@@ -19,7 +19,7 @@ package org.apache.kyuubi.engine.hive.operation
 
 import java.util.List
 
-import org.apache.hadoop.hive.conf.HiveConf.ConfVars
+import org.apache.hadoop.hive.conf.HiveConf
 
 import org.apache.kyuubi.config.KyuubiConf._
 import org.apache.kyuubi.engine.hive.session.HiveSessionImpl
@@ -162,6 +162,7 @@ class HiveOperationManager() extends OperationManager("HiveOperationManager") {
   override def getQueryId(operation: Operation): String = {
     val hiveOperation = operation.asInstanceOf[HiveOperation]
     val internalHiveOperation = hiveOperation.internalHiveOperation
-    internalHiveOperation.getParentSession.getHiveConf.getVar(ConfVars.HIVEQUERYID)
+    internalHiveOperation.getParentSession.getHiveConf.getVar(
+      HiveConf.getConfVars("hive.query.id"))
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->
As initial step to bring hive 4 compatibility in Kyuubi, has addressed the following incompatible changes on ConfVars enum via HIVE-27925.
https://github.com/apache/hive/pull/4919
https://github.com/apache/hive/pull/5107
HiveConf.getConfVars or config names is more robust way to handle this incompatibility.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Build locally and CI


### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
