### PR TITLE
[KYUUBI #6830] Allow indicate advisory shuffle partition size when me…

### DIFF
--- a/extensions/spark/kyuubi-extension-spark-3-5/src/main/scala/org/apache/kyuubi/sql/KyuubiSQLConf.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-5/src/main/scala/org/apache/kyuubi/sql/KyuubiSQLConf.scala
@@ -103,6 +103,14 @@ object KyuubiSQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val REBALANCE_ADVISORY_PARTITION_SIZE_IN_BYTES =
+    buildConf("spark.sql.optimizer.rebalanceAdvisoryPartitionSize")
+      .doc("The advisory size in bytes of the shuffle partition during merge small files. " +
+        s"It takes effect when Spark coalesces small shuffle partitions or splits skewed " +
+        s"shuffle partition.")
+      .version("1.10.1")
+      .fallbackConf(ADVISORY_PARTITION_SIZE_IN_BYTES)
+
   val WATCHDOG_MAX_PARTITIONS =
     buildConf("spark.sql.watchdog.maxPartitions")
       .doc("Set the max partition number when spark scans a data source. " +

--- a/extensions/spark/kyuubi-extension-spark-3-5/src/main/scala/org/apache/kyuubi/sql/RebalanceBeforeWriting.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-5/src/main/scala/org/apache/kyuubi/sql/RebalanceBeforeWriting.scala
@@ -27,7 +27,8 @@ trait RepartitionBuilderWithRebalance extends RepartitionBuilder {
       query: LogicalPlan): LogicalPlan = {
     if (!conf.getConf(KyuubiSQLConf.INFER_REBALANCE_AND_SORT_ORDERS) ||
       dynamicPartitionColumns.nonEmpty) {
-      RebalancePartitions(dynamicPartitionColumns, query)
+      val adviceBytes = conf.getConf(KyuubiSQLConf.REBALANCE_ADVISORY_PARTITION_SIZE_IN_BYTES)
+      RebalancePartitions(dynamicPartitionColumns, query, None, Option.apply(adviceBytes))
     } else {
       val maxColumns = conf.getConf(KyuubiSQLConf.INFER_REBALANCE_AND_SORT_ORDERS_MAX_COLUMNS)
       val inferred = InferRebalanceAndSortOrders.infer(query)


### PR DESCRIPTION
### Why are the changes needed?
when merging small files(set `spark.sql.optimizer.insertRepartitionBeforeWrite.enabled`=true) , the default session advisory partition size (64MB) will be used as target. This default value can still lead to small files because the written data can be compressed nicely using columnar file formats (usually 1/4 or smaller of the shuffle exchange size, the result is often around 15MB).

Spark now support configuring the rebalance expression advisory size in https://github.com/apache/spark/pull/40421 . So we can have a configuration that can configure the merge size separately.


### Was this patch authored or co-authored using generative AI tooling?
no
