### PR TITLE
[INFRA] Disable K8s CI image GHA cache

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -420,6 +420,8 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          cache-binary: false
       - name: Build Kyuubi Docker Image
         uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->

The GHA cache `engine-archives` seems frequently to be evicted because of exceeding the project cache capacity(10GiB), and I found the K8s IT job produces fresh large cache objects frequently, we should disable that to let `engine-archives` survive, to avoid downloading from the fragile `archive.apache.org` each time.

```
Connect to archive.apache.org:443 [archive.apache.org/65.108.204.189, archive.apache.org/2a01:4f9:1a:a084:0:0:0:2] failed: Network is unreachable (connect failed)
```

<img width="1306" alt="Xnip2024-12-04_17-36-03" src="https://github.com/user-attachments/assets/7e00ecad-8492-4a3e-b669-03b56a05747c">

PS: I deleted bunches of `buildkit-blob-*` manually to save `engine-archives`

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Monitor GHA after merging.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.
