### PR TITLE
Fix PodMonitor pods selection

### DIFF
--- a/charts/kyuubi/templates/kyuubi-podmonitor.yaml
+++ b/charts/kyuubi/templates/kyuubi-podmonitor.yaml
@@ -25,7 +25,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: {{ .Release.Name }}
+      {{- include "kyuubi.selectorLabels" . | nindent 6 }}
   podMetricsEndpoints:
     {{- toYaml .Values.metrics.podMonitor.podMetricsEndpoints | nindent 4 }}
 {{- end }}

--- a/charts/kyuubi/values.yaml
+++ b/charts/kyuubi/values.yaml
@@ -282,6 +282,9 @@ metrics:
     enabled: false
     # List of pod endpoints serving metrics to be scraped by Prometheus, see Prometheus Operator docs for more details
     podMetricsEndpoints: []
+    #  podMetricsEndpoints：
+    #    - path: /metrics
+    #      port: prometheus
 
   # ServiceMonitor by Prometheus Operator
   serviceMonitor:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->
I am using the podminitor of kyuubi metrics, But I found using the podmonitor's selector.matchLabels can not select correct pods . So I fix it . 

I also changed the values.yaml to add an example of podmonitor to improve the usability.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
```
helm install kyuubi .
# kubectl get podmonitor kyuubi -oyaml
apiVersion: monitoring.coreos.com/v1
kind: PodMonitor
metadata:
  annotations:
    meta.helm.sh/release-name: kyuubi
    meta.helm.sh/release-namespace: default
  creationTimestamp: "2024-12-06T07:46:12Z"
  generation: 1
  labels:
    app.kubernetes.io/instance: kyuubi
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: kyuubi
    app.kubernetes.io/version: 1.8.0
    helm.sh/chart: kyuubi-0.1.0
  name: kyuubi
  namespace: default
  resourceVersion: "7583800"
  uid: 0dd11e43-d126-434e-988a-7f1914586e2b
spec:
  podMetricsEndpoints:
  - path: /metrics
    port: prometheus
  selector:
    matchLabels:
      app.kubernetes.io/instance: kyuubi
      app.kubernetes.io/name: kyuubi
# kubectl get po -l app.kubernetes.io/instance=kyuubi
NAME       READY   STATUS    RESTARTS   AGE
kyuubi-0   1/1     Running   0          24m
kyuubi-1   1/1     Running   0          22m
# kubectl get po -l  app.kubernetes.io/name=kyuubi
NAME       READY   STATUS    RESTARTS   AGE
kyuubi-0   1/1     Running   0          24m
kyuubi-1   1/1     Running   0          23m
```
### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
