### PR TITLE
Support additional labels for PodMonitor to be discovered by Prometheus

### DIFF
--- a/charts/kyuubi/templates/kyuubi-podmonitor.yaml
+++ b/charts/kyuubi/templates/kyuubi-podmonitor.yaml
@@ -22,6 +22,9 @@ metadata:
   name: {{ .Release.Name }}
   labels:
     {{- include "kyuubi.labels" . | nindent 4 }}
+    {{- if .Values.metrics.podMonitor.labels }}
+    {{- toYaml .Values.metrics.podMonitor.labels | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/kyuubi/values.yaml
+++ b/charts/kyuubi/values.yaml
@@ -285,6 +285,8 @@ metrics:
     #  podMetricsEndpoints：
     #    - path: /metrics
     #      port: prometheus
+    # Additional labels to be used to make podMonitor discovered by Prometheus
+    labels: {}
 
   # ServiceMonitor by Prometheus Operator
   serviceMonitor:

--- a/charts/kyuubi/values.yaml
+++ b/charts/kyuubi/values.yaml
@@ -285,7 +285,7 @@ metrics:
     #  podMetricsEndpoints：
     #    - path: /metrics
     #      port: prometheus
-    # Additional labels to be used to make podMonitor discovered by Prometheus
+    # Additional labels for PodMonitor to be discovered by Prometheus
     labels: {}
 
   # ServiceMonitor by Prometheus Operator


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
the prometheus can not discover the podMonitor created by kyuubi helm chart. 


### How was this patch tested?
1. enable pod monitor:
```
metrics:
  # Enable metrics system, used for 'kyuubi.metrics.enabled' property
  enabled: true
  # A comma-separated list of metrics reporters, used for 'kyuubi.metrics.reporters' property
  reporters: PROMETHEUS
  # Prometheus port, used for 'kyuubi.metrics.prometheus.port' property
  prometheusPort: 10019

  # PodMonitor by Prometheus Operator
  podMonitor:
    # Enable PodMonitor creation
    enabled: true
    # List of pod endpoints serving metrics to be scraped by Prometheus, see Prometheus Operator docs for more details
    #podMetricsEndpoints: []
    podMetricsEndpoints:
      - path: /metrics
        port: prometheus
```
2. Helm install kyuubi .
3. check prometheus web ui.

### Was this patch authored or co-authored using generative AI tooling?
No

