### PR TITLE
[KYUUBI #6864][FOLLOWUP] Support to apply instance with existing labels

### DIFF
--- a/kyuubi-metrics/src/main/scala/org/apache/kyuubi/metrics/PrometheusReporterService.scala
+++ b/kyuubi-metrics/src/main/scala/org/apache/kyuubi/metrics/PrometheusReporterService.scala
@@ -140,20 +140,35 @@ class PrometheusReporterService(registry: MetricRegistry)
     val metricsSnapshotWriter = new java.io.StringWriter
     val contentType = TextFormat.chooseContentType(null)
     TextFormat.writeFormat(contentType, metricsSnapshotWriter, bridgeRegistry.metricFamilySamples())
-    val labelStr = labelString(labels)
     metricsSnapshotWriter.toString.split("\n").map { line =>
       if (line.startsWith("#")) {
         line
       } else {
         line.split("\\s+", 2) match {
-          case Array(metrics, rest) => s"""$metrics${labelStr} $rest"""
+          case Array(metrics, rest) =>
+            val metricsWithNewLabels = PrometheusReporterService.applyExtraLabels(metrics, labels)
+            s"""$metricsWithNewLabels $rest"""
           case _ => line
         }
       }
     }.mkString("\n")
   }
+}
 
-  private def labelString(labels: Map[String, String]): String = {
-    labels.map { case (k, v) => s"""$k="$v"""" }.toArray.sorted.mkString("{", ",", "}")
+object PrometheusReporterService {
+  def applyExtraLabels(metrics: String, labels: Map[String, String]): String = {
+    if (labels.isEmpty) return metrics
+
+    val labelString = labels.map { case (k, v) => s"""$k="$v"""" }.toArray.sorted.mkString(",")
+    val labelStartIdx = metrics.indexOf("{")
+    val labelEndIdx = metrics.indexOf("}")
+    if (labelStartIdx > 0 && labelEndIdx > 0) {
+      metrics.substring(0, labelEndIdx).stripSuffix(",") +
+        "," +
+        labelString +
+        metrics.substring(labelEndIdx)
+    } else {
+      s"$metrics{${labelString}}"
+    }
   }
 }

--- a/kyuubi-metrics/src/test/scala/org/apache/kyuubi/metrics/PrometheusReporterServiceSuite.scala
+++ b/kyuubi-metrics/src/test/scala/org/apache/kyuubi/metrics/PrometheusReporterServiceSuite.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.metrics
+
+import org.apache.kyuubi.KyuubiFunSuite
+
+class PrometheusReporterServiceSuite extends KyuubiFunSuite {
+  test("apply extra labels on metrics") {
+    val labels = Map("instance" -> "kyuubi-0")
+    val labelStr = labels.map { case (k, v) => s"""$k="$v"""" }.toArray.sorted.mkString(",")
+    val metrics1 = "kyuubi_backend_service_close_operation{quantile=\"0.5\",}"
+    assert(PrometheusReporterService.applyExtraLabels(metrics1, labelStr) ==
+      "kyuubi_backend_service_close_operation{quantile=\"0.5\",instance=\"kyuubi-0\"}")
+    val metrics2 = "kyuubi_backend_service_close_operation"
+    assert(PrometheusReporterService.applyExtraLabels(metrics2, labelStr) ==
+      "kyuubi_backend_service_close_operation{instance=\"kyuubi-0\"}")
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->
For histogram and timer metrics, it already has label, so need to support apply the instance label with existing ones.

For example:
```
# HELP kyuubi_backend_service_close_operation Generated from Dropwizard metric import (metric=kyuubi.backend_service.close_operation, type=com.codahale.metrics.Timer)
# TYPE kyuubi_backend_service_close_operation summary
kyuubi_backend_service_close_operation{quantile="0.5",}{instance="hadoopkyuubi-1.hadoopkyuubihl.hadoopmaster-dev.svc.140.tess.io:10019"} 0.032923216000000005
```

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

UT.
### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.