### PR TITLE
[KYUUBI #6869]Fix  Beeline SQL querying cannot be stopped immediately by pressing Ctrl-C.

### DIFF
--- a/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/BeeLineOpts.java
+++ b/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/BeeLineOpts.java
@@ -115,6 +115,8 @@ class BeeLineOpts implements Completer {
 
   private String delimiter = DEFAULT_DELIMITER;
 
+  private boolean cancelImmediate = false;
+
   @Retention(RetentionPolicy.RUNTIME)
   public @interface Ignore {
     // marker annotations for functions that Reflector should ignore / pretend it does not exist
@@ -647,5 +649,13 @@ class BeeLineOpts implements Completer {
   @Ignore
   public static void setEnv(Env envToUse) {
     env = envToUse;
+  }
+
+  public boolean getCancelImmediate() {
+    return cancelImmediate;
+  }
+
+  public void setCancelImmediate(boolean cancelImmediate) {
+    this.cancelImmediate = cancelImmediate;
   }
 }

--- a/kyuubi-hive-beeline/src/main/resources/BeeLine.properties
+++ b/kyuubi-hive-beeline/src/main/resources/BeeLine.properties
@@ -204,6 +204,12 @@ Options:\n\
 \                                  Only applicable if --outputformat=table.\n\n\
 \  --incrementalBufferRows=NUMROWS The number of rows to buffer when printing rows on stdout,\n\
 \                                  defaults to 1000; only applicable if --incremental=true\n\
+\  --cancelImmediate=[true|false]  Defaults to false.When set to false, canceling by Ctrl-C will wait \n\
+\                                  until buffer rows is full.There is two sisititon to set it true; \n\
+\                                  Sitisiton 1: incrementalBufferRows is too large but you want to cancel job \n\
+\                                  immediate.\n\
+\                                  Sitisiton 2: Runing flink sql streaming (you do not want to wait \n\
+\                                  until `kyuubi.session.engine.flink.max.rows` is reached.).\n\
 \                                  and --outputformat=table.\n\n\
 \  --truncateTable=[true|false]    Truncate table column when it exceeds length.\n\
 \  --delimiterForDSV=DELIMITER     Specify the delimiter for delimiter-separated values output format (default: |).\n\

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiStatement.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiStatement.java
@@ -861,4 +861,8 @@ public class KyuubiStatement implements SQLStatement, KyuubiLoggable {
       resultSet = null;
     }
   }
+
+  public boolean getIsCancelled() {
+    return isCancelled;
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->
# :mag: Description
## Issue References 🔗

This pull request fixes #6869

## Describe Your Solution 🔧

Expose isCancelled in KyuubiStatement ;And expose beeline cancelImmediate for user.  

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
This PR should recover CI and include negative and positive cases ;

### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No