### PR TITLE
Fix get existing gauge issue

### DIFF
--- a/kyuubi-metrics/src/main/scala/org/apache/kyuubi/metrics/MetricsSystem.scala
+++ b/kyuubi-metrics/src/main/scala/org/apache/kyuubi/metrics/MetricsSystem.scala
@@ -20,6 +20,8 @@ package org.apache.kyuubi.metrics
 import java.lang.management.ManagementFactory
 import java.util.concurrent.TimeUnit
 
+import scala.collection.JavaConverters._
+
 import com.codahale.metrics.{Gauge, MetricRegistry, Snapshot}
 import com.codahale.metrics.jvm._
 
@@ -58,8 +60,8 @@ class MetricsSystem extends CompositeService("MetricsSystem") {
     meter.mark(value)
   }
 
-  def getGauge[T](name: String): Option[Gauge[T]] = {
-    Option(registry.gauge(name))
+  def getGauge(name: String): Option[Gauge[_]] = {
+    registry.getGauges((metricsName, _) => { metricsName == name }).asScala.map(_._2).headOption
   }
 
   def registerGauge[T](name: String, value: => T, default: T): Unit = {

--- a/kyuubi-metrics/src/main/scala/org/apache/kyuubi/metrics/MetricsSystem.scala
+++ b/kyuubi-metrics/src/main/scala/org/apache/kyuubi/metrics/MetricsSystem.scala
@@ -20,8 +20,6 @@ package org.apache.kyuubi.metrics
 import java.lang.management.ManagementFactory
 import java.util.concurrent.TimeUnit
 
-import scala.collection.JavaConverters._
-
 import com.codahale.metrics.{Gauge, MetricRegistry, Snapshot}
 import com.codahale.metrics.jvm._
 
@@ -61,7 +59,7 @@ class MetricsSystem extends CompositeService("MetricsSystem") {
   }
 
   def getGauge(name: String): Option[Gauge[_]] = {
-    registry.getGauges((metricsName, _) => { metricsName == name }).asScala.map(_._2).headOption
+    Option(registry.getGauges().get(name))
   }
 
   def registerGauge[T](name: String, value: => T, default: T): Unit = {

--- a/kyuubi-metrics/src/test/scala/org/apache/kyuubi/metrics/MetricsSystemSuite.scala
+++ b/kyuubi-metrics/src/test/scala/org/apache/kyuubi/metrics/MetricsSystemSuite.scala
@@ -96,13 +96,7 @@ class MetricsSystemSuite extends KyuubiFunSuite {
   }
 
   test("metrics - get gauge") {
-    val testContextPath = "/prometheus-metrics"
-
-    val conf = KyuubiConf()
-      .set(MetricsConf.METRICS_ENABLED, true)
-      .set(MetricsConf.METRICS_REPORTERS, Set(ReporterType.PROMETHEUS.toString))
-      .set(MetricsConf.METRICS_PROMETHEUS_PORT, 0) // random port
-      .set(MetricsConf.METRICS_PROMETHEUS_PATH, testContextPath)
+    val conf = KyuubiConf().set(MetricsConf.METRICS_ENABLED, true)
     val metricsSystem = new MetricsSystem()
     metricsSystem.initialize(conf)
     metricsSystem.start()
@@ -110,9 +104,9 @@ class MetricsSystemSuite extends KyuubiFunSuite {
     assert(metricsSystem.getGauge(MetricsConstants.THRIFT_SSL_CERT_EXPIRATION).isEmpty)
     metricsSystem.registerGauge(
       MetricsConstants.THRIFT_SSL_CERT_EXPIRATION,
-      () => System.currentTimeMillis(),
+      1000,
       0)
-    assert(metricsSystem.getGauge(MetricsConstants.THRIFT_SSL_CERT_EXPIRATION).isDefined)
+    assert(metricsSystem.getGauge(MetricsConstants.THRIFT_SSL_CERT_EXPIRATION).get.getValue == 1000)
 
     metricsSystem.stop()
   }

--- a/kyuubi-metrics/src/test/scala/org/apache/kyuubi/metrics/MetricsSystemSuite.scala
+++ b/kyuubi-metrics/src/test/scala/org/apache/kyuubi/metrics/MetricsSystemSuite.scala
@@ -94,4 +94,26 @@ class MetricsSystemSuite extends KyuubiFunSuite {
     checkJsonFileMetrics(reportFile, "20181117")
     metricsSystem.stop()
   }
+
+  test("metrics - get gauge") {
+    val testContextPath = "/prometheus-metrics"
+
+    val conf = KyuubiConf()
+      .set(MetricsConf.METRICS_ENABLED, true)
+      .set(MetricsConf.METRICS_REPORTERS, Set(ReporterType.PROMETHEUS.toString))
+      .set(MetricsConf.METRICS_PROMETHEUS_PORT, 0) // random port
+      .set(MetricsConf.METRICS_PROMETHEUS_PATH, testContextPath)
+    val metricsSystem = new MetricsSystem()
+    metricsSystem.initialize(conf)
+    metricsSystem.start()
+
+    assert(metricsSystem.getGauge(MetricsConstants.THRIFT_SSL_CERT_EXPIRATION).isEmpty)
+    metricsSystem.registerGauge(
+      MetricsConstants.THRIFT_SSL_CERT_EXPIRATION,
+      () => System.currentTimeMillis(),
+      0)
+    assert(metricsSystem.getGauge(MetricsConstants.THRIFT_SSL_CERT_EXPIRATION).isDefined)
+
+    metricsSystem.stop()
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->

For the `com.codahale.metrics.MetricRegistry::gauge`.
It `getOrAdd` the gauge with name.
```
    public <T extends Gauge> T gauge(String name) {
        return (Gauge)this.getOrAdd(name, MetricRegistry.MetricBuilder.GAUGES);
    }
```

So we have to get all the gauges to check whether the gauge exists.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

UT.
### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.
