### PR TITLE
[KYUUBI #6901] Default policy for spark

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/resources/service-defs/ranger-servicedef-spark.json
+++ b/extensions/spark/kyuubi-spark-authz/src/main/resources/service-defs/ranger-servicedef-spark.json
@@ -1,0 +1,464 @@
+{
+	"id":3,
+	"name": "hive",
+	"displayName": "Hadoop SQL",
+	"implClass": "org.apache.ranger.services.hive.RangerServiceHive",
+	"label": "Hive Server2",
+	"description": "Hive Server2",
+	"guid": "3e1afb5a-184a-4e82-9d9c-87a5cacc243c",
+	"resources": 
+	[
+		{
+			"itemId": 1,
+			"name": "database",
+			"type": "string",
+			"level": 10,
+			"parent": "",
+			"mandatory": true,
+			"lookupSupported": true,
+			"recursiveSupported": false,
+			"excludesSupported": true,
+			"matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+			"matcherOptions": { "wildCard":true, "ignoreCase":true },
+			"validationRegEx":"",
+			"validationMessage": "",
+			"uiHint":"",
+			"label": "Hive Database",
+			"description": "Hive Database",
+			"isValidLeaf": true
+		},
+
+		{
+			"itemId": 2,
+			"name": "table",
+			"type": "string",
+			"level": 20,
+			"parent": "database",
+			"mandatory": true,
+			"lookupSupported": true,
+			"recursiveSupported": false,
+			"excludesSupported": true,
+			"matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+			"matcherOptions": { "wildCard":true, "ignoreCase":true },
+			"validationRegEx":"",
+			"validationMessage": "",
+			"uiHint":"",
+			"label": "Hive Table",
+			"description": "Hive Table",
+			"isValidLeaf": true
+		},
+
+		{
+			"itemId": 3,
+			"name": "udf",
+			"type": "string",
+			"level": 20,
+			"parent": "database",
+			"mandatory": true,
+			"lookupSupported": true,
+			"recursiveSupported": false,
+			"excludesSupported": true,
+			"matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+			"matcherOptions": { "wildCard":true, "ignoreCase":true },
+			"validationRegEx":"",
+			"validationMessage": "",
+			"uiHint":"",
+			"label": "Hive UDF",
+			"description": "Hive UDF"
+		},
+
+		{
+			"itemId": 4,
+			"name": "column",
+			"type": "string",
+			"level": 30,
+			"parent": "table",
+			"mandatory": true,
+			"lookupSupported": true,
+			"recursiveSupported": false,
+			"excludesSupported": true,
+			"matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+			"matcherOptions": { "wildCard":true, "ignoreCase":true },
+			"validationRegEx":"",
+			"validationMessage": "",
+			"uiHint":"",
+			"label": "Hive Column",
+			"description": "Hive Column"
+		},
+
+		{
+			"itemId": 5,
+			"name": "url",
+			"type": "string",
+			"level": 10,
+			"parent": "",
+			"mandatory": true,
+			"lookupSupported": false,
+			"recursiveSupported": true,
+			"excludesSupported": false,
+			"matcher": "org.apache.ranger.plugin.resourcematcher.RangerURLResourceMatcher",
+			"matcherOptions": { "wildCard":true, "ignoreCase":false },
+			"validationRegEx":"",
+			"validationMessage": "",
+			"uiHint":"",
+			"label": "URL",
+			"description": "URL"
+		},
+
+		{
+			"itemId": 6,
+			"name": "hiveservice",
+			"type": "string",
+			"level": 10,
+			"parent": "",
+			"mandatory": true,
+			"lookupSupported": false,
+			"recursiveSupported": false,
+			"excludesSupported": false,
+			"matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+			"matcherOptions": { "wildCard":true, "ignoreCase":false },
+			"validationRegEx":"",
+			"validationMessage": "",
+			"uiHint":"",
+			"label": "Hive Service",
+			"description": "Hive Service"
+		},
+		{
+			"itemId": 7,
+			"name": "global",
+			"type": "string",
+			"level": 10,
+			"parent": "",
+			"mandatory": true,
+			"lookupSupported": false,
+			"recursiveSupported": false,
+			"excludesSupported": false,
+			"matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+			"matcherOptions": {
+				"wildCard": true,
+				"ignoreCase": false
+			},
+			"validationRegEx": "",
+			"validationMessage": "",
+			"uiHint": "",
+			"label": "Global",
+			"description": "Global"
+		}
+	],
+
+	"accessTypes": 
+	[
+		{
+			"itemId": 1,
+			"name": "select",
+			"label": "select",
+			"category": "READ"
+		},
+
+		{
+			"itemId": 2,
+			"name": "update",
+			"label": "update",
+			"category": "UPDATE"
+		},
+
+		{
+			"itemId": 3,
+			"name": "create",
+			"label": "Create",
+			"category": "CREATE"
+		},
+
+		{
+			"itemId": 4,
+			"name": "drop",
+			"label": "Drop",
+			"category": "DELETE"
+		},
+
+		{
+			"itemId": 5,
+			"name": "alter",
+			"label": "Alter",
+			"category": "CREATE"
+		},
+
+		{
+			"itemId": 6,
+			"name": "index",
+			"label": "Index",
+			"category": "MANAGE"
+		},
+
+		{
+			"itemId": 7,
+			"name": "lock",
+			"label": "Lock",
+			"category": "MANAGE"
+		},
+
+		{
+			"itemId": 8,
+			"name": "all",
+			"label": "All",
+			"impliedGrants":
+			[
+				"select",
+				"update",
+				"create",
+				"drop",
+				"alter",
+				"index",
+				"lock",
+				"read",
+				"write",
+				"repladmin",
+				"serviceadmin",
+				"refresh"
+			]
+		},
+
+		{
+			"itemId": 9,
+			"name": "read",
+			"label": "Read",
+			"category": "READ"
+		},
+
+		{
+			"itemId": 10,
+			"name": "write",
+			"label": "Write",
+			"category": "UPDATE"
+		},
+
+		{
+			"itemId": 11,
+			"name": "repladmin",
+			"label": "ReplAdmin",
+			"category": "MANAGE"
+		},
+
+		{
+			"itemId": 12,
+			"name": "serviceadmin",
+			"label": "Service Admin",
+			"category": "MANAGE"
+		},
+
+		{
+			"itemId": 13,
+			"name": "tempudfadmin",
+			"label": "Temporary UDF Admin",
+			"category": "MANAGE"
+		},
+
+		{
+			"itemId": 14,
+			"name": "refresh",
+			"label": "Refresh",
+			"category": "MANAGE"
+		}
+	],
+
+	"configs": 
+	[
+		{
+			"itemId": 1,
+			"name": "username",
+			"type": "string",
+			"mandatory": true,
+			"validationRegEx":"",
+			"validationMessage": "",
+			"uiHint":"",
+			"label": "Username"
+		},
+
+		{
+			"itemId": 2,
+			"name": "password",
+			"type": "password",
+			"mandatory": true,
+			"validationRegEx":"",
+			"validationMessage": "",
+			"uiHint":"",
+			"label": "Password"
+		},
+
+		{
+			"itemId": 3,
+			"name": "jdbc.driverClassName",
+			"type": "string",
+			"mandatory": true,
+			"validationRegEx":"",
+			"validationMessage": "",
+			"uiHint":"",
+			"defaultValue": "org.apache.hive.jdbc.HiveDriver"
+		},
+
+		{
+			"itemId": 4,
+			"name": "jdbc.url",
+			"type": "string",
+			"mandatory": true,
+			"defaultValue": "",
+			"validationRegEx":"",
+			"validationMessage": "",
+			"uiHint":"{\"TextFieldWithIcon\":true, \"info\": \"1.For Remote Mode, eg.<br>jdbc:hive2://&lt;host&gt;:&lt;port&gt;<br>2.For Embedded Mode (no host or port), eg.<br>jdbc:hive2:///;initFile=&lt;file&gt;<br>3.For HTTP Mode, eg.<br>jdbc:hive2://&lt;host&gt;:&lt;port&gt;/;<br>transportMode=http;httpPath=&lt;httpPath&gt;<br>4.For SSL Mode, eg.<br>jdbc:hive2://&lt;host&gt;:&lt;port&gt;/;ssl=true;<br>sslTrustStore=tStore;trustStorePassword=pw<br>5.For ZooKeeper Mode, eg.<br>jdbc:hive2://&lt;host&gt;/;serviceDiscoveryMode=<br>zooKeeper;zooKeeperNamespace=hiveserver2<br>6.For Kerberos Mode, eg.<br>jdbc:hive2://&lt;host&gt;:&lt;port&gt;/;<br>principal=hive/domain@EXAMPLE.COM<br>\"}"
+		},
+
+		{
+			"itemId": 5,
+			"name": "commonNameForCertificate",
+			"type": "string",
+			"mandatory": false,
+			"validationRegEx":"",
+			"validationMessage": "",
+			"uiHint":"",
+			"label": "Common Name for Certificate"
+		},
+
+		{
+			"itemId": 6,
+			"name": "ranger.plugin.audit.filters",
+			"type": "string",
+			"subType": "",
+			"mandatory": false,
+			"validationRegEx":"",
+			"validationMessage": "",
+			"uiHint":"",
+			"label": "Ranger Default Audit Filters",
+			"defaultValue": "[ {'accessResult': 'DENIED', 'isAudited': true}, {'actions':['METADATA OPERATION'], 'isAudited': false}, {'users':['hive','hue'],'actions':['SHOW_ROLES'],'isAudited':false} ]"
+		}
+	],
+
+	"enums": 
+	[
+		
+	],
+
+	"contextEnrichers": 
+	[
+	],
+
+	"policyConditions": 
+	[
+	],
+	"dataMaskDef": {
+		"accessTypes": [
+			{
+				"name": "select"
+			}
+		],
+		"resources": [
+			{
+				"name": "database",
+				"matcherOptions": {
+					"wildCard": "false"
+				},
+				"lookupSupported": true,
+				"uiHint":"{ \"singleValue\":true }"
+			},
+			{
+				"name": "table",
+				"matcherOptions": {
+					"wildCard": "false"
+				},
+				"lookupSupported": true,
+				"uiHint":"{ \"singleValue\":true }"
+			},
+			{
+				"name": "column",
+				"matcherOptions": {
+					"wildCard": "false"
+				},
+				"lookupSupported": true,
+				"uiHint":"{ \"singleValue\":true }"
+			}
+		],
+		"maskTypes": [
+			{
+				"itemId": 1,
+				"name": "MASK",
+				"label": "Redact",
+				"description": "Replace lowercase with 'x', uppercase with 'X', digits with '0'",
+				"transformer": "mask({col})",
+				"dataMaskOptions": {
+				}
+			},
+			{
+				"itemId": 2,
+				"name": "MASK_SHOW_LAST_4",
+				"label": "Partial mask: show last 4",
+				"description": "Show last 4 characters; replace rest with 'x'",
+				"transformer": "mask_show_last_n({col}, 4, 'x', 'x', 'x', -1, '1')"
+			},
+			{
+				"itemId": 3,
+				"name": "MASK_SHOW_FIRST_4",
+				"label": "Partial mask: show first 4",
+				"description": "Show first 4 characters; replace rest with 'x'",
+				"transformer": "mask_show_first_n({col}, 4, 'x', 'x', 'x', -1, '1')"
+			},
+			{
+				"itemId": 4,
+				"name": "MASK_HASH",
+				"label": "Hash",
+				"description": "Hash the value",
+				"transformer": "mask_hash({col})"
+			},
+			{
+				"itemId": 5,
+				"name": "MASK_NULL",
+				"label": "Nullify",
+				"description": "Replace with NULL"
+			},
+			{
+				"itemId": 6,
+				"name": "MASK_NONE",
+				"label": "Unmasked (retain original value)",
+				"description": "No masking"
+			},
+			{
+				"itemId": 12,
+				"name": "MASK_DATE_SHOW_YEAR",
+				"label": "Date: show only year",
+				"description": "Date: show only year",
+				"transformer": "mask({col}, 'x', 'x', 'x', -1, '1', 1, 0, -1)"
+			},
+			{
+				"itemId": 13,
+				"name": "CUSTOM",
+				"label": "Custom",
+				"description": "Custom"
+			}
+		]
+	},
+	"rowFilterDef": {
+		"accessTypes": [
+			{
+				"name": "select"
+			}
+		],
+		"resources": [
+			{
+				"name": "database",
+				"matcherOptions": {
+					"wildCard": "false"
+				},
+				"lookupSupported": true,
+				"mandatory": true,
+				"uiHint": "{ \"singleValue\":true }"
+			},
+			{
+				"name": "table",
+				"matcherOptions": {
+					"wildCard": "false"
+				},
+				"lookupSupported": true,
+				"mandatory": true,
+				"uiHint": "{ \"singleValue\":true }"
+			}
+		]
+	}
+}


### PR DESCRIPTION
### Why are the changes needed?
Added a service definition for spark which in turn enables the creation of a default policy for the spark service.
Default policy will block access until another policy is downloaded from Apache Ranger.

### How was this patch tested?
Tested manually.
Configure Kyuubi Authz plugin. Do not start Apache Ranger, it must not be reachable.
Make sure that policy cache is empty.
Start Kyuubi engine and try to query any tables. The default policy should not allow any access.
Previously the access was not restricted because there wasn't a default policy defined.

### Was this patch authored or co-authored using generative AI tooling?
No.