### PR TITLE
[KYUUBI #6905] PyHive HTTP/HTTPS dialect to use the database name from url

### DIFF
--- a/python/pyhive/sqlalchemy_hive.py
+++ b/python/pyhive/sqlalchemy_hive.py
@@ -421,6 +421,7 @@ class HiveHTTPDialect(HiveDialect):
             "scheme": self.scheme,
             "username": url.username or None,
             "password": url.password or None,
+            'database': url.database or 'default',
         }
         if url.query:
             kwargs.update(url.query)

--- a/python/pyhive/sqlalchemy_hive.py
+++ b/python/pyhive/sqlalchemy_hive.py
@@ -421,7 +421,7 @@ class HiveHTTPDialect(HiveDialect):
             "scheme": self.scheme,
             "username": url.username or None,
             "password": url.password or None,
-            'database': url.database or 'default',
+            "database": url.database or "default",
         }
         if url.query:
             kwargs.update(url.query)


### PR DESCRIPTION
### Why are the changes needed?
HTTP dialect ignores the database specified in the URL and uses the "default" instead.

### How was this patch tested?
Tested manually.

### Was this patch authored or co-authored using generative AI tooling?
No.
