### PR TITLE
[KYUUBI #6912][LINEAGE] Properly handle empty attribute set on mergeRelationColumnLineage

### DIFF
--- a/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/helper/SparkSQLLineageParseHelper.scala
+++ b/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/helper/SparkSQLLineageParseHelper.scala
@@ -176,10 +176,10 @@ trait LineageParser {
       relationColumnLineage: AttributeMap[AttributeSet]): AttributeMap[AttributeSet] = {
     val mergedRelationColumnLineage = {
       relationOutput.foldLeft((ListMap[Attribute, AttributeSet](), relationColumnLineage)) {
+        case ((acc, x), attr) if x.isEmpty =>
+          (acc + (attr -> AttributeSet.empty), x.empty)
         case ((acc, x), attr) =>
-          val head_2 = if (x.isEmpty) AttributeSet.empty else x.head._2
-          val tail = if (x.isEmpty) x.empty else x.tail
-          (acc + (attr -> head_2), tail)
+          (acc + (attr -> x.head._2), x.tail)
       }._1
     }
     joinColumnsLineage(parentColumnsLineage, mergedRelationColumnLineage)

--- a/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/helper/SparkSQLLineageParseHelper.scala
+++ b/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/helper/SparkSQLLineageParseHelper.scala
@@ -177,7 +177,9 @@ trait LineageParser {
     val mergedRelationColumnLineage = {
       relationOutput.foldLeft((ListMap[Attribute, AttributeSet](), relationColumnLineage)) {
         case ((acc, x), attr) =>
-          (acc + (attr -> x.head._2), x.tail)
+          val head_2 = if (x.isEmpty) AttributeSet.empty else x.head._2
+          val tail = if (x.isEmpty) x.empty else x.tail
+          (acc + (attr -> head_2), tail)
       }._1
     }
     joinColumnsLineage(parentColumnsLineage, mergedRelationColumnLineage)

--- a/extensions/spark/kyuubi-spark-lineage/src/test/scala/org/apache/kyuubi/plugin/lineage/helper/SparkSQLLineageParserHelperSuite.scala
+++ b/extensions/spark/kyuubi-spark-lineage/src/test/scala/org/apache/kyuubi/plugin/lineage/helper/SparkSQLLineageParserHelperSuite.scala
@@ -1452,7 +1452,7 @@ class SparkSQLLineageParserHelperSuite extends KyuubiFunSuite
       s"""
         | CREATE OR REPLACE TEMPORARY VIEW temp_view
         |(
-        |	`a` STRING COMMENT '',
+        | `a` STRING COMMENT '',
         | `b` STRING COMMENT ''
         |)
         |USING csv OPTIONS(
@@ -1465,8 +1465,8 @@ class SparkSQLLineageParserHelperSuite extends KyuubiFunSuite
       s"""
         |insert overwrite table test_db.test_table_from_dir
         |SELECT
-        |	`a`,
-        |	`b`
+        | `a`,
+        | `b`
         |FROM temp_view
         |""".stripMargin)
 

--- a/extensions/spark/kyuubi-spark-lineage/src/test/scala/org/apache/kyuubi/plugin/lineage/helper/SparkSQLLineageParserHelperSuite.scala
+++ b/extensions/spark/kyuubi-spark-lineage/src/test/scala/org/apache/kyuubi/plugin/lineage/helper/SparkSQLLineageParserHelperSuite.scala
@@ -64,8 +64,11 @@ class SparkSQLLineageParserHelperSuite extends KyuubiFunSuite
   }
 
   override def afterAll(): Unit = {
-    Seq("test_db0.test_table0", "test_db0.test_table1",
-      "test_db0.test_table_part0", "test_db.test_table_from_dir").foreach { t =>
+    Seq(
+      "test_db0.test_table0",
+      "test_db0.test_table1",
+      "test_db0.test_table_part0",
+      "test_db.test_table_from_dir").foreach { t =>
       spark.sql(s"drop table if exists $t")
     }
     spark.sql("drop database if exists test_db")
@@ -1450,25 +1453,25 @@ class SparkSQLLineageParserHelperSuite extends KyuubiFunSuite
     val sourceFile = File(inputFile).createFile()
     spark.sql(
       s"""
-        | CREATE OR REPLACE TEMPORARY VIEW temp_view
-        |(
-        | `a` STRING COMMENT '',
-        | `b` STRING COMMENT ''
-        |)
-        |USING csv OPTIONS(
-        |    sep='\t',
-        |    path='${sourceFile.path}'
-        |);
-        |""".stripMargin).collect()
+         | CREATE OR REPLACE TEMPORARY VIEW temp_view
+         |(
+         | `a` STRING COMMENT '',
+         | `b` STRING COMMENT ''
+         |)
+         |USING csv OPTIONS(
+         |    sep='\t',
+         |    path='${sourceFile.path}'
+         |);
+         |""".stripMargin).collect()
 
     val ret0 = extractLineageWithoutExecuting(
       s"""
-        |insert overwrite table test_db.test_table_from_dir
-        |SELECT
-        | `a`,
-        | `b`
-        |FROM temp_view
-        |""".stripMargin)
+         |insert overwrite table test_db.test_table_from_dir
+         |SELECT
+         | `a`,
+         | `b`
+         |FROM temp_view
+         |""".stripMargin)
 
     assert(ret0 == Lineage(
       List(),

--- a/extensions/spark/kyuubi-spark-lineage/src/test/scala/org/apache/kyuubi/plugin/lineage/helper/SparkSQLLineageParserHelperSuite.scala
+++ b/extensions/spark/kyuubi-spark-lineage/src/test/scala/org/apache/kyuubi/plugin/lineage/helper/SparkSQLLineageParserHelperSuite.scala
@@ -59,10 +59,13 @@ class SparkSQLLineageParserHelperSuite extends KyuubiFunSuite
       "  partitioned by(pid)")
     spark.sql("create table if not exists test_db0.test_table1" +
       " (key int, value string) using parquet")
+    spark.sql("create table test_db.test_table_from_dir" +
+      " (`a0` string, `b0` string) using parquet")
   }
 
   override def afterAll(): Unit = {
-    Seq("test_db0.test_table0", "test_db0.test_table1", "test_db0.test_table_part0").foreach { t =>
+    Seq("test_db0.test_table0", "test_db0.test_table1",
+      "test_db0.test_table_part0", "test_db.test_table_from_dir").foreach { t =>
       spark.sql(s"drop table if exists $t")
     }
     spark.sql("drop database if exists test_db")
@@ -1440,6 +1443,39 @@ class SparkSQLLineageParserHelperSuite extends KyuubiFunSuite
           (s"$DEFAULT_CATALOG.default.t1.c", Set(s"$DEFAULT_CATALOG.default.t2.d")),
           (s"$DEFAULT_CATALOG.default.t1.d", Set(s"$DEFAULT_CATALOG.default.t2.d")))))
     }
+  }
+
+  test("test directory to table") {
+    val inputFile = getClass.getResource("/").getPath + "input_file"
+    val sourceFile = File(inputFile).createFile()
+    spark.sql(
+      s"""
+        | CREATE OR REPLACE TEMPORARY VIEW temp_view
+        |(
+        |	`a` STRING COMMENT '',
+        | `b` STRING COMMENT ''
+        |)
+        |USING csv OPTIONS(
+        |    sep='\t',
+        |    path='${sourceFile.path}'
+        |);
+        |""".stripMargin).collect()
+
+    val ret0 = extractLineageWithoutExecuting(
+      s"""
+        |insert overwrite table test_db.test_table_from_dir
+        |SELECT
+        |	`a`,
+        |	`b`
+        |FROM temp_view
+        |""".stripMargin)
+
+    assert(ret0 == Lineage(
+      List(),
+      List(s"spark_catalog.test_db.test_table_from_dir"),
+      List(
+        (s"spark_catalog.test_db.test_table_from_dir.a0", Set()),
+        (s"spark_catalog.test_db.test_table_from_dir.b0", Set()))))
   }
 
   private def extractLineageWithoutExecuting(sql: String): Lineage = {

--- a/extensions/spark/kyuubi-spark-lineage/src/test/scala/org/apache/kyuubi/plugin/lineage/helper/SparkSQLLineageParserHelperSuite.scala
+++ b/extensions/spark/kyuubi-spark-lineage/src/test/scala/org/apache/kyuubi/plugin/lineage/helper/SparkSQLLineageParserHelperSuite.scala
@@ -1453,8 +1453,7 @@ class SparkSQLLineageParserHelperSuite extends KyuubiFunSuite
     val sourceFile = File(inputFile).createFile()
     spark.sql(
       s"""
-         |CREATE OR REPLACE TEMPORARY VIEW temp_view
-         |(
+         |CREATE OR REPLACE TEMPORARY VIEW temp_view (
          | `a` STRING COMMENT '',
          | `b` STRING COMMENT ''
          |) USING csv OPTIONS(

--- a/extensions/spark/kyuubi-spark-lineage/src/test/scala/org/apache/kyuubi/plugin/lineage/helper/SparkSQLLineageParserHelperSuite.scala
+++ b/extensions/spark/kyuubi-spark-lineage/src/test/scala/org/apache/kyuubi/plugin/lineage/helper/SparkSQLLineageParserHelperSuite.scala
@@ -1457,8 +1457,8 @@ class SparkSQLLineageParserHelperSuite extends KyuubiFunSuite
          | `a` STRING COMMENT '',
          | `b` STRING COMMENT ''
          |) USING csv OPTIONS(
-         |    sep='\t',
-         |    path='${sourceFile.path}'
+         |  sep='\t',
+         |  path='${sourceFile.path}'
          |);
          |""".stripMargin).collect()
 

--- a/extensions/spark/kyuubi-spark-lineage/src/test/scala/org/apache/kyuubi/plugin/lineage/helper/SparkSQLLineageParserHelperSuite.scala
+++ b/extensions/spark/kyuubi-spark-lineage/src/test/scala/org/apache/kyuubi/plugin/lineage/helper/SparkSQLLineageParserHelperSuite.scala
@@ -1453,12 +1453,11 @@ class SparkSQLLineageParserHelperSuite extends KyuubiFunSuite
     val sourceFile = File(inputFile).createFile()
     spark.sql(
       s"""
-         | CREATE OR REPLACE TEMPORARY VIEW temp_view
+         |CREATE OR REPLACE TEMPORARY VIEW temp_view
          |(
          | `a` STRING COMMENT '',
          | `b` STRING COMMENT ''
-         |)
-         |USING csv OPTIONS(
+         |) USING csv OPTIONS(
          |    sep='\t',
          |    path='${sourceFile.path}'
          |);
@@ -1466,11 +1465,8 @@ class SparkSQLLineageParserHelperSuite extends KyuubiFunSuite
 
     val ret0 = extractLineageWithoutExecuting(
       s"""
-         |insert overwrite table test_db.test_table_from_dir
-         |SELECT
-         | `a`,
-         | `b`
-         |FROM temp_view
+         |INSERT OVERWRITE TABLE test_db.test_table_from_dir
+         |SELECT `a`, `b` FROM temp_view
          |""".stripMargin)
 
     assert(ret0 == Lineage(


### PR DESCRIPTION
# Why are the changes needed?
## Issue reference:
https://github.com/apache/kyuubi/issues/6912

## How to reproduce the issue?
The changes in this PR will avoid a wrong result when generating the instance of org.apache.kyuubi.plugin.lineage.Lineage, in the certain case as follows:
step 1: create a temporary view from a file
step 2: insert into a table by selecting from the temporary view in step 1
step 3: generate the lineage when executing the insert statement in step 2
In detail, please see the UT code submission in this patch.

## The issue analysis
Let's see the current code when getting the Lineage object by resolving a LogicalPlan object:
<img width="694" alt="image" src="https://github.com/user-attachments/assets/65256a0d-320d-4271-968f-59eafb74de9f" />

According to the above logic, a None org.apache.kyuubi.plugin.lineage.Lineage object will be generated due to "try-catch" self-protection, in this certain case. This None object will lead to problems in the following 2 scenes:
### Unit Test Environment
In Unit Test, when the code runs here a "None.get" exception will be raised:
<img width="682" alt="image" src="https://github.com/user-attachments/assets/102dc9bd-294f-4b1e-b1c6-01b6fee50fed" />

Here's the runtime exception stack:
```
None.get
java.util.NoSuchElementException: None.get
	at scala.None$.get(Option.scala:529)
	at scala.None$.get(Option.scala:527)
	at org.apache.kyuubi.plugin.lineage.helper.SparkSQLLineageParserHelperSuite.extractLineageWithoutExecuting(SparkSQLLineageParserHelperSuite.scala:1485)
	at org.apache.kyuubi.plugin.lineage.helper.SparkSQLLineageParserHelperSuite.$anonfun$new$83(SparkSQLLineageParserHelperSuite.scala:1465)
```
### Production Environment
This Lineage object cannot be used in the production environment because it has a None value which lacks some necessary lineage information. The right content of the Lineage instance in the above case should be:
```
inputTables(List())
outputTables(List(spark_catalog.test_db.test_table_from_dir))
columnLineage(List(ColumnLineage(spark_catalog.test_db.test_table_from_dir.a0,Set()), ColumnLineage(spark_catalog.test_db.test_table_from_dir.b0,Set())))
```

a newly added test case(test directory to table) passed after this issue is fixed.

# How to fix the issue?
Add a "Empty judgment" logic. In detail, please see the code submission in this patch.

# How was this patch tested?
1. by adding a new test case in UT code and make sure it passes
2. by submitting a Spark application including the SQL of this case in the production environment, and make sure a right Lineage instance is generated, instead of a None object


# Was this patch authored or co-authored using generative AI tooling?
No

