### PR TITLE
[KYUUBI #6918] Cache client ipAddress in kyuubi jdbc connection

### DIFF
--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
@@ -835,11 +835,7 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
           "set:hiveconf:hive.server2.thrift.resultset.default.fetch.size",
           Integer.toString(fetchSize));
     }
-    try {
-      openConf.put("kyuubi.client.ipAddress", InetAddress.getLocalHost().getHostAddress());
-    } catch (UnknownHostException e) {
-      LOG.debug("Error getting Kyuubi session local client ip address", e);
-    }
+    openConf.put("kyuubi.client.ipAddress", Utils.CLIENT_IP_ADDRESS);
     openConf.put(Utils.KYUUBI_CLIENT_VERSION_KEY, Utils.getVersion());
     openReq.setConfiguration(openConf);
 

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
@@ -27,8 +27,6 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.*;

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/Utils.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/Utils.java
@@ -68,6 +68,17 @@ public class Utils {
   public static final Pattern KYUUBI_OPERATION_HINT_PATTERN =
       Pattern.compile("^__kyuubi_operation_result_(.*)__=(.*)", Pattern.CASE_INSENSITIVE);
 
+  public static final String CLIENT_IP_ADDRESS;
+  static {
+    String localIpAddress = null;
+    try {
+      localIpAddress = InetAddress.getLocalHost().getHostAddress();
+    } catch (UnknownHostException e) {
+      LOG.debug("Error getting Kyuubi local client ip address", e);
+    }
+    CLIENT_IP_ADDRESS = localIpAddress;
+  }
+
   static String getMatchedUrlPrefix(String uri) throws JdbcUriParseException {
     for (String urlPrefix : URL_PREFIX_LIST) {
       if (uri.startsWith(urlPrefix)) {

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/Utils.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/Utils.java
@@ -69,6 +69,7 @@ public class Utils {
       Pattern.compile("^__kyuubi_operation_result_(.*)__=(.*)", Pattern.CASE_INSENSITIVE);
 
   public static final String CLIENT_IP_ADDRESS;
+
   static {
     String localIpAddress = null;
     try {

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/Utils.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/Utils.java
@@ -75,7 +75,7 @@ public class Utils {
     try {
       localIpAddress = InetAddress.getLocalHost().getHostAddress();
     } catch (UnknownHostException e) {
-      LOG.warn("Error getting Kyuubi local client ip address", e);
+      LOG.warn("Error getting Kyuubi local client IP address", e);
     }
     if (StringUtils.isBlank(localIpAddress)) {
       localIpAddress = "unknown";

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/Utils.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/Utils.java
@@ -71,12 +71,14 @@ public class Utils {
   public static final String CLIENT_IP_ADDRESS;
 
   static {
-    String localIpAddress;
+    String localIpAddress = null;
     try {
       localIpAddress = InetAddress.getLocalHost().getHostAddress();
     } catch (UnknownHostException e) {
-      localIpAddress = "unknown";
       LOG.warn("Error getting Kyuubi local client ip address", e);
+    }
+    if (StringUtils.isBlank(localIpAddress)) {
+      localIpAddress = "unknown";
     }
     CLIENT_IP_ADDRESS = localIpAddress;
   }

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/Utils.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/Utils.java
@@ -71,11 +71,12 @@ public class Utils {
   public static final String CLIENT_IP_ADDRESS;
 
   static {
-    String localIpAddress = null;
+    String localIpAddress;
     try {
       localIpAddress = InetAddress.getLocalHost().getHostAddress();
     } catch (UnknownHostException e) {
-      LOG.debug("Error getting Kyuubi local client ip address", e);
+      localIpAddress = "unknown";
+      LOG.warn("Error getting Kyuubi local client ip address", e);
     }
     CLIENT_IP_ADDRESS = localIpAddress;
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?

add Utils.CLIENT_IP_ADDRESS to cache local ipAddress

closes #6918

### How was this patch tested?

minor fix

### Was this patch authored or co-authored using generative AI tooling?

No
