### PR TITLE
[KYUUBI #6908] Connection class ssl context object paramater

### DIFF
--- a/python/pyhive/hive.py
+++ b/python/pyhive/hive.py
@@ -175,6 +175,9 @@ class Connection(object):
             Incompatible with host, port, auth, kerberos_service_name, and password.
         :param ssl_context: A custom SSL context to use for HTTPS connections. If provided,
             this overrides check_hostname and ssl_cert parameters.
+        The way to support LDAP and GSSAPI is originated from cloudera/Impyla:
+        https://github.com/cloudera/impyla/blob/255b07ed973d47a3395214ed92d35ec0615ebf62
+        /impala/_thrift_api.py#L152-L160
         """
         if scheme in ("https", "http") and thrift_transport is None:
             port = port or 1000

--- a/python/pyhive/hive.py
+++ b/python/pyhive/hive.py
@@ -159,7 +159,8 @@ class Connection(object):
         password=None,
         check_hostname=None,
         ssl_cert=None,
-        thrift_transport=None
+        thrift_transport=None,
+        ssl_context=None
     ):
         """Connect to HiveServer2
 
@@ -172,19 +173,17 @@ class Connection(object):
         :param password: Use with auth='LDAP' or auth='CUSTOM' only
         :param thrift_transport: A ``TTransportBase`` for custom advanced usage.
             Incompatible with host, port, auth, kerberos_service_name, and password.
-
-        The way to support LDAP and GSSAPI is originated from cloudera/Impyla:
-        https://github.com/cloudera/impyla/blob/255b07ed973d47a3395214ed92d35ec0615ebf62
-        /impala/_thrift_api.py#L152-L160
+        :param ssl_context: A custom SSL context to use for HTTPS connections. If provided,
+            this overrides check_hostname and ssl_cert parameters.
         """
         if scheme in ("https", "http") and thrift_transport is None:
             port = port or 1000
-            ssl_context = None
             if scheme == "https":
-                ssl_context = create_default_context()
-                ssl_context.check_hostname = check_hostname == "true"
-                ssl_cert = ssl_cert or "none"
-                ssl_context.verify_mode = ssl_cert_parameter_map.get(ssl_cert, CERT_NONE)
+                if ssl_context is None:
+                    ssl_context = create_default_context()
+                    ssl_context.check_hostname = check_hostname == "true"
+                    ssl_cert = ssl_cert or "none"
+                    ssl_context.verify_mode = ssl_cert_parameter_map.get(ssl_cert, CERT_NONE)
             thrift_transport = thrift.transport.THttpClient.THttpClient(
                 uri_or_host="{scheme}://{host}:{port}/cliservice/".format(
                     scheme=scheme, host=host, port=port

--- a/python/pyhive/tests/test_hive.py
+++ b/python/pyhive/tests/test_hive.py
@@ -130,8 +130,15 @@ class TestHive(unittest.TestCase, DBAPITestCase):
 
     def test_ssl_context_mtls_configuration(self):
         """Test that SSL context can be configured for mTLS"""
+        # Create and configure mTLS context before creating the connection
         mtls_context = mock.MagicMock()
         mtls_context.load_cert_chain = mock.MagicMock()
+        
+        # Configure mTLS before passing to Connection
+        mtls_context.load_cert_chain(
+            certfile='client.crt',
+            keyfile='client.key'
+        )
         
         conn = hive.Connection(
             host=_HOST,
@@ -139,12 +146,7 @@ class TestHive(unittest.TestCase, DBAPITestCase):
             ssl_context=mtls_context
         )
         
-        # Configure mTLS after connection creation
-        mtls_context.load_cert_chain(
-            certfile='client.crt',
-            keyfile='client.key'
-        )
-        
+        # Verify mTLS was configured correctly
         mtls_context.load_cert_chain.assert_called_once_with(
             certfile='client.crt',
             keyfile='client.key'


### PR DESCRIPTION
**Why are the changes needed:**
Currently looking to connect to a HiveServer2 behind an NGINX proxy that is requiring mTLS communication. pyHive seems to lack the capability to establish an mTLS connection in applications such as Airflow directly communicating to the HiveServer2 instance.

The change needed is to be able to pass in the parameters for a proper mTLS ssl context to be established. I believe that creating your own ssl_context object is the quickest and cleanest way to do so, leaving the responsibility of configuring it to further implementations and users. Also cuts down on code length.

**How was this patch tested:**
Corresponding pytest fixtures have been added, using the mock module to see if ssl_context object was properly accessed, or if the default one created in the Connection initialization was properly configured.

Was not able to run pytest fixtures specifically, was lacking JDBC driver, first time contributing to open source, happy to run tests if provided guidance. Passed a clean build and test of the entire kyuubi project in local dev environment.

**Was this patch authored or co-authored using generative AI tooling**
Yes, Generated-by Cursor-AI with Claude Sonnet 3.5 agent