### PR TITLE
Bump log4j version to 2.24.3 to fix ConcurrentModificationException in LoggerContext

### DIFF
--- a/dev/dependencyList
+++ b/dev/dependencyList
@@ -123,11 +123,11 @@ kubernetes-model-rbac/6.13.1//kubernetes-model-rbac-6.13.1.jar
 kubernetes-model-resource/6.13.1//kubernetes-model-resource-6.13.1.jar
 kubernetes-model-scheduling/6.13.1//kubernetes-model-scheduling-6.13.1.jar
 kubernetes-model-storageclass/6.13.1//kubernetes-model-storageclass-6.13.1.jar
-log4j-1.2-api/2.24.2//log4j-1.2-api-2.24.2.jar
-log4j-api/2.24.2//log4j-api-2.24.2.jar
-log4j-core/2.24.2//log4j-core-2.24.2.jar
-log4j-layout-template-json/2.24.2//log4j-layout-template-json-2.24.2.jar
-log4j-slf4j-impl/2.24.2//log4j-slf4j-impl-2.24.2.jar
+log4j-1.2-api/2.24.3//log4j-1.2-api-2.24.3.jar
+log4j-api/2.24.3//log4j-api-2.24.3.jar
+log4j-core/2.24.3//log4j-core-2.24.3.jar
+log4j-layout-template-json/2.24.3//log4j-layout-template-json-2.24.3.jar
+log4j-slf4j-impl/2.24.3//log4j-slf4j-impl-2.24.3.jar
 logging-interceptor/3.12.12//logging-interceptor-3.12.12.jar
 metrics-core/4.2.26//metrics-core-4.2.26.jar
 metrics-jmx/4.2.26//metrics-jmx-4.2.26.jar

--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
         <kyuubi-relocated.version>0.4.1</kyuubi-relocated.version>
         <kyuubi-relocated-zookeeper.artifacts>kyuubi-relocated-zookeeper-34</kyuubi-relocated-zookeeper.artifacts>
         <ldapsdk.version>6.0.5</ldapsdk.version>
-        <log4j.version>2.24.2</log4j.version>
+        <log4j.version>2.24.3</log4j.version>
         <mysql.jdbc.version>8.4.0</mysql.jdbc.version>
         <mockito.version>4.11.0</mockito.version>
         <netty.version>4.1.108.Final</netty.version>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->

Bump the log4j version to fix below issue:
```
2025-03-04 22:27:58.291 WARN [main-SendThread(xxxx:2181)] org.apache.kyuubi.shaded.zookeeper.ClientCnxn: Session 0x0 for server null, unexpected error, closing socket connection and attempting reconnect
: java.lang.ExceptionInInitializerError
        at org.apache.log4j.Logger.getLogger(Logger.java:35)
        at org.apache.kyuubi.shaded.zookeeper.Login.<init>(Login.java:44)
        at org.apache.kyuubi.shaded.zookeeper.client.ZooKeeperSaslClient.createSaslClient(ZooKeeperSaslClient.java:228)
        at org.apache.kyuubi.shaded.zookeeper.client.ZooKeeperSaslClient.<init>(ZooKeeperSaslClient.java:131)
        at org.apache.kyuubi.shaded.zookeeper.ClientCnxn$SendThread.startConnect(ClientCnxn.java:990)
        at org.apache.kyuubi.shaded.zookeeper.ClientCnxn$SendThread.run(ClientCnxn.java:1042)
Caused by: java.util.ConcurrentModificationException
        at java.util.HashMap$ValueSpliterator.forEachRemaining(HashMap.java:1657)
        at java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:647)
        at java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:272)
        at java.util.WeakHashMap$ValueSpliterator.forEachRemaining(WeakHashMap.java:1216)
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482)
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
        at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
        at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:485)
        at org.apache.logging.log4j.core.LoggerContext.updateLoggers(LoggerContext.java:776)
        at org.apache.logging.log4j.core.LoggerContext.updateLoggers(LoggerContext.java:766)
        at org.apache.logging.log4j.core.config.Configurator.setLevel(Configurator.java:379)
        at org.apache.logging.log4j.core.config.Configurator.setLevel(Configurator.java:344)
        at org.apache.log4j.legacy.core.CategoryUtil.setLevel(CategoryUtil.java:131)
        at org.apache.log4j.Category.setLevel(Category.java:643)
        at org.apache.log4j.Category.setLevel(Category.java:638)
        at org.apache.log4j.spi.RootLogger.setLevel(RootLogger.java:60)
        at org.apache.log4j.spi.RootLogger.<init>(RootLogger.java:39)
        at org.apache.log4j.LogManager.<clinit>(LogManager.java:70)
        ... 6 more
```

It is fixed in https://github.com/apache/logging-log4j2/releases/tag/rel%2F2.24.3 

https://github.com/apache/logging-log4j2/issues/3234 
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Existing GA.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.