### PR TITLE
[DOC] Fix "Title underline too short" issues

### DIFF
--- a/docs/client/jdbc/mysql_jdbc.rst
+++ b/docs/client/jdbc/mysql_jdbc.rst
@@ -14,12 +14,12 @@
    limitations under the License.
 
 
-`MySQL Connectors`_
+MySQL Connectors
 ================
 
 .. versionadded:: 1.4.0
 
-Kyuubi provides an frontend service that enables the connectivity and accessibility from MySQL connectors.
+Kyuubi provides an frontend service that enables the connectivity and accessibility from `MySQL Connectors`_.
 
 .. warning:: The document you are visiting now is incomplete, please help kyuubi community to fix it if appropriate for you.
 

--- a/docs/connector/flink/paimon.rst
+++ b/docs/connector/flink/paimon.rst
@@ -13,10 +13,10 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 
-`Apache Paimon (Incubating)`_
-=============================
+Apache Paimon (Incubating)
+==========================
 
-Apache Paimon (Incubating) is a streaming data lake platform that supports high-speed data ingestion, change data tracking, and efficient real-time analytics.
+`Apache Paimon (Incubating)`_ is a streaming data lake platform that supports high-speed data ingestion, change data tracking, and efficient real-time analytics.
 
 .. tip::
    This article assumes that you have mastered the basic knowledge and operation of `Apache Paimon (Incubating)`_.

--- a/docs/connector/hive/paimon.rst
+++ b/docs/connector/hive/paimon.rst
@@ -13,10 +13,10 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 
-`Apache Paimon (Incubating)`_
-==========
+Apache Paimon (Incubating)
+==========================
 
-Apache Paimon(incubating) is a streaming data lake platform that supports high-speed data ingestion, change data tracking and efficient real-time analytics.
+`Apache Paimon (Incubating)`_ is a streaming data lake platform that supports high-speed data ingestion, change data tracking and efficient real-time analytics.
 
 .. tip::
    This article assumes that you have mastered the basic knowledge and operation of `Apache Paimon (Incubating)`_.
@@ -28,7 +28,7 @@ convenient, easy to understand, and easy to expand than directly using
 Hive to manipulate Apache Paimon (Incubating).
 
 Apache Paimon (Incubating) Integration
--------------------
+--------------------------------------
 
 To enable the integration of kyuubi hive sql engine and Apache Paimon (Incubating), you need to:
 
@@ -69,8 +69,8 @@ Configurations
 
 If you are using HDFS, make sure that the environment variable HADOOP_HOME or HADOOP_CONF_DIR is set.
 
-Apache Paimon (Incubating)  Operations
-------------------
+Apache Paimon (Incubating) Operations
+-------------------------------------
 
 Apache Paimon (Incubating) only supports only reading table store tables through Hive.
 A common scenario is to write data with Spark or Flink and read data with Hive.

--- a/docs/connector/spark/hive.rst
+++ b/docs/connector/spark/hive.rst
@@ -64,7 +64,7 @@ To activate functionality of Kyuubi Spark Hive connector, we can set the followi
    spark.sql.catalog.hive_catalog.<other.hadoop.conf>  <value>
 
 Hive Connector Operations
-------------------
+-------------------------
 
 Taking ``CREATE NAMESPACE`` as a example,
 

--- a/docs/connector/spark/paimon.rst
+++ b/docs/connector/spark/paimon.rst
@@ -13,10 +13,10 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 
-`Apache Paimon (Incubating)`_
-==========
+Apache Paimon (Incubating)
+==========================
 
-Apache Paimon(incubating) is a streaming data lake platform that supports high-speed data ingestion, change data tracking and efficient real-time analytics.
+`Apache Paimon (Incubating)`_ is a streaming data lake platform that supports high-speed data ingestion, change data tracking and efficient real-time analytics.
 
 .. tip::
    This article assumes that you have mastered the basic knowledge and operation of `Apache Paimon (Incubating)`_.
@@ -28,7 +28,7 @@ convenient, easy to understand, and easy to expand than directly using
 spark to manipulate Apache Paimon (Incubating).
 
 Apache Paimon (Incubating) Integration
--------------------
+--------------------------------------
 
 To enable the integration of Kyuubi Spark SQL engine and Apache Paimon (Incubating) through
 Spark DataSource V2 API, you need to:
@@ -68,7 +68,7 @@ To activate functionality of Apache Paimon (Incubating), we can set the followin
    spark.sql.catalog.paimon.warehouse=file:/tmp/paimon
 
 Apache Paimon (Incubating) Operations
-------------------
+-------------------------------------
 
 
 Taking ``CREATE NAMESPACE`` as a example,

--- a/docs/connector/spark/tpcds.rst
+++ b/docs/connector/spark/tpcds.rst
@@ -14,7 +14,7 @@
    limitations under the License.
 
 TPC-DS
-=====
+======
 
 The TPC-DS is a decision support benchmark. It consists of a suite of business oriented ad-hoc queries and concurrent
 data modifications. The queries and the data populating the database have been chosen to have broad industry-wide
@@ -82,7 +82,7 @@ To add TPC-DS tables as a catalog, we can set the following configurations in ``
    spark.sql.catalog.tpcds.read.maxPartitionBytes=128m
 
 TPC-DS Operations
-----------------
+-----------------
 
 Listing databases under `tpcds` catalog.
 

--- a/docs/connector/trino/paimon.rst
+++ b/docs/connector/trino/paimon.rst
@@ -13,10 +13,10 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 
-`Apache Paimon (Incubating)`_
-==========
+Apache Paimon (Incubating)
+==========================
 
-Apache Paimon(incubating) is a streaming data lake platform that supports high-speed data ingestion, change data tracking and efficient real-time analytics.
+`Apache Paimon (Incubating)`_ is a streaming data lake platform that supports high-speed data ingestion, change data tracking and efficient real-time analytics.
 
 .. tip::
    This article assumes that you have mastered the basic knowledge and operation of `Apache Paimon (Incubating)`_.
@@ -28,7 +28,7 @@ convenient, easy to understand, and easy to expand than directly using
 trino to manipulate Apache Paimon (Incubating).
 
 Apache Paimon (Incubating) Integration
--------------------
+--------------------------------------
 
 To enable the integration of kyuubi trino sql engine and Apache Paimon (Incubating), you need to:
 
@@ -71,7 +71,7 @@ For example, create $TRINO_SERVER_HOME/etc/catalog/tablestore.properties with th
    warehouse=file:///tmp/warehouse
 
 Apache Paimon (Incubating) Operations
-------------------
+-------------------------------------
 
 Apache Paimon (Incubating) supports reading table store tables through Trino.
 A common scenario is to write data with Spark or Flink and read data with Trino.

--- a/docs/extensions/server/events.rst
+++ b/docs/extensions/server/events.rst
@@ -14,7 +14,7 @@
    limitations under the License.
 
 Configure Kyuubi to use Custom EventHandler
-=======================================
+===========================================
 
 Kyuubi provide event processing mechanism, it can help us to record some events. Beside the builtin ``JsonLoggingEventHandler``,
 Kyuubi supports custom event handler. It is usually used to write Kyuubi events to some external systems.

--- a/docs/tools/kyuubi-ctl.rst
+++ b/docs/tools/kyuubi-ctl.rst
@@ -109,7 +109,8 @@ List all the service nodes for a particular domain.
 .. _create_servers:
 
 Create server
-***********
+*************
+
 Expose Kyuubi server instance to another domain.
 
 First read ``kyuubi.ha.namespace`` in ``conf/kyuubi-defaults.conf``, if there are server instances under this namespace, register them in the new namespace specified by the ``--namespace`` parameter.
@@ -132,7 +133,7 @@ Get Kyuubi server info of domain.
 .. _delete_servers:
 
 Delete server
-***********
+*************
 
 Delete the specified service node for a domain.
 


### PR DESCRIPTION
### Why are the changes needed?

The PR resolves multiple `"Title underline too short"` warnings to reduce noise during documentation building, for instance:
```shell
./kyuubi/docs/client/jdbc/mysql_jdbc.rst:18: WARNING: Title underline too short.

`MySQL Connectors`_
================ [docutils]

./kyuubi/docs/connector/hive/paimon.rst:17: WARNING: Title underline too short.

`Apache Paimon (Incubating)`_
========== [docutils]
./kyuubi/docs/connector/hive/paimon.rst:31: WARNING: Title underline too short.

Apache Paimon (Incubating) Integration
------------------- [docutils]
```

### How was this patch tested?

Checked that there are no `"Title underline too short"` warnings during the documentation build process.
```shell
make html
```


### Was this patch authored or co-authored using generative AI tooling?

No

