### PR TITLE
[DOC] Remove empty note block

### DIFF
--- a/docs/contributing/doc/get_started.rst
+++ b/docs/contributing/doc/get_started.rst
@@ -75,9 +75,6 @@ Editing And Testing
 Make the necessary changes to the documentation files using a text editor.
 `Build and verify`_ the changes you have made to see if they look fine.
 
-.. note::
-   :class: dropdown, toggle
-
 Create A Pull Request
 ~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
### Why are the changes needed?

The change fixes minor issue that resolves the following error:
```shell
../kyuubi/docs/contributing/doc/get_started.rst:78: ERROR: Content block expected for the "note" directive; none found. [docutils]
```


### How was this patch tested?

Built documentation locally and checked there are no difference and error message.

Before changes:
<img width="1214" alt="image" src="https://github.com/user-attachments/assets/f53398d8-b04a-4367-8040-3e6573cc54f2" />

After changes:
<img width="1197" alt="image" src="https://github.com/user-attachments/assets/3b08e1ee-11c2-4386-b178-35e33d6a56dc" />


### Was this patch authored or co-authored using generative AI tooling?

No

