### PR TITLE
[KYUUBI #5376] Change the GetSchemas and GetTables functions on kyuubi to use DDL to obtain information

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/GetTables.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/GetTables.scala
@@ -77,17 +77,8 @@ class GetTables(
           catalog,
           schemaPattern,
           tablePattern,
-          tableTypes,
           ignoreTableProperties)
-
-      val allTableAndViews =
-        if (tableTypes.exists("VIEW".equalsIgnoreCase)) {
-          catalogTablesAndViews ++
-            SparkCatalogUtils.getTempViews(spark, catalog, schemaPattern, tablePattern)
-        } else {
-          catalogTablesAndViews
-        }
-      iter = new IterableFetchIterator(allTableAndViews)
+      iter = new IterableFetchIterator(catalogTablesAndViews)
     } catch {
       onError()
     }


### PR DESCRIPTION
Change the GetSchemas and GetTables functions on kyuubi to use DDL to obtain information, thereby resolving the issue of DBeaver bypassing Ranger's permission restrictions.

### Why are the changes needed?
The ranger plugin has been enabled to control permissions. When using DBeaver to connect to Kyuubi, users without permission for the database and tables can still see the database and tables on the left side.
After applying this modification, the access to the database tables can be controlled through the Ranger plugin. When users use DBeaver, they can only see the database tables for which they have permissions in the "Tables" column on the left side.


### How was this patch tested?
Use the ranger plugin of Kyuubi for authorization, and use DBeaver to connect to Kyuubi for testing.


### Was this patch authored or co-authored using generative AI tooling?
No

