### PR TITLE
[DOC] Fix nested lists

### DIFF
--- a/docs/contributing/doc/style.rst
+++ b/docs/contributing/doc/style.rst
@@ -59,17 +59,20 @@ ReStructuredText
 Headings
 ~~~~~~~~
 
-- Use **Pascal Case**, every word starts with an uppercase letter,
-  e.g., 'Documentation Style Guide'
+- Use **Pascal Case**, every word starts with an uppercase letter, e.g., 'Documentation Style Guide'
 - Use a max of **three levels**
- - Split into multiple files when there comes an H4
- - Prefer `directive rubric`_ than H4
+
+  - Split into multiple files when there comes an H4
+  - Prefer `directive rubric`_ than H4
+
 - Use underline-only adornment styles, **DO NOT** use overline
- - The length of underline characters **SHOULD** match the title
- - H1 should be underlined with '='
- - H2 should be underlined with '-'
- - H3 should be underlined with '~'
- - H4 should be underlined with '^', but it's better to avoid using H4
+
+  - The length of underline characters **SHOULD** match the title
+  - H1 should be underlined with '='
+  - H2 should be underlined with '-'
+  - H3 should be underlined with '~'
+  - H4 should be underlined with '^', but it's better to avoid using H4
+
 - **DO NOT** use numbering for sections
 - **DO NOT** use "Kyuubi" in titles if possible
 
@@ -100,10 +103,11 @@ Markdown
 Headings
 ~~~~~~~~
 
-- Use **Pascal Case**, every word starts with an uppercase letter,
-  e.g., 'Documentation Style Guide'
+- Use **Pascal Case**, every word starts with an uppercase letter, e.g., 'Documentation Style Guide'
 - Use a max of **three levels**
- - Split into multiple files when there comes an H4
+
+  - Split into multiple files when there comes an H4
+
 - **DO NOT** use numbering for sections
 - **DO NOT** use "Kyuubi" in titles if possible
 


### PR DESCRIPTION
### Why are the changes needed?

The PR fixes [nested lists formatting](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#lists-and-quote-like-blocks) and resolves the following warnings:
```shell
../kyuubi/docs/contributing/doc/style.rst:65: WARNING: Bullet list ends without a blank line; unexpected unindent. [docutils]
../kyuubi/docs/contributing/doc/style.rst:67: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
../kyuubi/docs/contributing/doc/style.rst:68: WARNING: Bullet list ends without a blank line; unexpected unindent. [docutils]
../kyuubi/docs/contributing/doc/style.rst:73: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
../kyuubi/docs/contributing/doc/style.rst:106: WARNING: Bullet list ends without a blank line; unexpected unindent. [docutils]
../kyuubi/docs/contributing/doc/style.rst:107: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
```


### How was this patch tested?

Built documentation locally and checked nested lists are fixed.

Before changes:
<img width="914" alt="image" src="https://github.com/user-attachments/assets/3ec7079a-e494-4614-9af0-d6e217bcad60" />

After changes:
<img width="1020" alt="image" src="https://github.com/user-attachments/assets/2d3b3231-094d-49bd-b3d7-c6149e13c939" />


### Was this patch authored or co-authored using generative AI tooling?

No

