### PR TITLE
[DOC] Fix multiple Pygments lexer name issues

### DIFF
--- a/docs/client/advanced/kerberos.md
+++ b/docs/client/advanced/kerberos.md
@@ -56,7 +56,7 @@ Send bug-reports to heimdal-bugs@h5l.org
 
 Windows command and output:
 
-```cmd
+```shell
 > klist -V
 Kerberos for Windows
 ```

--- a/docs/client/bi_tools/hue.md
+++ b/docs/client/bi_tools/hue.md
@@ -27,7 +27,7 @@
 
 [Get the server Started](../../quick_start/quick_start.html) first before your try Hue with Kyuubi.
 
-```bash
+```
 Welcome to
   __  __                           __
  /\ \/\ \                         /\ \      __

--- a/docs/client/jdbc/hive_jdbc.md
+++ b/docs/client/jdbc/hive_jdbc.md
@@ -49,7 +49,7 @@ libraryDependencies += "org.apache.hive" % "hive-jdbc" % "2.3.8"
 
 - **gradle**
 
-```gradle
+```groovy
 implementation group: 'org.apache.hive', name: 'hive-jdbc', version: '2.3.8'
 ```
 

--- a/docs/client/jdbc/kyuubi_jdbc.rst
+++ b/docs/client/jdbc/kyuubi_jdbc.rst
@@ -108,7 +108,7 @@ Basic Connection URL format
 Use the connection URL to supply connection information to the kyuubi server or cluster that you are
 accessing. The following is the format of the connection URL for the Kyuubi Hive JDBC Driver
 
-.. code-block:: jdbc
+.. code-block::
 
    jdbc:subprotocol://host:port[/catalog]/[schema];<clientProperties;><[#|?]sessionProperties>
 
@@ -131,7 +131,7 @@ Connection URL over HTTP
 
 .. versionadded:: 1.6.0
 
-.. code-block:: jdbc
+.. code-block::
 
    jdbc:subprotocol://host:port/schema;transportMode=http;httpPath=<http_endpoint>
 
@@ -140,7 +140,7 @@ Connection URL over HTTP
 Connection URL over Service Discovery
 *************************************
 
-.. code-block:: jdbc
+.. code-block::
 
    jdbc:subprotocol://<zookeeper quorum>/;serviceDiscoveryMode=zooKeeper;zooKeeperNamespace=kyuubi
 
@@ -160,7 +160,7 @@ to server by default.
 If you need to connect to HiveServer2 before 2.3.0,
 please set client property `clientProtocolVersion` to a lower number.
 
-.. code-block:: jdbc
+.. code-block::
 
    jdbc:subprotocol://host:port[/catalog]/[schema];clientProtocolVersion=9;
 

--- a/docs/connector/spark/delta_lake_with_azure_blob.rst
+++ b/docs/connector/spark/delta_lake_with_azure_blob.rst
@@ -188,7 +188,7 @@ Start Kyuubi
 
 Check kyuubi log, in order to check kyuubi start status and find the jdbc connection url:
 
-.. code-block:: log
+.. code-block::
 
    2021-11-26 17:49:50.235 INFO service.ThriftFrontendService: Starting and exposing JDBC connection at: jdbc:kyuubi://HOST:10009/
    2021-11-26 17:49:50.265 INFO client.ServiceDiscovery: Created a /kyuubi/serviceUri=host:10009;version=1.3.1-incubating;sequence=0000000037 on ZooKeeper for KyuubiServer uri: host:10009

--- a/docs/deployment/hive_metastore.md
+++ b/docs/deployment/hive_metastore.md
@@ -40,7 +40,7 @@ So the whole thing here is to let Spark applications use this copy of Hive confi
 By default, Kyuubi launches Spark SQL engines pointing to a dummy embedded [Apache Derby](https://db.apache.org/derby/)-based metastore for each application,
 and this metadata can only be seen by one user at a time, e.g.
 
-```shell script
+```shell
 bin/kyuubi-beeline -u 'jdbc:kyuubi://localhost:10009/' -n kentyao
 Connecting to jdbc:kyuubi://localhost:10009/
 Connected to: Spark SQL (version 3.4.2)
@@ -175,7 +175,7 @@ For example, Spark 3.0 was released with a built-in Hive client (2.3.7), so, ide
 
 If you do have a legacy Hive metastore server that cannot be easily upgraded, and you may face the issue by default like this,
 
-```java
+```
 Caused by: org.apache.thrift.TApplicationException: Invalid method name: 'get_table_req'
 	at org.apache.thrift.TServiceClient.receiveBase(TServiceClient.java:79)
 	at org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore$Client.recv_get_table_req(ThriftHiveMetastore.java:1567)

--- a/docs/extensions/server/authentication.rst
+++ b/docs/extensions/server/authentication.rst
@@ -72,7 +72,7 @@ To enable the custom authentication method, we need to
 - Configure the following properties to ``$KYUUBI_HOME/conf/kyuubi-defaults.conf``
   on each node where kyuubi server is installed.
 
-.. code-block:: property
+.. code-block:: properties
 
    kyuubi.authentication=CUSTOM
    kyuubi.authentication.custom.class=YourAuthenticationProvider

--- a/docs/extensions/server/events.rst
+++ b/docs/extensions/server/events.rst
@@ -73,7 +73,7 @@ To enable the custom EventHandler, we need to
 - Configure the following properties to ``$KYUUBI_HOME/conf/kyuubi-defaults.conf``
   on each node where kyuubi server is installed. If you need use other event handler, it can be appended after the ``CUSTOM``.
 
-.. code-block:: property
+.. code-block:: properties
 
    kyuubi.backend.server.event.loggers=CUSTOM
 

--- a/docs/monitor/logging.md
+++ b/docs/monitor/logging.md
@@ -57,7 +57,7 @@ $ cd ~/svn-kyuubi/v1.3.1-incubating-rc0/apache-kyuubi-1.3.1-incubating-bin
 $ bin/kyuubi start
 ```
 
-```log
+```
 Starting Kyuubi Server from /Users/kentyao/svn-kyuubi/v1.3.1-incubating-rc0/apache-kyuubi-1.3.1-incubating-bin
 Warn: Not find kyuubi environment file /Users/kentyao/svn-kyuubi/v1.3.1-incubating-rc0/apache-kyuubi-1.3.1-incubating-bin/conf/kyuubi-env.sh, using default ones...
 JAVA_HOME: /Library/Java/JavaVirtualMachines/jdk1.8.0_251.jdk/Contents/Home
@@ -96,7 +96,7 @@ $ mkdir /Users/kentyao/tmp
 $ KYUUBI_LOG_DIR=/Users/kentyao/tmp bin/kyuubi start
 ```
 
-```log
+```
 Starting org.apache.kyuubi.server.KyuubiServer, logging to /Users/kentyao/tmp/kyuubi-kentyao-org.apache.kyuubi.server.KyuubiServer-hulk.local.out
 ```
 
@@ -233,7 +233,7 @@ kyuubi-beeline -u 'jdbc:kyuubi://10.242.189.214:2181/;serviceDiscoveryMode=zooKe
 
 You will both get the final results and the corresponding operation logs telling you the journey of the query.
 
-```log
+```
 0: jdbc:kyuubi://10.242.189.214:2181/> select * from src;
 2021-10-27 17:00:19.399 INFO operation.ExecuteStatement: Processing kent's query[fb5f57d2-2b50-4a46-961b-3a5c6a2d2597]: INITIALIZED_STATE -> PENDING_STATE, statement: select * from src
 2021-10-27 17:00:19.401 INFO operation.ExecuteStatement: Processing kent's query[fb5f57d2-2b50-4a46-961b-3a5c6a2d2597]: PENDING_STATE -> RUNNING_STATE, statement: select * from src

--- a/docs/security/kerberos.rst
+++ b/docs/security/kerberos.rst
@@ -101,7 +101,7 @@ Configure the authentication properties
 Configure the following properties to ``$KYUUBI_HOME/conf/kyuubi-defaults.conf``
 on each node where kyuubi server is installed.
 
-.. code-block:: property
+.. code-block:: properties
 
    kyuubi.authentication=KERBEROS
    kyuubi.kinit.principal=superuser/FQDN@REALM

--- a/docs/security/ldap.md
+++ b/docs/security/ldap.md
@@ -28,7 +28,7 @@ To enable LDAP authentication for Kyuubi, LDAP-related configurations is require
 
 For example,
 
-```properties example
+```properties
 kyuubi.authentication=LDAP
 kyuubi.authentication.ldap.baseDN=dc=org
 kyuubi.authentication.ldap.domain=apache.org
@@ -43,7 +43,7 @@ Kyuubi also supports complex LDAP cases as [Apache Hive](https://cwiki.apache.or
 
 For example,
 
-```properties example
+```properties
 # Group Membership
 kyuubi.authentication.ldap.groupClassKey=groupOfNames
 kyuubi.authentication.ldap.groupDNPattern=CN=%s,OU=Groups,DC=apache,DC=org


### PR DESCRIPTION
### Why are the changes needed?

The PR fixes multiple `Pygments lexer name` issues and resolves the following warnings during the documentation build process:
```
../kyuubi/docs/client/advanced/kerberos.md:37: WARNING: Pygments lexer name 'cmd' is not known
../kyuubi/docs/client/bi_tools/hue.md:26: WARNING: Lexing literal_block "Welcome to\n  __  __                           __\n /\\ \\/\\ \\                         /\\ \\      __\n \\ \\ \\/'/'  __  __  __  __  __  __\\ \\ \\____/\\_\\\n  \\ \\ , <  /\\ \\/\\ \\/\\ \\/\\ \\/\\ \\/\\ \\\\ \\ '__`\\/\\ \\\n   \\ \\ \\\\`\\\\ \\ \\_\\ \\ \\ \\_\\ \\ \\ \\_\\ \\\\ \\ \\L\\ \\ \\ \\\n    \\ \\_\\ \\_\\/`____ \\ \\____/\\ \\____/ \\ \\_,__/\\ \\_\\\n     \\/_/\\/_/`/___/> \\/___/  \\/___/   \\/___/  \\/_/\n                /\\___/\n                \\/__/" as "bash" resulted in an error at token: "'". Retrying in relaxed mode. [misc.highlighting_failure]
../kyuubi/docs/client/jdbc/hive_jdbc.md:27: WARNING: Pygments lexer name 'gradle' is not known
../kyuubi/docs/client/jdbc/kyuubi_jdbc.rst:111: WARNING: Pygments lexer name 'jdbc' is not known
../kyuubi/docs/client/jdbc/kyuubi_jdbc.rst:134: WARNING: Pygments lexer name 'jdbc' is not known
../kyuubi/docs/client/jdbc/kyuubi_jdbc.rst:143: WARNING: Pygments lexer name 'jdbc' is not known
../kyuubi/docs/client/jdbc/kyuubi_jdbc.rst:163: WARNING: Pygments lexer name 'jdbc' is not known
../kyuubi/docs/connector/spark/delta_lake_with_azure_blob.rst:191: WARNING: Pygments lexer name 'log' is not known
../kyuubi/docs/deployment/hive_metastore.md:38: WARNING: Pygments lexer name 'shell script' is not known
../kyuubi/docs/deployment/hive_metastore.md:207: WARNING: Lexing literal_block "Caused by: org.apache.thrift.TApplicationException: Invalid method name: 'get_table_req'\n\tat org.apache.thrift.TServiceClient.receiveBase(TServiceClient.java:79)\n\tat org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore$Client.recv_get_table_req(ThriftHiveMetastore.java:1567)\n\tat org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore$Client.get_table_req(ThriftHiveMetastore.java:1554)\n\tat org.apache.hadoop.hive.metastore.HiveMetaStoreClient.getTable(HiveMetaStoreClient.java:1350)\n\tat org.apache.hadoop.hive.ql.metadata.SessionHiveMetaStoreClient.getTable(SessionHiveMetaStoreClient.java:127)\n\tat sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n\tat sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)\n\tat sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n\tat java.lang.reflect.Method.invoke(Method.java:498)\n\tat org.apache.hadoop.hive.metastore.RetryingMetaStoreClient.invoke(RetryingMetaStoreClient.java:173)\n\tat com.sun.proxy.$Proxy37.getTable(Unknown Source)\n\tat sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n\tat sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)\n\tat sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n\tat java.lang.reflect.Method.invoke(Method.java:498)\n\tat org.apache.hadoop.hive.metastore.HiveMetaStoreClient$SynchronizedHandler.invoke(HiveMetaStoreClient.java:2336)\n\tat com.sun.proxy.$Proxy37.getTable(Unknown Source)\n\tat org.apache.hadoop.hive.ql.metadata.Hive.getTable(Hive.java:1274)\n\t... 93 more" as "java" resulted in an error at token: "'". Retrying in relaxed mode. [misc.highlighting_failure]
../kyuubi/docs/extensions/server/authentication.rst:75: WARNING: Pygments lexer name 'property' is not known
../kyuubi/docs/extensions/server/events.rst:76: WARNING: Pygments lexer name 'property' is not known
../kyuubi/docs/monitor/logging.md:38: WARNING: Pygments lexer name 'log' is not known
../kyuubi/docs/monitor/logging.md:86: WARNING: Pygments lexer name 'log' is not known
../kyuubi/docs/monitor/logging.md:222: WARNING: Pygments lexer name 'log' is not known
../kyuubi/docs/security/kerberos.rst:104: WARNING: Pygments lexer name 'property' is not known
../kyuubi/docs/security/ldap.md:24: WARNING: Pygments lexer name 'properties example' is not known
../kyuubi/docs/security/ldap.md:40: WARNING: Pygments lexer name 'properties example' is not known

```

Supported languages: [Pygments lexers](https://pygments.org/docs/lexers) and [highlightjs](https://github.com/highlightjs/highlight.js/blob/main/SUPPORTED_LANGUAGES.md).


### How was this patch tested?

Built documentation locally and checked there are related warnings.



### Was this patch authored or co-authored using generative AI tooling?

No

