### PR TITLE
[DOC] Fix Unknown target name issues

### DIFF
--- a/docs/contributing/doc/get_started.rst
+++ b/docs/contributing/doc/get_started.rst
@@ -108,7 +108,8 @@ If you don't have time to fix the doc issue and submit a pull request on your ow
 - Choose the documentation report template
 - Fill out the required field in the documentation report
 
-.. _Home Page: https://kyuubi.apache.org
+.. _Github repository: https://github.com/apache/kyuubi
+.. _Read The Docs: https://kyuubi.rtfd.io
 .. _Fork: https://github.com/apache/kyuubi/fork
 .. _Build and verify: build.html
 .. _Create A Pull Request: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request

--- a/docs/contributing/doc/style.rst
+++ b/docs/contributing/doc/style.rst
@@ -130,7 +130,7 @@ third-party references, depending on the nature of your question:
 .. References
 
 .. _ASF 3RD PARTY LICENSE POLICY: https://www.apache.org/legal/resolved.html#asf-3rd-party-license-policy
-.. _directive rubric :https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-rubric
+.. _directive rubric: https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-rubric
 .. _ReStructuredText: https://docutils.sourceforge.io/rst.html
 .. _Markdown: https://en.wikipedia.org/wiki/Markdown
 .. _draw.io: https://www.diagrams.net/


### PR DESCRIPTION
### Why are the changes needed?

The PR fixes few `Unknown target name: "XYZ". [docutils]` issues and resolves the following errors messages:
```
../kyuubi/docs/contributing/doc/get_started.rst:27: ERROR: Unknown target name: "github repository". [docutils]
../kyuubi/docs/contributing/doc/get_started.rst:27: ERROR: Unknown target name: "read the docs". [docutils]

../kyuubi/docs/contributing/doc/style.rst:66: ERROR: Unknown target name: "directive rubric". [docutils]
```


### How was this patch tested?

Built documentation locally, checked there are no related error messages and doc pages are correct.

##### Page `contributing/doc/get_started.html`
Before changes
<img width="1114" alt="image" src="https://github.com/user-attachments/assets/f1a19c51-3c4c-4268-bf83-7ca0c60315b1" />

After changes
<img width="1113" alt="image" src="https://github.com/user-attachments/assets/437edef1-0fd9-43bf-bd3f-bda43035a2c9" />

##### Page `contributing/doc/style.html`
Before changes
<img width="1128" alt="image" src="https://github.com/user-attachments/assets/39666841-1155-439f-9045-06a9d78624c3" />

After changes
<img width="1117" alt="image" src="https://github.com/user-attachments/assets/2e1f8663-5c1e-4a3c-887e-5f65d01b4cf3" />


### Was this patch authored or co-authored using generative AI tooling?

No

