### PR TITLE
[KYUUBI #6989] Calculate expected join partitions based on scanned table size

### DIFF
--- a/extensions/spark/kyuubi-extension-spark-3-5/src/test/scala/org/apache/spark/sql/DynamicShufflePartitionsSuite.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-5/src/test/scala/org/apache/spark/sql/DynamicShufflePartitionsSuite.scala
@@ -80,27 +80,30 @@ class DynamicShufflePartitionsSuite extends KyuubiSparkSQLExtensionTest {
             val exchanges = collectExchanges(df.queryExecution.executedPlan)
             val (joinExchanges, rebalanceExchanges) = exchanges
               .partition(_.shuffleOrigin == ENSURE_REQUIREMENTS)
-            // table scan size: 7369 3287
             assert(joinExchanges.size == 2)
             if (dynamicShufflePartitions) {
-              joinExchanges.foreach(e =>
-                assert(e.outputPartitioning.numPartitions
-                  == Math.min(expectedJoinPartitionNum, maxDynamicShufflePartitionNum)))
+              joinExchanges.foreach { e =>
+                val expected = Math.min(expectedJoinPartitionNum, maxDynamicShufflePartitionNum)
+                assert(e.outputPartitioning.numPartitions == expected)
+              }
             } else {
-              joinExchanges.foreach(e =>
-                assert(e.outputPartitioning.numPartitions == initialPartitionNum))
+              joinExchanges.foreach { e =>
+                assert(e.outputPartitioning.numPartitions == initialPartitionNum)
+              }
             }
 
             assert(rebalanceExchanges.size == 1)
             if (dynamicShufflePartitions) {
               if (maxDynamicShufflePartitionNum == 8) {
-                // shuffle query size: 1424 451
-                assert(rebalanceExchanges.head.outputPartitioning.numPartitions ==
-                  Math.min(4, maxDynamicShufflePartitionNum))
+                // shuffle query size: 1424 451 (the size may change with spark version updates
+                // or shuffle configuration updates)
+                val expected = Math.min(4, maxDynamicShufflePartitionNum)
+                assert(rebalanceExchanges.head.outputPartitioning.numPartitions == expected)
               } else {
-                // shuffle query size: 2057 664
-                assert(rebalanceExchanges.head.outputPartitioning.numPartitions ==
-                  Math.min(6, maxDynamicShufflePartitionNum))
+                // shuffle query size: 2057 664 (the size may change with spark version updates
+                // or shuffle configuration updates)
+                val expected = Math.min(6, maxDynamicShufflePartitionNum)
+                assert(rebalanceExchanges.head.outputPartitioning.numPartitions == expected)
               }
             } else {
               assert(
@@ -114,7 +117,7 @@ class DynamicShufflePartitionsSuite extends KyuubiSparkSQLExtensionTest {
             DYNAMIC_SHUFFLE_PARTITIONS_MAX_NUM.key -> maxDynamicShufflePartitionNum.toString,
             AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
             COALESCE_PARTITIONS_INITIAL_PARTITION_NUM.key -> initialPartitionNum.toString,
-            ADVISORY_PARTITION_SIZE_IN_BYTES.key -> "500",
+            ADVISORY_PARTITION_SIZE_IN_BYTES.key -> advisoryPartitionSizeInBytes.toString,
             CONVERT_METASTORE_PARQUET.key -> "false") {
             val df = sql("insert overwrite table3 " +
               " select a.c1 as c1, b.c2 as c2 from table1 a join table2 b on a.c1 = b.c1")
@@ -122,21 +125,23 @@ class DynamicShufflePartitionsSuite extends KyuubiSparkSQLExtensionTest {
             val exchanges = collectExchanges(df.queryExecution.executedPlan)
             val (joinExchanges, rebalanceExchanges) = exchanges
               .partition(_.shuffleOrigin == ENSURE_REQUIREMENTS)
-            // table scan size: 7369 3287
             assert(joinExchanges.size == 2)
             if (dynamicShufflePartitions) {
-              joinExchanges.foreach(e =>
-                assert(e.outputPartitioning.numPartitions ==
-                  Math.min(22, maxDynamicShufflePartitionNum)))
+              joinExchanges.foreach { e =>
+                val expected = Math.min(expectedJoinPartitionNum, maxDynamicShufflePartitionNum)
+                assert(e.outputPartitioning.numPartitions == expected)
+              }
             } else {
-              joinExchanges.foreach(e =>
-                assert(e.outputPartitioning.numPartitions == initialPartitionNum))
+              joinExchanges.foreach { e =>
+                assert(e.outputPartitioning.numPartitions == initialPartitionNum)
+              }
             }
-            // shuffle query size: 5154 720
+            // shuffle query size: 5154 720 (the size may change with spark version updates
+            // or shuffle configuration updates)
             assert(rebalanceExchanges.size == 1)
             if (dynamicShufflePartitions) {
-              assert(rebalanceExchanges.head.outputPartitioning.numPartitions
-                == Math.min(12, maxDynamicShufflePartitionNum))
+              val expected = Math.min(12, maxDynamicShufflePartitionNum)
+              assert(rebalanceExchanges.head.outputPartitioning.numPartitions == expected)
             } else {
               assert(rebalanceExchanges.head.outputPartitioning.numPartitions ==
                 initialPartitionNum)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->
Avoid unstable test case caused by table size changes, this is likely to happen when upgrading Parquet/ORC/Spark.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
unit test

### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
