### PR TITLE
Exclude aws-java-sdk-logs from kyuubi-spark-authz-shaded

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/pom.xml
+++ b/extensions/spark/kyuubi-spark-authz/pom.xml
@@ -213,6 +213,10 @@
                     <groupId>com.amazonaws</groupId>
                     <artifactId>aws-java-sdk-bundle</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.amazonaws</groupId>
+                    <artifactId>aws-java-sdk-logs</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/extensions/spark/kyuubi-spark-authz/pom.xml
+++ b/extensions/spark/kyuubi-spark-authz/pom.xml
@@ -209,6 +209,9 @@
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
+                <!--
+                  RANGER-4831 (2.5.0) switches from aws-java-sdk-bundle to aws-java-sdk-logs
+                  -->
                 <exclusion>
                     <groupId>com.amazonaws</groupId>
                     <artifactId>aws-java-sdk-bundle</artifactId>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->
RANGER-4831 (2.5.0) switches from aws-java-sdk-bundle to aws-java-sdk-logs

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
I checked the packaged jar content

```
$ build/mvn clean install -DskipTests -pl :kyuubi-spark-authz-shaded_2.12 -am
$ jar -tf extensions/spark/kyuubi-spark-authz-shaded/target/kyuubi-spark-authz-shaded_2.12-1.11.0-SNAPSHOT.jar \
  | grep -v 'org/apache/ranger/' \
  | grep -v 'org/apache/kyuubi/' \
  | grep -v 'com/sun/jna/' \
  | grep -v 'META-INF/services/' \
  | grep -v 'service-defs/ranger-servicedef-'
META-INF/
META-INF/MANIFEST.MF
META-INF/LICENSE
META-INF/NOTICE
database_command_spec.json
function_command_spec.json
org/
org/apache/
scan_command_spec.json
service-defs/
table_command_spec.json
org/apache/hadoop/
org/apache/hadoop/security/
org/apache/hadoop/security/SecureClientLogin.class
etc/
etc/ranger/
etc/ranger/geo/
etc/ranger/geo/geo.txt
org/apache/hadoop/security/SecureClientLoginConfiguration.class
etc/ranger/geo/geo_long.txt
resourcenamemap.properties
org/apache/hadoop/security/KrbPasswordSaverLoginModule.class
META-INF/jersey-module-version
com/
com/sun/
META-INF/persistence.xml
```

### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
