### PR TITLE
Cut out JNA dependencies for authZ plugin

### DIFF
--- a/extensions/spark/kyuubi-spark-authz-shaded/pom.xml
+++ b/extensions/spark/kyuubi-spark-authz-shaded/pom.xml
@@ -51,11 +51,7 @@
                             <include>org.apache.ranger:*</include>
                             <include>org.codehaus.jackson:*</include>
                             <include>com.sun.jersey:*</include>
-                            <include>com.kstruct:gethostname4j</include>
                             <include>javax.ws.rs:jsr311-api</include>
-                            <!-- JNA is the transitive dependency of gethostname4j -->
-                            <include>net.java.dev.jna:jna</include>
-                            <include>net.java.dev.jna:jna-platform</include>
                         </includes>
                     </artifactSet>
                     <filters>

--- a/extensions/spark/kyuubi-spark-authz/pom.xml
+++ b/extensions/spark/kyuubi-spark-authz/pom.xml
@@ -33,10 +33,7 @@
 
     <properties>
         <ranger.version>2.5.0</ranger.version>
-        <!-- the following components' version may need to tune to align w/ the ranger.version-->
-        <gethostname4j.version>1.0.0</gethostname4j.version>
         <jersey.client.version>1.19.4</jersey.client.version>
-        <jna.version>5.7.0</jna.version>
     </properties>
 
     <dependencies>
@@ -106,24 +103,6 @@
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-client</artifactId>
             <version>${jersey.client.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.kstruct</groupId>
-            <artifactId>gethostname4j</artifactId>
-            <version>${gethostname4j.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>net.java.dev.jna</groupId>
-            <artifactId>jna</artifactId>
-            <version>${jna.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>net.java.dev.jna</groupId>
-            <artifactId>jna-platform</artifactId>
-            <version>${jna.version}</version>
         </dependency>
 
         <dependency>

--- a/extensions/spark/kyuubi-spark-authz/src/main/java/com/kstruct/gethostname4j/Hostname.java
+++ b/extensions/spark/kyuubi-spark-authz/src/main/java/com/kstruct/gethostname4j/Hostname.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.kstruct.gethostname4j;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.SystemUtils;
+
+// Alternative for RANGER-4125 to cut out JNA dependencies
+public class Hostname {
+
+  // The highest priority environment variable which allows user to
+  // set hostname for Ranger client
+  public static final String RANGER_CLIENT_HOSTNAME = "RANGER_CLIENT_HOSTNAME";
+
+  /** @return the hostname the of the current machine */
+  public static String getHostname() {
+    String hostname = System.getenv(RANGER_CLIENT_HOSTNAME);
+    if (isValid(hostname)) return hostname;
+
+    // Gets the host name from an environment variable
+    // (COMPUTERNAME on Windows, HOSTNAME elsewhere)
+    hostname = SystemUtils.getHostName();
+    if (isValid(hostname)) return hostname;
+
+    try {
+      return InetAddress.getLocalHost().getHostName();
+    } catch (UnknownHostException rethrow) {
+      throw new RuntimeException(rethrow);
+    }
+  }
+
+  private static boolean isValid(String hostname) {
+    return StringUtils.isNotBlank(hostname) && !"localhost".equals(hostname);
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->
This PR provides an alternative for RANGER-4125 to cut out JNA dependencies for authZ plugin.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Pass GHA, and I checked the content of authz-shaded jar

```
$ jar tf extensions/spark/kyuubi-spark-authz-shaded/target/kyuubi-spark-authz-shaded_2.12-1.11.0-SNAPSHOT.jar | grep Hostname
org/apache/kyuubi/shade/com/kstruct/gethostname4j/Hostname.class
```

### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.
