### PR TITLE
Backport HIVE-26723: Configurable canonical name checking.

### DIFF
--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/JdbcConnectionParams.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/JdbcConnectionParams.java
@@ -55,6 +55,8 @@ public class JdbcConnectionParams {
   public static final String AUTH_KERBEROS_AUTH_TYPE_FROM_KEYTAB = "fromKeytab";
   public static final String AUTH_KERBEROS_AUTH_TYPE_FROM_SUBJECT = "fromSubject";
   public static final String AUTH_KERBEROS_AUTH_TYPE_FROM_TICKET_CACHE = "fromTicketCache";
+  public static final String AUTH_KERBEROS_ENABLE_CANONICAL_HOSTNAME_CHECK =
+      "kerberosEnableCanonicalHostnameCheck";
   public static final String AUTH_TYPE_JWT = "jwt";
   public static final String AUTH_TYPE_JWT_KEY = "jwt";
   public static final String AUTH_JWT_ENV = "JWT";

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
@@ -146,7 +146,11 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
     // hive_conf_list -> hiveConfMap
     // hive_var_list -> hiveVarMap
     if (isKerberosAuthMode()) {
-      host = Utils.getCanonicalHostName(connParams.getHost());
+      if (isEnableCanonicalHostnameCheck()) {
+        host = Utils.getCanonicalHostName(connParams.getHost());
+      } else {
+        host = connParams.getHost();
+      }
     } else {
       host = connParams.getHost();
     }
@@ -213,7 +217,7 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
           }
           // Update with new values
           jdbcUriString = connParams.getJdbcUriString();
-          if (isKerberosAuthMode()) {
+          if (isKerberosAuthMode() && isEnableCanonicalHostnameCheck()) {
             host = Utils.getCanonicalHostName(connParams.getHost());
           } else {
             host = connParams.getHost();
@@ -1001,6 +1005,12 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
 
   private boolean isKerberosAuthMode() {
     return isSaslAuthMode() && hasSessionValue(AUTH_PRINCIPAL);
+  }
+
+  private boolean isEnableCanonicalHostnameCheck() {
+    return Boolean.parseBoolean(
+        sessConfMap.getOrDefault(
+            JdbcConnectionParams.AUTH_KERBEROS_ENABLE_CANONICAL_HOSTNAME_CHECK, "true"));
   }
 
   private Subject createSubject() {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->
Backport https://github.com/apache/hive/pull/3749

It is not possible to create SSL connection with Kerberos authentication when the server certificate is not issued to the canonical host name but to an alternative domain name.

See details about the exception and steps for reproducing in the [HIVE-26723](https://issues.apache.org/jira/browse/HIVE-26723)

Hive JDBC client validates the host name by its canonical name by default. This behaviour leads to SSLHandshakeExcpetion when trying to connect using alias name with Kerberos authentication. To solve this issue a new connection property is introduced to be able disabling canonical host name check: enableCanonicalHostnameCheck having default value true.

When the property is not given in connection string (or its value is true) then the original behaviour is applied i.e. checking canonical host name.




### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
There are no new unit tests because the fix is in the HiveConnection constructor which contains lot of logic inside and also builds new SSL connections.
IMO it would have been far too much effort to mock the whole environment for creating unit tests against this tiny change. :(

There wasn't any already existing test against HiveConnection that could be extended with this new feature/bugfix. It is misleading that there is a class having name TestHiveConnection but there is no any tests that would test the class HiveConnection itself.

BTW It was tested manually: after this fix when the steps in JIRA are executed again using the new JARs then the SSL connection is created successfully, and I was able to execute queries.

### Does this PR introduce any user-facing change?
A new JDBC connection URL property has been introduced: enableCanonicalHostnameCheck to be able to turn off the canonical host name checking. Its default value is true so if it is not set the canonical host name is checked when building up the SSL connection.

To turn off the canonical host name checking just add this property to the connection string, i.e:

```
./beeline -u "jdbc:hive2://hs2.subdomain.example.com:443/default;transportMode=http;httpPath=cliservice;socketTimeout=60;ssl=true;retries=1;principal=myhiveprincipal/mydomain.example.com;enableCanonicalHostnameCheck=false;"
```
### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.