### PR TITLE
Set kyuubi session engine client after opening engine session successfully 

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
@@ -180,6 +180,7 @@ class KyuubiSessionImpl(
             logSessionInfo(s"Connected to engine [$host:$port]/[${client.engineId.getOrElse("")}]" +
               s" with ${_engineSessionHandle}]")
             shouldRetry = false
+            engineLaunched = true
           } catch {
             case e: TTransportException
                 if attempt < maxAttempts && e.getCause.isInstanceOf[java.net.ConnectException] &&
@@ -319,7 +320,7 @@ class KyuubiSessionImpl(
   }
 
   def checkEngineConnectionAlive(): Boolean = {
-    if (client == null) return true // client has not been initialized
+    if (!engineLaunched || client == null) return true // client has not been initialized
     if (client.engineConnectionClosed) return false
     !client.remoteEngineBroken
   }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
@@ -167,6 +167,7 @@ class KyuubiSessionImpl(
                 warn(s"Error on de-registering engine [${engine.engineSpace} $host:$port]", e)
             }
 
+          var engineClient: KyuubiSyncThriftClient = null
           try {
             val passwd =
               if (sessionManager.getConf.get(ENGINE_SECURITY_ENABLED)) {
@@ -174,13 +175,13 @@ class KyuubiSessionImpl(
               } else {
                 Option(password).filter(_.nonEmpty).getOrElse("anonymous")
               }
-            val engineClient =
+            engineClient =
               KyuubiSyncThriftClient.createClient(user, passwd, host, port, sessionConf)
             _engineSessionHandle =
               engineClient.openSession(protocol, user, passwd, openEngineSessionConf)
-            _client = engineClient
             logSessionInfo(s"Connected to engine [$host:$port]/[${client.engineId.getOrElse("")}]" +
               s" with ${_engineSessionHandle}]")
+            _client = engineClient
             shouldRetry = false
           } catch {
             case e: TTransportException
@@ -209,9 +210,9 @@ class KyuubiSessionImpl(
               throw e
           } finally {
             attempt += 1
-            if (shouldRetry && _client != null) {
+            if (shouldRetry && engineClient != null) {
               try {
-                _client.closeSession()
+                engineClient.closeSession()
               } catch {
                 case e: Throwable =>
                   warn(

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
@@ -54,7 +54,6 @@ class KyuubiSessionImpl(
   extends KyuubiSession(protocol, user, password, ipAddress, conf, sessionManager) {
 
   override val sessionType: SessionType = SessionType.INTERACTIVE
-  def engineLaunched: Boolean = _engineLaunched
 
   private[kyuubi] val optimizedConf: Map[String, String] = {
     val confOverlay = sessionManager.sessionConfAdvisor.map(_.getConfOverlay(
@@ -181,7 +180,7 @@ class KyuubiSessionImpl(
             logSessionInfo(s"Connected to engine [$host:$port]/[${client.engineId.getOrElse("")}]" +
               s" with ${_engineSessionHandle}]")
             shouldRetry = false
-            _engineLaunched = true
+            engineLaunched = true
           } catch {
             case e: TTransportException
                 if attempt < maxAttempts && e.getCause.isInstanceOf[java.net.ConnectException] &&
@@ -245,10 +244,10 @@ class KyuubiSessionImpl(
     super.runOperation(operation)
   }
 
-  @volatile private var _engineLaunched: Boolean = false
+  @volatile private var engineLaunched: Boolean = false
 
   private def waitForEngineLaunched(): Unit = {
-    if (!_engineLaunched) {
+    if (!engineLaunched) {
       Option(launchEngineOp).foreach { op =>
         val waitingStartTime = System.currentTimeMillis()
         logSessionInfo(s"Starting to wait the launch engine operation finished")
@@ -264,7 +263,7 @@ class KyuubiSessionImpl(
           throw ex
         }
 
-        _engineLaunched = true
+        engineLaunched = true
       }
     }
   }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
@@ -179,9 +179,9 @@ class KyuubiSessionImpl(
               KyuubiSyncThriftClient.createClient(user, passwd, host, port, sessionConf)
             _engineSessionHandle =
               engineClient.openSession(protocol, user, passwd, openEngineSessionConf)
+            _client = engineClient
             logSessionInfo(s"Connected to engine [$host:$port]/[${client.engineId.getOrElse("")}]" +
               s" with ${_engineSessionHandle}]")
-            _client = engineClient
             shouldRetry = false
           } catch {
             case e: TTransportException


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->
Since https://github.com/apache/kyuubi/pull/3618
Kyuubi server could retry opening the engine when encountering a special error.
https://github.com/apache/kyuubi/blob/1937dd93f9488cd209df96c603472134c3fab22d/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala#L177-L212

The `_client` might be reset and closed.

So, we shall set `_client` after open engine session successfully, as the `client` method is a public method.
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Existing UT.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.
