### PR TITLE
[KYUUBI #6997][FOLLOWUP][1.9] Fix build issue

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/AbstractOperation.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/AbstractOperation.scala
@@ -103,7 +103,7 @@ abstract class AbstractOperation(session: Session) extends Operation with Loggin
 
   protected def setOperationException(opEx: KyuubiSQLException): Unit = {
     this.operationException = opEx
-    withOperationLog(error(s"Error operating $opType: ${opEx.getMessage}", opEx))
+    error(s"Error operating $opType: ${opEx.getMessage}", opEx)
   }
 
   def getOperationJobProgress: TProgressUpdateResp = operationJobProgress

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
@@ -163,8 +163,8 @@ class BatchJobSubmission(
       opState: OperationState,
       appState: ApplicationState.ApplicationState): ApplicationState.ApplicationState = {
     if (opState == OperationState.ERROR && !ApplicationState.isTerminated(appState)) {
-      withOperationLog(error(s"Batch $batchId state is $opState," +
-        s" but the application state is $appState and not terminated, set to UNKNOWN."))
+      error(s"Batch $batchId state is $opState," +
+        s" but the application state is $appState and not terminated, set to UNKNOWN.")
       ApplicationState.UNKNOWN
     } else {
       appState


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->

Followup @6997 for branch-1.9.

Fix build issue:
```
Error: ] /home/runner/work/kyuubi/kyuubi/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/AbstractOperation.scala:106: not found: value withOperationLog
Error: [ERROR] one error found
Error:  Failed to execute goal net.alchim31.maven:scala-maven-plugin:4.9.2:compile (scala-compile-first) on project kyuubi-common_2.12: Execution scala-compile-first of goal net.alchim31.maven:scala-maven-plugin:4.9.2:compile failed: org.apache.commons.exec.ExecuteException: Process exited with an error: 255 (Exit value: 255) -> [Help 1]
```

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
GA.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.