### PR TITLE
Record the session disconnected info into kyuubi session event

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiTBinaryFrontendService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiTBinaryFrontendService.scala
@@ -26,7 +26,6 @@ import org.apache.kyuubi.cli.Handle
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.KYUUBI_SERVER_THRIFT_RESULTSET_DEFAULT_FETCH_SIZE
 import org.apache.kyuubi.config.KyuubiReservedKeys._
-import org.apache.kyuubi.events.EventBus
 import org.apache.kyuubi.ha.client.{KyuubiServiceDiscovery, ServiceDiscovery}
 import org.apache.kyuubi.metrics.MetricsConstants._
 import org.apache.kyuubi.metrics.MetricsSystem
@@ -78,7 +77,6 @@ final class KyuubiTBinaryFrontendService(
             .flatMap(_.getSessionEvent).foreach { sessionEvent =>
               sessionEvent.exception = Some(new KyuubiException(
                 s"Session between client and Kyuubi server disconnected without closing properly."))
-              EventBus.post(sessionEvent)
             }
         }
         super.deleteContext(serverContext, input, output)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiTBinaryFrontendService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiTBinaryFrontendService.scala
@@ -26,6 +26,7 @@ import org.apache.kyuubi.cli.Handle
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.KYUUBI_SERVER_THRIFT_RESULTSET_DEFAULT_FETCH_SIZE
 import org.apache.kyuubi.config.KyuubiReservedKeys._
+import org.apache.kyuubi.events.EventBus
 import org.apache.kyuubi.ha.client.{KyuubiServiceDiscovery, ServiceDiscovery}
 import org.apache.kyuubi.metrics.MetricsConstants._
 import org.apache.kyuubi.metrics.MetricsSystem
@@ -77,6 +78,7 @@ final class KyuubiTBinaryFrontendService(
             .flatMap(_.getSessionEvent).foreach { sessionEvent =>
               sessionEvent.exception = Some(new KyuubiException(
                 s"Session between client and Kyuubi server disconnected without closing properly"))
+              EventBus.post(sessionEvent)
             }
         }
         super.deleteContext(serverContext, input, output)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiTBinaryFrontendService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiTBinaryFrontendService.scala
@@ -77,7 +77,7 @@ final class KyuubiTBinaryFrontendService(
             .map(_.asInstanceOf[KyuubiSessionImpl])
             .flatMap(_.getSessionEvent).foreach { sessionEvent =>
               sessionEvent.exception = Some(new KyuubiException(
-                s"Session between client and Kyuubi server disconnected without closing properly"))
+                s"Session between client and Kyuubi server disconnected without closing properly."))
               EventBus.post(sessionEvent)
             }
         }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiTBinaryFrontendService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiTBinaryFrontendService.scala
@@ -21,7 +21,7 @@ import java.util.Base64
 
 import org.apache.hadoop.conf.Configuration
 
-import org.apache.kyuubi.KyuubiSQLException
+import org.apache.kyuubi.{KyuubiException, KyuubiSQLException}
 import org.apache.kyuubi.cli.Handle
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.KYUUBI_SERVER_THRIFT_RESULTSET_DEFAULT_FETCH_SIZE
@@ -69,6 +69,16 @@ final class KyuubiTBinaryFrontendService(
           serverContext: ServerContext,
           input: TProtocol,
           output: TProtocol): Unit = {
+        val handle = serverContext.getSessionHandle
+        if (handle != null) {
+          be.sessionManager
+            .getSessionOption(handle)
+            .map(_.asInstanceOf[KyuubiSessionImpl])
+            .flatMap(_.getSessionEvent).foreach { sessionEvent =>
+              sessionEvent.exception = Some(new KyuubiException(
+                s"Session between client and Kyuubi server disconnected without closing properly"))
+            }
+        }
         super.deleteContext(serverContext, input, output)
         MetricsSystem.tracing { ms =>
           ms.decCount(THRIFT_BINARY_CONN_OPEN)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->

Currently, if the kyuubi session between client and kyuubi session disconnected without closing properly, it is difficult to debug, and we have to check the kyuubi server log.

It is better that, we can record such kind of information into kyuubi session event.
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
IT.

<img width="1264" alt="image" src="https://github.com/user-attachments/assets/d2c5b6d0-6298-46ec-9b73-ce648551120c" />


### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.
