### PR TITLE
Supports fully asynchronous Engine initialization

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/KyuubiOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/KyuubiOperation.scala
@@ -172,7 +172,7 @@ abstract class KyuubiOperation(session: Session) extends AbstractOperation(sessi
   }
 
   override def getResultSetMetadata: TGetResultSetMetadataResp = {
-    if (_remoteOpHandle == null) {
+    if (_remoteOpHandle == null || !hasResultSet) {
       val tColumnDesc = new TColumnDesc()
       tColumnDesc.setColumnName("Result")
       val desc = new TTypeDesc


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->
When `SESSION_ENGINE_LAUNCH_ASYNC` is set to `True`, the client should not block while waiting for the engine to initialize. This is particularly important in scenarios where cluster resources are constrained, as engine initialization can be significantly delayed, potentially causing the client to block during execute calls. This can lead to serious issues—for example, we found that PyHive may lose connection with Kyuubi under such circumstances. This PR enables fully asynchronous engine startup, thereby reducing client response latency and improving the overall user experience.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

