### PR TITLE
Expose optimizedConf into kyuubi session event

### DIFF
--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/api/v1/dto/KyuubiSessionEvent.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/api/v1/dto/KyuubiSessionEvent.java
@@ -45,6 +45,8 @@ public class KyuubiSessionEvent {
 
   private Map<String, String> conf;
 
+  private Map<String, String> optimizedConf;
+
   private long eventTime;
 
   private long openedTime;
@@ -72,6 +74,7 @@ public class KyuubiSessionEvent {
       String clientIp,
       String serverIp,
       Map<String, String> conf,
+      Map<String, String> optimizedConf,
       long eventTime,
       long openedTime,
       long startTime,
@@ -90,6 +93,7 @@ public class KyuubiSessionEvent {
     this.clientIp = clientIp;
     this.serverIp = serverIp;
     this.conf = conf;
+    this.optimizedConf = optimizedConf;
     this.eventTime = eventTime;
     this.openedTime = openedTime;
     this.startTime = startTime;
@@ -126,6 +130,8 @@ public class KyuubiSessionEvent {
     private String serverIp;
 
     private Map<String, String> conf;
+
+    private Map<String, String> optimizedConf;
 
     private long eventTime;
 
@@ -202,6 +208,12 @@ public class KyuubiSessionEvent {
       return this;
     }
 
+    public KyuubiSessionEvent.KyuubiSessionEventBuilder optimizedConf(
+        final Map<String, String> optimizedConf) {
+      this.optimizedConf = optimizedConf;
+      return this;
+    }
+
     public KyuubiSessionEvent.KyuubiSessionEventBuilder eventTime(final long eventTime) {
       this.eventTime = eventTime;
       return this;
@@ -246,6 +258,7 @@ public class KyuubiSessionEvent {
           clientIp,
           serverIp,
           conf,
+          optimizedConf,
           eventTime,
           openedTime,
           startTime,
@@ -349,6 +362,14 @@ public class KyuubiSessionEvent {
 
   public void setConf(Map<String, String> conf) {
     this.conf = conf;
+  }
+
+  public Map<String, String> getOptimizedConf() {
+    return optimizedConf;
+  }
+
+  public void setOptimizedConf(Map<String, String> optimizedConf) {
+    this.optimizedConf = optimizedConf;
   }
 
   public long getEventTime() {

--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/api/v1/dto/SessionData.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/api/v1/dto/SessionData.java
@@ -29,6 +29,7 @@ public class SessionData {
   private String user;
   private String ipAddr;
   private Map<String, String> conf;
+  private Map<String, String> optimizedConf;
   private Long createTime;
   private Long duration;
   private Long idleTime;
@@ -49,6 +50,7 @@ public class SessionData {
       String user,
       String ipAddr,
       Map<String, String> conf,
+      Map<String, String> optimizedConf,
       Long createTime,
       Long duration,
       Long idleTime,
@@ -65,6 +67,7 @@ public class SessionData {
     this.user = user;
     this.ipAddr = ipAddr;
     this.conf = conf;
+    this.optimizedConf = optimizedConf;
     this.createTime = createTime;
     this.duration = duration;
     this.idleTime = idleTime;
@@ -119,6 +122,14 @@ public class SessionData {
 
   public void setConf(Map<String, String> conf) {
     this.conf = conf;
+  }
+
+  public Map<String, String> getOptimizedConf() {
+    return optimizedConf;
+  }
+
+  public void setOptimizedConf(Map<String, String> optimizedConf) {
+    this.optimizedConf = optimizedConf;
   }
 
   public Long getCreateTime() {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/events/KyuubiSessionEvent.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/events/KyuubiSessionEvent.scala
@@ -48,6 +48,7 @@ case class KyuubiSessionEvent(
     clientIP: String,
     serverIP: String,
     conf: Map[String, String],
+    optimizedConf: Map[String, String],
     eventTime: Long,
     startTime: Long,
     var remoteSessionId: String = "",
@@ -73,6 +74,7 @@ object KyuubiSessionEvent {
       session.ipAddress,
       session.connectionUrl,
       session.conf,
+      session.optimizedConf,
       System.currentTimeMillis(),
       session.createTime)
   }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/ApiUtils.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/ApiUtils.scala
@@ -38,6 +38,7 @@ object ApiUtils extends Logging {
         .clientIp(event.clientIP)
         .serverIp(event.serverIP)
         .conf(event.conf.asJava)
+        .optimizedConf(event.optimizedConf.asJava)
         .remoteSessionId(event.remoteSessionId)
         .engineId(event.engineId)
         .engineName(event.engineName)
@@ -59,6 +60,7 @@ object ApiUtils extends Logging {
       session.user,
       session.ipAddress,
       session.conf.asJava,
+      session.normalizedConf.asJava,
       session.createTime,
       session.lastAccessTime - session.createTime,
       session.getNoOperationTime,

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSession.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSession.scala
@@ -40,6 +40,8 @@ abstract class KyuubiSession(
 
   val realUser = conf.getOrElse(KYUUBI_SESSION_REAL_USER_KEY, user)
 
+  val optimizedConf: Map[String, String]
+
   def getSessionEvent: Option[KyuubiSessionEvent]
 
   def checkSessionAccessPathURIs(): Unit

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
@@ -55,7 +55,7 @@ class KyuubiSessionImpl(
 
   override val sessionType: SessionType = SessionType.INTERACTIVE
 
-  private[kyuubi] val optimizedConf: Map[String, String] = {
+  override val optimizedConf: Map[String, String] = {
     val confOverlay = sessionManager.sessionConfAdvisor.map(_.getConfOverlay(
       user,
       normalizedConf.asJava).asScala).reduce(_ ++ _)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->


With `SessionConfAdvisor::getConfOverlay`, the original session conf and optimizedConf might be absolute different.

And we also need to reserved the original conf to track the source configuration.

So, it is better to expose the additional optimizedConf as well.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

UT.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.

