### PR TITLE
Treat YARN/Kubernetes application NOT_FOUND as failed to prevent data quality issue

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ApplicationOperation.scala
@@ -99,10 +99,14 @@ object ApplicationState extends Enumeration {
 
   def isFailed(
       state: ApplicationState,
-      appOperation: Option[ApplicationOperation]): Boolean = state match {
+      appOperation: Option[ApplicationOperation]): Boolean = {
+    isFailed(state, appOperation.exists(_.supportPersistedAppState))
+  }
+
+  def isFailed(state: ApplicationState, supportPersistedAppState: Boolean): Boolean = state match {
     case FAILED => true
     case KILLED => true
-    case NOT_FOUND => appOperation.exists(_.supportPersistedAppState)
+    case NOT_FOUND => supportPersistedAppState
     case _ => false
   }
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ApplicationOperation.scala
@@ -94,6 +94,7 @@ object ApplicationState extends Enumeration {
   def isFailed(state: ApplicationState): Boolean = state match {
     case FAILED => true
     case KILLED => true
+    case NOT_FOUND => true
     case _ => false
   }
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ApplicationOperation.scala
@@ -106,7 +106,7 @@ object ApplicationState extends Enumeration {
   def isFailed(state: ApplicationState, supportPersistedAppState: Boolean): Boolean = state match {
     case FAILED => true
     case KILLED => true
-    case NOT_FOUND => supportPersistedAppState
+    case NOT_FOUND if supportPersistedAppState => true
     case _ => false
   }
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/JpsApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/JpsApplicationOperation.scala
@@ -105,5 +105,7 @@ class JpsApplicationOperation extends ApplicationOperation {
     // TODO check if the process is zombie
   }
 
+  override def supportPersistedAppState: Boolean = false
+
   override def stop(): Unit = {}
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
@@ -283,6 +283,8 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
     }
   }
 
+  override def supportPersistedAppState: Boolean = true
+
   override def stop(): Unit = {
     enginePodInformers.asScala.foreach { case (_, informer) =>
       Utils.tryLogNonFatalError(informer.stop())

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
@@ -576,8 +576,7 @@ object KubernetesApplicationOperation extends Logging {
       case None => podAppState
     }
     val applicationError = {
-      // here the applicationState could not been NOT_FOUND, safe to use None ApplicationOperation
-      if (ApplicationState.isFailed(applicationState, appOperation = None)) {
+      if (ApplicationState.isFailed(applicationState, supportPersistedAppState = true)) {
         val errorMap = containerStatusToBuildAppState.map { cs =>
           Map(
             "Pod" -> podName,

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KyuubiApplicationManager.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KyuubiApplicationManager.scala
@@ -103,6 +103,11 @@ class KyuubiApplicationManager(metadataManager: Option[MetadataManager])
     operations.find(_.isInstanceOf[KubernetesApplicationOperation])
       .map(_.asInstanceOf[KubernetesApplicationOperation])
   }
+
+  private[kyuubi] def getApplicationOperation(appMgrInfo: ApplicationManagerInfo)
+      : Option[ApplicationOperation] = {
+    operations.find(_.isSupported(appMgrInfo))
+  }
 }
 
 object KyuubiApplicationManager {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/YarnApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/YarnApplicationOperation.scala
@@ -165,6 +165,8 @@ class YarnApplicationOperation extends ApplicationOperation with Logging {
     }
   }
 
+  override def supportPersistedAppState: Boolean = true
+
   override def stop(): Unit = adminYarnClient.foreach { yarnClient =>
     Utils.tryLogNonFatalError(yarnClient.stop())
   }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
@@ -216,7 +216,7 @@ class BatchJobSubmission(
           case Some(metadata) if metadata.peerInstanceClosed =>
             setState(OperationState.CANCELED)
           case Some(metadata)
-              // in case it has been updated by peer kyuubi instance, see KYUUBI-6278
+              // in case it has been updated by peer kyuubi instance, see KYUUBI #6278
               if StringUtils.isNotBlank(metadata.engineState) &&
                 ApplicationState.isTerminated(ApplicationState.withName(metadata.engineState)) =>
             _applicationInfo = Some(new ApplicationInfo(

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
@@ -129,8 +129,9 @@ private[v1] class BatchesResource extends ApiRequestContext with Logging {
       metadata: Metadata,
       batchAppStatus: Option[ApplicationInfo]): Batch = {
     batchAppStatus.map { appStatus =>
+      val appOp = sessionManager.applicationManager.getApplicationOperation(metadata.appMgrInfo)
       val currentBatchState =
-        if (BatchJobSubmission.applicationFailed(batchAppStatus)) {
+        if (BatchJobSubmission.applicationFailed(batchAppStatus, appOp)) {
           OperationState.ERROR.toString
         } else if (BatchJobSubmission.applicationTerminated(batchAppStatus)) {
           OperationState.FINISHED.toString


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->

Currently, NOT_FOUND application stated is treated as a terminated but not failed state.

It might cause some data quality issue if downstream application depends on the batch state for data processing.

So, I think we should treat NOT_FOUND as a failed state instead.

Currently, we support 3 types of application manager.
1. [JpsApplicationOperation](https://github.com/apache/kyuubi/blob/master/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/JpsApplicationOperation.scala)
2. [YarnApplicationOperation](https://github.com/apache/kyuubi/blob/master/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/YarnApplicationOperation.scala)
3. [KubernetesApplicationOperation](https://github.com/apache/kyuubi/blob/master/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala)

YarnApplicationOperation and KubernetesApplicationOperation are widely used in production use case.

And in multiple kyuubi instance mode, the NOT_FOUND case should rarely happen.
1.  https://github.com/apache/kyuubi/blob/7e199d6fdbdf52222bb3eadd056b9e5a2295f36e/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala#L369-L385

3. https://github.com/apache/kyuubi/pull/7029

So, I think we should treat NOT_FOUND as a failed state in production use case.
It is better to fail some corner cases than to mistakenly set unsuccessful batches to the finished state.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

GA.
### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.