### PR TITLE
[KUBERNETES] Prefer to use pod `spark-app-name` label as application name than pod name

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationAuditLogger.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationAuditLogger.scala
@@ -23,7 +23,7 @@ import io.fabric8.kubernetes.api.model.Pod
 
 import org.apache.kyuubi.Logging
 import org.apache.kyuubi.config.KyuubiConf.KubernetesApplicationStateSource.KubernetesApplicationStateSource
-import org.apache.kyuubi.engine.KubernetesApplicationOperation.{toApplicationStateAndError, LABEL_KYUUBI_UNIQUE_KEY, SPARK_APP_ID_LABEL}
+import org.apache.kyuubi.engine.KubernetesApplicationOperation.{getPodAppId, getPodAppName, toApplicationStateAndError, LABEL_KYUUBI_UNIQUE_KEY}
 import org.apache.kyuubi.engine.KubernetesResourceEventTypes.KubernetesResourceEventType
 
 object KubernetesApplicationAuditLogger extends Logging {
@@ -49,7 +49,8 @@ object KubernetesApplicationAuditLogger extends Logging {
       s"${containerState.getName}->${containerState.getState}"
     }.mkString("[", ",", "]")
     sb.append(s"containers=$containerStatuses").append("\t")
-    sb.append(s"appId=${pod.getMetadata.getLabels.get(SPARK_APP_ID_LABEL)}").append("\t")
+    sb.append(s"appId=${getPodAppId(pod)}").append("\t")
+    sb.append(s"appName=${getPodAppName(pod)}").append("\t")
     val (appState, appError) =
       toApplicationStateAndError(pod, appStateSource, appStateContainer, eventType)
     sb.append(s"appState=$appState").append("\t")

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
@@ -408,16 +408,16 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
         appInfoStore.put(
           kyuubiUniqueKey,
           kubernetesInfo -> appInfo.copy(
-            id = pod.getMetadata.getLabels.get(SPARK_APP_ID_LABEL),
-            name = pod.getMetadata.getName,
+            id = getPodAppId(pod),
+            name = getPodAppName(pod),
             state = appState,
             error = appError))
       }.getOrElse {
         appInfoStore.put(
           kyuubiUniqueKey,
           kubernetesInfo -> ApplicationInfo(
-            id = pod.getMetadata.getLabels.get(SPARK_APP_ID_LABEL),
-            name = pod.getMetadata.getName,
+            id = getPodAppId(pod),
+            name = getPodAppName(pod),
             state = appState,
             error = appError))
       }
@@ -506,7 +506,8 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
 
 object KubernetesApplicationOperation extends Logging {
   val LABEL_KYUUBI_UNIQUE_KEY = "kyuubi-unique-tag"
-  val SPARK_APP_ID_LABEL = "spark-app-selector"
+  private val SPARK_APP_ID_LABEL = "spark-app-selector"
+  private val SPARK_APP_NAME_LABEL = "spark-app-name"
   val KUBERNETES_SERVICE_HOST = "KUBERNETES_SERVICE_HOST"
   val KUBERNETES_SERVICE_PORT = "KUBERNETES_SERVICE_PORT"
   val SPARK_UI_PORT_NAME = "spark-ui"
@@ -633,5 +634,13 @@ object KubernetesApplicationOperation extends Logging {
       .replace("{{KUBERNETES_CONTEXT}}", kubernetesContext)
       .replace("{{KUBERNETES_NAMESPACE}}", kubernetesNamespace)
       .replace("{{SPARK_UI_PORT}}", sparkUiPort.toString)
+  }
+
+  def getPodAppId(pod: Pod): String = {
+    pod.getMetadata.getLabels.get(SPARK_APP_ID_LABEL)
+  }
+
+  def getPodAppName(pod: Pod): String = {
+    Option(pod.getMetadata.getLabels.get(SPARK_APP_NAME_LABEL)).getOrElse(pod.getMetadata.getName)
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->

After https://github.com/apache/spark/pull/34460 (Since Spark 3.3.0), the `spark-app-name` is available.

We shall use it as the application name if it exists.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Minor change.
### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.