### PR TITLE
Close the operation by operation manager to prevent operation leak

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
@@ -238,7 +238,7 @@ class KyuubiSessionImpl(
         waitForEngineLaunched()
       } catch {
         case t: Throwable =>
-          operation.close()
+          sessionManager.operationManager.closeOperation(operation.getHandle)
           throw t
       }
       sessionEvent.totalOperations += 1


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->
To fix the operation leak if the session init timeout.

1. the operationHandle has not been added into session `opHandleSet` (super.runOperation).
2. The `operation.close()` only close the operation, but it does not remove it from `handleToOperation` map.
3. the session close would not remove the opHandle from `handleToOperation` as it has not been added into session `opHandleSet`


So here we can resolve the operation leak by invoking `operationManager.closeOperation` to remove the operation handle and close session.
https://github.com/apache/kyuubi/blob/cc68cb4c852dccd920ba53a4d853aa407ff83faa/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala#L235-L246

https://github.com/apache/kyuubi/blob/cc68cb4c852dccd920ba53a4d853aa407ff83faa/kyuubi-common/src/main/scala/org/apache/kyuubi/session/AbstractSession.scala#L100-L103 

https://github.com/apache/kyuubi/blob/cc68cb4c852dccd920ba53a4d853aa407ff83faa/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/OperationManager.scala#L127-L130

https://github.com/apache/kyuubi/blob/cc68cb4c852dccd920ba53a4d853aa407ff83faa/kyuubi-common/src/main/scala/org/apache/kyuubi/session/AbstractSession.scala#L89-L92

FYI: the operation was added into `handleToOperation` during new operation.
https://github.com/apache/kyuubi/blob/cc68cb4c852dccd920ba53a4d853aa407ff83faa/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/KyuubiOperationManager.scala#L56-L64

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Minor change.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.