### PR TITLE
[KYUUBI #7034][FOLLOWUP] Decouple the kubernetes pod name and app name

### DIFF
--- a/integration-tests/kyuubi-kubernetes-it/src/test/scala/org/apache/kyuubi/kubernetes/test/spark/SparkOnKubernetesTestsSuite.scala
+++ b/integration-tests/kyuubi-kubernetes-it/src/test/scala/org/apache/kyuubi/kubernetes/test/spark/SparkOnKubernetesTestsSuite.scala
@@ -230,7 +230,8 @@ class KyuubiOperationKubernetesClusterClusterModeSuite
         appMgrInfo,
         sessionHandle.identifier.toString)
       assert(appInfo.state == RUNNING)
-      assert(appInfo.name.startsWith(driverPodNamePrefix))
+      // See KYUUBI-7034: prefer to use pod `spark-app-name` label instead of pod name
+      // assert(appInfo.name.startsWith(driverPodNamePrefix))
     }
 
     val killResponse = k8sOperation.killApplicationByTag(

--- a/integration-tests/kyuubi-kubernetes-it/src/test/scala/org/apache/kyuubi/kubernetes/test/spark/SparkOnKubernetesTestsSuite.scala
+++ b/integration-tests/kyuubi-kubernetes-it/src/test/scala/org/apache/kyuubi/kubernetes/test/spark/SparkOnKubernetesTestsSuite.scala
@@ -28,7 +28,7 @@ import org.apache.kyuubi._
 import org.apache.kyuubi.client.util.BatchUtils._
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf._
-import org.apache.kyuubi.engine.{ApplicationInfo, ApplicationManagerInfo, ApplicationOperation, KubernetesApplicationInfo, KubernetesApplicationOperation}
+import org.apache.kyuubi.engine.{ApplicationInfo, ApplicationManagerInfo, ApplicationOperation, KubernetesApplicationOperation}
 import org.apache.kyuubi.engine.ApplicationState.{FAILED, NOT_FOUND, RUNNING}
 import org.apache.kyuubi.engine.spark.SparkProcessBuilder
 import org.apache.kyuubi.kubernetes.test.MiniKube
@@ -230,8 +230,7 @@ class KyuubiOperationKubernetesClusterClusterModeSuite
         appMgrInfo,
         sessionHandle.identifier.toString)
       assert(appInfo.state == RUNNING)
-      assert(
-        appInfo.asInstanceOf[KubernetesApplicationInfo].podName.startsWith(driverPodNamePrefix))
+      assert(appInfo.podName.exists(_.startsWith(driverPodNamePrefix)))
     }
 
     val killResponse = k8sOperation.killApplicationByTag(

--- a/integration-tests/kyuubi-kubernetes-it/src/test/scala/org/apache/kyuubi/kubernetes/test/spark/SparkOnKubernetesTestsSuite.scala
+++ b/integration-tests/kyuubi-kubernetes-it/src/test/scala/org/apache/kyuubi/kubernetes/test/spark/SparkOnKubernetesTestsSuite.scala
@@ -126,6 +126,7 @@ class SparkClusterModeOnKubernetesSuiteBase
       .set("spark.kubernetes.driver.podTemplateFile", driverTemplate.getPath)
       .set(ZK_CLIENT_PORT_ADDRESS.key, localhostAddress)
       .set(FRONTEND_THRIFT_BINARY_BIND_HOST.key, localhostAddress)
+      .set(BATCH_APPLICATION_CHECK_INTERVAL.key, "100")
   }
 }
 
@@ -224,7 +225,7 @@ class KyuubiOperationKubernetesClusterClusterModeSuite
       batchRequest)
 
     // wait for driver pod start
-    eventually(timeout(3.minutes), interval(5.second)) {
+    eventually(timeout(3.minutes), interval(100.milliseconds)) {
       // trigger k8sOperation init here
       val appInfo = k8sOperation.getApplicationInfoByTag(
         appMgrInfo,

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ApplicationOperation.scala
@@ -112,7 +112,9 @@ case class ApplicationInfo(
     name: String,
     state: ApplicationState,
     url: Option[String] = None,
-    error: Option[String] = None) {
+    error: Option[String] = None,
+    // only used for K8s and still possible to be None for cases like NOT_FOUND state for K8s cases
+    podName: Option[String] = None) {
 
   def toMap: Map[String, String] = {
     Map(
@@ -120,40 +122,14 @@ case class ApplicationInfo(
       "name" -> name,
       "state" -> state.toString,
       "url" -> url.orNull,
-      "error" -> error.orNull)
+      "error" -> error.orNull) ++
+      podName.map("podName" -> _).toMap
   }
 }
 
 object ApplicationInfo {
   val NOT_FOUND: ApplicationInfo = ApplicationInfo(null, null, ApplicationState.NOT_FOUND)
   val UNKNOWN: ApplicationInfo = ApplicationInfo(null, null, ApplicationState.UNKNOWN)
-}
-
-class KubernetesApplicationInfo(
-    id: String,
-    name: String,
-    state: ApplicationState,
-    url: Option[String] = None,
-    error: Option[String] = None,
-    val podName: String) extends ApplicationInfo(id, name, state, url, error) {
-  override def toMap: Map[String, String] = super.toMap ++ Map("podName" -> podName)
-}
-
-object KubernetesApplicationInfo {
-  val NOT_FOUND: KubernetesApplicationInfo = new KubernetesApplicationInfo(
-    null,
-    null,
-    ApplicationState.NOT_FOUND,
-    None,
-    None,
-    null)
-  val UNKNOWN: KubernetesApplicationInfo = new KubernetesApplicationInfo(
-    null,
-    null,
-    ApplicationState.UNKNOWN,
-    None,
-    None,
-    null)
 }
 
 object ApplicationOperation {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ApplicationOperation.scala
@@ -129,6 +129,33 @@ object ApplicationInfo {
   val UNKNOWN: ApplicationInfo = ApplicationInfo(null, null, ApplicationState.UNKNOWN)
 }
 
+class KubernetesApplicationInfo(
+    id: String,
+    name: String,
+    state: ApplicationState,
+    url: Option[String] = None,
+    error: Option[String] = None,
+    val podName: String) extends ApplicationInfo(id, name, state, url, error) {
+  override def toMap: Map[String, String] = super.toMap ++ Map("podName" -> podName)
+}
+
+object KubernetesApplicationInfo {
+  val NOT_FOUND: KubernetesApplicationInfo = new KubernetesApplicationInfo(
+    null,
+    null,
+    ApplicationState.NOT_FOUND,
+    None,
+    None,
+    null)
+  val UNKNOWN: KubernetesApplicationInfo = new KubernetesApplicationInfo(
+    null,
+    null,
+    ApplicationState.UNKNOWN,
+    None,
+    None,
+    null)
+}
+
 object ApplicationOperation {
   val NOT_FOUND = "APPLICATION_NOT_FOUND"
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
@@ -473,11 +473,12 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
       podLabelUniqueKey: String): Unit = {
     try {
       val kubernetesClient = getOrCreateKubernetesClient(kubernetesInfo)
-      val deleted = Option(podName) match {
-        case Some(_) => !kubernetesClient.pods().withName(podName).delete().isEmpty
-        case None => !kubernetesClient.pods().withLabel(
-            LABEL_KYUUBI_UNIQUE_KEY,
-            podLabelUniqueKey).delete().isEmpty
+      val deleted = if (podName == null) {
+        !kubernetesClient.pods()
+          .withLabel(LABEL_KYUUBI_UNIQUE_KEY, podLabelUniqueKey)
+          .delete().isEmpty
+      } else {
+        !kubernetesClient.pods().withName(podName).delete().isEmpty
       }
       if (deleted) {
         info(s"[$kubernetesInfo] Operation of delete pod $podName with" +


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->
Followup for #7034  to fix the SparkOnKubernetesTestsSuite.

Sorry, I forget that the appInfo name and pod name were deeply bound before, the appInfo name was used as pod name and used to delete pod.

In this PR, we add `podName` into applicationInfo to separate app name and pod name.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
GA should pass.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.