### PR TITLE
Support to exclude server only configs with prefixes

### DIFF
--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/config/KyuubiConfSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/config/KyuubiConfSuite.scala
@@ -230,4 +230,10 @@ class KyuubiConfSuite extends KyuubiFunSuite {
     assert(kubernetesConf2.get(KyuubiConf.KUBERNETES_AUTHENTICATE_OAUTH_TOKEN_FILE) ==
       Some("/var/run/secrets/kubernetes.io/token.ns2"))
   }
+
+  test("KYUUBI #7053 - Support to exclude server only configs with prefixes") {
+    val kyuubiConf = KyuubiConf(false)
+    kyuubiConf.set("kyuubi.kubernetes.28.master.address", "k8s://master")
+    assert(kyuubiConf.getUserDefaults("kyuubi").getAll.size == 0)
+  }
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/events/handler/ServerKafkaLoggingEventHandler.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/events/handler/ServerKafkaLoggingEventHandler.scala
@@ -28,4 +28,5 @@ case class ServerKafkaLoggingEventHandler(
 
 object ServerKafkaLoggingEventHandler {
   val KAFKA_SERVER_EVENT_HANDLER_PREFIX = "kyuubi.backend.server.event.kafka"
+  KyuubiConf.registerServerOnlyConfigPrefix(KAFKA_SERVER_EVENT_HANDLER_PREFIX)
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/jdbc/JDBCMetadataStoreConf.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/jdbc/JDBCMetadataStoreConf.scala
@@ -25,6 +25,7 @@ import org.apache.kyuubi.util.JavaUtils
 
 object JDBCMetadataStoreConf {
   final val METADATA_STORE_JDBC_DATASOURCE_PREFIX = "kyuubi.metadata.store.jdbc.datasource"
+  KyuubiConf.registerServerOnlyConfigPrefix(METADATA_STORE_JDBC_DATASOURCE_PREFIX)
 
   def getMetadataStoreJdbcUrl(conf: KyuubiConf): String = {
     val rawJdbcUrl = conf.get(METADATA_STORE_JDBC_URL)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->
Support to exclude server only configs with prefixes.

Currently, too many configs involved for kyuubi interactive sessions.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
UT.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.
