### PR TITLE
Support to filter out server only configs with prefixes

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -193,6 +193,16 @@ case class KyuubiConf(loadSysDefault: Boolean = true) extends Logging {
     cloned
   }
 
+  private lazy val serverOnlyPrefixes = get(KyuubiConf.SERVER_ONLY_PREFIXES)
+  private lazy val serverOnlyPrefixConfigKeys = settings.keys().asScala
+    // for ConfigEntry, respect the serverOnly flag and exclude it here
+    .filter(key => getConfigEntry(key) == null)
+    .filter { key =>
+      serverOnlyPrefixes.exists { prefix =>
+        key.startsWith(prefix)
+      }
+    }
+
   def getUserDefaults(user: String): KyuubiConf = {
     val cloned = KyuubiConf(false)
 
@@ -205,6 +215,7 @@ case class KyuubiConf(loadSysDefault: Boolean = true) extends Logging {
       cloned.set(k, v)
     }
     serverOnlyConfEntries.foreach(cloned.unset)
+    serverOnlyPrefixConfigKeys.foreach(cloned.unset)
     cloned
   }
 
@@ -2842,6 +2853,22 @@ object KyuubiConf {
       .version("1.6.1")
       .stringConf
       .createWithDefault("ENGINE")
+
+  val SERVER_ONLY_PREFIXES: ConfigEntry[Set[String]] =
+    buildConf("kyuubi.config.server.only.prefixes")
+      .internal
+      .serverOnly
+      .doc("A comma-separated list of prefixes for server-only configs. It's used to filter out " +
+        "the server-only configs to prevent passing them to the engine end. Note that, " +
+        "it only take affects for the configs that is not defined as a Kyuubi ConfigEntry. " +
+        "For example, you can exclude `kyuubi.kubernetes.28.master.address=k8s://master` by" +
+        " setting it to `kyuubi.kubernetes.28.`.")
+      .version("1.11.0")
+      .stringConf
+      .toSet()
+      .createWithDefault(Set(
+        "kyuubi.backend.server.event.kafka.",
+        "kyuubi.metadata.store.jdbc.datasource."))
 
   val ENGINE_SPARK_SHOW_PROGRESS: ConfigEntry[Boolean] =
     buildConf("kyuubi.session.engine.spark.showProgress")

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -2861,8 +2861,8 @@ object KyuubiConf {
       .doc("A comma-separated list of prefixes for server-only configs. It's used to filter out " +
         "the server-only configs to prevent passing them to the engine end. Note that, " +
         "it only take affects for the configs that is not defined as a Kyuubi ConfigEntry. " +
-        "For example, you can exclude `kyuubi.kubernetes.28.master.address=k8s://master` by" +
-        " setting it to `kyuubi.kubernetes.28.`.")
+        "For example, you can exclude `kyuubi.kubernetes.28.master.address=k8s://master` by " +
+        "setting it to `kyuubi.kubernetes.28.`.")
       .version("1.11.0")
       .stringConf
       .toSet()

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/config/KyuubiConfSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/config/KyuubiConfSuite.scala
@@ -230,4 +230,10 @@ class KyuubiConfSuite extends KyuubiFunSuite {
     assert(kubernetesConf2.get(KyuubiConf.KUBERNETES_AUTHENTICATE_OAUTH_TOKEN_FILE) ==
       Some("/var/run/secrets/kubernetes.io/token.ns2"))
   }
+
+  test("KYUUBI #7053 - Support to exclude server only configs with prefixes") {
+    val kyuubiConf = KyuubiConf(false)
+    kyuubiConf.set("kyuubi.backend.server.event.kafka.broker", "localhost:9092")
+    assert(kyuubiConf.getUserDefaults("kyuubi").getAll.size == 0)
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->
To filter out server only configs with prefixes.

For some kyuubi configs, there is no related defined ConfigEntry, and we can not filter out them and have to populate them to engien end.

For example:
```
kyuubi.kubernetes.28.master.address=k8s://master
kyuubi.backend.server.event.kafka.broker=localhost:9092
kyuubi.metadata.store.jdbc.driver=com.mysql.cj.jdbc.Driver
kyuubi.metadata.store.jdbc.datasource.maximumPoolSize=600
kyuubi.metadata.store.jdbc.datasource.minimumIdle=100
kyuubi.metadata.store.jdbc.datasource.idleTimeout=60000
```

This PR supports to exclude them by setting:
```
kyuubi.config.server.only.prefixes=kyuubi.backend.server.event.kafka.,kyuubi.metadata.store.jdbc.datasource.,kyuubi.kubernetes.28.
```

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

UT
### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.
