### PR TITLE
[WIP][KYUUBI #7064] Fix thrift GetSchemas/GetTables with custom session catalog

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/repl/DataFrameHolder.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/repl/DataFrameHolder.scala
@@ -17,7 +17,7 @@
 
 package org.apache.kyuubi.engine.spark.repl
 
-import java.util
+import java.util.HashMap
 
 import org.apache.spark.kyuubi.SparkContextHelper
 import org.apache.spark.sql.{DataFrame, SparkSession}
@@ -29,7 +29,7 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
  */
 class DataFrameHolder(spark: SparkSession) {
 
-  private val results = new util.HashMap[String, DataFrame]()
+  private val results = new HashMap[String, DataFrame]()
 
   private def currentId: String = {
     SparkContextHelper.getCurrentStatementId(spark.sparkContext)

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/repl/DataFrameHolder.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/repl/DataFrameHolder.scala
@@ -17,7 +17,7 @@
 
 package org.apache.kyuubi.engine.spark.repl
 
-import java.util.HashMap
+import java.util
 
 import org.apache.spark.kyuubi.SparkContextHelper
 import org.apache.spark.sql.{DataFrame, SparkSession}
@@ -29,7 +29,7 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
  */
 class DataFrameHolder(spark: SparkSession) {
 
-  private val results = new HashMap[String, DataFrame]()
+  private val results = new util.HashMap[String, DataFrame]()
 
   private def currentId: String = {
     SparkContextHelper.getCurrentStatementId(spark.sparkContext)

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/util/SparkCatalogUtils.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/util/SparkCatalogUtils.scala
@@ -41,7 +41,7 @@ object SparkCatalogUtils extends Logging {
   val sparkTableTypes: Set[String] = Set(VIEW, TABLE)
 
   // ///////////////////////////////////////////////////////////////////////////////////////////////
-  //                                          Catalog                                            //
+  //                                          Catalog                                             //
   // ///////////////////////////////////////////////////////////////////////////////////////////////
 
   // SPARK-46050 (4.2.0) changed CatalogManager from a class to an interface, breaking
@@ -73,7 +73,7 @@ object SparkCatalogUtils extends Logging {
     invokeAs[Boolean](catalogManager(spark), "isCatalogRegistered", (classOf[String], name))
 
   /**
-   * Get all register catalogs in Spark's `CatalogManager`
+   * Note that the result only contains loaded catalogs because catalogs are lazily loaded in Spark.
    */
   def getCatalogs(spark: SparkSession): Seq[Row] = {
     val catalogMgr = catalogManager(spark)
@@ -103,25 +103,30 @@ object SparkCatalogUtils extends Logging {
     }
   }
 
+  // SPARK-50700 (4.0.0) adds the `builtin` magic value
+  private def hasCustomSessionCatalog(spark: SparkSession): Boolean = {
+    spark.conf.get(s"spark.sql.catalog.$SESSION_CATALOG", "builtin") != "builtin"
+  }
+
   // ///////////////////////////////////////////////////////////////////////////////////////////////
-  //                                           Schema                                            //
+  //                                           Schema                                             //
   // ///////////////////////////////////////////////////////////////////////////////////////////////
 
   /**
-   * a list of [[Row]]s, with 2 fields `schemaName: String, catalogName: String`
+   * Return a list of [[Row]]s, with 2 fields `schemaName: String, catalogName: String`
    */
   def getSchemas(
       spark: SparkSession,
       catalogName: String,
       schemaPattern: String): Seq[Row] = {
-    if (catalogName == SparkCatalogUtils.SESSION_CATALOG) {
-      (spark.sessionState.catalog.listDatabases(schemaPattern) ++
-        getGlobalTempViewManager(spark, schemaPattern))
-        .map(Row(_, SparkCatalogUtils.SESSION_CATALOG))
+    val dbs = if (catalogName == SESSION_CATALOG && !hasCustomSessionCatalog(spark)) {
+      spark.sessionState.catalog.listDatabases(schemaPattern)
     } else {
-      val catalog = getCatalog(spark, catalogName)
-      getSchemasWithPattern(catalog, schemaPattern).map(Row(_, catalog.name))
+      getSchemasWithPattern(getCatalog(spark, catalogName), schemaPattern)
     }
+    lazy val globalTempDb = getGlobalTempViewManager(spark, schemaPattern)
+    val schemaNames = if (catalogName == SESSION_CATALOG) dbs ++ globalTempDb else dbs
+    schemaNames.map(Row(_, catalogName))
   }
 
   private def getGlobalTempViewManager(
@@ -174,7 +179,7 @@ object SparkCatalogUtils extends Logging {
   }
 
   // ///////////////////////////////////////////////////////////////////////////////////////////////
-  //                                        Table & View                                         //
+  //                                        Table & View                                          //
   // ///////////////////////////////////////////////////////////////////////////////////////////////
 
   def getCatalogTablesOrViews(
@@ -187,6 +192,21 @@ object SparkCatalogUtils extends Logging {
     val catalog = getCatalog(spark, catalogName)
     val namespaces = listNamespacesWithPattern(catalog, schemaPattern)
     catalog match {
+      case tc: TableCatalog =>
+        val tp = tablePattern.r.pattern
+        val identifiers = namespaces.flatMap { ns =>
+          tc.listTables(ns).filter(i => tp.matcher(quoteIfNeeded(i.name())).matches())
+        }
+        identifiers.map { ident =>
+          // TODO: restore view type for session catalog
+          val comment = if (ignoreTableProperties) ""
+          else { // load table is a time consuming operation
+            tc.loadTable(ident).properties().getOrDefault(TableCatalog.PROP_COMMENT, "")
+          }
+          val schema = ident.namespace().map(quoteIfNeeded).mkString(".")
+          val tableName = quoteIfNeeded(ident.name())
+          Row(catalog.name(), schema, tableName, TABLE, comment, null, null, null, null, null)
+        }
       case builtin if builtin.name() == SESSION_CATALOG =>
         val sessionCatalog = spark.sessionState.catalog
         val databases = sessionCatalog.listDatabases(schemaPattern)
@@ -230,21 +250,6 @@ object SparkCatalogUtils extends Logging {
                   null)
               }
           }
-        }
-      case tc: TableCatalog =>
-        val tp = tablePattern.r.pattern
-        val identifiers = namespaces.flatMap { ns =>
-          tc.listTables(ns).filter(i => tp.matcher(quoteIfNeeded(i.name())).matches())
-        }
-        identifiers.map { ident =>
-          // TODO: restore view type for session catalog
-          val comment = if (ignoreTableProperties) ""
-          else { // load table is a time consuming operation
-            tc.loadTable(ident).properties().getOrDefault(TableCatalog.PROP_COMMENT, "")
-          }
-          val schema = ident.namespace().map(quoteIfNeeded).mkString(".")
-          val tableName = quoteIfNeeded(ident.name())
-          Row(catalog.name(), schema, tableName, TABLE, comment, null, null, null, null, null)
         }
       case _ => Seq.empty[Row]
     }

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/SparkIcebergOperationSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/SparkIcebergOperationSuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.kyuubi.engine.spark.operation
 
+import org.apache.kyuubi.WithSimpleHMSContainer
 import org.apache.kyuubi.engine.spark.WithSparkSQLEngine
 import org.apache.kyuubi.operation.{IcebergMetadataTests, RowLevelOperationTests}
 import org.apache.kyuubi.tags.IcebergTest
@@ -24,9 +25,26 @@ import org.apache.kyuubi.tags.IcebergTest
 @IcebergTest
 class SparkIcebergOperationSuite extends WithSparkSQLEngine
   with IcebergMetadataTests
-  with RowLevelOperationTests {
+  with RowLevelOperationTests
+  with WithSimpleHMSContainer {
 
   override protected def jdbcUrl: String = getJdbcUrl
 
   override def withKyuubiConf: Map[String, String] = extraConfigs
+
+  override def extraConfigs: Map[String, String] = Map(
+    "spark.sql.catalogImplementation" -> "hive",
+    "spark.hadoop.hive.metastore.uris" -> hmsThriftUris,
+    "spark.sql.defaultCatalog" -> catalog,
+    "spark.sql.extensions" -> "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+    "spark.sql.catalog.spark_catalog" -> "org.apache.iceberg.spark.SparkSessionCatalog",
+    "spark.sql.catalog.spark_catalog.type" -> "hive",
+    "spark.sql.catalog.spark_catalog.uris" -> hmsThriftUris,
+    "spark.sql.catalog.spark_catalog.cache-enabled" -> "false",
+    "spark.hadoop.iceberg.engine.hive.lock-enabled" -> "false",
+    "spark.hadoop.iceberg.engine.hive.enabled" -> "true",
+    s"spark.sql.catalog.$catalog" -> "org.apache.iceberg.spark.SparkCatalog",
+    s"spark.sql.catalog.$catalog.type" -> "hadoop",
+    s"spark.sql.catalog.$catalog.warehouse" -> warehouse.toString,
+    "spark.jars" -> extraJars)
 }

--- a/kyuubi-common/pom.xml
+++ b/kyuubi-common/pom.xml
@@ -142,6 +142,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.dimafeng</groupId>
+            <artifactId>testcontainers-scala-scalatest_${scala.binary.version}</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-minikdc</artifactId>
             <scope>test</scope>

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/DeltaSuiteMixin.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/DeltaSuiteMixin.scala
@@ -21,19 +21,19 @@ import java.nio.file.Path
 
 trait DeltaSuiteMixin extends DataLakeSuiteMixin {
 
-  override protected def format: String = "delta"
+  override protected val format: String = "delta"
 
-  override protected def catalog: String = "spark_catalog"
+  override protected val catalog: String = "spark_catalog"
 
-  override protected def warehouse: Path = Utils.createTempDir()
+  override protected val warehouse: Path = Utils.createTempDir()
 
-  override protected def extraJars: String = {
+  override protected val extraJars: String = {
     System.getProperty("java.class.path")
       .split(":")
       .filter(_.contains("io/delta/delta")).mkString(",")
   }
 
-  override protected def extraConfigs = Map(
+  override protected val extraConfigs: Map[String, String] = Map(
     "spark.sql.catalogImplementation" -> "in-memory",
     "spark.sql.defaultCatalog" -> catalog,
     "spark.sql.extensions" -> "io.delta.sql.DeltaSparkSessionExtension",

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/DeltaSuiteMixin.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/DeltaSuiteMixin.scala
@@ -21,19 +21,19 @@ import java.nio.file.Path
 
 trait DeltaSuiteMixin extends DataLakeSuiteMixin {
 
-  override protected def format: String = "delta"
+  override protected val format: String = "delta"
 
-  override protected def catalog: String = "spark_catalog"
+  override protected val catalog: String = "spark_catalog"
 
-  override protected def warehouse: Path = Utils.createTempDir()
+  override protected val warehouse: Path = Utils.createTempDir()
 
-  override protected def extraJars: String = {
+  override protected val extraJars: String = {
     System.getProperty("java.class.path")
       .split(":")
       .filter(_.contains("io/delta/delta")).mkString(",")
   }
 
-  override protected def extraConfigs = Map(
+  override protected def extraConfigs: Map[String, String] = Map(
     "spark.sql.catalogImplementation" -> "in-memory",
     "spark.sql.defaultCatalog" -> catalog,
     "spark.sql.extensions" -> "io.delta.sql.DeltaSparkSessionExtension",

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/IcebergSuiteMixin.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/IcebergSuiteMixin.scala
@@ -21,19 +21,19 @@ import java.nio.file.Path
 
 trait IcebergSuiteMixin extends DataLakeSuiteMixin {
 
-  override protected def format: String = "iceberg"
+  override protected val format: String = "iceberg"
 
-  override protected def catalog: String = "hadoop_prod"
+  override protected val catalog: String = "hadoop_prod"
 
-  override protected def warehouse: Path = Utils.createTempDir()
+  override protected val warehouse: Path = Utils.createTempDir()
 
-  override protected def extraJars: String = {
+  override protected val extraJars: String = {
     System.getProperty("java.class.path")
       .split(":")
       .filter(_.contains("iceberg-spark")).head
   }
 
-  override protected def extraConfigs = Map(
+  override protected val extraConfigs: Map[String, String] = Map(
     "spark.sql.catalogImplementation" -> "in-memory",
     "spark.sql.defaultCatalog" -> catalog,
     "spark.sql.extensions" -> "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/IcebergSuiteMixin.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/IcebergSuiteMixin.scala
@@ -21,19 +21,19 @@ import java.nio.file.Path
 
 trait IcebergSuiteMixin extends DataLakeSuiteMixin {
 
-  override protected def format: String = "iceberg"
+  override protected val format: String = "iceberg"
 
-  override protected def catalog: String = "hadoop_prod"
+  override protected val catalog: String = "hadoop_prod"
 
-  override protected def warehouse: Path = Utils.createTempDir()
+  override protected val warehouse: Path = Utils.createTempDir()
 
-  override protected def extraJars: String = {
+  override protected val extraJars: String = {
     System.getProperty("java.class.path")
       .split(":")
       .filter(_.contains("iceberg-spark")).head
   }
 
-  override protected def extraConfigs = Map(
+  override protected def extraConfigs: Map[String, String] = Map(
     "spark.sql.catalogImplementation" -> "in-memory",
     "spark.sql.defaultCatalog" -> catalog,
     "spark.sql.extensions" -> "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/WithSimpleHMSContainer.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/WithSimpleHMSContainer.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi
+
+import com.dimafeng.testcontainers.{ContainerDef, GenericContainer}
+import com.dimafeng.testcontainers.scalatest.TestContainerForAll
+import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy
+
+trait WithSimpleHMSContainer extends KyuubiFunSuite with TestContainerForAll {
+
+  final val DOCKER_IMAGE_NAME = "nekyuubi/kyuubi-hive-metastore:latest"
+
+  private val exposedHmsPort = 9083
+
+  private var _hmsThriftUris: String = _
+
+  def hmsThriftUris: String = _hmsThriftUris
+
+  override val containerDef: SimpleHMSContainer.Def =
+    SimpleHMSContainer.Def(DOCKER_IMAGE_NAME, exposedHmsPort)
+
+  override def afterContainersStart(containers: Containers): Unit = {
+    _hmsThriftUris = "thrift://localhost:" + containers.mappedPort(exposedHmsPort)
+  }
+}
+
+object SimpleHMSContainer {
+  case class Def(
+      dockerImage: String,
+      exposedHmsPort: Int,
+      env: Map[String, String] = Map())
+    extends ContainerDef {
+
+    override type Container = GenericContainer
+
+    override def createContainer(): Container = new GenericContainer(
+      GenericContainer(
+        dockerImage,
+        exposedPorts = Seq(exposedHmsPort),
+        env = env,
+        waitStrategy = new HostPortWaitStrategy().forPorts(exposedHmsPort)))
+  }
+}

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/IcebergMetadataTests.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/IcebergMetadataTests.scala
@@ -19,7 +19,7 @@ package org.apache.kyuubi.operation
 
 import scala.collection.mutable.ListBuffer
 
-import org.apache.kyuubi.{IcebergSuiteMixin, SPARK_COMPILE_VERSION}
+import org.apache.kyuubi.IcebergSuiteMixin
 import org.apache.kyuubi.operation.meta.ResultSetSchemaConstant._
 import org.apache.kyuubi.util.AssertionUtils._
 import org.apache.kyuubi.util.SparkVersionUtil
@@ -51,12 +51,9 @@ trait IcebergMetadataTests extends HiveJDBCTestHelper with IcebergSuiteMixin wit
         checkGetSchemas(metaData.getSchemas("spark_catalog", pattern), dbDflts, "spark_catalog")
       }
 
-      Seq(null, catalog).foreach { cg =>
+      Seq("spark_catalog", catalog).foreach { cg =>
         matchAllPatterns foreach { pattern =>
-          checkGetSchemas(
-            metaData.getSchemas(cg, pattern),
-            dbs,
-            catalog)
+          checkGetSchemas(metaData.getSchemas(cg, pattern), dbs, catalog)
         }
       }
 
@@ -87,7 +84,7 @@ trait IcebergMetadataTests extends HiveJDBCTestHelper with IcebergSuiteMixin wit
       dbs.foreach(db => statement.execute(s"CREATE NAMESPACE IF NOT EXISTS $db"))
       val metaData = statement.getConnection.getMetaData
 
-      Seq(null, catalog).foreach { cg =>
+      Seq("spark_catalog", catalog).foreach { cg =>
         matchAllPatterns foreach { pattern =>
           checkGetSchemas(
             metaData.getSchemas(cg, pattern),
@@ -116,7 +113,7 @@ trait IcebergMetadataTests extends HiveJDBCTestHelper with IcebergSuiteMixin wit
       dbs.foreach(db => statement.execute(s"CREATE NAMESPACE IF NOT EXISTS $db"))
       val metaData = statement.getConnection.getMetaData
 
-      Seq(catalog).foreach { cg =>
+      Seq("spark_catalog", catalog).foreach { cg =>
         dbs.foreach { db =>
           try {
             statement.execute(
@@ -156,12 +153,9 @@ trait IcebergMetadataTests extends HiveJDBCTestHelper with IcebergSuiteMixin wit
       "map<int, bigint>",
       "date",
       "timestamp",
-      // SPARK-37931
-      if (SPARK_ENGINE_RUNTIME_VERSION >= "3.3") "struct<X: bigint, Y: double>"
-      else "struct<`X`: bigint, `Y`: double>",
+      "struct<X: bigint, Y: double>",
       "binary",
-      // SPARK-37931
-      if (SPARK_COMPILE_VERSION >= "3.3") "struct<X: string>" else "struct<`X`: string>")
+      "struct<X: string>")
     val cols = dataTypes.zipWithIndex.map { case (dt, idx) => s"c$idx" -> dt }
     val (colNames, _) = cols.unzip
 

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/IcebergMetadataTests.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/IcebergMetadataTests.scala
@@ -53,10 +53,7 @@ trait IcebergMetadataTests extends HiveJDBCTestHelper with IcebergSuiteMixin wit
 
       Seq(null, catalog).foreach { cg =>
         matchAllPatterns foreach { pattern =>
-          checkGetSchemas(
-            metaData.getSchemas(cg, pattern),
-            dbs,
-            catalog)
+          checkGetSchemas(metaData.getSchemas(cg, pattern), dbs, catalog)
         }
       }
 
@@ -110,26 +107,23 @@ trait IcebergMetadataTests extends HiveJDBCTestHelper with IcebergSuiteMixin wit
       "`a.b.c`",
       "db1.db2.db3",
       "db4") ++ (if (SPARK_ENGINE_RUNTIME_VERSION < "4.0") Seq("`a.b``.c`") else Nil)
-
     withDatabases(dbs: _*) { statement =>
-      dbs.foreach(db => statement.execute(s"CREATE NAMESPACE IF NOT EXISTS $db"))
-      val metaData = statement.getConnection.getMetaData
-
-      Seq(catalog).foreach { cg =>
+      Seq("spark_catalog", catalog).foreach { cg =>
+        dbs.foreach(db => statement.execute(s"CREATE NAMESPACE IF NOT EXISTS $cg.$db"))
+        val metaData = statement.getConnection.getMetaData
         dbs.foreach { db =>
           try {
             statement.execute(
               s"CREATE TABLE IF NOT EXISTS $cg.$db.tbl(c STRING) USING iceberg")
 
             val rs1 = metaData.getTables(cg, db, "%", null)
-            while (rs1.next()) {
-              val catalogName = rs1.getString(TABLE_CAT)
-              assert(catalogName === cg)
-              assert(rs1.getString(TABLE_SCHEM) === db)
-              assert(rs1.getString(TABLE_NAME) === "tbl")
-              assert(rs1.getString(TABLE_TYPE) == "TABLE")
-              assert(rs1.getString(REMARKS) === "")
-            }
+            assert(rs1.next())
+            val catalogName = rs1.getString(TABLE_CAT)
+            assert(catalogName === cg)
+            assert(rs1.getString(TABLE_SCHEM) === db)
+            assert(rs1.getString(TABLE_NAME) === "tbl")
+            assert(rs1.getString(TABLE_TYPE) == "TABLE")
+            assert(rs1.getString(REMARKS) === "")
             assert(!rs1.next())
           } finally {
             statement.execute(s"DROP TABLE IF EXISTS $cg.$db.tbl PURGE")


### PR DESCRIPTION
### Why are the changes needed?

The thrift `GetSchemas`/`GetTables` operations assumed `spark_catalog` is always the builtin V1 session catalog and listed databases/tables via `spark.sessionState.catalog`. When a custom session catalog is configured, e.g.

```
spark.sql.catalog.spark_catalog=org.apache.iceberg.spark.SparkSessionCatalog
```

these operations bypass the DSv2 catalog APIs (`SupportsNamespaces`/`TableCatalog`) and the V1 session catalog path cannot even parse the V2 table metadata the custom catalog persists in HMS - it may return wrong results, or throw and fail the whole request. #7673 is a real-world example: `GetTables` fails with `ClassNotFoundException: org.apache.iceberg.mr.hive.HiveIcebergSerDe` when the V1 `HiveExternalCatalog` tries to load tables registered by Iceberg with `storage_handler = org.apache.iceberg.mr.hive.HiveIcebergStorageHandler`.

### What changes are in this patch?

- `SparkCatalogUtils.hasCustomSessionCatalog`: detects a custom session catalog via the `builtin` magic value (SPARK-50700)
- `getSchemas`: when `spark_catalog` has a custom session catalog, list namespaces through the DSv2 API instead of `spark.sessionState.catalog`
- `getCatalogTablesOrViews`: match `TableCatalog` before the builtin session-catalog case so a custom session catalog takes the DSv2 listing path
- test infra: `WithSimpleHMSContainer` (testcontainers) runs a real HMS; `SparkIcebergOperationSuite` now runs with `catalogImplementation=hive`, an Iceberg `SparkSessionCatalog` as session catalog and a hadoop-type Iceberg catalog as default catalog; the get tables test covers both `spark_catalog` and the v2 catalog

### Current status (WIP, takeover welcome)

Rebased onto apache/master (`b090cc28e`) as single commit `8bd7d9fc8`; includes local WIP test extensions (null catalogName coverage, per-catalog namespace creation) not yet on the remote branch.

Local run on JDK 17 / Spark 3.5.8:

```
build/mvn test -pl externals/kyuubi-spark-sql-engine -am -Dtest=none \
  -DwildcardSuites=org.apache.kyuubi.engine.spark.operation.SparkIcebergOperationSuite \
  -Dmaven.plugin.scalatest.include.tags=org.apache.kyuubi.tags.IcebergTest \
  -Dmaven.plugin.scalatest.exclude.tags=
```

Result: 5 passed, 3 failed, all in `IcebergMetadataTests`:

1. `get schemas` / `get schemas with multipart namespaces`: `metaData.getSchemas(null, ...)` returns `null` as TABLE_CAT, expected the resolved default catalog name (`hadoop_prod`). Regression of this PR's `getSchemas` rewrite: rows are tagged with the raw `catalogName` argument, while master tags non-session-catalog rows with the resolved `catalog.name`. Fix: use the resolved catalog name in the DSv2 branch.
2. `get tables`: `CREATE NAMESPACE spark_catalog.`a.b`` fails with `` `a.b` is not a valid name for tables/databases`` - Spark's V1 session catalog rejects dotted names and Iceberg's `SparkSessionCatalog` delegates to it. Dotted namespaces are only creatable on the v2 catalog; the test should create them only under the v2 catalog (master does so against the default catalog only).

Remaining work:

- fix the `getSchemas` catalogName tagging (item 1)
- restructure the get tables test data (item 2): flat namespaces under both catalogs, dotted only under the v2 catalog
- decide whether `nekyuubi/kyuubi-hive-metastore:latest` should live somewhere more official/maintained
- TODO already in code: view type is not restored for the session catalog in `getCatalogTablesOrViews`
- verify against Spark 4.x profiles

### How was this patch tested?

`SparkIcebergOperationSuite` extended (real HMS via testcontainers + custom session catalog coverage). Currently 3 failures as described above; the other 5 tests in the suite pass.

### Was this patch assisted by generative AI tooling?

Assisted-by: GLM 5.3
