### PR TITLE
Add ability to annotate pods and headless service in Kyuubi helm chart

### DIFF
--- a/charts/kyuubi/templates/kyuubi-headless-service.yaml
+++ b/charts/kyuubi/templates/kyuubi-headless-service.yaml
@@ -21,6 +21,10 @@ metadata:
   name: {{ .Release.Name }}-headless
   labels:
     {{- include "kyuubi.labels" $ | nindent 4 }}
+  {{- with .Values.service.headless.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/charts/kyuubi/templates/kyuubi-statefulset.yaml
+++ b/charts/kyuubi/templates/kyuubi-statefulset.yaml
@@ -40,6 +40,9 @@ spec:
       annotations:
         checksum/conf: {{ include (print $.Template.BasePath "/kyuubi-configmap.yaml") . | sha256sum }}
         checksum/conf-hadoop: {{ include (print $.Template.BasePath "/kyuubi-hadoop-configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets: {{- toYaml . | nindent 8 }}

--- a/charts/kyuubi/values.yaml
+++ b/charts/kyuubi/values.yaml
@@ -27,6 +27,9 @@ replicaCount: 2
 # The default policy is `OrderedReady`, alternative policy is `Parallel`.
 podManagementPolicy: OrderedReady
 
+# Optional additional annotations to add to Kyuubi server pods
+podAnnotations: {}
+
 # Minimum number of seconds for which a newly created kyuubi server
 # should be ready without any of its container crashing for it to be considered available.
 minReadySeconds: 30
@@ -75,6 +78,12 @@ rbac:
     - apiGroups: [""]
       resources: ["pods"]
       verbs: ["create", "list", "delete"]
+
+service:
+  # configuration of the headless service
+  headless:
+    # Optional additional annotations to add to the headless service
+    annotations: {}
 
 server:
   # Thrift Binary protocol (HiveServer2 compatible)


### PR DESCRIPTION
### Why are the changes needed?

Support adding arbitrary annotations to Kyuubi pods and services - for example, those needed for annotation-based auto-discovery via [k8s-monitoring-helm](https://github.com/grafana/k8s-monitoring-helm/blob/main/charts/k8s-monitoring/docs/examples/features/annotation-autodiscovery/default/README.md)

### How was this patch tested?

Helm chart installs with and without annotations added

### Was this patch authored or co-authored using generative AI tooling?

No