### PR TITLE
Fix `serverOnlyPrefixConfigKeys` is iterator issue

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -193,15 +193,15 @@ case class KyuubiConf(loadSysDefault: Boolean = true) extends Logging {
     cloned
   }
 
-  private lazy val serverOnlyPrefixes = get(KyuubiConf.SERVER_ONLY_PREFIXES)
-  private lazy val serverOnlyPrefixConfigKeys = settings.keys().asScala
+  private lazy val serverOnlyPrefixes: Set[String] = get(KyuubiConf.SERVER_ONLY_PREFIXES)
+  private lazy val serverOnlyPrefixConfigKeys: Set[String] = settings.keys().asScala
     // for ConfigEntry, respect the serverOnly flag and exclude it here
     .filter(key => getConfigEntry(key) == null)
     .filter { key =>
       serverOnlyPrefixes.exists { prefix =>
         key.startsWith(prefix)
       }
-    }
+    }.toSet
 
   def getUserDefaults(user: String): KyuubiConf = {
     val cloned = KyuubiConf(false)

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/config/KyuubiConfSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/config/KyuubiConfSuite.scala
@@ -231,9 +231,10 @@ class KyuubiConfSuite extends KyuubiFunSuite {
       Some("/var/run/secrets/kubernetes.io/token.ns2"))
   }
 
-  test("KYUUBI #7053 - Support to exclude server only configs with prefixes") {
+  test("KYUUBI #7055 - Support to exclude server only configs with prefixes") {
     val kyuubiConf = KyuubiConf(false)
     kyuubiConf.set("kyuubi.backend.server.event.kafka.broker", "localhost:9092")
     assert(kyuubiConf.getUserDefaults("kyuubi").getAll.size == 0)
+    assert(kyuubiConf.getUserDefaults("user").getAll.size == 0)
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->
Followup for #7055 
Before this PR, the `serverOnlyPrefixConfigKeys` is type of iterator.

After one time iteration, it become empty.

In this PR, we convert it to `Set` to fix this issue.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
UT.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.