### PR TITLE
[KYUUBI #7122] Support ORC hive table pushdown filter

### DIFF
--- a/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/KyuubiHiveConnectorConf.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/KyuubiHiveConnectorConf.scala
@@ -19,6 +19,8 @@ package org.apache.kyuubi.spark.connector.hive
 
 import java.util.Locale
 
+import org.apache.spark.sql.internal.SQLConf.buildConf
+
 object KyuubiHiveConnectorConf {
 
   import org.apache.spark.sql.internal.SQLConf.buildStaticConf
@@ -39,4 +41,12 @@ object KyuubiHiveConnectorConf {
         "Invalid value for 'spark.sql.kyuubi.hive.connector.externalCatalog.share.policy'." +
           "Valid values are 'ONE_FOR_ONE', 'ONE_FOR_ALL'.")
       .createWithDefault(OneForAllPolicy.name)
+
+  val READ_CONVERT_METASTORE_ORC =
+    buildConf("spark.sql.kyuubi.hive.connector.read.convertMetastoreOrc")
+      .doc(s"When set to true, the built-in ORC reader are used to process " +
+        "ORC tables created by using the HiveQL syntax, instead of Hive serde.")
+      .version("1.11.0")
+      .booleanConf
+      .createWithDefault(true)
 }

--- a/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/read/HiveFileIndex.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/read/HiveFileIndex.scala
@@ -54,6 +54,13 @@ class HiveCatalogFileIndex(
 
   override def partitionSchema: StructType = table.partitionSchema
 
+  override def listFiles(
+      partitionFilters: Seq[Expression],
+      dataFilters: Seq[Expression]): Seq[PartitionDirectory] = {
+    val fileIndex = filterPartitions(partitionFilters)
+    fileIndex.listFiles(partitionFilters, dataFilters)
+  }
+
   private[hive] def listHiveFiles(partitionFilters: Seq[Expression], dataFilters: Seq[Expression])
       : (Seq[PartitionDirectory], Map[PartitionDirectory, CatalogTablePartition]) = {
     val fileIndex = filterPartitions(partitionFilters)

--- a/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/HiveCatalogSuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/HiveCatalogSuite.scala
@@ -37,6 +37,7 @@ import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 import org.apache.kyuubi.spark.connector.hive.HiveTableCatalog.IdentifierHelper
+import org.apache.kyuubi.spark.connector.hive.KyuubiHiveConnectorConf.READ_CONVERT_METASTORE_ORC
 import org.apache.kyuubi.spark.connector.hive.read.HiveScan
 
 class HiveCatalogSuite extends KyuubiHiveTest {
@@ -356,8 +357,17 @@ class HiveCatalogSuite extends KyuubiHiveTest {
     val orcProps: util.Map[String, String] = new util.HashMap[String, String]()
     orcProps.put(TableCatalog.PROP_PROVIDER, "orc")
     val ot = catalog.createTable(orc_table, schema, Array.empty[Transform], orcProps)
+
     val orcScan = ot.asInstanceOf[HiveTable]
       .newScanBuilder(CaseInsensitiveStringMap.empty()).build().asInstanceOf[OrcScan]
     assert(orcScan.isSplitable(new Path("empty")))
+
+    withSparkSession(Map(READ_CONVERT_METASTORE_ORC.key -> "false")) {
+      _ =>
+        val orcScan = ot.asInstanceOf[HiveTable]
+          .newScanBuilder(CaseInsensitiveStringMap.empty()).build().asInstanceOf[HiveScan]
+        assert(orcScan.isSplitable(new Path("empty")))
+    }
+
   }
 }

--- a/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/HiveCatalogSuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/HiveCatalogSuite.scala
@@ -31,6 +31,7 @@ import org.apache.spark.sql.catalyst.analysis.{NoSuchNamespaceException, NoSuchT
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog}
 import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.execution.datasources.v2.orc.OrcScan
 import org.apache.spark.sql.hive.kyuubi.connector.HiveBridgeHelper._
 import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
@@ -356,7 +357,7 @@ class HiveCatalogSuite extends KyuubiHiveTest {
     orcProps.put(TableCatalog.PROP_PROVIDER, "orc")
     val ot = catalog.createTable(orc_table, schema, Array.empty[Transform], orcProps)
     val orcScan = ot.asInstanceOf[HiveTable]
-      .newScanBuilder(CaseInsensitiveStringMap.empty()).build().asInstanceOf[HiveScan]
+      .newScanBuilder(CaseInsensitiveStringMap.empty()).build().asInstanceOf[OrcScan]
     assert(orcScan.isSplitable(new Path("empty")))
   }
 }

--- a/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/HiveCatalogSuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/HiveCatalogSuite.scala
@@ -358,16 +358,16 @@ class HiveCatalogSuite extends KyuubiHiveTest {
     orcProps.put(TableCatalog.PROP_PROVIDER, "orc")
     val ot = catalog.createTable(orc_table, schema, Array.empty[Transform], orcProps)
 
-    val orcScan = ot.asInstanceOf[HiveTable]
-      .newScanBuilder(CaseInsensitiveStringMap.empty()).build().asInstanceOf[OrcScan]
-    assert(orcScan.isSplitable(new Path("empty")))
-
-    withSparkSession(Map(READ_CONVERT_METASTORE_ORC.key -> "false")) {
-      _ =>
-        val orcScan = ot.asInstanceOf[HiveTable]
-          .newScanBuilder(CaseInsensitiveStringMap.empty()).build().asInstanceOf[HiveScan]
+    Seq("true", "false").foreach { value =>
+      withSparkSession(Map(READ_CONVERT_METASTORE_ORC.key -> value)) { _ =>
+        val scan = ot.asInstanceOf[HiveTable]
+          .newScanBuilder(CaseInsensitiveStringMap.empty()).build()
+        val orcScan = value match {
+          case "true" => scan.asInstanceOf[OrcScan]
+          case "false" => scan.asInstanceOf[HiveScan]
+        }
         assert(orcScan.isSplitable(new Path("empty")))
+      }
     }
-
   }
 }

--- a/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/HiveCatalogSuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/HiveCatalogSuite.scala
@@ -362,9 +362,18 @@ class HiveCatalogSuite extends KyuubiHiveTest {
       withSparkSession(Map(READ_CONVERT_METASTORE_ORC.key -> value)) { _ =>
         val scan = ot.asInstanceOf[HiveTable]
           .newScanBuilder(CaseInsensitiveStringMap.empty()).build()
+
         val orcScan = value match {
-          case "true" => scan.asInstanceOf[OrcScan]
-          case "false" => scan.asInstanceOf[HiveScan]
+          case "true" =>
+            assert(
+              scan.isInstanceOf[OrcScan],
+              s"Expected OrcScan, got ${scan.getClass.getSimpleName}")
+            scan.asInstanceOf[OrcScan]
+          case "false" =>
+            assert(
+              scan.isInstanceOf[HiveScan],
+              s"Expected HiveScan, got ${scan.getClass.getSimpleName}")
+            scan.asInstanceOf[HiveScan]
         }
         assert(orcScan.isSplitable(new Path("empty")))
       }

--- a/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/HiveCatalogSuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/HiveCatalogSuite.scala
@@ -374,6 +374,9 @@ class HiveCatalogSuite extends KyuubiHiveTest {
               scan.isInstanceOf[HiveScan],
               s"Expected HiveScan, got ${scan.getClass.getSimpleName}")
             scan.asInstanceOf[HiveScan]
+          case _ =>
+            throw new IllegalArgumentException(
+              s"Unexpected value: '$value'. Only 'true' or 'false' are allowed.")
         }
         assert(orcScan.isSplitable(new Path("empty")))
       }

--- a/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/HiveQuerySuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/HiveQuerySuite.scala
@@ -320,8 +320,8 @@ class HiveQuerySuite extends KyuubiHiveTest {
       """)
       assert(df3.count() === 1)
       // contains like : PushedFilters: [IsNotNull(value), GreaterThan(value,1)]
-      assert(df3.collect().map(_.getString(0))
-        .map(s => s.contains("PushedFilters") && !s.contains("PushedFilters: []")).toSet.size > 0)
+      assert(df3.collect().map(_.getString(0)).filter(s =>
+        s.contains("PushedFilters") && !s.contains("PushedFilters: []")).toSet.size == 1)
 
       // Test aggregation pushdown partition filters
       spark.conf.set("spark.sql.orc.aggregatePushdown", true)
@@ -344,9 +344,8 @@ class HiveQuerySuite extends KyuubiHiveTest {
       """)
       assert(df5.count() === 1)
       // contains like :  PushedAggregation: [COUNT(*)],
-      assert(df3.collect().map(_.getString(0))
-        .map(s =>
-          s.contains("PushedAggregation") && !s.contains("PushedAggregation: []")).toSet.size > 0)
+      assert(df5.collect().map(_.getString(0)).filter(s =>
+        s.contains("PushedAggregation") && !s.contains("PushedAggregation: []")).toSet.size == 1)
 
       spark.conf.set("spark.sql.orc.aggregatePushdown", false)
 

--- a/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/HiveQuerySuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/HiveQuerySuite.scala
@@ -52,15 +52,6 @@ class HiveQuerySuite extends KyuubiHiveTest {
     finally spark.sql(s"DROP TABLE $table")
   }
 
-  def withTempPushFilterPartitionedTable(
-      spark: SparkSession,
-      table: String,
-      createTableSql: String)(f: => Unit): Unit = {
-    spark.sql(createTableSql).collect()
-    try f
-    finally spark.sql(s"DROP TABLE $table")
-  }
-
   def checkQueryResult(
       sql: String,
       sparkSession: SparkSession,
@@ -272,51 +263,58 @@ class HiveQuerySuite extends KyuubiHiveTest {
   test("ORC filter pushdown") {
     val table = "hive.default.orc_filter_pushdown"
     withTable(table) {
-      spark.sql(s"""
-                   | CREATE TABLE $table (
-                   |  id INT,
-                   |  data STRING,
-                   |  value INT
-                   |  ) PARTITIONED BY (dt STRING, region STRING)
-                   |  STORED AS ORC
-                   | """.stripMargin).collect()
+      spark.sql(
+        s"""
+           | CREATE TABLE $table (
+           |  id INT,
+           |  data STRING,
+           |  value INT
+           |  ) PARTITIONED BY (dt STRING, region STRING)
+           |  STORED AS ORC
+           | """.stripMargin).collect()
 
       // Insert test data with partitions
-      spark.sql(s"""
-                   | INSERT INTO $table PARTITION (dt='2024-01-01', region='east')
-                   | VALUES (1, 'a', 100), (2, 'b', 200), (11, 'aa', 100), (22, 'b', 200)
-                   |""".stripMargin)
+      spark.sql(
+        s"""
+           | INSERT INTO $table PARTITION (dt='2024-01-01', region='east')
+           | VALUES (1, 'a', 100), (2, 'b', 200), (11, 'aa', 100), (22, 'b', 200)
+           |""".stripMargin)
 
-      spark.sql(s"""
-                   | INSERT INTO $table PARTITION (dt='2024-01-01', region='west')
-                   | VALUES (3, 'c', 300), (4, 'd', 400), (33, 'cc', 300), (44, 'dd', 400)
-                   |""".stripMargin)
-      spark.sql(s"""
-                   | INSERT INTO $table PARTITION (dt='2024-01-02', region='east')
-                   | VALUES (5, 'e', 500), (6, 'f', 600), (55, 'ee', 500), (66, 'ff', 600)
-                   | """.stripMargin)
+      spark.sql(
+        s"""
+           | INSERT INTO $table PARTITION (dt='2024-01-01', region='west')
+           | VALUES (3, 'c', 300), (4, 'd', 400), (33, 'cc', 300), (44, 'dd', 400)
+           |""".stripMargin)
+      spark.sql(
+        s"""
+           | INSERT INTO $table PARTITION (dt='2024-01-02', region='east')
+           | VALUES (5, 'e', 500), (6, 'f', 600), (55, 'ee', 500), (66, 'ff', 600)
+           | """.stripMargin)
 
       // Test multiple partition filters
-      val df1 = spark.sql(s"""
-                             | SELECT * FROM $table
-                             | WHERE dt = '2024-01-01' AND region = 'east' AND value > 1500
-                             |""".stripMargin)
+      val df1 = spark.sql(
+        s"""
+           | SELECT * FROM $table
+           | WHERE dt = '2024-01-01' AND region = 'east' AND value > 1500
+           |""".stripMargin)
       assert(df1.count() === 0)
 
       // Test multiple partition filters
-      val df2 = spark.sql(s"""
-                             | SELECT * FROM $table
-                             | WHERE dt = '2024-01-01' AND region = 'east' AND value > 150
-                             |""".stripMargin)
+      val df2 = spark.sql(
+        s"""
+           | SELECT * FROM $table
+           | WHERE dt = '2024-01-01' AND region = 'east' AND value > 150
+           |""".stripMargin)
       assert(df2.count() === 2)
       assert(df2.collect().map(_.getInt(0)).toSet === Set(2, 22))
 
       // Test explain
-      val df3 = spark.sql(s"""
-                             | EXPLAIN SELECT count(*) as total_rows
-                             | FROM $table
-                             | WHERE dt = '2024-01-01' AND region = 'east' AND value > 1
-                             |""".stripMargin)
+      val df3 = spark.sql(
+        s"""
+           | EXPLAIN SELECT count(*) as total_rows
+           | FROM $table
+           | WHERE dt = '2024-01-01' AND region = 'east' AND value > 1
+           |""".stripMargin)
       assert(df3.count() === 1)
       // contains like : PushedFilters: [IsNotNull(value), GreaterThan(value,1)]
       assert(df3.collect().map(_.getString(0)).filter { s =>
@@ -327,21 +325,23 @@ class HiveQuerySuite extends KyuubiHiveTest {
       spark.conf.set("spark.sql.orc.aggregatePushdown", true)
 
       // Test aggregation pushdown partition filters
-      val df4 = spark.sql(s"""
-                             | SELECT count(*) as total_rows
-                             | FROM $table
-                             | WHERE dt = '2024-01-01' AND region = 'east'
-                             | group by dt, region
-                             | """.stripMargin)
+      val df4 = spark.sql(
+        s"""
+           | SELECT count(*) as total_rows
+           | FROM $table
+           | WHERE dt = '2024-01-01' AND region = 'east'
+           | group by dt, region
+           | """.stripMargin)
       assert(df4.count() === 1)
       assert(df4.collect().map(_.getLong(0)).toSet === Set(4L))
 
-      val df5 = spark.sql(s"""
-                             | EXPLAIN SELECT count(*) as total_rows
-                             | FROM $table
-                             | WHERE dt = '2024-01-01' AND region = 'east'
-                             | group by dt, region
-                             | """.stripMargin)
+      val df5 = spark.sql(
+        s"""
+           | EXPLAIN SELECT count(*) as total_rows
+           | FROM $table
+           | WHERE dt = '2024-01-01' AND region = 'east'
+           | group by dt, region
+           | """.stripMargin)
       assert(df5.count() === 1)
       // contains like :  PushedAggregation: [COUNT(*)],
       assert(df5.collect().map(_.getString(0)).filter { s =>

--- a/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/KyuubiHiveTest.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/KyuubiHiveTest.scala
@@ -21,6 +21,7 @@ import org.apache.spark.SparkConf
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{QueryTest, SparkSession}
 import org.apache.spark.sql.connector.catalog.{SupportsNamespaces, TableCatalog}
+import org.apache.spark.sql.hive.kyuubi.connector.HiveBridgeHelper.Utils
 
 import org.apache.kyuubi.spark.connector.common.LocalSparkSession
 
@@ -75,6 +76,17 @@ abstract class KyuubiHiveTest extends QueryTest with Logging {
       case (k, v) => innerSpark.sessionState.conf.setConfString(k, v)
     }
     f(innerSpark)
+  }
+
+  /**
+   * Drops table `tableName` after calling `f`.
+   */
+  protected def withTable(tableNames: String*)(f: => Unit): Unit = {
+    Utils.tryWithSafeFinally(f) {
+      tableNames.foreach { name =>
+        spark.sql(s"DROP TABLE IF EXISTS $name")
+      }
+    }
   }
 
   override def spark: SparkSession = innerSpark

--- a/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/command/DDLCommandTestUtils.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/command/DDLCommandTestUtils.scala
@@ -78,19 +78,6 @@ trait DDLCommandTestUtils extends KyuubiHiveTest {
     fs.makeQualified(hadoopPath).toUri
   }
 
-  /**
-   * Drops table `tableName` after calling `f`.
-   */
-  protected def withTable(tableNames: String*)(f: => Unit): Unit = {
-    try {
-      f
-    } finally {
-      tableNames.foreach { name =>
-        spark.sql(s"DROP TABLE IF EXISTS $name")
-      }
-    }
-  }
-
   protected def withNamespaceAndTable(
       ns: String,
       tableName: String,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->
Previously, the `HiveScan` class was used to read data. If it is determined to be ORC type, the `ORCScan` from Spark datasourcev2 can be used. `ORCScan` supports pushfilter down, but `HiveScan` does not yet support it. 

In our testing, we are able to achieve approximately 2x performance improvement.

The conversation can be controlled by setting `spark.sql.kyuubi.hive.connector.read.convertMetastoreOrc`. When enabled, the data source ORC reader is used to process ORC tables created by using the HiveQL syntax, instead of Hive SerDe.

close https://github.com/apache/kyuubi/issues/7122


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
added unit test

### Was this patch authored or co-authored using generative AI tooling?
No
