### PR TITLE
[KYUUBI #6924] Upgrade Spark Ranger plugin to 2.6.0

### DIFF
--- a/docs/security/authorization/spark/build.md
+++ b/docs/security/authorization/spark/build.md
@@ -85,6 +85,7 @@ The available `ranger.version`s are shown in the following table.
 
 | Ranger Version | Supported |                                          Remark                                           |
 |:--------------:|:---------:|:-----------------------------------------------------------------------------------------:|
+|     2.6.x      |     √     |                                             -                                             |
 |     2.5.x      |     √     |                                             -                                             |
 |     2.4.x      |     √     |                                             -                                             |
 |     2.3.x      |     √     |                                             -                                             |

--- a/extensions/spark/kyuubi-spark-authz/README.md
+++ b/extensions/spark/kyuubi-spark-authz/README.md
@@ -26,7 +26,7 @@
 ## Build
 
 ```shell
-build/mvn clean package -DskipTests -pl :kyuubi-spark-authz_2.12 -am -Dspark.version=3.2.1 -Dranger.version=2.5.0
+build/mvn clean package -DskipTests -pl :kyuubi-spark-authz_2.12 -am -Dspark.version=3.2.1 -Dranger.version=2.6.0
 ```
 
 ### Supported Apache Spark Versions
@@ -46,7 +46,8 @@ build/mvn clean package -DskipTests -pl :kyuubi-spark-authz_2.12 -am -Dspark.ver
 
 `-Dranger.version=`
 
-- [x] 2.5.x (default)
+- [x] 2.6.x (default)
+- [x] 2.5.x
 - [x] 2.4.x
 - [x] 2.3.x
 - [x] 2.2.x

--- a/extensions/spark/kyuubi-spark-authz/pom.xml
+++ b/extensions/spark/kyuubi-spark-authz/pom.xml
@@ -32,7 +32,7 @@
     <url>https://kyuubi.apache.org/</url>
 
     <properties>
-        <ranger.version>2.5.0</ranger.version>
+        <ranger.version>2.6.0</ranger.version>
         <jersey.client.version>1.19.4</jersey.client.version>
     </properties>
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #6924

## Describe Your Solution 🔧

Bump ranger version to 2.6.0
Release notes: https://cwiki.apache.org/confluence/display/RANGER/Apache+Ranger+2.6.0+-+Release+Notes



## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**