### PR TITLE
[KYUUBI #7109] Ignore the ? in backticks

### DIFF
--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/Utils.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/Utils.java
@@ -124,6 +124,7 @@ public class Utils {
     boolean inSingleQuote = false;
     boolean inDoubleQuote = false;
     boolean inComment = false;
+    boolean inBackticks = false;
     int off = 0;
     boolean skip = false;
 
@@ -148,8 +149,13 @@ public class Utils {
             inDoubleQuote = !inDoubleQuote;
           }
           break;
-        case '-':
+        case '`':
           if (!inSingleQuote && !inDoubleQuote) {
+            inBackticks = !inBackticks;
+          }
+          break;
+        case '-':
+          if (!inSingleQuote && !inDoubleQuote && !inBackticks) {
             if (i < sql.length() - 1 && sql.charAt(i + 1) == '-') {
               inComment = true;
             }
@@ -161,7 +167,7 @@ public class Utils {
           }
           break;
         case '?':
-          if (!inSingleQuote && !inDoubleQuote) {
+          if (!inSingleQuote && !inDoubleQuote && !inBackticks) {
             parts.add(sql.substring(off, i));
             off = i + 1;
           }
@@ -191,7 +197,7 @@ public class Utils {
   }
 
   public static JdbcConnectionParams parseURL(String uri)
-      throws JdbcUriParseException, SQLException, ZooKeeperHiveClientException {
+      throws JdbcUriParseException, ZooKeeperHiveClientException {
     return parseURL(uri, new Properties());
   }
 
@@ -215,7 +221,7 @@ public class Utils {
    * jdbc:hive2://server:10001/db;user=foo;password=bar?hive.server2.transport.mode=http;hive.server2.thrift.http.path=hs2
    */
   public static JdbcConnectionParams parseURL(String uri, Properties info)
-      throws JdbcUriParseException, SQLException, ZooKeeperHiveClientException {
+      throws JdbcUriParseException, ZooKeeperHiveClientException {
     JdbcConnectionParams connParams = extractURLComponents(uri, info);
     if (ZooKeeperHiveClientHelper.isZkDynamicDiscoveryMode(connParams.getSessionVars())) {
       configureConnParamsFromZooKeeper(connParams);

--- a/kyuubi-hive-jdbc/src/test/java/org/apache/kyuubi/jdbc/hive/UtilsTest.java
+++ b/kyuubi-hive-jdbc/src/test/java/org/apache/kyuubi/jdbc/hive/UtilsTest.java
@@ -197,5 +197,17 @@ public class UtilsTest {
     assertEquals("--comments\n" + "select --? \n", splitSql.get(0));
     assertEquals(" from ", splitSql.get(1));
     assertEquals("", splitSql.get(2));
+
+    String inIdentifierQuoted =
+        "SELECT "
+            + "regexp_replace(col2, '\\n|\\r|\\t', '') as col2, "
+            + "`(col2|col2)?+.+` "
+            + "FROM ?";
+    splitSql = Utils.splitSqlStatement(inIdentifierQuoted);
+    assertEquals(2, splitSql.size());
+    assertEquals(
+        "SELECT regexp_replace(col2, '\\n|\\r|\\t', '') as col2, `(col2|col2)?+.+` FROM ",
+        splitSql.get(0));
+    assertEquals("", splitSql.get(1));
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
We will split the sql by `?` when we use `KyuubiPreparedStatement`. But there exist corner case when ? exist in backticks.
For example, below sql contains `?`, but we shouldn't split it by `?`.
```sql
SELECT `(ds|hr)?+.+` FROM sales
```
More details can find at https://hive.apache.org/docs/latest/languagemanual-select_27362043/#regex-column-specification

Hive upstream fix - HIVE-29060

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
UT.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
NO.
