### PR TITLE
Support Per-Client Initialization SQL in Shared Engine Mode

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/session/SparkSQLSessionManager.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/session/SparkSQLSessionManager.scala
@@ -105,7 +105,7 @@ class SparkSQLSessionManager private (name: String, spark: SparkSession)
     userIsolatedSparkSessionThread.foreach(_.shutdown())
   }
 
-  private def getOrNewSparkSession(user: String): SparkSession = {
+  private def getOrNewSparkSession(user: String, sessionConf: Map[String, String]): SparkSession = {
     if (singleSparkSession) {
       spark
     } else {
@@ -113,8 +113,8 @@ class SparkSQLSessionManager private (name: String, spark: SparkSession)
         // it's unnecessary to create a new spark session in connection share level
         // since the session is only one
         case CONNECTION => spark
-        case USER => newSparkSession(spark)
-        case GROUP | SERVER if userIsolatedSparkSession => newSparkSession(spark)
+        case USER => newSparkSession(spark, sessionConf)
+        case GROUP | SERVER if userIsolatedSparkSession => newSparkSession(spark, sessionConf)
         case GROUP | SERVER =>
           userIsolatedCacheLock.synchronized {
             if (userIsolatedCache.containsKey(user)) {
@@ -123,7 +123,7 @@ class SparkSQLSessionManager private (name: String, spark: SparkSession)
               userIsolatedCache.get(user)
             } else {
               userIsolatedCacheCount.put(user, (1, System.currentTimeMillis()))
-              val newSession = newSparkSession(spark)
+              val newSession = newSparkSession(spark, sessionConf)
               userIsolatedCache.put(user, newSession)
               newSession
             }
@@ -132,11 +132,16 @@ class SparkSQLSessionManager private (name: String, spark: SparkSession)
     }
   }
 
-  private def newSparkSession(rootSparkSession: SparkSession): SparkSession = {
+  private def newSparkSession(
+      rootSparkSession: SparkSession,
+      sessionConf: Map[String, String]): SparkSession = {
     val newSparkSession = rootSparkSession.newSession()
     KyuubiSparkUtil.initializeSparkSession(
       newSparkSession,
-      conf.get(ENGINE_SESSION_SPARK_INITIALIZE_SQL))
+      conf.get(ENGINE_SESSION_SPARK_INITIALIZE_SQL)) ++
+         sessionConf.get(ENGINE_SESSION_SPARK_INITIALIZE_SQL.key).filter(_.nonEmpty)
+           .map(_.split(";").toSeq
+           .getOrElse(Nil))
     newSparkSession
   }
 
@@ -150,7 +155,7 @@ class SparkSQLSessionManager private (name: String, spark: SparkSession)
       getSessionOption).getOrElse {
       val sparkSession =
         try {
-          getOrNewSparkSession(user)
+          getOrNewSparkSession(user, conf)
         } catch {
           case e: Exception => throw KyuubiSQLException(e)
         }

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/session/SparkSQLSessionManager.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/session/SparkSQLSessionManager.scala
@@ -138,10 +138,11 @@ class SparkSQLSessionManager private (name: String, spark: SparkSession)
     val newSparkSession = rootSparkSession.newSession()
     KyuubiSparkUtil.initializeSparkSession(
       newSparkSession,
-      conf.get(ENGINE_SESSION_SPARK_INITIALIZE_SQL)) ++
-         sessionConf.get(ENGINE_SESSION_SPARK_INITIALIZE_SQL.key).filter(_.nonEmpty)
-           .map(_.split(";").toSeq
-           .getOrElse(Nil))
+      sessionConf.get(ENGINE_SESSION_SPARK_INITIALIZE_SQL.key)
+        .filter(_.nonEmpty)
+        .map(_.split(";")
+          .toSeq)
+        .getOrElse(conf.get(ENGINE_SESSION_SPARK_INITIALIZE_SQL)))
     newSparkSession
   }
 


### PR DESCRIPTION
### Why are the changes needed?
<img width="891" height="596" alt="image" src="https://github.com/user-attachments/assets/09e5d5eb-bd37-42d7-9aa1-54d58728478d" />
**Current Behavior:**

When "kyuubi.engine.share.level = USER/GROUP/SERVER", the first client (Client A) calling openSession creates a Kyuubi-Spark-SQL-Engine (Spark Driver), where the initialization SQL configured in "kyuubi.engine.spark.initialize.sql" takes effect.

Subsequent clients (e.g., Client B) connecting via openSession will reuse the existing Kyuubi-Spark-SQL-Engine (Spark Driver) created in step 1, where the initialization SQL configured in "kyuubi.engine.spark.initialize.sql" becomes ineffective.

**Why This Capability Is Needed:**

Currently, kyuubi.engine.spark.initialize.sql only applies to the first openSession client. All subsequent SQL operations inherit the initialization SQL configuration from the first client (this appears to be a potential bug).

Client A may need to set "USE dbA" in its current SQL context, while Client B may need "USE dbB" in its own context - such scenarios should be supported.


### How was this patch tested?
Tested on local Kyuubi/Spark cluster. No existing unit tests cover this scenario. Please point me to any relevant tests so I can add them


### Was this patch authored or co-authored using generative AI tooling?
No

