### PR TITLE
Remove direct usage of `sun.misc.Signal`

### DIFF
--- a/kyuubi-common/pom.xml
+++ b/kyuubi-common/pom.xml
@@ -109,6 +109,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.kyuubi</groupId>
+            <artifactId>kyuubi-relocated-util</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-scala_${scala.binary.version}</artifactId>
         </dependency>

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/util/SignalRegister.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/util/SignalRegister.scala
@@ -17,18 +17,20 @@
 
 package org.apache.kyuubi.util
 
+import java.util
 import java.util.Collections
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 
 import org.apache.commons.lang3.SystemUtils
 import org.slf4j.Logger
-import sun.misc.{Signal, SignalHandler}
 
 import org.apache.kyuubi.Logging
+import org.apache.kyuubi.shaded.util.{Signal, SignalHandler}
 
 object SignalRegister extends Logging {
-  private val handlers = new scala.collection.mutable.HashMap[String, ActionHandler]
+  private val handlers = new mutable.HashMap[String, ActionHandler]
 
   def registerLogger(log: Logger): Unit = {
     Seq("TERM", "HUP", "INT").foreach { sig =>
@@ -41,7 +43,7 @@ object SignalRegister extends Logging {
               ActionHandler(signal)
             })
           handler.register({
-            log.error(s"RECEIVED SIGNAL ${signal.getNumber}: " + sig)
+            log.error(s"RECEIVED SIGNAL ${signal.getNumber}: $sig")
             false
           })
         } catch {
@@ -52,7 +54,7 @@ object SignalRegister extends Logging {
   }
 
   case class ActionHandler(signal: Signal) extends SignalHandler {
-    private val actions = Collections.synchronizedList(new java.util.LinkedList[() => Boolean])
+    private val actions = Collections.synchronizedList(new util.LinkedList[() => Boolean])
     private val prevHandler: SignalHandler = Signal.handle(signal, this)
 
     override def handle(sig: Signal): Unit = {

--- a/kyuubi-hive-beeline/pom.xml
+++ b/kyuubi-hive-beeline/pom.xml
@@ -47,6 +47,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.kyuubi</groupId>
+            <artifactId>kyuubi-relocated-util</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client-api</artifactId>
         </dependency>

--- a/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/SunSignalHandler.java
+++ b/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/SunSignalHandler.java
@@ -24,8 +24,8 @@ package org.apache.hive.beeline;
 
 import java.sql.SQLException;
 import java.sql.Statement;
-import sun.misc.Signal;
-import sun.misc.SignalHandler;
+import org.apache.kyuubi.shaded.util.Signal;
+import org.apache.kyuubi.shaded.util.SignalHandler;
 
 public class SunSignalHandler implements BeeLineSignalHandler, SignalHandler {
   private Statement stmt = null;

--- a/pom.xml
+++ b/pom.xml
@@ -115,8 +115,9 @@
     <properties>
         <java.version>8</java.version>
         <maven.version>3.9.10</maven.version>
-        <maven.compiler.source>${java.version}</maven.compiler.source>
-        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
         <scala.version>2.12.19</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <scala-collection-compat.version>2.12.0</scala-collection-compat.version>
@@ -174,7 +175,7 @@
         <junit.version>4.13.2</junit.version>
         <kafka.version>3.5.2</kafka.version>
         <kubernetes-client.version>6.13.5</kubernetes-client.version>
-        <kyuubi-relocated.version>0.5.0</kyuubi-relocated.version>
+        <kyuubi-relocated.version>0.6.0-SNAPSHOT</kyuubi-relocated.version>
         <kyuubi-relocated-zookeeper.artifacts>kyuubi-relocated-zookeeper-34</kyuubi-relocated-zookeeper.artifacts>
         <ldapsdk.version>6.0.5</ldapsdk.version>
         <log4j.version>2.24.3</log4j.version>
@@ -308,6 +309,11 @@
             <dependency>
                 <groupId>org.apache.kyuubi</groupId>
                 <artifactId>kyuubi-relocated-hive-service-rpc</artifactId>
+                <version>${kyuubi-relocated.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.kyuubi</groupId>
+                <artifactId>kyuubi-relocated-util</artifactId>
                 <version>${kyuubi-relocated.version}</version>
             </dependency>
             <dependency>
@@ -1951,10 +1957,6 @@
             </activation>
             <properties>
                 <java.version>11</java.version>
-                <maven.compiler.source></maven.compiler.source>
-                <maven.compiler.target></maven.compiler.target>
-                <maven.compiler.release>${java.version}</maven.compiler.release>
-                <minimalJavaBuildVersion>${java.version}</minimalJavaBuildVersion>
             </properties>
         </profile>
 
@@ -1965,10 +1967,6 @@
             </activation>
             <properties>
                 <java.version>17</java.version>
-                <maven.compiler.source></maven.compiler.source>
-                <maven.compiler.target></maven.compiler.target>
-                <maven.compiler.release>${java.version}</maven.compiler.release>
-                <minimalJavaBuildVersion>${java.version}</minimalJavaBuildVersion>
             </properties>
         </profile>
 
@@ -1979,9 +1977,6 @@
             </activation>
             <properties>
                 <java.version>21</java.version>
-                <maven.compiler.source></maven.compiler.source>
-                <maven.compiler.target></maven.compiler.target>
-                <maven.compiler.release>${java.version}</maven.compiler.release>
                 <!-- TODO: The current version of spotless(2.30.0) and google-java-format(1.7)
                            does not support Java 21, but new version produces different outputs.
                            Re-evaluate once we dropped support for Java 8. -->

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
         <junit.version>4.13.2</junit.version>
         <kafka.version>3.5.2</kafka.version>
         <kubernetes-client.version>6.13.5</kubernetes-client.version>
-        <kyuubi-relocated.version>0.6.0-SNAPSHOT</kyuubi-relocated.version>
+        <kyuubi-relocated.version>0.6.0</kyuubi-relocated.version>
         <kyuubi-relocated-zookeeper.artifacts>kyuubi-relocated-zookeeper-34</kyuubi-relocated-zookeeper.artifacts>
         <ldapsdk.version>6.0.5</ldapsdk.version>
         <log4j.version>2.24.3</log4j.version>
@@ -1298,6 +1298,18 @@
             <id>central</id>
             <name>Maven Repository</name>
             <url>https://repo.maven.apache.org/maven2</url>
+        </repository>
+
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>shaded-staging</id>
+            <name>Kyuubi Shaded 0.6.0 RC</name>
+            <url>https://repository.apache.org/content/repositories/orgapachekyuubi-1059/</url>
         </repository>
     </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,7 @@
         <maven.version>3.9.10</maven.version>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
+        <enforcer.maxJdkVersion>8</enforcer.maxJdkVersion>
         <scala.version>2.12.19</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <scala-collection-compat.version>2.12.0</scala-collection-compat.version>
@@ -1895,7 +1896,7 @@
                         <configuration>
                             <rules>
                                 <enforceBytecodeVersion>
-                                    <maxJdkVersion>${maven.compiler.target}</maxJdkVersion>
+                                    <maxJdkVersion>${enforcer.maxJdkVersion}</maxJdkVersion>
                                     <ignoredScopes>provided</ignoredScopes>
                                     <ignoredScopes>test</ignoredScopes>
                                     <ignoreClasses>
@@ -2046,6 +2047,7 @@
                 <module>extensions/spark/kyuubi-spark-connector-hive</module>
             </modules>
             <properties>
+                <enforcer.maxJdkVersion>17</enforcer.maxJdkVersion>
                 <spark.version>4.0.0</spark.version>
                 <spark.binary.version>4.0</spark.binary.version>
                 <antlr4.version>4.13.1</antlr4.version>
@@ -2066,6 +2068,7 @@
         <profile>
             <id>spark-master</id>
             <properties>
+                <enforcer.maxJdkVersion>17</enforcer.maxJdkVersion>
                 <spark.version>4.0.0-SNAPSHOT</spark.version>
                 <antlr4.version>4.13.1</antlr4.version>
                 <maven.plugin.scalatest.exclude.tags>org.scalatest.tags.Slow,org.apache.kyuubi.tags.DeltaTest,org.apache.kyuubi.tags.IcebergTest,org.apache.kyuubi.tags.PaimonTest,org.apache.kyuubi.tags.HudiTest,org.apache.kyuubi.tags.PySparkTest</maven.plugin.scalatest.exclude.tags>

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,6 @@
         <maven.version>3.9.10</maven.version>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
-        <maven.compiler.release>8</maven.compiler.release>
         <scala.version>2.12.19</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <scala-collection-compat.version>2.12.0</scala-collection-compat.version>
@@ -1959,6 +1958,16 @@
                   And it may have compatible issue with Spark 3.5.4+, see Iceberg #11731
                   -->
                 <iceberg.version>1.6.1</iceberg.version>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>jdk9+</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <properties>
+                <maven.compiler.release>8</maven.compiler.release>
             </properties>
         </profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1298,18 +1298,6 @@
             <name>Maven Repository</name>
             <url>https://repo.maven.apache.org/maven2</url>
         </repository>
-
-        <repository>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>shaded-staging</id>
-            <name>Kyuubi Shaded 0.6.0 RC</name>
-            <url>https://repository.apache.org/content/repositories/orgapachekyuubi-1059/</url>
-        </repository>
     </repositories>
 
     <pluginRepositories>

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,6 @@
     </distributionManagement>
 
     <properties>
-        <java.version>8</java.version>
         <maven.version>3.9.10</maven.version>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
@@ -1896,7 +1895,8 @@
                         <configuration>
                             <rules>
                                 <enforceBytecodeVersion>
-                                    <maxJdkVersion>${java.version}</maxJdkVersion>
+                                    <maxJdkVersion>${maven.compiler.target}</maxJdkVersion>
+                                    <ignoredScopes>provided</ignoredScopes>
                                     <ignoredScopes>test</ignoredScopes>
                                     <ignoreClasses>
                                         <!--
@@ -1940,7 +1940,6 @@
                 <jdk>8</jdk>
             </activation>
             <properties>
-                <java.version>8</java.version>
                 <!--
                   Iceberg drops support for Java 8 since 1.7.0.
                   And it may have compatible issue with Spark 3.5.4+, see Iceberg #11731
@@ -1960,32 +1959,11 @@
         </profile>
 
         <profile>
-            <id>java-11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <java.version>11</java.version>
-            </properties>
-        </profile>
-
-        <profile>
-            <id>java-17</id>
-            <activation>
-                <jdk>17</jdk>
-            </activation>
-            <properties>
-                <java.version>17</java.version>
-            </properties>
-        </profile>
-
-        <profile>
             <id>java-21</id>
             <activation>
                 <jdk>21</jdk>
             </activation>
             <properties>
-                <java.version>21</java.version>
                 <!-- TODO: The current version of spotless(2.30.0) and google-java-format(1.7)
                            does not support Java 21, but new version produces different outputs.
                            Re-evaluate once we dropped support for Java 8. -->


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->
This PR replaces the `sun.misc.Signal` with the Kyuubi wrapped one, see https://github.com/apache/kyuubi-shaded/pull/64, which allows Kyuubi to use any of Java 8+ to compile with `-release:8` while still ensuring compatibility with Java 8.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Pass GHA.

Local tested by building against JDK 21, running on JDK 8, everything works as expected.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.
