### PR TITLE
Fix spark.kubernetes.file.upload.path permission

### DIFF
--- a/integration-tests/kyuubi-kubernetes-it/src/test/scala/org/apache/kyuubi/kubernetes/test/deployment/KyuubiOnKubernetesTestsSuite.scala
+++ b/integration-tests/kyuubi-kubernetes-it/src/test/scala/org/apache/kyuubi/kubernetes/test/deployment/KyuubiOnKubernetesTestsSuite.scala
@@ -117,11 +117,11 @@ class KyuubiOnKubernetesWithClusterSparkTestsSuite
   override def beforeAll(): Unit = {
     super.beforeAll()
     val fs = FileSystem.get(getHadoopConf)
-    fs.mkdirs(
+    FileSystem.mkdirs(
+      fs,
       new Path("/spark"),
       new FsPermission(FsAction.ALL, FsAction.ALL, FsAction.ALL))
     fs.setPermission(new Path("/"), new FsPermission(FsAction.ALL, FsAction.ALL, FsAction.ALL))
-    fs.setPermission(new Path("/spark"), new FsPermission(FsAction.ALL, FsAction.ALL, FsAction.ALL))
     fs.copyFromLocalFile(new Path(driverTemplate.getPath), new Path("/spark/driver.yml"))
   }
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
@@ -296,7 +296,8 @@ class SparkProcessBuilder(
             fs = path.getFileSystem(hadoopConf)
             if (!fs.exists(path)) {
               info(s"Try creating $KUBERNETES_FILE_UPLOAD_PATH: $uploadPath")
-              fs.mkdirs(path, KUBERNETES_UPLOAD_PATH_PERMISSION)
+              // SPARK-30860: use the class method to avoid the umask causing permission issues
+              FileSystem.mkdirs(fs, path, KUBERNETES_UPLOAD_PATH_PERMISSION)
             }
           } catch {
             case ioe: IOException =>
@@ -410,7 +411,8 @@ object SparkProcessBuilder {
   final val INTERNAL_RESOURCE = "spark-internal"
 
   final val KUBERNETES_FILE_UPLOAD_PATH = "spark.kubernetes.file.upload.path"
-  final val KUBERNETES_UPLOAD_PATH_PERMISSION = new FsPermission(Integer.parseInt("777", 8).toShort)
+  final val KUBERNETES_UPLOAD_PATH_PERMISSION =
+    FsPermission.createImmutable(Integer.parseInt("777", 8).toShort)
 
   final val YEAR_FMT = DateTimeFormatter.ofPattern("yyyy")
   final val MONTH_FMT = DateTimeFormatter.ofPattern("MM")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->
The default behavior of HDFS is to set the permission of a file created with `FileSystem.create` or `FileSystem.mkdirs` to `(P & ^umask)`, where `P` is the permission in the API call and umask is a system value set by `fs.permissions.umask-mode` and defaults to `0022`. This means, with default settings, any mkdirs call can have at most `755` permissions.

The same issue also got reported in [SPARK-30860](https://issues.apache.org/jira/browse/SPARK-30860)

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Manual test.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.
