### PR TITLE
[KYUUBI #7153]  Share JAAS configuration for Zookeeper client to avoid server OOM

### DIFF
--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/zookeeper/ZookeeperClientProvider.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/zookeeper/ZookeeperClientProvider.scala
@@ -40,7 +40,7 @@ import org.apache.kyuubi.util.reflect.DynConstructors
 object ZookeeperClientProvider extends Logging {
 
   /**
-   * Sharing JAAS configuration for Zookeeper client with same keytab and principal to
+   * Share JAAS configuration for Zookeeper client with same keytab and principal to
    * avoid server OOM due to each new JAAS configuration references the previous instance.
    * See KYUUBI #7154 for more details.
    */

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/zookeeper/ZookeeperClientProvider.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/zookeeper/ZookeeperClientProvider.scala
@@ -40,8 +40,9 @@ import org.apache.kyuubi.util.reflect.DynConstructors
 object ZookeeperClientProvider extends Logging {
 
   /**
-   * Sharing jaas configuration for zookeeper client with same keytab and principal to
-   * avoid server oom due to nested jaas configuration. see KYUUBI #7154 for more details.
+   * Sharing JAAS configuration for Zookeeper client with same keytab and principal to
+   * avoid server OOM due to each new JAAS configuration references the previous instance.
+   * See KYUUBI #7154 for more details.
    */
   val jaasConfigurationCache = new ConcurrentHashMap[(String, String), Configuration]()
 

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/zookeeper/ZookeeperClientProvider.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/zookeeper/ZookeeperClientProvider.scala
@@ -39,6 +39,10 @@ import org.apache.kyuubi.util.reflect.DynConstructors
 
 object ZookeeperClientProvider extends Logging {
 
+  /**
+   * Sharing jaas configuration for zookeeper client with same keytab and principal to
+   * avoid server oom due to nested jaas configuration. see KYUUBI #7154 for more details.
+   */
   val jaasConfigurationCache = new ConcurrentHashMap[(String, String), Configuration]()
 
   /**
@@ -116,7 +120,6 @@ object ZookeeperClientProvider extends Logging {
           System.setProperty("zookeeper.server.principal", zkServerPrincipal)
         }
         val zkClientPrincipal = KyuubiHadoopUtils.getServerPrincipal(principal)
-        // HDFS-16591 makes breaking change on JaasConfiguration
         val jaasConf = jaasConfigurationCache.computeIfAbsent(
           (principal, keytab),
           _ => {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->

Sharing jaas configuration for zookeeper client with same keytab and principal to avoid server oom due to nested jaas configuration. 

fix issue https://github.com/apache/kyuubi/issues/7153

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

ut

### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

no
