### PR TITLE
Spark engine respects session-level idle timeout threshold

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/session/SparkSessionImpl.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/session/SparkSessionImpl.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.ui.SparkUIUtils.formatDuration
 
 import org.apache.kyuubi.KyuubiSQLException
+import org.apache.kyuubi.config.KyuubiConf.SESSION_IDLE_TIMEOUT
 import org.apache.kyuubi.config.KyuubiReservedKeys.KYUUBI_SESSION_HANDLE_KEY
 import org.apache.kyuubi.engine.spark.events.SessionEvent
 import org.apache.kyuubi.engine.spark.operation.SparkSQLOperationManager
@@ -55,6 +56,13 @@ class SparkSessionImpl(
     } catch {
       case e: AnalysisException => warn(e.getMessage())
     }
+  }
+
+  override val sessionIdleTimeoutThreshold: Long = {
+    conf.get(SESSION_IDLE_TIMEOUT.key)
+      .map(_.toLong)
+      .getOrElse(
+        sessionManager.getConf.get(SESSION_IDLE_TIMEOUT))
   }
 
   private val sessionEvent = SessionEvent(this)

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/session/AbstractSession.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/session/AbstractSession.scala
@@ -56,7 +56,12 @@ abstract class AbstractSession(
     if (lastIdleTime > 0) System.currentTimeMillis() - _lastIdleTime else 0
   }
 
-  override val sessionIdleTimeoutThreshold: Long = sessionManager.getConf.get(SESSION_IDLE_TIMEOUT)
+  override val sessionIdleTimeoutThreshold: Long = {
+    conf.get(SESSION_IDLE_TIMEOUT.key)
+      .map(_.toLong)
+      .getOrElse(
+        sessionManager.getConf.get(SESSION_IDLE_TIMEOUT))
+  }
 
   val normalizedConf: Map[String, String] = sessionManager.validateAndNormalizeConf(conf)
 

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/session/AbstractSession.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/session/AbstractSession.scala
@@ -56,12 +56,7 @@ abstract class AbstractSession(
     if (lastIdleTime > 0) System.currentTimeMillis() - _lastIdleTime else 0
   }
 
-  override val sessionIdleTimeoutThreshold: Long = {
-    conf.get(SESSION_IDLE_TIMEOUT.key)
-      .map(_.toLong)
-      .getOrElse(
-        sessionManager.getConf.get(SESSION_IDLE_TIMEOUT))
-  }
+  override val sessionIdleTimeoutThreshold: Long = sessionManager.getConf.get(SESSION_IDLE_TIMEOUT)
 
   val normalizedConf: Map[String, String] = sessionManager.validateAndNormalizeConf(conf)
 


### PR DESCRIPTION
### Why are the changes needed?
Fixes the same class of issue as 
https://github.com/apache/kyuubi/pull/7138

Previously, `sessionIdleTimeoutThreshold` was initialized only once during session creation using `sessionManager.getConf`, preventing dynamic updates when clients pass new configurations during connection.

we now:
- Allow clients to set session-specific kyuubi.session.idle.timeout` during connection
- Dynamically adjust idle timeout per session
- Prevent connection pile-up by timely recycling idle sessions

