### PR TITLE
Use single try-with-resources blocks in docs example

### DIFF
--- a/docs/quick_start/quick_start_with_jdbc.md
+++ b/docs/quick_start/quick_start_with_jdbc.md
@@ -48,13 +48,12 @@ public class KyuubiJDBC {
   private static String kyuubiJdbcUrl = "jdbc:kyuubi://localhost:10009/default;";
 
   public static void main(String[] args) throws SQLException {
-    try (Connection conn = DriverManager.getConnection(kyuubiJdbcUrl)) {
-      try (Statement stmt = conn.createStatement()) {
-        try (ResultSet rs = stmt.executeQuery("show databases")) {
-          while (rs.next()) {
-            System.out.println(rs.getString(1));
-          }
-        }   
+    try (
+      Connection conn = DriverManager.getConnection(kyuubiJdbcUrl);
+      Statement stmt = conn.createStatement();
+      ResultSet rs = stmt.executeQuery("show databases")) {
+      while (rs.next()) {
+        System.out.println(rs.getString(1));
       }
     }
   }
@@ -81,13 +80,12 @@ public class KyuubiJDBCDemo {
     String clientKeytab = args[1];    // Keytab file location
     String serverPrincipal = args[2]; // Kerberos principal used by Kyuubi Server
     String kyuubiJdbcUrl = String.format(kyuubiJdbcUrlTemplate, clientPrincipal, clientKeytab, serverPrincipal);
-    try (Connection conn = DriverManager.getConnection(kyuubiJdbcUrl)) {
-      try (Statement stmt = conn.createStatement()) {
-        try (ResultSet rs = stmt.executeQuery("show databases")) {
-          while (rs.next()) {
-            System.out.println(rs.getString(1));
-          }
-        }
+    try (
+      Connection conn = DriverManager.getConnection(kyuubiJdbcUrl);
+      Statement stmt = conn.createStatement();
+      ResultSet rs = stmt.executeQuery("show databases")) {
+      while (rs.next()) {
+        System.out.println(rs.getString(1));
       }
     }
   }


### PR DESCRIPTION
Gets rid of the nested try-with-resources blocks. Improves legibility slightly.

### Why are the changes needed?
Make the example code just a bit nicer.

### How was this patch tested?
It still compiles. I created a simple (maven) project using only these two java files.

### Was this patch authored or co-authored using generative AI tooling?
No

