### PR TITLE
Fix empty list engine result when etcd is used as the service registry

### DIFF
--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/DiscoveryClient.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/DiscoveryClient.scala
@@ -66,6 +66,7 @@ trait DiscoveryClient extends Logging {
    */
   def pathNonExists(path: String): Boolean
 
+  def pathNonExists(path: String, isPrefix: Boolean): Boolean
   /**
    * Delete a path.
    * @param path the path to be deleted

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/DiscoveryClient.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/DiscoveryClient.scala
@@ -67,6 +67,7 @@ trait DiscoveryClient extends Logging {
   def pathNonExists(path: String): Boolean
 
   def pathNonExists(path: String, isPrefix: Boolean): Boolean
+
   /**
    * Delete a path.
    * @param path the path to be deleted

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/DiscoveryClient.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/DiscoveryClient.scala
@@ -66,6 +66,7 @@ trait DiscoveryClient extends Logging {
    * The isPrefix is set to true by default for Etcd to retrieve all entries under the given path.
    * For other discovery service, it can be set false by default to only check the exact path.
    * @param path The path to check
+   * @param isPrefix whether to check all paths with the given path as prefix
    * @return true if the path and all its sub-paths are non-existent; false otherwise
    */
   def pathNonExists(path: String, isPrefix: Boolean = false): Boolean

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/DiscoveryClient.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/DiscoveryClient.scala
@@ -62,11 +62,13 @@ trait DiscoveryClient extends Logging {
   def pathExists(path: String): Boolean
 
   /**
-   * Check if the path non exists.
+   * Checks whether the given path and all its child paths (prefix matches) do not exist.
+   * The isPrefix is set to true by default for Etcd to retrieve all entries under the given path.
+   * For other discovery service, it can be set false by default to only check the exact path.
+   * @param path The path to check
+   * @return true if the path and all its sub-paths are non-existent; false otherwise
    */
-  def pathNonExists(path: String): Boolean
-
-  def pathNonExists(path: String, isPrefix: Boolean): Boolean
+  def pathNonExists(path: String, isPrefix: Boolean = false): Boolean
 
   /**
    * Delete a path.

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/etcd/EtcdDiscoveryClient.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/etcd/EtcdDiscoveryClient.scala
@@ -147,11 +147,7 @@ class EtcdDiscoveryClient(conf: KyuubiConf) extends DiscoveryClient {
     !pathNonExists(path)
   }
 
-  override def pathNonExists(path: String): Boolean = {
-    kvClient.get(ByteSequence.from(path.getBytes())).get().getKvs.isEmpty
-  }
-
-  override def pathNonExists(path: String, isPrefix: Boolean): Boolean = {
+  override def pathNonExists(path: String, isPrefix: Boolean = true): Boolean = {
     kvClient.get(
       ByteSequence.from(path.getBytes()),
       GetOption.newBuilder().isPrefix(isPrefix).build()).get().getKvs.isEmpty

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/etcd/EtcdDiscoveryClient.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/etcd/EtcdDiscoveryClient.scala
@@ -313,7 +313,7 @@ class EtcdDiscoveryClient(conf: KyuubiConf) extends DiscoveryClient {
   override def getAndIncrement(path: String, delta: Int = 1): Int = {
     val lockPath = s"${path}_tmp_for_lock"
     tryWithLock(lockPath, 60 * 1000) {
-      if (pathNonExists(path)) {
+      if (pathNonExists(path, isPrefix = false)) {
         create(path, "PERSISTENT")
         setData(path, String.valueOf(0).getBytes)
       }

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/etcd/EtcdDiscoveryClient.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/etcd/EtcdDiscoveryClient.scala
@@ -151,6 +151,12 @@ class EtcdDiscoveryClient(conf: KyuubiConf) extends DiscoveryClient {
     kvClient.get(ByteSequence.from(path.getBytes())).get().getKvs.isEmpty
   }
 
+  override def pathNonExists(path: String, isPrefix: Boolean): Boolean = {
+    kvClient.get(
+      ByteSequence.from(path.getBytes()),
+      GetOption.newBuilder().isPrefix(isPrefix).build()).get().getKvs.isEmpty
+  }
+
   override def delete(path: String, deleteChildren: Boolean = false): Unit = {
     kvClient.delete(
       ByteSequence.from(path.getBytes()),

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/zookeeper/ZookeeperDiscoveryClient.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/zookeeper/ZookeeperDiscoveryClient.scala
@@ -86,10 +86,6 @@ class ZookeeperDiscoveryClient(conf: KyuubiConf) extends DiscoveryClient {
     zkClient.checkExists().forPath(path) != null
   }
 
-  override def pathNonExists(path: String): Boolean = {
-    zkClient.checkExists().forPath(path) == null
-  }
-
   override def pathNonExists(path: String, isPrefix: Boolean): Boolean = {
     zkClient.checkExists().forPath(path) == null
   }

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/zookeeper/ZookeeperDiscoveryClient.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/zookeeper/ZookeeperDiscoveryClient.scala
@@ -90,6 +90,10 @@ class ZookeeperDiscoveryClient(conf: KyuubiConf) extends DiscoveryClient {
     zkClient.checkExists().forPath(path) == null
   }
 
+  override def pathNonExists(path: String, isPrefix: Boolean): Boolean = {
+    zkClient.checkExists().forPath(path) == null
+  }
+
   override def delete(path: String, deleteChildren: Boolean = false): Unit = {
     if (deleteChildren) {
       zkClient.delete().deletingChildrenIfNeeded().forPath(path)

--- a/kyuubi-ha/src/test/scala/org/apache/kyuubi/ha/client/etcd/EtcdDiscoveryClientSuite.scala
+++ b/kyuubi-ha/src/test/scala/org/apache/kyuubi/ha/client/etcd/EtcdDiscoveryClientSuite.scala
@@ -100,7 +100,7 @@ class EtcdDiscoveryClientSuite extends DiscoveryClientTests {
       // set
       discoveryClient.create(path, "PERSISTENT")
       assert(discoveryClient.pathExists(path))
-      assert(!discoveryClient.pathNonExists(pathPrefix, isPrefix = true))
+      assert(!discoveryClient.pathNonExists(pathPrefix))
 
       // get
       assert(new String(discoveryClient.getData(path), StandardCharsets.UTF_8) == path)

--- a/kyuubi-ha/src/test/scala/org/apache/kyuubi/ha/client/etcd/EtcdDiscoveryClientSuite.scala
+++ b/kyuubi-ha/src/test/scala/org/apache/kyuubi/ha/client/etcd/EtcdDiscoveryClientSuite.scala
@@ -92,4 +92,22 @@ class EtcdDiscoveryClientSuite extends DiscoveryClientTests {
       assert(!discoveryClient.pathExists(path))
     }
   }
+
+  test("etcd test: set, get with path prefix and delete") {
+    withDiscoveryClient(conf) { discoveryClient =>
+      val path = "/kyuubi_version_USER_SPARK_SQL/test/default"
+      val pathPrefix = "/kyuubi_version_USER_SPARK_SQL/test"
+      // set
+      discoveryClient.create(path, "PERSISTENT")
+      assert(discoveryClient.pathExists(path))
+      assert(!discoveryClient.pathNonExists(pathPrefix, isPrefix = true))
+
+      // get
+      assert(new String(discoveryClient.getData(path), StandardCharsets.UTF_8) == path)
+
+      // delete
+      discoveryClient.delete(path)
+      assert(!discoveryClient.pathExists(path))
+    }
+  }
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/AdminResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/AdminResource.scala
@@ -349,7 +349,7 @@ private[v1] class AdminResource extends ApiRequestContext with Logging {
         case Some(_) =>
           info(s"Listing engine nodes under $engineSpace")
           engineNodes ++= discoveryClient.getServiceNodesInfo(engineSpace)
-        case None if discoveryClient.pathNonExists(engineSpace) =>
+        case None if discoveryClient.pathNonExists(engineSpace, isPrefix = true) =>
           warn(s"Path $engineSpace does not exist. user: $userName, engine type: $engineType, " +
             s"share level: $shareLevel, subdomain: $subdomain")
         case None =>

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/AdminResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/AdminResource.scala
@@ -349,7 +349,7 @@ private[v1] class AdminResource extends ApiRequestContext with Logging {
         case Some(_) =>
           info(s"Listing engine nodes under $engineSpace")
           engineNodes ++= discoveryClient.getServiceNodesInfo(engineSpace)
-        case None if discoveryClient.pathNonExists(engineSpace, isPrefix = true) =>
+        case None if discoveryClient.pathNonExists(engineSpace) =>
           warn(s"Path $engineSpace does not exist. user: $userName, engine type: $engineType, " +
             s"share level: $shareLevel, subdomain: $subdomain")
         case None =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->

In etcd, keys are stored in a flat namespace where / is just part of the key name. For example, /kyuubi_version_USER_SPARK_SQL/test/default is treated as a complete single key. 

To retrieve all entries under a similar path, a prefix query (--prefix) is required.

In ZooKeeper, data is organized in a hierarchical tree structure where / represents parent-child relationships.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

added a UT to verify code.
### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
