### PR TITLE
Shade kyuubi spark lineage module

### DIFF
--- a/extensions/spark/kyuubi-spark-lineage/pom.xml
+++ b/extensions/spark/kyuubi-spark-lineage/pom.xml
@@ -183,6 +183,29 @@
         </testResources>
         <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
         <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <configuration>
+                    <shadedArtifactAttached>false</shadedArtifactAttached>
+                    <artifactSet>
+                        <includes>
+                            <include>org.apache.kyuubi:*</include>
+                        </includes>
+                    </artifactSet>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <phase>package</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
 </project>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?

To avoid the issues of kyuubi util classes not being found when placing lineage plugin jar in $SPARK_HOME/jars .

### How was this patch tested?

run `mvn clean -DskipTests package -am -pl extensions/spark/kyuubi-spark-lineage`

logs:
```
[INFO] --- shade:3.5.2:shade (default) @ kyuubi-spark-lineage_2.12 ---
[INFO] Including org.apache.kyuubi:kyuubi-util-scala_2.12:jar:1.11.0-SNAPSHOT in the shaded jar.
[INFO] Including org.apache.kyuubi:kyuubi-util:jar:1.11.0-SNAPSHOT in the shaded jar.
[INFO] Excluding org.scala-lang:scala-library:jar:2.12.19 from the shaded jar.
[INFO] Excluding org.slf4j:slf4j-api:jar:1.7.36 from the shaded jar.
[INFO] Excluding org.apache.atlas:atlas-client-v2:jar:2.3.0 from the shaded jar.
[INFO] Excluding org.apache.atlas:atlas-intg:jar:2.3.0 from the shaded jar.
[INFO] Excluding commons-validator:commons-validator:jar:1.6 from the shaded jar.
[INFO] Excluding commons-beanutils:commons-beanutils:jar:1.9.2 from the shaded jar.
[INFO] Excluding commons-digester:commons-digester:jar:1.8.1 from the shaded jar.
[INFO] Excluding com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:jar:2.15.4 from the shaded jar.
[INFO] Excluding com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:jar:2.15.4 from the shaded jar.
[INFO] Excluding com.fasterxml.jackson.module:jackson-module-jaxb-annotations:jar:2.15.4 from the shaded jar.
[INFO] Excluding jakarta.xml.bind:jakarta.xml.bind-api:jar:2.3.2 from the shaded jar.
[INFO] Excluding jakarta.activation:jakarta.activation-api:jar:1.2.2 from the shaded jar.
[INFO] Excluding javax.inject:javax.inject:jar:1 from the shaded jar.
[INFO] Excluding commons-configuration:commons-configuration:jar:1.10 from the shaded jar.
[INFO] Excluding org.apache.commons:commons-configuration2:jar:2.8.0 from the shaded jar.
[INFO] Excluding org.apache.atlas:atlas-client-common:jar:2.3.0 from the shaded jar.
[INFO] Excluding com.sun.jersey:jersey-client:jar:1.19 from the shaded jar.
[INFO] Excluding com.sun.jersey.contribs:jersey-multipart:jar:1.19 from the shaded jar.
[INFO] Excluding org.jvnet.mimepull:mimepull:jar:1.9.3 from the shaded jar.
[INFO] Excluding com.sun.jersey:jersey-core:jar:1.19 from the shaded jar.
[INFO] Excluding javax.ws.rs:jsr311-api:jar:1.1.1 from the shaded jar.
[INFO] Excluding cglib:cglib:jar:2.2.2 from the shaded jar.
[INFO] Excluding asm:asm:jar:3.3.1 from the shaded jar.
[INFO] Excluding commons-lang:commons-lang:jar:2.6 from the shaded jar.
[INFO] Dependency-reduced POM written at: /Users/wforget/work/git/kyuubi/extensions/spark/kyuubi-spark-lineage/dependency-reduced-pom.xml
[WARNING] kyuubi-spark-lineage_2.12-1.11.0-SNAPSHOT.jar, kyuubi-util-1.11.0-SNAPSHOT.jar, kyuubi-util-scala_2.12-1.11.0-SNAPSHOT.jar define 4 overlapping resources: 
[WARNING]   - META-INF/DEPENDENCIES
[WARNING]   - META-INF/LICENSE
[WARNING]   - META-INF/MANIFEST.MF
[WARNING]   - META-INF/NOTICE
[WARNING] maven-shade-plugin has detected that some files are
[WARNING] present in two or more JARs. When this happens, only one
[WARNING] single version of the file is copied to the uber jar.
[WARNING] Usually this is not harmful and you can skip these warnings,
[WARNING] otherwise try to manually exclude artifacts based on
[WARNING] mvn dependency:tree -Ddetail=true and the above output.
[WARNING] See https://maven.apache.org/plugins/maven-shade-plugin/
[INFO] Replacing original artifact with shaded artifact.
[INFO] Replacing /Users/wforget/work/git/kyuubi/extensions/spark/kyuubi-spark-lineage/target/kyuubi-spark-lineage_2.12-1.11.0-SNAPSHOT.jar with /Users/wforget/work/git/kyuubi/extensions/spark/kyuubi-spark-lineage/target/kyuubi-spark-lineage_2.12-1.11.0-SNAPSHOT-shaded.jar
```


### Was this patch authored or co-authored using generative AI tooling?

No

