### PR TITLE
[KYUUBI #7180][LINEAGE] Subquery in the project should drill down to get the column lineage relationships

### DIFF
--- a/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/helper/SparkSQLLineageParseHelper.scala
+++ b/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/helper/SparkSQLLineageParseHelper.scala
@@ -119,14 +119,15 @@ trait LineageParser {
     val exps = named.map {
       case exp: Alias =>
         val references =
-          if (exp.references.nonEmpty) exp.references
-          else {
+          if (exp.references.isEmpty || exp.child.isInstanceOf[ScalarSubquery]) {
             val attrRefs = getExpressionSubqueryPlans(exp.child)
               .map(extractColumnsLineage(_, ListMap[Attribute, AttributeSet]()))
               .foldLeft(ListMap[Attribute, AttributeSet]())(mergeColumnsLineage).values
               .foldLeft(AttributeSet.empty)(_ ++ _)
               .map(attr => attr.withQualifier(attr.qualifier :+ SUBQUERY_COLUMN_IDENTIFIER))
             AttributeSet(attrRefs)
+          } else {
+            exp.references
           }
         (
           exp.toAttribute,

--- a/extensions/spark/kyuubi-spark-lineage/src/test/scala/org/apache/kyuubi/plugin/lineage/helper/SparkSQLLineageParserHelperSuite.scala
+++ b/extensions/spark/kyuubi-spark-lineage/src/test/scala/org/apache/kyuubi/plugin/lineage/helper/SparkSQLLineageParserHelperSuite.scala
@@ -1143,6 +1143,18 @@ abstract class SparkSQLLineageParserHelperSuite extends KyuubiFunSuite
         List(
           ("a", Set(s"$DEFAULT_CATALOG.default.table1.a")),
           ("b", Set(s"$DEFAULT_CATALOG.default.table1.b")))))
+
+      val sql12 =
+        """
+          |select (select sum(a) from table0 where table1.b = table0.b) as aa, b from table1
+          |""".stripMargin
+      val ret12 = extractLineage(sql12)
+      assert(ret12 == Lineage(
+        List(s"$DEFAULT_CATALOG.default.table0", s"$DEFAULT_CATALOG.default.table1"),
+        List(),
+        List(
+          ("aa", Set(s"$DEFAULT_CATALOG.default.table0.a")),
+          ("b", Set(s"$DEFAULT_CATALOG.default.table1.b")))))
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->
The following SQL statement will get the wrong column lineage result:
create table table0(a int, b string, c string)
create table table1(a int, b string, c string)
select (select sum(a) from table0 where table1.b = table0.b) as aa, b from table1

The root cause:  
From  https://github.com/apache/spark/pull/32687 ,  we can know the references for a subquery expression are defined as outer attribute references.  So we should always drill down to get the corresponding column lineage relationship for the subquery plan.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
add new ut

### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

no