### PR TITLE
[KYUUBI #7156] Support update HBase delegation token for Spark SQL Engine

### DIFF
--- a/build/Dockerfile.HBase
+++ b/build/Dockerfile.HBase
@@ -47,9 +47,7 @@ ENV PATH=$PATH:$HBASE_HOME/bin
 RUN apt-get update && apt-get install -y \
     krb5-kdc \
     krb5-admin-server \
-    openjdk-8-jdk \
     wget \
-    supervisor \
     busybox \
     && mkdir /opt/busybox && \
     busybox --install /opt/busybox
@@ -190,16 +188,6 @@ COPY <<"EOF" ${HBASE_HOME}/conf/core-site.xml
 
 <configuration>
     <property>
-            <name>hadoop.security.authentication</name>
-            <value>kerberos</value>
-    </property>
-
-    <property>
-        <name>fs.defaultFS</name>
-        <value>hdfs://localhost:9000</value>
-    </property>
-
-    <property>
         <name>hadoop.security.authentication</name>
         <value>kerberos</value>
     </property>
@@ -313,7 +301,7 @@ mkdir -p ${HBASE_HOME}/logs/
 mkdir -p ${ZK_HOME}/logs/
 
 echo "Principals created. Starting supervisor..."
-# create kdc service
+# start kdc service
 echo "Start kdc ..."
 /etc/init.d/krb5-kdc start
 wait_for_service "kdc" 15 1 88
@@ -326,17 +314,15 @@ wait_for_service "zookeeper" 15 1 2181
 
 kinit -kt ${HBASE_CONF_DIR}/hbase.keytab hbase/localhost@${REALM}
 
-# # start hbase master server
+# start hbase master server
 nohup /opt/hbase/bin/hbase master start  > "/opt/hbase/logs/master.log" 2>&1 < /dev/null &
 wait_for_service "master" 15 1 16000
 
-# # start hbase region server
+# start hbase region server
 nohup /opt/hbase/bin/hbase regionserver start  > "/opt/hbase/logs/regionserver.log" 2>&1 < /dev/null &
 wait_for_service "master" 15 1 16020
 
 tail -F --follow=name --retry -v  /opt/zookeeper/logs/* /opt/hbase/logs/*
-
-
 EOF
 
 RUN chmod +x /entrypoint.sh

--- a/build/Dockerfile.HBase
+++ b/build/Dockerfile.HBase
@@ -82,86 +82,86 @@ EOF
 COPY <<"EOF" ${HBASE_HOME}/conf/hbase-site.xml
 
 <configuration>
-	<property>
-		<name>hbase.cluster.distributed</name>
-		<value>true</value>
-	</property>
-	<property>
-		<name>hbase.rootdir</name>
-		<value>file:///tmp/hbase-data</value>
-	</property>
-	<property>
-		<name>hbase.security.authentication</name>
-		<value>kerberos</value>
-	</property>
-	<property>
-		<name>hbase.master.kerberos.principal</name>
-		<value>hbase/localhost@TEST.ORG</value>
-	</property>
-	<property>
-		<name>hbase.master.keytab.file</name>
-		<value>/opt/hbase/conf/hbase.keytab</value>
-	</property>
-	<property>
-		<name>hbase.regionserver.kerberos.principal</name>
-		<value>hbase/localhost@TEST.ORG</value>
-	</property>
-	<property>
-		<name>hbase.regionserver.keytab.file</name>
-		<value>/opt/hbase/conf/hbase.keytab</value>
-	</property>
-	<property>
-		<name>hbase.security.authorization</name>
-		<value>true</value>
-	</property>
-	<property>
-		<name>hbase.master.hostname</name>
-		<value>localhost</value>
-	</property>
-	<property>
-		<name>hbase.regionserver.hostname</name>
-		<value>localhost</value>
-	</property>
-	<property>
-		<name>hbase.unsafe.regionserver.hostname</name>
-		<value>localhost</value>
-	</property>
-	<property>
-		<name>hbase.regionserver.ipc.address</name>
-		<value>0.0.0.0</value>
-	</property>
-	<property>
-		<name>hbase.master.ipc.address</name>
-		<value>0.0.0.0</value>
-	</property>
-	<property>
-		<name>hbase.zookeeper.quorum</name>
-		<value>localhost</value>
-	</property>
-	<property>
-		<name>hbase.zookeeper.property.clientPort</name>
-		<value>2181</value>
-	</property>
-	<property>
-		<name>hbase.zookeeper.client.keytab.file</name>
-		<value>/opt/hbase/conf/hbase.keytab</value>
-	</property>
-	<property>
-		<name>hbase.zookeeper.client.kerberos.principal</name>
-		<value>hbase/localhost@TEST.ORG</value>
-	</property>
-	<property>
-		<name>hbase.unsafe.stream.capability.enforce</name>
-		<value>false</value>
-	</property>
-	<property>
-		<name>hbase.coprocessor.region.classes</name>
-		<value>org.apache.hadoop.hbase.security.token.TokenProvider,org.apache.hadoop.hbase.security.access.AccessController</value>
-	</property>
-	<property>
-		<name>hbase.coprocessor.master.classes</name>
-		<value>org.apache.hadoop.hbase.security.access.AccessController</value>
-	</property>
+    <property>
+        <name>hbase.cluster.distributed</name>
+        <value>true</value>
+    </property>
+    <property>
+        <name>hbase.rootdir</name>
+        <value>file:///tmp/hbase-data</value>
+    </property>
+    <property>
+        <name>hbase.security.authentication</name>
+        <value>kerberos</value>
+    </property>
+    <property>
+        <name>hbase.master.kerberos.principal</name>
+        <value>hbase/localhost@TEST.ORG</value>
+    </property>
+    <property>
+        <name>hbase.master.keytab.file</name>
+        <value>/opt/hbase/conf/hbase.keytab</value>
+    </property>
+    <property>
+        <name>hbase.regionserver.kerberos.principal</name>
+        <value>hbase/localhost@TEST.ORG</value>
+    </property>
+    <property>
+        <name>hbase.regionserver.keytab.file</name>
+        <value>/opt/hbase/conf/hbase.keytab</value>
+    </property>
+    <property>
+        <name>hbase.security.authorization</name>
+        <value>true</value>
+    </property>
+    <property>
+        <name>hbase.master.hostname</name>
+        <value>localhost</value>
+    </property>
+    <property>
+        <name>hbase.regionserver.hostname</name>
+        <value>localhost</value>
+    </property>
+    <property>
+        <name>hbase.unsafe.regionserver.hostname</name>
+        <value>localhost</value>
+    </property>
+    <property>
+        <name>hbase.regionserver.ipc.address</name>
+        <value>0.0.0.0</value>
+    </property>
+    <property>
+        <name>hbase.master.ipc.address</name>
+        <value>0.0.0.0</value>
+    </property>
+    <property>
+        <name>hbase.zookeeper.quorum</name>
+        <value>localhost</value>
+    </property>
+    <property>
+        <name>hbase.zookeeper.property.clientPort</name>
+        <value>2181</value>
+    </property>
+    <property>
+        <name>hbase.zookeeper.client.keytab.file</name>
+        <value>/opt/hbase/conf/hbase.keytab</value>
+    </property>
+    <property>
+        <name>hbase.zookeeper.client.kerberos.principal</name>
+        <value>hbase/localhost@TEST.ORG</value>
+    </property>
+    <property>
+        <name>hbase.unsafe.stream.capability.enforce</name>
+        <value>false</value>
+    </property>
+    <property>
+        <name>hbase.coprocessor.region.classes</name>
+        <value>org.apache.hadoop.hbase.security.token.TokenProvider,org.apache.hadoop.hbase.security.access.AccessController</value>
+    </property>
+    <property>
+        <name>hbase.coprocessor.master.classes</name>
+        <value>org.apache.hadoop.hbase.security.access.AccessController</value>
+    </property>
 </configuration>
 
 EOF
@@ -173,17 +173,14 @@ COPY <<"EOF" ${HBASE_HOME}/conf/core-site.xml
         <name>hadoop.security.authentication</name>
         <value>kerberos</value>
     </property>
-
     <property>
         <name>hadoop.security.authorization</name>
         <value>true</value>
     </property>
-
     <property>
         <name>hadoop.proxyuser.hbase.hosts</name>
         <value>*</value>
     </property>
-
     <property>
         <name>hadoop.proxyuser.hbase.groups</name>
         <value>*</value>

--- a/build/Dockerfile.HBase
+++ b/build/Dockerfile.HBase
@@ -1,0 +1,355 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This Dockerfile is for building a HBase Cluster used in testing
+
+# Usage:
+#   Run the docker command below
+#      docker build \
+#        --build-arg APACHE_MIRROR="https://archive.apache.org/dist" \
+#        --build-arg HBASE_VERSION="2.5.12" \
+#        --build-arg ZK_VERSION="3.8.4" \
+#        --file build/Dockerfile.HBase \
+#        --tag nekyuubi/kyuubi-hbase-cluster:<tag> \
+#        .
+#   Options:
+#     -f, --file  this docker file
+#     -t, --tag   the target repo and tag name
+#     more options can be found with -h, --help
+
+FROM eclipse-temurin:8-jdk-focal
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+ARG HBASE_VERSION=2.5.12
+ARG APACHE_MIRROR=https://archive.apache.org/dist
+ARG ZK_VERSION=3.8.1
+
+ENV HBASE_HOME=/opt/hbase
+ENV ZK_HOME=/opt/zookeeper
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$PATH:$HBASE_HOME/bin
+
+RUN apt-get update && apt-get install -y \
+    krb5-kdc \
+    krb5-admin-server \
+    openjdk-8-jdk \
+    wget \
+    supervisor \
+    busybox \
+    && mkdir /opt/busybox && \
+    busybox --install /opt/busybox
+
+# download hbase
+RUN wget -q ${APACHE_MIRROR}/hbase/${HBASE_VERSION}/hbase-${HBASE_VERSION}-bin.tar.gz && \
+    tar -xzf hbase-${HBASE_VERSION}-bin.tar.gz -C /opt && \
+    mv /opt/hbase-${HBASE_VERSION} ${HBASE_HOME} && \
+    rm hbase-${HBASE_VERSION}-bin.tar.gz
+
+# download zookeeper
+RUN wget -q ${APACHE_MIRROR}/zookeeper/zookeeper-${ZK_VERSION}/apache-zookeeper-${ZK_VERSION}-bin.tar.gz && \
+    tar -xzf apache-zookeeper-${ZK_VERSION}-bin.tar.gz -C /opt && \
+    mv /opt/apache-zookeeper-${ZK_VERSION}-bin ${ZK_HOME} && \
+    rm apache-zookeeper-${ZK_VERSION}-bin.tar.gz
+
+# add config files
+COPY <<"EOF" /etc/krb5.conf
+
+[libdefaults]
+    default_realm = TEST.ORG
+    dns_lookup_realm = false
+    dns_lookup_kdc = false
+
+[realms]
+    TEST.ORG = {
+        kdc = localhost:88
+    }
+
+EOF
+
+COPY <<"EOF" ${HBASE_HOME}/conf/hbase-site.xml
+
+<configuration>
+    <property>
+        <name>hbase.cluster.distributed</name>
+        <value>true</value>
+    </property>
+
+    <property>
+        <name>hbase.rootdir</name>
+        <value>file:///tmp/hbase-data</value>
+    </property>
+    <property>
+        <name>hbase.security.authentication</name>
+        <value>kerberos</value>
+    </property>
+    <property>
+        <name>hbase.master.kerberos.principal</name>
+        <value>hbase/localhost@TEST.ORG</value>
+    </property>
+    <property>
+        <name>hbase.master.keytab.file</name>
+        <value>/opt/hbase/conf/hbase.keytab</value>
+    </property>
+    <property>
+        <name>hbase.regionserver.kerberos.principal</name>
+        <value>hbase/localhost@TEST.ORG</value>
+    </property>
+    <property>
+        <name>hbase.regionserver.keytab.file</name>
+        <value>/opt/hbase/conf/hbase.keytab</value>
+    </property>
+
+    <property>
+        <name>hbase.security.authorization</name>
+        <value>true</value>
+    </property>
+
+     <property>
+     <name>hadoop.security.authentication</name>
+     <value>kerberos</value>
+     </property>
+
+     <property>
+        <name>hbase.master.hostname</name>
+        <value>localhost</value>
+    </property>
+
+    <property>
+        <name>hbase.regionserver.hostname</name>
+        <value>localhost</value>
+    </property>
+
+    <property>
+        <name>hbase.unsafe.regionserver.hostname</name>
+        <value>localhost</value>
+    </property>
+
+    <property>
+        <name>hbase.regionserver.ipc.address</name>
+        <value>0.0.0.0</value>
+    </property>
+
+    <property>
+        <name>hbase.master.ipc.address</name>
+        <value>0.0.0.0</value>
+    </property>
+
+    <property>
+        <name>hbase.zookeeper.quorum</name>
+        <value>localhost</value>
+    </property>
+    <property>
+        <name>hbase.zookeeper.property.clientPort</name>
+        <value>2181</value>
+    </property>
+
+    <property>
+        <name>hbase.zookeeper.client.keytab.file</name>
+        <value>/opt/hbase/conf/hbase.keytab</value>
+    </property>
+
+    <property>
+        <name>hbase.zookeeper.client.kerberos.principal</name>
+        <value>hbase/localhost@TEST.ORG</value>
+    </property>
+
+    <property>
+        <name>hbase.unsafe.stream.capability.enforce</name>
+        <value>false</value>
+    </property>
+
+    <property>
+        <name>hbase.coprocessor.region.classes</name>
+        <value>org.apache.hadoop.hbase.security.token.TokenProvider,org.apache.hadoop.hbase.security.access.AccessController</value>
+    </property>
+
+    <property>
+    <name>hbase.coprocessor.master.classes</name>
+    <value>org.apache.hadoop.hbase.security.access.AccessController</value>
+    </property>
+</configuration>
+
+EOF
+
+COPY <<"EOF" ${HBASE_HOME}/conf/core-site.xml
+
+<configuration>
+    <property>
+            <name>hadoop.security.authentication</name>
+            <value>kerberos</value>
+    </property>
+
+    <property>
+        <name>fs.defaultFS</name>
+        <value>hdfs://localhost:9000</value>
+    </property>
+
+    <property>
+        <name>hadoop.security.authentication</name>
+        <value>kerberos</value>
+    </property>
+
+    <property>
+        <name>hadoop.security.authorization</name>
+        <value>true</value>
+    </property>
+
+    <property>
+        <name>hadoop.proxyuser.hbase.hosts</name>
+        <value>*</value>
+    </property>
+
+    <property>
+        <name>hadoop.proxyuser.hbase.groups</name>
+        <value>*</value>
+    </property>
+
+</configuration>
+
+EOF
+
+COPY <<"EOF" ${ZK_HOME}/conf/zk-jaas.conf
+Server {
+  com.sun.security.auth.module.Krb5LoginModule required
+  useKeyTab=true
+  storeKey=true
+  useTicketCache=false
+  keyTab="/opt/zookeeper/conf/zookeeper.keytab"
+  principal="zookeeper/localhost@TEST.ORG";
+};
+
+Client {
+   com.sun.security.auth.module.Krb5LoginModule required
+   useTicketCache=true;
+};
+EOF
+
+COPY <<"EOF" ${ZK_HOME}/conf/zoo.cfg
+tickTime=2000
+dataDir=/opt/zookeeper/data
+clientPort=2181
+# Kerberos settings
+authProvider.1=org.apache.zookeeper.server.auth.SASLAuthenticationProvider
+kerberos.keytab.file=/opt/zookeeper/conf/zk.keytab
+kerberos.principal=zookeeper/localhost@TEST.ORG
+requireClientAuthScheme=sasl
+EOF
+
+COPY <<"EOF" /entrypoint.sh
+#!/bin/bash
+set -e
+
+# Function: Wait for a service to be available on specified ports
+# Parameters:
+#   $1 - Service name
+#   $2 - Timeout in seconds, default 60 seconds
+#   $3 - Check interval in seconds, default 1 second
+#   Remaining parameters - List of ports to check
+wait_for_service() {
+    local service_name="$1"
+    local timeout="${2:-60}"
+    local interval="${3:-1}"
+    shift 3  # Remove the first three parameters, remaining are ports
+
+    local end_time=$((SECONDS + timeout))
+    local ports_available=false
+    echo "Starting to wait for $service_name service to be available on ports $@..."
+
+    while [ $SECONDS -lt $end_time ]; do
+        ports_available=true
+
+        # Check all provided ports
+        for port in "$@"; do
+            if ! /opt/busybox/nc localhost "$port" -e true; then
+                ports_available=false
+                break
+            fi
+        done
+
+        if $ports_available; then
+            echo "$service_name service is now available"
+            return 0
+        else
+            echo "$service_name service is not available, retrying in $interval seconds..."
+            sleep $interval
+        fi
+    done
+
+    echo "Timeout reached. $service_name service is still not available."
+    exit 1
+}
+
+export REALM="TEST.ORG"
+export KADMIN_PASS="admin"
+export HBASE_CONF_DIR="${HBASE_HOME}/conf"
+export ZK_CONF_DIR="${ZK_HOME}/conf"
+
+echo "Creating KDC database..."
+kdb5_util create -r ${REALM} -s -P ${KADMIN_PASS}
+
+echo "Creating principals and keytabs..."
+kadmin.local -q "addprinc -randkey hbase/localhost@${REALM}"
+kadmin.local -q "ktadd -k ${HBASE_CONF_DIR}/hbase.keytab hbase/localhost@${REALM}"
+
+kadmin.local -q "addprinc -randkey zookeeper/localhost@${REALM}"
+kadmin.local -q "ktadd -k ${ZK_CONF_DIR}/zookeeper.keytab zookeeper/localhost@${REALM}"
+
+mkdir -p ${HBASE_HOME}/logs/
+mkdir -p ${ZK_HOME}/logs/
+
+echo "Principals created. Starting supervisor..."
+# create kdc service
+echo "Start kdc ..."
+/etc/init.d/krb5-kdc start
+wait_for_service "kdc" 15 1 88
+
+# start zookeeper server
+export JVMFLAGS="-Djava.security.auth.login.config=/opt/zookeeper/conf/zk-jaas.conf"
+/opt/zookeeper/bin/zkServer.sh start
+unset JVMFLAGS
+wait_for_service "zookeeper" 15 1 2181
+
+kinit -kt ${HBASE_CONF_DIR}/hbase.keytab hbase/localhost@${REALM}
+
+# # start hbase master server
+nohup /opt/hbase/bin/hbase master start  > "/opt/hbase/logs/master.log" 2>&1 < /dev/null &
+wait_for_service "master" 15 1 16000
+
+# # start hbase region server
+nohup /opt/hbase/bin/hbase regionserver start  > "/opt/hbase/logs/regionserver.log" 2>&1 < /dev/null &
+wait_for_service "master" 15 1 16020
+
+tail -F --follow=name --retry -v  /opt/zookeeper/logs/* /opt/hbase/logs/*
+
+
+EOF
+
+RUN chmod +x /entrypoint.sh
+
+# HBase Master UI
+EXPOSE 16010
+# Kerberos
+EXPOSE 88/udp
+# zookeeper
+EXPOSE 2181
+# HBase Master
+EXPOSE 16000
+# HBase RegionServer
+EXPOSE 16020
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/build/Dockerfile.HBase
+++ b/build/Dockerfile.HBase
@@ -82,104 +82,86 @@ EOF
 COPY <<"EOF" ${HBASE_HOME}/conf/hbase-site.xml
 
 <configuration>
-    <property>
-        <name>hbase.cluster.distributed</name>
-        <value>true</value>
-    </property>
-
-    <property>
-        <name>hbase.rootdir</name>
-        <value>file:///tmp/hbase-data</value>
-    </property>
-    <property>
-        <name>hbase.security.authentication</name>
-        <value>kerberos</value>
-    </property>
-    <property>
-        <name>hbase.master.kerberos.principal</name>
-        <value>hbase/localhost@TEST.ORG</value>
-    </property>
-    <property>
-        <name>hbase.master.keytab.file</name>
-        <value>/opt/hbase/conf/hbase.keytab</value>
-    </property>
-    <property>
-        <name>hbase.regionserver.kerberos.principal</name>
-        <value>hbase/localhost@TEST.ORG</value>
-    </property>
-    <property>
-        <name>hbase.regionserver.keytab.file</name>
-        <value>/opt/hbase/conf/hbase.keytab</value>
-    </property>
-
-    <property>
-        <name>hbase.security.authorization</name>
-        <value>true</value>
-    </property>
-
-     <property>
-     <name>hadoop.security.authentication</name>
-     <value>kerberos</value>
-     </property>
-
-     <property>
-        <name>hbase.master.hostname</name>
-        <value>localhost</value>
-    </property>
-
-    <property>
-        <name>hbase.regionserver.hostname</name>
-        <value>localhost</value>
-    </property>
-
-    <property>
-        <name>hbase.unsafe.regionserver.hostname</name>
-        <value>localhost</value>
-    </property>
-
-    <property>
-        <name>hbase.regionserver.ipc.address</name>
-        <value>0.0.0.0</value>
-    </property>
-
-    <property>
-        <name>hbase.master.ipc.address</name>
-        <value>0.0.0.0</value>
-    </property>
-
-    <property>
-        <name>hbase.zookeeper.quorum</name>
-        <value>localhost</value>
-    </property>
-    <property>
-        <name>hbase.zookeeper.property.clientPort</name>
-        <value>2181</value>
-    </property>
-
-    <property>
-        <name>hbase.zookeeper.client.keytab.file</name>
-        <value>/opt/hbase/conf/hbase.keytab</value>
-    </property>
-
-    <property>
-        <name>hbase.zookeeper.client.kerberos.principal</name>
-        <value>hbase/localhost@TEST.ORG</value>
-    </property>
-
-    <property>
-        <name>hbase.unsafe.stream.capability.enforce</name>
-        <value>false</value>
-    </property>
-
-    <property>
-        <name>hbase.coprocessor.region.classes</name>
-        <value>org.apache.hadoop.hbase.security.token.TokenProvider,org.apache.hadoop.hbase.security.access.AccessController</value>
-    </property>
-
-    <property>
-    <name>hbase.coprocessor.master.classes</name>
-    <value>org.apache.hadoop.hbase.security.access.AccessController</value>
-    </property>
+	<property>
+		<name>hbase.cluster.distributed</name>
+		<value>true</value>
+	</property>
+	<property>
+		<name>hbase.rootdir</name>
+		<value>file:///tmp/hbase-data</value>
+	</property>
+	<property>
+		<name>hbase.security.authentication</name>
+		<value>kerberos</value>
+	</property>
+	<property>
+		<name>hbase.master.kerberos.principal</name>
+		<value>hbase/localhost@TEST.ORG</value>
+	</property>
+	<property>
+		<name>hbase.master.keytab.file</name>
+		<value>/opt/hbase/conf/hbase.keytab</value>
+	</property>
+	<property>
+		<name>hbase.regionserver.kerberos.principal</name>
+		<value>hbase/localhost@TEST.ORG</value>
+	</property>
+	<property>
+		<name>hbase.regionserver.keytab.file</name>
+		<value>/opt/hbase/conf/hbase.keytab</value>
+	</property>
+	<property>
+		<name>hbase.security.authorization</name>
+		<value>true</value>
+	</property>
+	<property>
+		<name>hbase.master.hostname</name>
+		<value>localhost</value>
+	</property>
+	<property>
+		<name>hbase.regionserver.hostname</name>
+		<value>localhost</value>
+	</property>
+	<property>
+		<name>hbase.unsafe.regionserver.hostname</name>
+		<value>localhost</value>
+	</property>
+	<property>
+		<name>hbase.regionserver.ipc.address</name>
+		<value>0.0.0.0</value>
+	</property>
+	<property>
+		<name>hbase.master.ipc.address</name>
+		<value>0.0.0.0</value>
+	</property>
+	<property>
+		<name>hbase.zookeeper.quorum</name>
+		<value>localhost</value>
+	</property>
+	<property>
+		<name>hbase.zookeeper.property.clientPort</name>
+		<value>2181</value>
+	</property>
+	<property>
+		<name>hbase.zookeeper.client.keytab.file</name>
+		<value>/opt/hbase/conf/hbase.keytab</value>
+	</property>
+	<property>
+		<name>hbase.zookeeper.client.kerberos.principal</name>
+		<value>hbase/localhost@TEST.ORG</value>
+	</property>
+	<property>
+		<name>hbase.unsafe.stream.capability.enforce</name>
+		<value>false</value>
+	</property>
+	<property>
+		<name>hbase.coprocessor.region.classes</name>
+		<value>org.apache.hadoop.hbase.security.token.TokenProvider,org.apache.hadoop.hbase.security.access.AccessController</value>
+	</property>
+	<property>
+		<name>hbase.coprocessor.master.classes</name>
+		<value>org.apache.hadoop.hbase.security.access.AccessController</value>
+	</property>
 </configuration>
 
 EOF
@@ -206,7 +188,6 @@ COPY <<"EOF" ${HBASE_HOME}/conf/core-site.xml
         <name>hadoop.proxyuser.hbase.groups</name>
         <value>*</value>
     </property>
-
 </configuration>
 
 EOF

--- a/dev/dependencyList
+++ b/dev/dependencyList
@@ -27,7 +27,6 @@ arrow-memory-core/16.0.0//arrow-memory-core-16.0.0.jar
 arrow-memory-netty-buffer-patch/16.0.0//arrow-memory-netty-buffer-patch-16.0.0.jar
 arrow-memory-netty/16.0.0//arrow-memory-netty-16.0.0.jar
 arrow-vector/16.0.0//arrow-vector-16.0.0.jar
-audience-annotations/0.13.0//audience-annotations-0.13.0.jar
 checker-qual/3.42.0//checker-qual-3.42.0.jar
 classgraph/4.8.138//classgraph-4.8.138.jar
 commons-codec/1.17.1//commons-codec-1.17.1.jar
@@ -50,7 +49,6 @@ gson/2.10.1//gson-2.10.1.jar
 guava/33.3.1-jre//guava-33.3.1-jre.jar
 hadoop-client-api/3.3.6//hadoop-client-api-3.3.6.jar
 hadoop-client-runtime/3.3.6//hadoop-client-runtime-3.3.6.jar
-hbase-shaded-client-byo-hadoop/2.5.12-hadoop3//hbase-shaded-client-byo-hadoop-2.5.12-hadoop3.jar
 hk2-api/2.6.1//hk2-api-2.6.1.jar
 hk2-locator/2.6.1//hk2-locator-2.6.1.jar
 hk2-utils/2.6.1//hk2-utils-2.6.1.jar
@@ -157,9 +155,6 @@ netty-transport/4.1.108.Final//netty-transport-4.1.108.Final.jar
 okhttp-urlconnection/3.14.9//okhttp-urlconnection-3.14.9.jar
 okhttp/3.12.12//okhttp-3.12.12.jar
 okio/1.15.0//okio-1.15.0.jar
-opentelemetry-api/1.49.0//opentelemetry-api-1.49.0.jar
-opentelemetry-context/1.49.0//opentelemetry-context-1.49.0.jar
-opentelemetry-semconv/1.29.0-alpha//opentelemetry-semconv-1.29.0-alpha.jar
 osgi-resource-locator/1.0.3//osgi-resource-locator-1.0.3.jar
 paranamer/2.8//paranamer-2.8.jar
 perfmark-api/0.26.0//perfmark-api-0.26.0.jar

--- a/dev/dependencyList
+++ b/dev/dependencyList
@@ -27,9 +27,12 @@ arrow-memory-core/16.0.0//arrow-memory-core-16.0.0.jar
 arrow-memory-netty-buffer-patch/16.0.0//arrow-memory-netty-buffer-patch-16.0.0.jar
 arrow-memory-netty/16.0.0//arrow-memory-netty-16.0.0.jar
 arrow-vector/16.0.0//arrow-vector-16.0.0.jar
+audience-annotations/0.13.0//audience-annotations-0.13.0.jar
 checker-qual/3.42.0//checker-qual-3.42.0.jar
 classgraph/4.8.138//classgraph-4.8.138.jar
 commons-codec/1.17.1//commons-codec-1.17.1.jar
+commons-crypto/1.1.0//commons-crypto-1.1.0.jar
+commons-io/2.16.1//commons-io-2.16.1.jar
 commons-lang3/3.18.0//commons-lang3-3.18.0.jar
 error_prone_annotations/2.23.0//error_prone_annotations-2.23.0.jar
 failsafe/3.3.2//failsafe-3.3.2.jar
@@ -49,6 +52,20 @@ gson/2.10.1//gson-2.10.1.jar
 guava/33.3.1-jre//guava-33.3.1-jre.jar
 hadoop-client-api/3.3.6//hadoop-client-api-3.3.6.jar
 hadoop-client-runtime/3.3.6//hadoop-client-runtime-3.3.6.jar
+hbase-client/2.5.12-hadoop3//hbase-client-2.5.12-hadoop3.jar
+hbase-common/2.5.12-hadoop3//hbase-common-2.5.12-hadoop3.jar
+hbase-hadoop-compat/2.5.12-hadoop3//hbase-hadoop-compat-2.5.12-hadoop3.jar
+hbase-hadoop2-compat/2.5.12-hadoop3//hbase-hadoop2-compat-2.5.12-hadoop3.jar
+hbase-logging/2.5.12-hadoop3//hbase-logging-2.5.12-hadoop3.jar
+hbase-metrics-api/2.5.12-hadoop3//hbase-metrics-api-2.5.12-hadoop3.jar
+hbase-metrics/2.5.12-hadoop3//hbase-metrics-2.5.12-hadoop3.jar
+hbase-protocol-shaded/2.5.12-hadoop3//hbase-protocol-shaded-2.5.12-hadoop3.jar
+hbase-protocol/2.5.12-hadoop3//hbase-protocol-2.5.12-hadoop3.jar
+hbase-shaded-gson/4.1.11//hbase-shaded-gson-4.1.11.jar
+hbase-shaded-miscellaneous/4.1.11//hbase-shaded-miscellaneous-4.1.11.jar
+hbase-shaded-netty/4.1.11//hbase-shaded-netty-4.1.11.jar
+hbase-shaded-protobuf/4.1.11//hbase-shaded-protobuf-4.1.11.jar
+hbase-unsafe/4.1.11//hbase-unsafe-4.1.11.jar
 hk2-api/2.6.1//hk2-api-2.6.1.jar
 hk2-locator/2.6.1//hk2-locator-2.6.1.jar
 hk2-utils/2.6.1//hk2-utils-2.6.1.jar
@@ -72,8 +89,10 @@ jakarta.validation-api/2.0.2//jakarta.validation-api-2.0.2.jar
 jakarta.ws.rs-api/2.1.6//jakarta.ws.rs-api-2.1.6.jar
 jakarta.xml.bind-api/2.3.2//jakarta.xml.bind-api-2.3.2.jar
 javassist/3.25.0-GA//javassist-3.25.0-GA.jar
+javax.activation-api/1.2.0//javax.activation-api-1.2.0.jar
 javax.servlet-api/4.0.1//javax.servlet-api-4.0.1.jar
 jcl-over-slf4j/1.7.36//jcl-over-slf4j-1.7.36.jar
+jcodings/1.0.55//jcodings-1.0.55.jar
 jersey-client/2.40//jersey-client-2.40.jar
 jersey-common/2.40//jersey-common-2.40.jar
 jersey-container-servlet-core/2.40//jersey-container-servlet-core-2.40.jar
@@ -96,6 +115,7 @@ jetty-servlet/9.4.57.v20241219//jetty-servlet-9.4.57.v20241219.jar
 jetty-util-ajax/9.4.57.v20241219//jetty-util-ajax-9.4.57.v20241219.jar
 jetty-util/9.4.57.v20241219//jetty-util-9.4.57.v20241219.jar
 jline/2.14.6//jline-2.14.6.jar
+joni/2.1.31//joni-2.1.31.jar
 jul-to-slf4j/1.7.36//jul-to-slf4j-1.7.36.jar
 kafka-clients/3.9.1//kafka-clients-3.9.1.jar
 kubernetes-client-api/6.13.5//kubernetes-client-api-6.13.5.jar
@@ -148,6 +168,7 @@ netty-handler/4.1.108.Final//netty-handler-4.1.108.Final.jar
 netty-resolver-dns/4.1.108.Final//netty-resolver-dns-4.1.108.Final.jar
 netty-resolver/4.1.108.Final//netty-resolver-4.1.108.Final.jar
 netty-transport-classes-epoll/4.1.108.Final//netty-transport-classes-epoll-4.1.108.Final.jar
+netty-transport-native-epoll/4.1.108.Final//netty-transport-native-epoll-4.1.108.Final.jar
 netty-transport-native-epoll/4.1.108.Final/linux-aarch_64/netty-transport-native-epoll-4.1.108.Final-linux-aarch_64.jar
 netty-transport-native-epoll/4.1.108.Final/linux-x86_64/netty-transport-native-epoll-4.1.108.Final-linux-x86_64.jar
 netty-transport-native-unix-common/4.1.108.Final//netty-transport-native-unix-common-4.1.108.Final.jar
@@ -155,6 +176,9 @@ netty-transport/4.1.108.Final//netty-transport-4.1.108.Final.jar
 okhttp-urlconnection/3.14.9//okhttp-urlconnection-3.14.9.jar
 okhttp/3.12.12//okhttp-3.12.12.jar
 okio/1.15.0//okio-1.15.0.jar
+opentelemetry-api/1.49.0//opentelemetry-api-1.49.0.jar
+opentelemetry-context/1.49.0//opentelemetry-context-1.49.0.jar
+opentelemetry-semconv/1.29.0-alpha//opentelemetry-semconv-1.29.0-alpha.jar
 osgi-resource-locator/1.0.3//osgi-resource-locator-1.0.3.jar
 paranamer/2.8//paranamer-2.8.jar
 perfmark-api/0.26.0//perfmark-api-0.26.0.jar
@@ -186,3 +210,5 @@ units/1.7//units-1.7.jar
 vertx-core/4.5.3//vertx-core-4.5.3.jar
 vertx-grpc/4.5.3//vertx-grpc-4.5.3.jar
 zjsonpatch/0.3.0//zjsonpatch-0.3.0.jar
+zookeeper-jute/3.8.4//zookeeper-jute-3.8.4.jar
+zookeeper/3.8.4//zookeeper-3.8.4.jar

--- a/dev/dependencyList
+++ b/dev/dependencyList
@@ -31,8 +31,6 @@ audience-annotations/0.13.0//audience-annotations-0.13.0.jar
 checker-qual/3.42.0//checker-qual-3.42.0.jar
 classgraph/4.8.138//classgraph-4.8.138.jar
 commons-codec/1.17.1//commons-codec-1.17.1.jar
-commons-crypto/1.1.0//commons-crypto-1.1.0.jar
-commons-io/2.16.1//commons-io-2.16.1.jar
 commons-lang3/3.18.0//commons-lang3-3.18.0.jar
 error_prone_annotations/2.23.0//error_prone_annotations-2.23.0.jar
 failsafe/3.3.2//failsafe-3.3.2.jar
@@ -52,20 +50,7 @@ gson/2.10.1//gson-2.10.1.jar
 guava/33.3.1-jre//guava-33.3.1-jre.jar
 hadoop-client-api/3.3.6//hadoop-client-api-3.3.6.jar
 hadoop-client-runtime/3.3.6//hadoop-client-runtime-3.3.6.jar
-hbase-client/2.5.12-hadoop3//hbase-client-2.5.12-hadoop3.jar
-hbase-common/2.5.12-hadoop3//hbase-common-2.5.12-hadoop3.jar
-hbase-hadoop-compat/2.5.12-hadoop3//hbase-hadoop-compat-2.5.12-hadoop3.jar
-hbase-hadoop2-compat/2.5.12-hadoop3//hbase-hadoop2-compat-2.5.12-hadoop3.jar
-hbase-logging/2.5.12-hadoop3//hbase-logging-2.5.12-hadoop3.jar
-hbase-metrics-api/2.5.12-hadoop3//hbase-metrics-api-2.5.12-hadoop3.jar
-hbase-metrics/2.5.12-hadoop3//hbase-metrics-2.5.12-hadoop3.jar
-hbase-protocol-shaded/2.5.12-hadoop3//hbase-protocol-shaded-2.5.12-hadoop3.jar
-hbase-protocol/2.5.12-hadoop3//hbase-protocol-2.5.12-hadoop3.jar
-hbase-shaded-gson/4.1.11//hbase-shaded-gson-4.1.11.jar
-hbase-shaded-miscellaneous/4.1.11//hbase-shaded-miscellaneous-4.1.11.jar
-hbase-shaded-netty/4.1.11//hbase-shaded-netty-4.1.11.jar
-hbase-shaded-protobuf/4.1.11//hbase-shaded-protobuf-4.1.11.jar
-hbase-unsafe/4.1.11//hbase-unsafe-4.1.11.jar
+hbase-shaded-client-byo-hadoop/2.5.12-hadoop3//hbase-shaded-client-byo-hadoop-2.5.12-hadoop3.jar
 hk2-api/2.6.1//hk2-api-2.6.1.jar
 hk2-locator/2.6.1//hk2-locator-2.6.1.jar
 hk2-utils/2.6.1//hk2-utils-2.6.1.jar
@@ -89,10 +74,8 @@ jakarta.validation-api/2.0.2//jakarta.validation-api-2.0.2.jar
 jakarta.ws.rs-api/2.1.6//jakarta.ws.rs-api-2.1.6.jar
 jakarta.xml.bind-api/2.3.2//jakarta.xml.bind-api-2.3.2.jar
 javassist/3.25.0-GA//javassist-3.25.0-GA.jar
-javax.activation-api/1.2.0//javax.activation-api-1.2.0.jar
 javax.servlet-api/4.0.1//javax.servlet-api-4.0.1.jar
 jcl-over-slf4j/1.7.36//jcl-over-slf4j-1.7.36.jar
-jcodings/1.0.55//jcodings-1.0.55.jar
 jersey-client/2.40//jersey-client-2.40.jar
 jersey-common/2.40//jersey-common-2.40.jar
 jersey-container-servlet-core/2.40//jersey-container-servlet-core-2.40.jar
@@ -115,7 +98,6 @@ jetty-servlet/9.4.57.v20241219//jetty-servlet-9.4.57.v20241219.jar
 jetty-util-ajax/9.4.57.v20241219//jetty-util-ajax-9.4.57.v20241219.jar
 jetty-util/9.4.57.v20241219//jetty-util-9.4.57.v20241219.jar
 jline/2.14.6//jline-2.14.6.jar
-joni/2.1.31//joni-2.1.31.jar
 jul-to-slf4j/1.7.36//jul-to-slf4j-1.7.36.jar
 kafka-clients/3.9.1//kafka-clients-3.9.1.jar
 kubernetes-client-api/6.13.5//kubernetes-client-api-6.13.5.jar
@@ -168,7 +150,6 @@ netty-handler/4.1.108.Final//netty-handler-4.1.108.Final.jar
 netty-resolver-dns/4.1.108.Final//netty-resolver-dns-4.1.108.Final.jar
 netty-resolver/4.1.108.Final//netty-resolver-4.1.108.Final.jar
 netty-transport-classes-epoll/4.1.108.Final//netty-transport-classes-epoll-4.1.108.Final.jar
-netty-transport-native-epoll/4.1.108.Final//netty-transport-native-epoll-4.1.108.Final.jar
 netty-transport-native-epoll/4.1.108.Final/linux-aarch_64/netty-transport-native-epoll-4.1.108.Final-linux-aarch_64.jar
 netty-transport-native-epoll/4.1.108.Final/linux-x86_64/netty-transport-native-epoll-4.1.108.Final-linux-x86_64.jar
 netty-transport-native-unix-common/4.1.108.Final//netty-transport-native-unix-common-4.1.108.Final.jar
@@ -210,5 +191,3 @@ units/1.7//units-1.7.jar
 vertx-core/4.5.3//vertx-core-4.5.3.jar
 vertx-grpc/4.5.3//vertx-grpc-4.5.3.jar
 zjsonpatch/0.3.0//zjsonpatch-0.3.0.jar
-zookeeper-jute/3.8.4//zookeeper-jute-3.8.4.jar
-zookeeper/3.8.4//zookeeper-3.8.4.jar

--- a/kyuubi-server/pom.xml
+++ b/kyuubi-server/pom.xml
@@ -124,6 +124,33 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.hbase</groupId>
+            <artifactId>hbase-client</artifactId>
+            <version>2.5.12-hadoop3</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-common</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-auth</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-auth</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-mapreduce-client-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-mapreduce-client-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>
         </dependency>

--- a/kyuubi-server/pom.xml
+++ b/kyuubi-server/pom.xml
@@ -125,30 +125,8 @@
 
         <dependency>
             <groupId>org.apache.hbase</groupId>
-            <artifactId>hbase-client</artifactId>
+            <artifactId>hbase-shaded-client-byo-hadoop</artifactId>
             <version>2.5.12-hadoop3</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.hadoop</groupId>
-                    <artifactId>hadoop-common</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.hadoop</groupId>
-                    <artifactId>hadoop-auth</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.hadoop</groupId>
-                    <artifactId>hadoop-auth</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.hadoop</groupId>
-                    <artifactId>hadoop-mapreduce-client-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.hadoop</groupId>
-                    <artifactId>hadoop-mapreduce-client-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/kyuubi-server/pom.xml
+++ b/kyuubi-server/pom.xml
@@ -125,31 +125,10 @@
 
         <dependency>
             <groupId>org.apache.hbase</groupId>
-            <artifactId>hbase-client</artifactId>
+            <artifactId>hbase-shaded-client</artifactId>
             <version>2.5.12-hadoop3</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.hadoop</groupId>
-                    <artifactId>hadoop-common</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.hadoop</groupId>
-                    <artifactId>hadoop-auth</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.hadoop</groupId>
-                    <artifactId>hadoop-auth</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.hadoop</groupId>
-                    <artifactId>hadoop-mapreduce-client-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.hadoop</groupId>
-                    <artifactId>hadoop-mapreduce-client-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
+
         <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>

--- a/kyuubi-server/pom.xml
+++ b/kyuubi-server/pom.xml
@@ -125,8 +125,30 @@
 
         <dependency>
             <groupId>org.apache.hbase</groupId>
-            <artifactId>hbase-shaded-client</artifactId>
+            <artifactId>hbase-client</artifactId>
             <version>2.5.12-hadoop3</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-common</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-auth</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-auth</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-mapreduce-client-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-mapreduce-client-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/kyuubi-server/pom.xml
+++ b/kyuubi-server/pom.xml
@@ -126,7 +126,6 @@
         <dependency>
             <groupId>org.apache.hbase</groupId>
             <artifactId>hbase-shaded-client-byo-hadoop</artifactId>
-            <version>2.5.12-hadoop3</version>
         </dependency>
 
         <dependency>

--- a/kyuubi-server/src/main/resources/META-INF/services/org.apache.kyuubi.credentials.HadoopDelegationTokenProvider
+++ b/kyuubi-server/src/main/resources/META-INF/services/org.apache.kyuubi.credentials.HadoopDelegationTokenProvider
@@ -15,6 +15,6 @@
 # limitations under the License.
 #
 
+org.apache.kyuubi.credentials.HBaseDelegationTokenProvider
 org.apache.kyuubi.credentials.HadoopFsDelegationTokenProvider
 org.apache.kyuubi.credentials.HiveDelegationTokenProvider
-org.apache.kyuubi.credentials.HBaseDelegationTokenProvider

--- a/kyuubi-server/src/main/resources/META-INF/services/org.apache.kyuubi.credentials.HadoopDelegationTokenProvider
+++ b/kyuubi-server/src/main/resources/META-INF/services/org.apache.kyuubi.credentials.HadoopDelegationTokenProvider
@@ -17,3 +17,5 @@
 
 org.apache.kyuubi.credentials.HadoopFsDelegationTokenProvider
 org.apache.kyuubi.credentials.HiveDelegationTokenProvider
+org.apache.kyuubi.credentials.YarnRMDelegationTokenProvider
+org.apache.kyuubi.credentials.HBaseDelegationTokenProvider

--- a/kyuubi-server/src/main/resources/META-INF/services/org.apache.kyuubi.credentials.HadoopDelegationTokenProvider
+++ b/kyuubi-server/src/main/resources/META-INF/services/org.apache.kyuubi.credentials.HadoopDelegationTokenProvider
@@ -17,5 +17,4 @@
 
 org.apache.kyuubi.credentials.HadoopFsDelegationTokenProvider
 org.apache.kyuubi.credentials.HiveDelegationTokenProvider
-org.apache.kyuubi.credentials.YarnRMDelegationTokenProvider
 org.apache.kyuubi.credentials.HBaseDelegationTokenProvider

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/credentials/HBaseDelegationTokenProvider.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/credentials/HBaseDelegationTokenProvider.scala
@@ -17,8 +17,6 @@
 
 package org.apache.kyuubi.credentials
 
-import java.io.Closeable
-
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.hbase.client.{Connection, ConnectionFactory}
 import org.apache.hadoop.hbase.security.token.ClientTokenUtil

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/credentials/HBaseDelegationTokenProvider.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/credentials/HBaseDelegationTokenProvider.scala
@@ -52,7 +52,6 @@ private class HBaseDelegationTokenProvider
         creds.addToken(token.getService, token)
       } catch {
         case e: Throwable =>
-          error(createFailedToGetTokenMessage(serviceName, e), e)
           throw new KyuubiException(s"Failed to get hbase token owned by $owner", e)
       }
     }
@@ -60,10 +59,5 @@ private class HBaseDelegationTokenProvider
 
   override def delegationTokensRequired(): Boolean = {
     tokenRequired
-  }
-
-  private def createFailedToGetTokenMessage(serviceName: String, e: scala.Throwable): String = {
-    val message = "Failed to get token from service %s due to %s. "
-    message.format(serviceName, e, serviceName, serviceName)
   }
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/credentials/HBaseDelegationTokenProvider.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/credentials/HBaseDelegationTokenProvider.scala
@@ -46,14 +46,14 @@ private class HBaseDelegationTokenProvider
       creds: Credentials): Unit = {
     doAsProxyUser(owner) {
       try {
-        info(s"Getting hbase token for ${owner} ...")
+        info(s"Getting HBase delegation token for ${owner} ...")
         val conn = ConnectionFactory.createConnection(hbaseConf)
         val token = ClientTokenUtil.obtainToken(conn)
-        info(s"Get hbase token ${token}")
+        info(s"Get HBase delegation token ${token}")
         creds.addToken(token.getService, token)
       } catch {
         case e: Throwable =>
-          throw new KyuubiException(s"Failed to get hbase token owned by $owner", e)
+          throw new KyuubiException(s"Failed to get HBase delegation token owned by $owner", e)
       }
     }
   }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/credentials/HBaseDelegationTokenProvider.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/credentials/HBaseDelegationTokenProvider.scala
@@ -37,7 +37,7 @@ private class HBaseDelegationTokenProvider
   override def initialize(hadoopConf: Configuration, kyuubiConf: KyuubiConf): Unit = {
     this.kyuubiConf = kyuubiConf
     this.hbaseConf = hadoopConf
-    this.tokenRequired = hbaseConf.get("hbase.security.authentication") == "kerberos"
+    this.tokenRequired = hbaseConf.get("hbase.security.authentication").toLowerCase() == "kerberos"
   }
 
   override def obtainDelegationTokens(

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/credentials/HBaseDelegationTokenProvider.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/credentials/HBaseDelegationTokenProvider.scala
@@ -37,7 +37,8 @@ private class HBaseDelegationTokenProvider
   override def initialize(hadoopConf: Configuration, kyuubiConf: KyuubiConf): Unit = {
     this.kyuubiConf = kyuubiConf
     this.hbaseConf = hadoopConf
-    this.tokenRequired = hbaseConf.get("hbase.security.authentication").toLowerCase() == "kerberos"
+    this.tokenRequired =
+      hbaseConf.get("hbase.security.authentication", "simple").toLowerCase() == "kerberos"
   }
 
   override def obtainDelegationTokens(

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/credentials/HBaseDelegationTokenProvider.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/credentials/HBaseDelegationTokenProvider.scala
@@ -54,8 +54,6 @@ private class HBaseDelegationTokenProvider
         case e: Throwable =>
           error(createFailedToGetTokenMessage(serviceName, e), e)
           throw new KyuubiException(s"Failed to get hbase token owned by $owner", e)
-      } finally {
-        info(s"finish get token ...")
       }
     }
   }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/credentials/HBaseDelegationTokenProvider.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/credentials/HBaseDelegationTokenProvider.scala
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.credentials
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.hbase.client.ConnectionFactory
+import org.apache.hadoop.hbase.security.token.ClientTokenUtil
+import org.apache.hadoop.security.Credentials
+
+import org.apache.kyuubi.{KyuubiException, Logging}
+import org.apache.kyuubi.config.KyuubiConf
+import org.apache.kyuubi.credentials.HadoopFsDelegationTokenProvider.doAsProxyUser
+
+private class HBaseDelegationTokenProvider
+  extends HadoopDelegationTokenProvider with Logging {
+
+  override def serviceName: String = "hbase"
+  private var tokenRequired: Boolean = _
+  private var hbaseConf: Configuration = _
+  private var kyuubiConf: KyuubiConf = _
+
+  override def initialize(hadoopConf: Configuration, kyuubiConf: KyuubiConf): Unit = {
+    this.kyuubiConf = kyuubiConf
+    this.hbaseConf = hadoopConf
+    this.tokenRequired = hbaseConf.get("hbase.security.authentication") == "kerberos"
+  }
+
+  override def obtainDelegationTokens(
+      owner: String,
+      creds: Credentials): Unit = {
+    doAsProxyUser(owner) {
+      try {
+        info(s"Getting hbase token for ${owner} ...")
+        val conn = ConnectionFactory.createConnection(hbaseConf)
+        val token = ClientTokenUtil.obtainToken(conn)
+        info(s"Get hbase token ${token}")
+        creds.addToken(token.getService, token)
+      } catch {
+        case e: Throwable =>
+          error(createFailedToGetTokenMessage(serviceName, e), e)
+          throw new KyuubiException(s"Failed to get hbase token owned by $owner", e)
+      } finally {
+        info(s"finish get token ...")
+      }
+    }
+  }
+
+  override def delegationTokensRequired(): Boolean = {
+    tokenRequired
+  }
+
+  private def createFailedToGetTokenMessage(serviceName: String, e: scala.Throwable): String = {
+    val message = "Failed to get token from service %s due to %s. "
+    message.format(serviceName, e, serviceName, serviceName)
+  }
+}

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/WithSecuredHBaseContainer.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/WithSecuredHBaseContainer.scala
@@ -33,7 +33,7 @@ trait WithSecuredHBaseContainer extends KerberizedTestHelper with TestContainerF
   final val HBASE_KERBEROS_REALM = "TEST.ORG"
   final val HBASE_KERBEROS_PRINCIPAL = "hbase/localhost"
   final val HBASE_KERBEROS_KEYTAB = "/opt/hbase/conf/hbase.keytab"
-  final val DOCKER_IMAGE_NAME = "z1wu97/kyuubi-hbase-cluster:latest"
+  final val DOCKER_IMAGE_NAME = "nekyuubi/kyuubi-hbase-cluster:latest"
 
   private val tempDir = Utils.createTempDir(prefix = "kyuubi-server-hbase")
   private val exposedKdcPort = 88

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/WithSecuredHBaseContainer.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/WithSecuredHBaseContainer.scala
@@ -120,6 +120,9 @@ object HBaseContainer {
       container.container.withExposedPorts(
         exposedKdcPort,
         exposedZkPort)
+      // The reason for using a fixed port here is that the addresses of the HBase Region Server
+      // and HBase Master Server are recorded in ZooKeeper and cannot be obtained through the
+      // method of container-mapped ports.
       container.container.withFixedExposedPort(
         exposedHbaseRegionServerPort,
         exposedHbaseRegionServerPort)

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/WithSecuredHBaseContainer.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/WithSecuredHBaseContainer.scala
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi
+
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Paths}
+
+import com.dimafeng.testcontainers.{ContainerDef, FixedHostPortGenericContainer}
+import com.dimafeng.testcontainers.scalatest.TestContainerForAll
+import com.github.dockerjava.api.model.{ExposedPort, Ports}
+import org.apache.hadoop.conf.Configuration
+import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy
+
+trait WithSecuredHBaseContainer extends KerberizedTestHelper with TestContainerForAll {
+
+  final val HADOOP_SECURITY_AUTHENTICATION = "kerberos"
+  final val HBASE_KERBEROS_REALM = "TEST.ORG"
+  final val HBASE_KERBEROS_PRINCIPAL = "hbase/localhost"
+  final val HBASE_KERBEROS_KEYTAB = "/opt/hbase/conf/hbase.keytab"
+  final val DOCKER_IMAGE_NAME = "z1wu97/kyuubi-hbase-cluster:latest"
+
+  private val tempDir = Utils.createTempDir(prefix = "kyuubi-server-hbase")
+  private val exposedKdcPort = 88
+  private val exposedZkPort = 2181
+  private val exposedHbaseMasterPort = 16000
+  private val exposedHbaseRegionServerPort = 16020
+  private val testPrincipalOverride =
+    HBASE_KERBEROS_PRINCIPAL + "@" + HBASE_KERBEROS_REALM
+  private val krb5ConfPathOverride = new File(tempDir.toFile, "krb5.conf").getAbsolutePath
+  val hbaseConf: Configuration = new Configuration(false)
+
+  override val testKeytab: String = new File(tempDir.toFile, "hbase.service.keytab").getAbsolutePath
+  override val containerDef: HBaseContainer.Def = HBaseContainer.Def(
+    DOCKER_IMAGE_NAME,
+    exposedKdcPort,
+    exposedHbaseMasterPort,
+    exposedHbaseRegionServerPort,
+    exposedZkPort)
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    testPrincipal = testPrincipalOverride
+    krb5ConfPath = krb5ConfPathOverride
+  }
+
+  override def afterContainersStart(containers: Containers): Unit = {
+    containers.copyFileFromContainer(HBASE_KERBEROS_KEYTAB, testKeytab)
+    hbaseConf.set("hbase.zookeeper.quorum", "localhost:" + containers.mappedPort(exposedZkPort))
+    hbaseConf.set("hbase.security.authentication", "kerberos")
+    hbaseConf.set("hadoop.security.authentication", "kerberos")
+    hbaseConf.set(
+      "hbase.master.kerberos.principal",
+      HBASE_KERBEROS_PRINCIPAL + "@" + HBASE_KERBEROS_REALM)
+    hbaseConf.set(
+      "hbase.regionserver.kerberos.principal",
+      HBASE_KERBEROS_PRINCIPAL + "@" + HBASE_KERBEROS_REALM)
+
+    val krb5ConfContent =
+      s"""[libdefaults]
+         |  default_realm = $HBASE_KERBEROS_REALM
+         |  dns_lookup_realm = false
+         |  dns_lookup_kdc = false
+         |  forwardable = true
+         |
+         |[realms]
+         |  ${HBASE_KERBEROS_REALM} = {
+         |    kdc = localhost:${containers.getKdcUdpPort}
+         |  }
+         |
+         |""".stripMargin
+
+    val writer = Files.newBufferedWriter(Paths.get(krb5ConfPathOverride), StandardCharsets.UTF_8)
+    writer.write(krb5ConfContent)
+    writer.close()
+  }
+}
+
+class HBaseContainer(exposedKdcPort: Int, dockerImage: String)
+  extends FixedHostPortGenericContainer(dockerImage) {
+
+  def getKdcUdpPort: Int = {
+    container.getContainerInfo.getNetworkSettings.getPorts.getBindings
+      .get(ExposedPort.udp(exposedKdcPort)).head.getHostPortSpec.toInt
+  }
+}
+
+object HBaseContainer {
+  case class Def(
+      dockerImage: String,
+      exposedKdcPort: Int,
+      exposedHbaseMasterPort: Int,
+      exposedHbaseRegionServerPort: Int,
+      exposedZkPort: Int,
+      env: Map[String, String] = Map())
+    extends ContainerDef {
+
+    override type Container = HBaseContainer
+
+    override def createContainer(): Container = {
+      val container = new HBaseContainer(
+        exposedKdcPort,
+        dockerImage)
+
+      container.container.withExposedPorts(
+        exposedKdcPort,
+        exposedZkPort)
+      container.container.withFixedExposedPort(
+        exposedHbaseRegionServerPort,
+        exposedHbaseRegionServerPort)
+      container.container.withFixedExposedPort(exposedHbaseMasterPort, exposedHbaseMasterPort)
+      container.container.setWaitStrategy(new HostPortWaitStrategy()
+        .forPorts(exposedHbaseMasterPort, exposedHbaseRegionServerPort, exposedZkPort))
+
+      container.container.withCreateContainerCmdModifier(cmd => {
+        val udpExposedPort = ExposedPort.udp(exposedKdcPort)
+        val exposedPorts = new java.util.LinkedList[ExposedPort]()
+        for (p <- cmd.getExposedPorts) {
+          exposedPorts.add(p)
+        }
+        exposedPorts.add(udpExposedPort)
+        cmd.withExposedPorts(exposedPorts)
+
+        // Add previous port bindings and UDP port binding
+        val ports = cmd.getHostConfig.getPortBindings
+        ports.bind(udpExposedPort, Ports.Binding.empty)
+        cmd.getHostConfig.withPortBindings(ports)
+      })
+      container
+    }
+  }
+}

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/credentials/HBaseDelegationTokenProviderSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/credentials/HBaseDelegationTokenProviderSuite.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.credentials
+
+import scala.collection.JavaConverters._
+
+import org.apache.hadoop.hbase.security.token.AuthenticationTokenIdentifier
+import org.apache.hadoop.io.Text
+import org.apache.hadoop.security.{Credentials, UserGroupInformation}
+
+import org.apache.kyuubi.WithSecuredHBaseContainer
+import org.apache.kyuubi.config.KyuubiConf
+
+class HBaseDelegationTokenProviderSuite extends WithSecuredHBaseContainer {
+
+  test("obtain hbase delegation token") {
+    tryWithSecurityEnabled {
+      UserGroupInformation.loginUserFromKeytab(testPrincipal, testKeytab)
+
+      val kyuubiConf = new KyuubiConf(false)
+      val provider = new HBaseDelegationTokenProvider()
+      provider.initialize(hbaseConf, kyuubiConf)
+      assert(provider.delegationTokensRequired())
+
+      val owner = "who"
+      val credentials = new Credentials
+      provider.obtainDelegationTokens(owner, credentials)
+
+      val aliasAndToken =
+        credentials.getTokenMap.asScala
+          .head
+      assert(aliasAndToken._2 != null)
+
+      val token = aliasAndToken._2
+      val tokenIdent = token.decodeIdentifier().asInstanceOf[AuthenticationTokenIdentifier]
+      assertResult(new Text("HBASE_AUTH_TOKEN"))(token.getKind)
+      assertResult(owner)(tokenIdent.getUsername)
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
         <clickhouse-java.version>0.6.5</clickhouse-java.version>
         <snakeyaml.version>2.2</snakeyaml.version>
         <hbase.version>2.5.12-hadoop3</hbase.version>
-        <hbase.deps.scope>compile</hbase.deps.scope>
+        <hbase.deps.scope>provided</hbase.deps.scope>
         <!--
           DO NOT forget to change the following properties when change the minor version of Spark:
           `delta.version`, `delta.artifact`, `maven.plugin.scalatest.exclude.tags`
@@ -1951,13 +1951,6 @@
                 <apache.archive.dist>https://dlcdn.apache.org</apache.archive.dist>
                 <nodeDownloadRoot>https://npmmirror.com/mirrors/node/</nodeDownloadRoot>
                 <pnpmDownloadRoot>https://registry.npmmirror.com/pnpm/-/</pnpmDownloadRoot>
-            </properties>
-        </profile>
-
-        <profile>
-            <id>hbase-provided</id>
-            <properties>
-                <hbase.deps.scope>provided</hbase.deps.scope>
             </properties>
         </profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1272,6 +1272,12 @@
                 <artifactId>hbase-shaded-client-byo-hadoop</artifactId>
                 <version>${hbase.version}</version>
                 <scope>${hbase.deps.scope}</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.yetus</groupId>
+                        <artifactId>audience-annotations</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -197,6 +197,8 @@
         <slf4j.version>1.7.36</slf4j.version>
         <clickhouse-java.version>0.6.5</clickhouse-java.version>
         <snakeyaml.version>2.2</snakeyaml.version>
+        <hbase.version>2.5.12-hadoop3</hbase.version>
+        <hbase.deps.scope>compile</hbase.deps.scope>
         <!--
           DO NOT forget to change the following properties when change the minor version of Spark:
           `delta.version`, `delta.artifact`, `maven.plugin.scalatest.exclude.tags`
@@ -1264,6 +1266,13 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+
+            <dependency>
+                <groupId>org.apache.hbase</groupId>
+                <artifactId>hbase-shaded-client-byo-hadoop</artifactId>
+                <version>${hbase.version}</version>
+                <scope>${hbase.deps.scope}</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -1942,6 +1951,13 @@
                 <apache.archive.dist>https://dlcdn.apache.org</apache.archive.dist>
                 <nodeDownloadRoot>https://npmmirror.com/mirrors/node/</nodeDownloadRoot>
                 <pnpmDownloadRoot>https://registry.npmmirror.com/pnpm/-/</pnpmDownloadRoot>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>hbase-provided</id>
+            <properties>
+                <hbase.deps.scope>provided</hbase.deps.scope>
             </properties>
         </profile>
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->

- There are some SQLs need to access hbase such as SQL read from Hive-Hbase Storage Handler tables. And for proxy-user basd SparkSQLEngine, it is unable to renew delegation token by itself. It would be convenient if kyuubi can renew hbase delegation token.
- Currently kyuubi server only supports updating hdfs and hms delegation token.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

#### unit test
Add a unit test which fetching delegation token from a hbase cluster created by in docker containter.

#### manual integrate test  with hbase deps

compile with `-Dhbase.deps.scope=compile`

```
./build/dist --tgz --spark-provided --flink-provided --hive-provided --name spark3.5 -Pspark3.5 -Dhbase.deps.scope=compile
```

<img width="489" height="35" alt="image" src="https://github.com/user-attachments/assets/c47303b9-1c6e-44a8-801f-de45ed732be1" />

run kyuubi server with hbase related conf 

``` conf
hbase.zookeeper.quorum xxxx
hbase.security.authentication kerberos
hbase.master.kerberos.principal xxx
hbase.regionserver.kerberos.principal xxx
```

request hbase token 

<img width="1632" height="278" alt="image" src="https://github.com/user-attachments/assets/e73b9534-5c3e-47f4-b1b4-df4ffef900a5" />

run sample sql 

<img width="1898" height="723" alt="image" src="https://github.com/user-attachments/assets/b7aa53a4-dd13-47fc-9218-31e01f43056e" />


#### manual integrate test  without hbase deps

compile without `-Dhbase.deps.scope=compile`

```
./build/dist --tgz --spark-provided --flink-provided --hive-provided --name spark3.5 -Pspark3.5
```

<img width="496" height="48" alt="image" src="https://github.com/user-attachments/assets/3d07b0ad-fa81-4aa9-aa98-436908afe721" />


only fetch HMS token and hdfs token

<img width="1468" height="58" alt="image" src="https://github.com/user-attachments/assets/4665f6f8-99df-4671-8d44-b64ffc8ac98d" />

run sample query 

<img width="1345" height="571" alt="image" src="https://github.com/user-attachments/assets/c33e6d34-d3d6-4429-9612-347fcee832c3" />


### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No
