### PR TITLE
[DOC] Remove unsupported 'logo_only' and 'extra_navbar' theme options

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -108,13 +108,11 @@ html_theme_options = {
     "use_fullscreen_button": True,
     "repository_branch": "master",
     "path_to_docs": "docs",
-    "logo_only": True,
     "home_page_in_toc": False,
     "show_navbar_depth": 1,
     "show_toc_level": 2,
     "announcement": "&#129418; Welcome to Kyuubi’s online documentation &#x2728;, v" + release,
     "toc_title": "",
-    "extra_navbar": "Version " + release,
 }
 
 html_logo = 'imgs/logo.png'


### PR DESCRIPTION
### Why are the changes needed?
The PR fixes two `unsupported theme option` warnings that are printed during the documentation building:
```shell
preparing documents... WARNING: unsupported theme option 'logo_only' given
WARNING: unsupported theme option 'extra_navbar' given
```
Both options were deleted from [sphinx_book_theme](https://github.com/executablebooks/sphinx-book-theme).


### How was this patch tested?
Built documentation locally and checked there are no warning message anymore.


### Was this patch authored or co-authored using generative AI tooling?
No

