### PR TITLE
[DOC] Use unordered list for Appendixes page

### DIFF
--- a/docs/appendix/index.rst
+++ b/docs/appendix/index.rst
@@ -18,7 +18,5 @@ Appendixes
 
 .. toctree::
     :maxdepth: 3
-    :numbered: 4
-
 
     terminology


### PR DESCRIPTION
### Why are the changes needed?
The PR is needed to align `Appendixes` page with [General Style](https://kyuubi.readthedocs.io/en/master/contributing/doc/style.html#general-style) and make it similar to other pages:
- Prefer unordered list than ordered.


### How was this patch tested?
Built documentation locally and checked a desired style is used.

Before changes:
<img width="1137" height="631" alt="image" src="https://github.com/user-attachments/assets/4bf430b4-acf0-4329-843d-a0df60900d4c" />

After changes:
<img width="1136" height="632" alt="image" src="https://github.com/user-attachments/assets/c5549947-09ab-49ec-b728-e14d7e70eb63" />


### Was this patch authored or co-authored using generative AI tooling?
No

