### PR TITLE
Support customized session protocol version to support binary type

### DIFF
--- a/docs/client/rest/rest_api.md
+++ b/docs/client/rest/rest_api.md
@@ -99,9 +99,10 @@ Create a session
 
 #### Request Parameters
 
-| Name    | Description                      | Type |
-|:--------|:---------------------------------|:-----|
-| configs | The configuration of the session | Map  |
+| Name            | Description                                                  | Type |
+|:----------------|:-------------------------------------------------------------|:-----|
+| protocolVersion | The session thrift protocol version, default value is 0 (V1) | Map  |
+| configs         | The configuration of the session                             | Map  |
 
 #### Response Body
 

--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/api/v1/dto/Field.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/api/v1/dto/Field.java
@@ -17,6 +17,7 @@
 
 package org.apache.kyuubi.client.api.v1.dto;
 
+import java.util.Base64;
 import java.util.Objects;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -41,6 +42,12 @@ public class Field {
   }
 
   public Object getValue() {
+    // For binary type column values, although the data type is "BINARY_VAL",
+    // the value is transmitted as a Base64-encoded string.
+    // Here, we decode it into a byte array.
+    if (value instanceof String && "BINARY_VAL".equalsIgnoreCase(dataType)) {
+      return Base64.getDecoder().decode((String) value);
+    }
     return value;
   }
 

--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/api/v1/dto/SessionOpenRequest.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/api/v1/dto/SessionOpenRequest.java
@@ -24,12 +24,26 @@ import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
 public class SessionOpenRequest {
+  private Integer protocolVersion;
   private Map<String, String> configs;
 
   public SessionOpenRequest() {}
 
   public SessionOpenRequest(Map<String, String> configs) {
     this.configs = configs;
+  }
+
+  public SessionOpenRequest(Integer protocolVersion, Map<String, String> configs) {
+    this.protocolVersion = protocolVersion;
+    this.configs = configs;
+  }
+
+  public Integer getProtocolVersion() {
+    return protocolVersion;
+  }
+
+  public void setProtocolVersion(Integer protocolVersion) {
+    this.protocolVersion = protocolVersion;
   }
 
   public Map<String, String> getConfigs() {
@@ -48,12 +62,13 @@ public class SessionOpenRequest {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     SessionOpenRequest that = (SessionOpenRequest) o;
-    return Objects.equals(getConfigs(), that.getConfigs());
+    return Objects.equals(getProtocolVersion(), that.getProtocolVersion())
+        && Objects.equals(getConfigs(), that.getConfigs());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(getConfigs());
+    return Objects.hash(getProtocolVersion(), getConfigs());
   }
 
   @Override

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/SessionsResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/SessionsResource.scala
@@ -136,7 +136,8 @@ private[v1] class SessionsResource extends ApiRequestContext with Logging {
     val userName = fe.getSessionUser(request.getConfigs.asScala.toMap)
     val ipAddress = fe.getIpAddress
     val handle = fe.be.openSession(
-      SessionsResource.SESSION_PROTOCOL_VERSION,
+      Option(request.getProtocolVersion).map(v => TProtocolVersion.findByValue(v))
+        .getOrElse(SessionsResource.DEFAULT_SESSION_PROTOCOL_VERSION),
       userName,
       "",
       ipAddress,
@@ -416,5 +417,5 @@ private[v1] class SessionsResource extends ApiRequestContext with Logging {
 }
 
 object SessionsResource {
-  final val SESSION_PROTOCOL_VERSION = TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V1
+  final val DEFAULT_SESSION_PROTOCOL_VERSION = TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V1
 }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/OperationsResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/OperationsResourceSuite.scala
@@ -32,12 +32,15 @@ import org.apache.kyuubi.client.api.v1.dto._
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.operation.{ExecuteStatement, OperationState}
 import org.apache.kyuubi.operation.OperationState.{FINISHED, OperationState}
-import org.apache.kyuubi.shaded.hive.service.rpc.thrift.TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V2
+import org.apache.kyuubi.shaded.hive.service.rpc.thrift.TProtocolVersion
+import org.apache.kyuubi.shaded.hive.service.rpc.thrift.TProtocolVersion.{HIVE_CLI_SERVICE_PROTOCOL_V10, HIVE_CLI_SERVICE_PROTOCOL_V2}
 
 class OperationsResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper {
 
   override protected lazy val conf: KyuubiConf = KyuubiConf()
     .set(KyuubiConf.SERVER_LIMIT_CLIENT_FETCH_MAX_ROWS, 5000)
+
+  protected val SESSION_PROTOCOL_VERSION = HIVE_CLI_SERVICE_PROTOCOL_V2
 
   test("get an operation event") {
     val catalogsHandleStr = getOpHandleStr("")
@@ -55,7 +58,7 @@ class OperationsResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper
 
   test("apply an action for an operation") {
     val sessionHandle = fe.be.openSession(
-      HIVE_CLI_SERVICE_PROTOCOL_V2,
+      SESSION_PROTOCOL_VERSION,
       "admin",
       "123456",
       "localhost",
@@ -207,7 +210,7 @@ class OperationsResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper
 
   test("support to return operation progress for REST api") {
     val sessionHandle = fe.be.openSession(
-      HIVE_CLI_SERVICE_PROTOCOL_V2,
+      SESSION_PROTOCOL_VERSION,
       "admin",
       "123456",
       "localhost",
@@ -222,9 +225,31 @@ class OperationsResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper
     }
   }
 
+  test("support binary type in result set") {
+    val opHandleStr = getOpHandleStr("select binary('kyuubi')")
+    checkOpState(opHandleStr, FINISHED)
+    val response = webTarget.path(
+      s"api/v1/operations/$opHandleStr/rowset")
+      .request(MediaType.APPLICATION_JSON).get()
+    assert(200 == response.getStatus)
+    val logRowSet = response.readEntity(classOf[ResultRowSet])
+    assert(logRowSet.getRowCount == 1)
+    val result = logRowSet.getRows.asScala.head.getFields.asScala.head
+    if (SESSION_PROTOCOL_VERSION.getValue >=
+        TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V6.getValue) {
+      // for ColumnBasedSet, the data type is BINARY_VAL
+      assert(result.getDataType == "BINARY_VAL")
+      assert(new String(result.getValue.asInstanceOf[Array[Byte]], "UTF-8") == "kyuubi")
+    } else {
+      // for RowBasedSet, the data type is STRING_VAL
+      assert(result.getDataType == "STRING_VAL")
+      assert(result.getValue == "kyuubi")
+    }
+  }
+
   def getOpHandleStr(statement: String = "show tables"): String = {
     val sessionHandle = fe.be.openSession(
-      HIVE_CLI_SERVICE_PROTOCOL_V2,
+      SESSION_PROTOCOL_VERSION,
       "admin",
       "123456",
       "localhost",
@@ -249,4 +274,8 @@ class OperationsResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper
       assert(operationEvent.getState === state.name())
     }
   }
+}
+
+class OperationsResourceV10ProtocolSuite extends OperationsResourceSuite {
+  override protected val SESSION_PROTOCOL_VERSION = HIVE_CLI_SERVICE_PROTOCOL_V10
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->


For RESTful api, the session protocol version is set to V1 before and not open to users.
https://github.com/apache/kyuubi/blob/aadf86683554ba6932126c80c9e33bf84cea8dee/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/SessionsResource.scala#L419

And before V6, the result is RowBased, since V6, it is ColumnBased.
https://github.com/apache/kyuubi/blob/aadf86683554ba6932126c80c9e33bf84cea8dee/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/cli/RowSetFactory.java#L29-L33

And with `HIVE_CLI_SERVICE_PROTOCOL_V1`, for `BINARY` type column, it is converted as STRING type for RESTful API.

In this PR, we make the session protocol open to users and support to transfer binary type values.

Why we need to support binary type? Because some bytes can not be converted to UTF-8 String.
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
UT.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.