### PR TITLE
Bump Paimon 1.3.1 and enable Paimon tests for Spark 4.0

### DIFF
--- a/dev/kyuubi-codecov/pom.xml
+++ b/dev/kyuubi-codecov/pom.xml
@@ -243,7 +243,11 @@
                     <artifactId>kyuubi-spark-connector-hive_${scala.binary.version}</artifactId>
                     <version>${project.version}</version>
                 </dependency>
-                <!-- TODO: support authz -->
+                <dependency>
+                    <groupId>org.apache.kyuubi</groupId>
+                    <artifactId>kyuubi-spark-authz_${scala.binary.version}</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
                 <dependency>
                     <groupId>org.apache.kyuubi</groupId>
                     <artifactId>kyuubi-spark-lineage_${scala.binary.version}</artifactId>

--- a/extensions/spark/kyuubi-spark-authz/src/main/resources/table_command_spec.json
+++ b/extensions/spark/kyuubi-spark-authz/src/main/resources/table_command_spec.json
@@ -57,6 +57,27 @@
     "comment" : ""
   } ]
 }, {
+  "classname" : "org.apache.spark.sql.catalyst.plans.logical.AlterColumns",
+  "tableDescs" : [ {
+    "fieldName" : "child",
+    "fieldExtractor" : "ResolvedTableTableExtractor",
+    "columnDesc" : null,
+    "actionTypeDesc" : null,
+    "tableTypeDesc" : null,
+    "catalogDesc" : null,
+    "isInput" : false,
+    "setCurrentDatabaseIfMissing" : false,
+    "comment" : ""
+  } ],
+  "opType" : "ALTERTABLE_ADDCOLS",
+  "queryDescs" : [ ],
+  "uriDescs" : [ {
+    "fieldName" : "child",
+    "fieldExtractor" : "ResolvedTableURIExtractor",
+    "isInput" : false,
+    "comment" : ""
+  } ]
+}, {
   "classname" : "org.apache.spark.sql.catalyst.plans.logical.AlterTable",
   "tableDescs" : [ {
     "fieldName" : "ident",

--- a/extensions/spark/kyuubi-spark-authz/src/main/resources/table_command_spec.json
+++ b/extensions/spark/kyuubi-spark-authz/src/main/resources/table_command_spec.json
@@ -57,27 +57,6 @@
     "comment" : ""
   } ]
 }, {
-  "classname" : "org.apache.spark.sql.catalyst.plans.logical.AlterColumns",
-  "tableDescs" : [ {
-    "fieldName" : "child",
-    "fieldExtractor" : "ResolvedTableTableExtractor",
-    "columnDesc" : null,
-    "actionTypeDesc" : null,
-    "tableTypeDesc" : null,
-    "catalogDesc" : null,
-    "isInput" : false,
-    "setCurrentDatabaseIfMissing" : false,
-    "comment" : ""
-  } ],
-  "opType" : "ALTERTABLE_ADDCOLS",
-  "queryDescs" : [ ],
-  "uriDescs" : [ {
-    "fieldName" : "child",
-    "fieldExtractor" : "ResolvedTableURIExtractor",
-    "isInput" : false,
-    "comment" : ""
-  } ]
-}, {
   "classname" : "org.apache.spark.sql.catalyst.plans.logical.AlterTable",
   "tableDescs" : [ {
     "fieldName" : "ident",

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/PaimonCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/PaimonCatalogRangerSparkExtensionSuite.scala
@@ -32,7 +32,7 @@ import org.apache.kyuubi.util.AssertionUtils._
 class PaimonCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
   override protected val catalogImpl: String = "hive"
   override protected val supportPurge: Boolean = false
-  private def isSupportedVersion = isScalaV212
+  private def isSupportedVersion = isScalaV212 || isSparkV40OrGreater
   override protected val sqlExtensions: String =
     if (isSupportedVersion) "org.apache.paimon.spark.extensions.PaimonSparkSessionExtensions"
     else ""

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/PaimonCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/PaimonCatalogRangerSparkExtensionSuite.scala
@@ -446,7 +446,7 @@ class PaimonCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
         doAs(
           admin,
           sql(s"SELECT commit_time FROM $catalogV2.$namespace1.`$table1$$snapshots`" +
-            s" ORDER BY commit_time ASC LIMIT 1").collect()(0).getTimestamp(0))
+            s" ORDER BY commit_time ASC LIMIT 1").collect()(0).get(0))
 
       val queryWithTimestamp =
         s"""
@@ -556,11 +556,13 @@ class PaimonCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
       val changingColumnTypeSql =
         s"""
            |ALTER TABLE $catalogV2.$namespace1.$table1
-           |ALTER COLUMN id TYPE DOUBLE
+           |ALTER COLUMN name TYPE STRING
            |""".stripMargin
 
       interceptEndsWith[AccessControlException] {
-        doAs(someone, sql(changingColumnTypeSql))
+        val df = doAs(someone, sql(changingColumnTypeSql))
+        df.queryExecution.executedPlan
+        df.show
       }(s"does not have [alter] privilege on [$namespace1/$table1]")
       doAs(admin, sql(changingColumnTypeSql))
     }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/PaimonCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/PaimonCatalogRangerSparkExtensionSuite.scala
@@ -560,9 +560,7 @@ class PaimonCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
            |""".stripMargin
 
       interceptEndsWith[AccessControlException] {
-        val df = doAs(someone, sql(changingColumnTypeSql))
-        df.queryExecution.executedPlan
-        df.show
+        doAs(someone, sql(changingColumnTypeSql))
       }(s"does not have [alter] privilege on [$namespace1/$table1]")
       doAs(admin, sql(changingColumnTypeSql))
     }

--- a/pom.xml
+++ b/pom.xml
@@ -2001,7 +2001,7 @@
                   here we choose 1.6.1 to ensure that tests happy when activate both -Pjava-8 and -Pspark-3.3.
                   -->
                 <iceberg.version>1.6.1</iceberg.version>
-                <!-- Exclude Paimon test due to paimon-common has runtime linkage issue on Spark 3.4 classes -->
+                <!-- Exclude Paimon test due to paimon-common has runtime linkage issue which refers to Spark 3.4 classes -->
                 <maven.plugin.scalatest.exclude.tags>org.scalatest.tags.Slow,org.apache.kyuubi.tags.PaimonTest</maven.plugin.scalatest.exclude.tags>
             </properties>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -2001,7 +2001,7 @@
                   here we choose 1.6.1 to ensure that tests happy when activate both -Pjava-8 and -Pspark-3.3.
                   -->
                 <iceberg.version>1.6.1</iceberg.version>
-                <!-- Exclude Paimon test due to paimon-common has linkage on Spark 3.4 classes -->
+                <!-- Exclude Paimon test due to paimon-common has runtime linkage issue on Spark 3.4 classes -->
                 <maven.plugin.scalatest.exclude.tags>org.scalatest.tags.Slow,org.apache.kyuubi.tags.PaimonTest</maven.plugin.scalatest.exclude.tags>
             </properties>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
         <netty.version>4.2.7.Final</netty.version>
         <openai.java.version>0.12.0</openai.java.version>
         <retrofit.version>2.9.0</retrofit.version>
-        <paimon.version>0.8.2</paimon.version>
+        <paimon.version>1.3.1</paimon.version>
         <paimon.artifact>paimon-spark-${spark.binary.version}</paimon.artifact>
         <phoenix.version>6.0.0</phoenix.version>
         <postgresql.version>42.7.2</postgresql.version>
@@ -2001,7 +2001,8 @@
                   here we choose 1.6.1 to ensure that tests happy when activate both -Pjava-8 and -Pspark-3.3.
                   -->
                 <iceberg.version>1.6.1</iceberg.version>
-                <maven.plugin.scalatest.exclude.tags>org.scalatest.tags.Slow</maven.plugin.scalatest.exclude.tags>
+                <!-- Exclude Paimon test due to paimon-common has linkage on Spark 3.4 classes -->
+                <maven.plugin.scalatest.exclude.tags>org.scalatest.tags.Slow,org.apache.kyuubi.tags.PaimonTest</maven.plugin.scalatest.exclude.tags>
             </properties>
         </profile>
 
@@ -2050,11 +2051,8 @@
                 <delta.artifact>delta-spark_${scala.binary.version}</delta.artifact>
                 <!-- TODO: update once Hudi support Spark 4.0 -->
                 <hudi.artifact>hudi-spark3.5-bundle_${scala.binary.version}</hudi.artifact>
-                <!-- TODO: update once Paimon support Spark 4.0.
-                           paimon-spark-3.5 contains Scala 2.12 classes cause conflicts with Scala 2.13 -->
-                <paimon.artifact>paimon-common</paimon.artifact>
                 <!-- Exclude SparkLocalClusterTest due to Scala 2.13.17 changes serialVersionUID of scala.collection.immutable.ArraySeq -->
-                <maven.plugin.scalatest.exclude.tags>org.scalatest.tags.Slow,org.apache.kyuubi.tags.PaimonTest,org.apache.kyuubi.tags.HudiTest,org.apache.kyuubi.tags.SparkLocalClusterTest</maven.plugin.scalatest.exclude.tags>
+                <maven.plugin.scalatest.exclude.tags>org.scalatest.tags.Slow,org.apache.kyuubi.tags.HudiTest,org.apache.kyuubi.tags.SparkLocalClusterTest</maven.plugin.scalatest.exclude.tags>
                 <spark.archive.name>spark-${spark.version}-bin-hadoop3.tgz</spark.archive.name>
             </properties>
         </profile>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->
Paimon 1.3 supports Spark 3.2 to 4.0
https://paimon.apache.org/docs/1.3/spark/quick-start/

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
GHA.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
