### PR TITLE
 Move the Auth module from server to common for reuse

### DIFF
--- a/kyuubi-common/pom.xml
+++ b/kyuubi-common/pom.xml
@@ -124,6 +124,11 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
         </dependency>

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/AuthSchemes.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/AuthSchemes.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.kyuubi.server.http.authentication
+package org.apache.kyuubi.service.authentication
 
 object AuthSchemes extends Enumeration {
   type AuthScheme = Value

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/AuthenticationAuditLogger.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/AuthenticationAuditLogger.scala
@@ -15,12 +15,12 @@
  * limitations under the License.
  */
 
-package org.apache.kyuubi.server.http.authentication
+package org.apache.kyuubi.service.authentication
 
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
 import org.apache.kyuubi.Logging
-import org.apache.kyuubi.server.http.authentication.AuthenticationFilter._
+import org.apache.kyuubi.service.authentication.AuthenticationFilter.{getForwardedAddresses, HTTP_AUTH_TYPE, HTTP_CLIENT_IP_ADDRESS, HTTP_CLIENT_PROXY_USER_NAME, HTTP_CLIENT_USER_NAME, HTTP_FORWARDED_ADDRESSES, HTTP_PROXY_HEADER_CLIENT_IP_ADDRESS}
 
 object AuthenticationAuditLogger extends Logging {
   final private val AUDIT_BUFFER = new ThreadLocal[StringBuilder]() {

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/AuthenticationFilter.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/AuthenticationFilter.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.kyuubi.server.http.authentication
+package org.apache.kyuubi.service.authentication
 
 import java.io.IOException
 import javax.security.sasl.AuthenticationException
@@ -27,18 +27,17 @@ import scala.collection.mutable
 import org.apache.kyuubi.Logging
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.{AUTHENTICATION_METHOD, FRONTEND_PROXY_HTTP_CLIENT_IP_HEADER}
-import org.apache.kyuubi.server.http.util.HttpAuthUtils.AUTHORIZATION_HEADER
-import org.apache.kyuubi.service.authentication.{AuthTypes, InternalSecurityAccessor}
 import org.apache.kyuubi.service.authentication.AuthTypes.{CUSTOM, KERBEROS, NOSASL}
+import org.apache.kyuubi.service.authentication.utils.HttpAuthUtils.AUTHORIZATION_HEADER
 
 class AuthenticationFilter(conf: KyuubiConf) extends Filter with Logging {
   import AuthenticationFilter._
   import AuthSchemes._
 
-  private[authentication] val authSchemeHandlers =
+  private[kyuubi] val authSchemeHandlers =
     new mutable.HashMap[AuthScheme, AuthenticationHandler]()
 
-  private[authentication] def addAuthHandler(authHandler: AuthenticationHandler): Unit = {
+  private[kyuubi] def addAuthHandler(authHandler: AuthenticationHandler): Unit = {
     authHandler.init(conf)
     if (authHandler.authenticationSupported) {
       if (authSchemeHandlers.contains(authHandler.authScheme)) {

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/AuthenticationHandler.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/AuthenticationHandler.scala
@@ -15,14 +15,14 @@
  * limitations under the License.
  */
 
-package org.apache.kyuubi.server.http.authentication
+package org.apache.kyuubi.service.authentication
 
 import javax.security.sasl.AuthenticationException
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
 import org.apache.kyuubi.config.KyuubiConf
-import org.apache.kyuubi.server.http.authentication.AuthSchemes.AuthScheme
-import org.apache.kyuubi.server.http.util.HttpAuthUtils.AUTHORIZATION_HEADER
+import org.apache.kyuubi.service.authentication.AuthSchemes.AuthScheme
+import org.apache.kyuubi.service.authentication.utils.HttpAuthUtils.AUTHORIZATION_HEADER
 
 trait AuthenticationHandler {
 

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/BearerAuthenticationHandler.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/BearerAuthenticationHandler.scala
@@ -15,33 +15,38 @@
  * limitations under the License.
  */
 
-package org.apache.kyuubi.server.http.authentication
+package org.apache.kyuubi.service.authentication
 
-import java.nio.charset.Charset
-import java.util.Base64
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
+
+import org.apache.commons.lang3.StringUtils
 
 import org.apache.kyuubi.Logging
 import org.apache.kyuubi.config.KyuubiConf
-import org.apache.kyuubi.server.http.authentication.AuthSchemes.AuthScheme
-import org.apache.kyuubi.server.http.util.HttpAuthUtils.{AUTHORIZATION_HEADER, WWW_AUTHENTICATE_HEADER}
-import org.apache.kyuubi.service.authentication.{AuthenticationProviderFactory, AuthMethods}
-import org.apache.kyuubi.service.authentication.AuthTypes._
+import org.apache.kyuubi.service.authentication.AuthSchemes.AuthScheme
+import org.apache.kyuubi.service.authentication.utils.HttpAuthUtils
+import org.apache.kyuubi.service.authentication.utils.HttpAuthUtils.{AUTHORIZATION_HEADER, WWW_AUTHENTICATE_HEADER}
 
-class BasicAuthenticationHandler(basicAuthType: AuthType)
+class BearerAuthenticationHandler(providerClass: String)
   extends AuthenticationHandler with Logging {
-
   private var conf: KyuubiConf = _
-  private val allowAnonymous = basicAuthType == NOSASL || basicAuthType == NONE
+  private val allowAnonymous = classOf[AnonymousAuthenticationProviderImpl].getName == providerClass
 
-  override val authScheme: AuthScheme = AuthSchemes.BASIC
+  override val authScheme: AuthScheme = AuthSchemes.BEARER
 
   override def init(conf: KyuubiConf): Unit = {
     this.conf = conf
   }
 
   override def authenticationSupported: Boolean = {
-    basicAuthType != null
+    Option(providerClass).exists { _ =>
+      try {
+        Class.forName(providerClass).isAssignableFrom(classOf[TokenAuthenticationProvider])
+        true
+      } catch {
+        case _: Throwable => false
+      }
+    }
   }
 
   override def matchAuthScheme(authorization: String): Boolean = {
@@ -64,29 +69,20 @@ class BasicAuthenticationHandler(basicAuthType: AuthType)
   override def authenticate(
       request: HttpServletRequest,
       response: HttpServletResponse): String = {
-    var authUser: String = null
+    var principal: String = null
+    val inputToken = getAuthorization(request)
 
-    val authorization = getAuthorization(request)
-    val inputToken = Option(authorization).map(a => Base64.getDecoder.decode(a.getBytes()))
-      .getOrElse(Array.empty[Byte])
-    val creds = new String(inputToken, Charset.forName("UTF-8")).split(":")
-
-    if (allowAnonymous) {
-      authUser = creds.take(1).headOption.filterNot(_.isEmpty).getOrElse("anonymous")
+    if (!allowAnonymous && StringUtils.isBlank(inputToken)) {
+      response.setHeader(WWW_AUTHENTICATE_HEADER, authScheme.toString)
+      response.setStatus(HttpServletResponse.SC_UNAUTHORIZED)
     } else {
-      if (creds.size < 2 || creds(0).trim.isEmpty || creds(1).trim.isEmpty) {
-        response.setHeader(WWW_AUTHENTICATE_HEADER, authScheme.toString)
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED)
-      } else {
-        val Seq(user, password) = creds.toSeq.take(2)
-        val passwdAuthenticationProvider = AuthenticationProviderFactory
-          .getHttpBasicAuthenticationProvider(AuthMethods.withName(basicAuthType.toString), conf)
-        passwdAuthenticationProvider.authenticate(user, password)
-        response.setStatus(HttpServletResponse.SC_OK)
-        authUser = user
-      }
+      val credential = DefaultTokenCredential(inputToken, HttpAuthUtils.getCredentialExtraInfo)
+      principal = AuthenticationProviderFactory
+        .getHttpBearerAuthenticationProvider(providerClass, conf)
+        .authenticate(credential).getName
+      response.setStatus(HttpServletResponse.SC_OK)
     }
-    authUser
+    principal
   }
 
   override def destroy(): Unit = {}

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/KerberosAuthenticationHandler.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/KerberosAuthenticationHandler.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.kyuubi.server.http.authentication
+package org.apache.kyuubi.service.authentication
 
 import java.io.{File, IOException}
 import java.security.{PrivilegedActionException, PrivilegedExceptionAction}
@@ -32,8 +32,8 @@ import org.ietf.jgss.{GSSContext, GSSCredential, GSSManager, Oid}
 
 import org.apache.kyuubi.Logging
 import org.apache.kyuubi.config.KyuubiConf
-import org.apache.kyuubi.server.http.authentication.AuthSchemes.AuthScheme
-import org.apache.kyuubi.server.http.util.HttpAuthUtils.{NEGOTIATE, WWW_AUTHENTICATE_HEADER}
+import org.apache.kyuubi.service.authentication.AuthSchemes.AuthScheme
+import org.apache.kyuubi.service.authentication.utils.HttpAuthUtils.{NEGOTIATE, WWW_AUTHENTICATE_HEADER}
 
 class KerberosAuthenticationHandler extends AuthenticationHandler with Logging {
 

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/KyuubiInternalAuthenticationHandler.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/KyuubiInternalAuthenticationHandler.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.kyuubi.server.http.authentication
+package org.apache.kyuubi.service.authentication
 
 import java.nio.charset.StandardCharsets
 import java.util.Base64
@@ -23,9 +23,8 @@ import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
 import org.apache.kyuubi.Logging
 import org.apache.kyuubi.config.KyuubiConf
-import org.apache.kyuubi.server.http.authentication.AuthSchemes.AuthScheme
-import org.apache.kyuubi.server.http.util.HttpAuthUtils.WWW_AUTHENTICATE_HEADER
-import org.apache.kyuubi.service.authentication.InternalSecurityAccessor
+import org.apache.kyuubi.service.authentication.AuthSchemes.AuthScheme
+import org.apache.kyuubi.service.authentication.utils.HttpAuthUtils.WWW_AUTHENTICATE_HEADER
 
 class KyuubiInternalAuthenticationHandler extends AuthenticationHandler with Logging {
 

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/utils/HttpAuthUtils.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/utils/HttpAuthUtils.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.kyuubi.server.http.util
+package org.apache.kyuubi.service.authentication.utils
 
 import java.nio.charset.StandardCharsets
 import java.security.SecureRandom
@@ -25,8 +25,7 @@ import java.util.{Base64, StringTokenizer}
 import scala.collection.mutable
 
 import org.apache.kyuubi.Logging
-import org.apache.kyuubi.server.http.authentication.{AuthenticationFilter, AuthSchemes}
-import org.apache.kyuubi.service.authentication.Credential
+import org.apache.kyuubi.service.authentication.{AuthenticationFilter, AuthSchemes, Credential}
 
 object HttpAuthUtils extends Logging {
   // HTTP header used by the server endpoint during an authentication sequence.

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiRestFrontendService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiRestFrontendService.scala
@@ -36,10 +36,10 @@ import org.apache.kyuubi.metrics.{MetricsConstants, MetricsSystem}
 import org.apache.kyuubi.metrics.MetricsConstants.OPERATION_BATCH_PENDING_MAX_ELAPSE
 import org.apache.kyuubi.operation.OperationState
 import org.apache.kyuubi.server.api.v1.ApiRootResource
-import org.apache.kyuubi.server.http.authentication.{AuthenticationFilter, KyuubiHttpAuthenticationFactory}
+import org.apache.kyuubi.server.http.authentication.KyuubiHttpAuthenticationFactory
 import org.apache.kyuubi.server.ui.{JettyServer, JettyUtils}
 import org.apache.kyuubi.service.{AbstractFrontendService, Serverable, Service, ServiceUtils}
-import org.apache.kyuubi.service.authentication.{AuthTypes, AuthUtils}
+import org.apache.kyuubi.service.authentication.{AuthenticationFilter, AuthTypes, AuthUtils}
 import org.apache.kyuubi.session.{KyuubiBatchSession, KyuubiSessionManager, SessionHandle}
 import org.apache.kyuubi.util.{JavaUtils, ThreadUtils}
 import org.apache.kyuubi.util.ThreadUtils.scheduleTolerableRunnableWithFixedDelay

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiTHttpFrontendService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiTHttpFrontendService.scala
@@ -44,9 +44,9 @@ import org.apache.kyuubi.config.KyuubiReservedKeys.{KYUUBI_SESSION_ENGINE_LAUNCH
 import org.apache.kyuubi.metrics.MetricsConstants.{THRIFT_HTTP_CONN_FAIL, THRIFT_HTTP_CONN_OPEN, THRIFT_HTTP_CONN_TOTAL}
 import org.apache.kyuubi.metrics.MetricsSystem
 import org.apache.kyuubi.server.http.ThriftHttpServlet
-import org.apache.kyuubi.server.http.authentication.AuthenticationFilter
 import org.apache.kyuubi.service.{Serverable, Service, ServiceUtils, TFrontendService}
 import org.apache.kyuubi.service.TFrontendService.{CURRENT_SERVER_CONTEXT, OK_STATUS}
+import org.apache.kyuubi.service.authentication.AuthenticationFilter
 import org.apache.kyuubi.session.KyuubiSessionImpl
 import org.apache.kyuubi.shaded.hive.service.rpc.thrift.{TCLIService, TOpenSessionReq, TOpenSessionResp}
 import org.apache.kyuubi.shaded.thrift.protocol.TBinaryProtocol

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/InternalRestClient.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/InternalRestClient.scala
@@ -26,7 +26,7 @@ import org.apache.kyuubi.Logging
 import org.apache.kyuubi.client.{BaseRestApi, BatchRestApi, KyuubiRestClient}
 import org.apache.kyuubi.client.api.v1.dto.{Batch, CloseBatchResponse, OperationLog}
 import org.apache.kyuubi.client.auth.AuthHeaderGenerator
-import org.apache.kyuubi.server.http.authentication.AuthSchemes
+import org.apache.kyuubi.service.authentication.AuthSchemes
 import org.apache.kyuubi.service.authentication.InternalSecurityAccessor
 
 /**

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/http/ThriftHttpServlet.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/http/ThriftHttpServlet.scala
@@ -29,10 +29,10 @@ import scala.collection.mutable
 import org.apache.kyuubi.Logging
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.FRONTEND_PROXY_HTTP_CLIENT_IP_HEADER
-import org.apache.kyuubi.server.http.authentication.{AuthenticationAuditLogger, AuthenticationFilter}
-import org.apache.kyuubi.server.http.util.{CookieSigner, HttpAuthUtils}
-import org.apache.kyuubi.server.http.util.HttpAuthUtils.AUTHORIZATION_HEADER
-import org.apache.kyuubi.service.authentication.KyuubiAuthenticationFactory
+import org.apache.kyuubi.server.http.util.CookieSigner
+import org.apache.kyuubi.service.authentication.{AuthenticationAuditLogger, AuthenticationFilter, KyuubiAuthenticationFactory}
+import org.apache.kyuubi.service.authentication.utils.HttpAuthUtils
+import org.apache.kyuubi.service.authentication.utils.HttpAuthUtils.AUTHORIZATION_HEADER
 import org.apache.kyuubi.shaded.thrift.TProcessor
 import org.apache.kyuubi.shaded.thrift.protocol.TProtocolFactory
 import org.apache.kyuubi.shaded.thrift.server.TServlet

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/http/authentication/KyuubiHttpAuthenticationFactory.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/http/authentication/KyuubiHttpAuthenticationFactory.scala
@@ -29,7 +29,7 @@ import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.{AUTHENTICATION_METHOD, ENGINE_SECURITY_ENABLED}
 import org.apache.kyuubi.metrics.MetricsConstants.{REST_CONN_FAIL, REST_CONN_OPEN, REST_CONN_TOTAL}
 import org.apache.kyuubi.metrics.MetricsSystem
-import org.apache.kyuubi.service.authentication.{AuthTypes, InternalSecurityAccessor}
+import org.apache.kyuubi.service.authentication.{AuthenticationFilter, AuthTypes, InternalSecurityAccessor}
 import org.apache.kyuubi.service.authentication.AuthTypes.KERBEROS
 
 class KyuubiHttpAuthenticationFactory(conf: KyuubiConf) {

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiRestAuthenticationSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiRestAuthenticationSuite.scala
@@ -29,9 +29,9 @@ import org.apache.hadoop.security.UserGroupInformation
 import org.apache.kyuubi.RestClientTestHelper
 import org.apache.kyuubi.client.api.v1.dto.{SessionHandle, SessionOpenCount, SessionOpenRequest}
 import org.apache.kyuubi.config.KyuubiConf
-import org.apache.kyuubi.server.http.authentication.AuthSchemes
-import org.apache.kyuubi.server.http.util.HttpAuthUtils._
 import org.apache.kyuubi.service.authentication.{AuthTypes, InternalSecurityAccessor, UserDefineAuthenticationProviderImpl, UserDefineTokenAuthenticationProviderImpl}
+import org.apache.kyuubi.service.authentication.AuthSchemes
+import org.apache.kyuubi.service.authentication.utils.HttpAuthUtils.{basicAuthorizationHeader, bearerAuthorizationHeader, AUTHORIZATION_HEADER}
 import org.apache.kyuubi.session.KyuubiSession
 
 class KyuubiRestAuthenticationSuite extends RestClientTestHelper {

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/AdminResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/AdminResourceSuite.scala
@@ -41,9 +41,9 @@ import org.apache.kyuubi.ha.client.{DiscoveryPaths, ServiceDiscovery}
 import org.apache.kyuubi.ha.client.DiscoveryClientProvider.withDiscoveryClient
 import org.apache.kyuubi.plugin.PluginLoader
 import org.apache.kyuubi.server.KyuubiRestFrontendService
-import org.apache.kyuubi.server.http.util.HttpAuthUtils
-import org.apache.kyuubi.server.http.util.HttpAuthUtils.AUTHORIZATION_HEADER
 import org.apache.kyuubi.service.authentication.AnonymousAuthenticationProviderImpl
+import org.apache.kyuubi.service.authentication.utils.HttpAuthUtils
+import org.apache.kyuubi.service.authentication.utils.HttpAuthUtils.AUTHORIZATION_HEADER
 import org.apache.kyuubi.session.SessionType
 import org.apache.kyuubi.shaded.hive.service.rpc.thrift.TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V2
 

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
@@ -43,9 +43,9 @@ import org.apache.kyuubi.metrics.{MetricsConstants, MetricsSystem}
 import org.apache.kyuubi.operation.{BatchJobSubmission, OperationState}
 import org.apache.kyuubi.operation.OperationState.OperationState
 import org.apache.kyuubi.server.KyuubiRestFrontendService
-import org.apache.kyuubi.server.http.util.HttpAuthUtils.{basicAuthorizationHeader, AUTHORIZATION_HEADER}
 import org.apache.kyuubi.server.metadata.api.{Metadata, MetadataFilter}
 import org.apache.kyuubi.service.authentication.{AnonymousAuthenticationProviderImpl, AuthUtils}
+import org.apache.kyuubi.service.authentication.utils.HttpAuthUtils.{basicAuthorizationHeader, AUTHORIZATION_HEADER}
 import org.apache.kyuubi.session.{KyuubiBatchSession, KyuubiSessionManager, SessionHandle, SessionType}
 import org.apache.kyuubi.shaded.hive.service.rpc.thrift.TProtocolVersion
 

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/SessionsResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/SessionsResourceSuite.scala
@@ -29,13 +29,13 @@ import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
 
 import org.apache.kyuubi.{KyuubiFunSuite, RestFrontendTestHelper}
 import org.apache.kyuubi.client.api.v1.dto
-import org.apache.kyuubi.client.api.v1.dto.{SessionData, _}
+import org.apache.kyuubi.client.api.v1.dto._
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiReservedKeys.KYUUBI_SESSION_CONNECTION_URL_KEY
 import org.apache.kyuubi.engine.ShareLevel
 import org.apache.kyuubi.metrics.{MetricsConstants, MetricsSystem}
 import org.apache.kyuubi.operation.OperationHandle
-import org.apache.kyuubi.server.http.util.HttpAuthUtils.{basicAuthorizationHeader, AUTHORIZATION_HEADER}
+import org.apache.kyuubi.service.authentication.utils.HttpAuthUtils.{basicAuthorizationHeader, AUTHORIZATION_HEADER}
 import org.apache.kyuubi.session.SessionType
 
 class SessionsResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper {

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/http/authentication/AuthenticationFilterSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/http/authentication/AuthenticationFilterSuite.scala
@@ -19,7 +19,7 @@ package org.apache.kyuubi.server.http.authentication
 
 import org.apache.kyuubi.KyuubiFunSuite
 import org.apache.kyuubi.config.KyuubiConf
-import org.apache.kyuubi.service.authentication.AuthTypes
+import org.apache.kyuubi.service.authentication.{AuthenticationFilter, AuthTypes, BasicAuthenticationHandler, KerberosAuthenticationHandler}
 
 class AuthenticationFilterSuite extends KyuubiFunSuite {
   test("add auth handler and destroy") {


### PR DESCRIPTION
### Why are the changes needed?

Move the most module related with auth to common for further reuse


### How was this patch tested?
Test with all the UT


### Was this patch authored or co-authored using generative AI tooling?
NO

