### PR TITLE
Add pyhive connection timeout

### DIFF
--- a/python/.gitignore
+++ b/python/.gitignore
@@ -16,4 +16,5 @@ cover/
 *.iml
 /scripts/.thrift_gen
 venv/
+.venv/
 .envrc

--- a/python/pyhive/hive.py
+++ b/python/pyhive/hive.py
@@ -161,7 +161,7 @@ class Connection(object):
         ssl_cert=None,
         thrift_transport=None,
         ssl_context=None,
-        socket_timeout=None
+        connection_timeout=None,
     ):
         """Connect to HiveServer2
 
@@ -176,7 +176,7 @@ class Connection(object):
             Incompatible with host, port, auth, kerberos_service_name, and password.
         :param ssl_context: A custom SSL context to use for HTTPS connections. If provided,
             this overrides check_hostname and ssl_cert parameters.
-        :param socket_timeout: Millisecond timeout for the Thrift socket connections.
+        :param connection_timeout: Millisecond timeout for Thrift connections.
         The way to support LDAP and GSSAPI is originated from cloudera/Impyla:
         https://github.com/cloudera/impyla/blob/255b07ed973d47a3395214ed92d35ec0615ebf62
         /impala/_thrift_api.py#L152-L160
@@ -195,6 +195,8 @@ class Connection(object):
                 ),
                 ssl_context=ssl_context,
             )
+            if connection_timeout:
+                thrift_transport.setTimeout(connection_timeout)
 
             if auth in ("BASIC", "NOSASL", "NONE", None):
                 # Always needs the Authorization header
@@ -238,8 +240,8 @@ class Connection(object):
             if auth is None:
                 auth = 'NONE'
             socket = thrift.transport.TSocket.TSocket(host, port)
-            if socket_timeout:
-                socket.setTimeout(socket_timeout)
+            if connection_timeout:
+                socket.setTimeout(connection_timeout)
             if auth == 'NOSASL':
                 # NOSASL corresponds to hive.server2.authentication=NOSASL in hive-site.xml
                 self._transport = thrift.transport.TTransport.TBufferedTransport(socket)

--- a/python/pyhive/hive.py
+++ b/python/pyhive/hive.py
@@ -195,7 +195,7 @@ class Connection(object):
                 ),
                 ssl_context=ssl_context,
             )
-            if connection_timeout:
+            if connection_timeout is not None:
                 thrift_transport.setTimeout(connection_timeout)
 
             if auth in ("BASIC", "NOSASL", "NONE", None):
@@ -240,7 +240,7 @@ class Connection(object):
             if auth is None:
                 auth = 'NONE'
             socket = thrift.transport.TSocket.TSocket(host, port)
-            if connection_timeout:
+            if connection_timeout is not None:
                 socket.setTimeout(connection_timeout)
             if auth == 'NOSASL':
                 # NOSASL corresponds to hive.server2.authentication=NOSASL in hive-site.xml

--- a/python/pyhive/hive.py
+++ b/python/pyhive/hive.py
@@ -176,7 +176,7 @@ class Connection(object):
             Incompatible with host, port, auth, kerberos_service_name, and password.
         :param ssl_context: A custom SSL context to use for HTTPS connections. If provided,
             this overrides check_hostname and ssl_cert parameters.
-        :param connection_timeout: Millisecond timeout for Thrift connections.
+        :param connection_timeout: Millisecond timeout for Thrift connections. Skipped if using thrift_transport.
         The way to support LDAP and GSSAPI is originated from cloudera/Impyla:
         https://github.com/cloudera/impyla/blob/255b07ed973d47a3395214ed92d35ec0615ebf62
         /impala/_thrift_api.py#L152-L160

--- a/python/pyhive/hive.py
+++ b/python/pyhive/hive.py
@@ -160,7 +160,8 @@ class Connection(object):
         check_hostname=None,
         ssl_cert=None,
         thrift_transport=None,
-        ssl_context=None
+        ssl_context=None,
+        socket_timeout=None
     ):
         """Connect to HiveServer2
 
@@ -175,6 +176,7 @@ class Connection(object):
             Incompatible with host, port, auth, kerberos_service_name, and password.
         :param ssl_context: A custom SSL context to use for HTTPS connections. If provided,
             this overrides check_hostname and ssl_cert parameters.
+        :param socket_timeout: Millisecond timeout for the Thrift socket connections.
         The way to support LDAP and GSSAPI is originated from cloudera/Impyla:
         https://github.com/cloudera/impyla/blob/255b07ed973d47a3395214ed92d35ec0615ebf62
         /impala/_thrift_api.py#L152-L160
@@ -236,6 +238,8 @@ class Connection(object):
             if auth is None:
                 auth = 'NONE'
             socket = thrift.transport.TSocket.TSocket(host, port)
+            if socket_timeout:
+                socket.setTimeout(socket_timeout)
             if auth == 'NOSASL':
                 # NOSASL corresponds to hive.server2.authentication=NOSASL in hive-site.xml
                 self._transport = thrift.transport.TTransport.TBufferedTransport(socket)

--- a/python/pyhive/tests/test_hive.py
+++ b/python/pyhive/tests/test_hive.py
@@ -259,6 +259,17 @@ class TestHive(unittest.TestCase, DBAPITestCase):
                 cursor.execute('SELECT 1 FROM one_row')
                 self.assertEqual(cursor.fetchall(), [(1,)])
 
+    def test_connection_timeout(self):
+        """Test that a connection timeout is set without error."""
+        with contextlib.closing(hive.connect(
+            host=_HOST,
+            port=10000,
+            connection_timeout=10 * 1000
+        )) as connection:
+            with contextlib.closing(connection.cursor()) as cursor:
+                # Use the same query pattern as other tests
+                cursor.execute('SELECT 1 FROM one_row')
+                self.assertEqual(cursor.fetchall(), [(1,)])
 
 def _restart_hs2():
     subprocess.check_call(['sudo', 'service', 'hive-server2', 'restart'])

--- a/python/pyhive/tests/test_hive.py
+++ b/python/pyhive/tests/test_hive.py
@@ -259,17 +259,37 @@ class TestHive(unittest.TestCase, DBAPITestCase):
                 cursor.execute('SELECT 1 FROM one_row')
                 self.assertEqual(cursor.fetchall(), [(1,)])
 
-    def test_connection_timeout(self):
+    def test_connection_timeout_sasl(self):
         """Test that a connection timeout is set without error."""
         with contextlib.closing(hive.connect(
             host=_HOST,
             port=10000,
-            connection_timeout=10 * 1000
+            connection_timeout=2_000,
         )) as connection:
-            with contextlib.closing(connection.cursor()) as cursor:
-                # Use the same query pattern as other tests
-                cursor.execute('SELECT 1 FROM one_row')
-                self.assertEqual(cursor.fetchall(), [(1,)])
+            # thrift converts milliseconds to seconds
+            assert connection._transport._trans._timeout == 2
+
+    def test_connection_timeout_nosasl(self):
+        """Test that a connection timeout is set without error."""
+        with contextlib.closing(hive.connect(
+            host=_HOST,
+            port=10000,
+            connection_timeout=2_000,
+            auth='NOSASL',
+        )) as connection:
+            # thrift converts milliseconds to seconds
+            assert connection._transport._TBufferedTransport__trans._timeout == 2
+
+    def test_connection_timeout_http(self):
+        """Test that a connection timeout is set without error."""
+        with contextlib.closing(hive.connect(
+            host=_HOST,
+            port=10000,
+            connection_timeout=2_000,
+            scheme='http',
+        )) as connection:
+            # thrift converts milliseconds to seconds
+            assert connection._transport._THttpClient__timeout == 2
 
 def _restart_hs2():
     subprocess.check_call(['sudo', 'service', 'hive-server2', 'restart'])


### PR DESCRIPTION
### Why are the changes needed?
Adds an optional parameter to pyhive hive connection class init to allow setting the socket connection timeout. By default, thrift socket connections have no timeout which causes connections to hang indefinitely when something goes wrong. This helps us in [dbt ](https://github.com/dbt-labs/dbt-adapters/blob/1657e9084fcafa0a1bee0b7362c870851c2d173c/dbt-spark/src/dbt/adapters/spark/connections.py#L542 )by allowing for multi-threaded management of connections while continuing to rely on pyhive thrift setup.

Reference thrift lines:
https://github.com/apache/thrift/blob/0d18fb2e97a00fc56997fa059d6819e54cdff64b/lib/py/src/transport/THttpClient.py#L130
https://github.com/apache/thrift/blob/0d18fb2e97a00fc56997fa059d6819e54cdff64b/lib/py/src/transport/TSocket.py#L111

### How was this patch tested?
Manually on TSocket path and added unit test

### Was this patch authored or co-authored using generative AI tooling?
No