### PR TITLE
[KYUUBI #7301] Fix engine not killed after deregisterEngine

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
@@ -367,6 +367,18 @@ private[kyuubi] class EngineRef(
             val msg = s"Deleting engine node:$sn"
             info(msg)
             discoveryClient.delete(s"$engineSpace/${sn.nodeName}")
+
+            if (shareLevel != CONNECTION && builder != null) {
+              try {
+                val appMgrInfo = builder.appMgrInfo()
+                engineManager.killApplication(appMgrInfo, engineRefId, Some(appUser))
+                info(s"Killed engine process for $engineRefId with share level $shareLevel")
+              } catch {
+                case e: Exception =>
+                  warn(s"Error killing engine process for $engineRefId", e)
+              }
+            }
+
             (true, msg)
           } else {
             val msg = s"Engine node:$sn is not matched with host&port[$hostPort]"

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
@@ -368,7 +368,7 @@ private[kyuubi] class EngineRef(
             info(msg)
             discoveryClient.delete(s"$engineSpace/${sn.nodeName}")
 
-            if (shareLevel != CONNECTION && builder != null) {
+            if (shareLevel != CONNECTION && builder != null && engineManager != null) {
               try {
                 val appMgrInfo = builder.appMgrInfo()
                 engineManager.killApplication(appMgrInfo, engineRefId, Some(appUser))


### PR DESCRIPTION
(cherry picked from commit b6b05e9cc9169f927c242dff8581883012b6ccb7)

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
Fix old engine not killed bug: https://github.com/apache/kyuubi/issues/7301


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->


### Was this patch authored or co-authored using generative AI tooling?
No

