### PR TITLE
[KYUUBI #7323] Support timeout at PlanOnlyMode

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/PlanOnlyStatement.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/PlanOnlyStatement.scala
@@ -18,6 +18,7 @@
 package org.apache.kyuubi.engine.spark.operation
 
 import java.lang.{Boolean => JBoolean}
+import java.util.concurrent.{TimeoutException, TimeUnit}
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
@@ -33,11 +34,12 @@ import org.apache.kyuubi.KyuubiSQLException
 import org.apache.kyuubi.config.KyuubiConf.{LINEAGE_PARSER_PLUGIN_PROVIDER, OPERATION_PLAN_ONLY_EXCLUDES, OPERATION_PLAN_ONLY_OUT_STYLE}
 import org.apache.kyuubi.engine.spark.KyuubiSparkUtil.getSessionConf
 import org.apache.kyuubi.engine.spark.operation.PlanOnlyStatement._
-import org.apache.kyuubi.operation.{AnalyzeMode, ArrayFetchIterator, ExecutionMode, IterableFetchIterator, JsonStyle, LineageMode, OperationHandle, OptimizeMode, OptimizeWithStatsMode, ParseMode, PhysicalMode, PlainStyle, PlanOnlyMode, PlanOnlyStyle, UnknownMode, UnknownStyle}
+import org.apache.kyuubi.operation.{AnalyzeMode, ArrayFetchIterator, ExecutionMode, IterableFetchIterator, JsonStyle, LineageMode, OperationHandle, OperationState, OptimizeMode, OptimizeWithStatsMode, ParseMode, PhysicalMode, PlainStyle, PlanOnlyMode, PlanOnlyStyle, UnknownMode, UnknownStyle}
 import org.apache.kyuubi.operation.PlanOnlyMode.{notSupportedModeError, unknownModeError}
 import org.apache.kyuubi.operation.PlanOnlyStyle.{notSupportedStyleError, unknownStyleError}
 import org.apache.kyuubi.operation.log.OperationLog
 import org.apache.kyuubi.session.Session
+import org.apache.kyuubi.util.ThreadUtils
 import org.apache.kyuubi.util.reflect.DynMethods
 
 /**
@@ -47,6 +49,7 @@ class PlanOnlyStatement(
     session: Session,
     override val statement: String,
     mode: PlanOnlyMode,
+    queryTimeout: Long,
     override protected val handle: OperationHandle)
   extends SparkOperation(session) {
 
@@ -76,26 +79,47 @@ class PlanOnlyStatement(
 
   override protected def runInternal(): Unit =
     try {
-      withLocalProperties {
-        SQLConf.withExistingConf(spark.sessionState.conf) {
-          val parsed = spark.sessionState.sqlParser.parsePlan(statement)
-          parsed match {
-            case cmd if planExcludes.contains(cmd.getClass.getSimpleName) =>
-              result = spark.sql(statement)
-              iter = new ArrayFetchIterator(result.collect())
-
-            case plan => style match {
-                case PlainStyle => explainWithPlainStyle(plan)
-                case JsonStyle => explainWithJsonStyle(plan)
-                case UnknownStyle => unknownStyleError(style)
-                case other => throw notSupportedStyleError(other, "Spark SQL")
-              }
-          }
+      if (queryTimeout > 0) {
+        val timeoutExecutor =
+          ThreadUtils.newDaemonSingleThreadScheduledExecutor("query-timeout-thread", false)
+        val future = timeoutExecutor.submit(new Runnable {
+          override def run(): Unit = doParsePlan()
+        })
+        try {
+          future.get(queryTimeout, TimeUnit.SECONDS)
+        } catch {
+          case _: TimeoutException =>
+            future.cancel(true)
+            cleanup(OperationState.TIMEOUT)
+        } finally {
+          timeoutExecutor.shutdownNow()
         }
+      } else {
+        doParsePlan()
       }
     } catch {
       onError()
     }
+
+  private def doParsePlan(): Unit = {
+    withLocalProperties {
+      SQLConf.withExistingConf(spark.sessionState.conf) {
+        val parsed = spark.sessionState.sqlParser.parsePlan(statement)
+        parsed match {
+          case cmd if planExcludes.contains(cmd.getClass.getSimpleName) =>
+            result = spark.sql(statement)
+            iter = new ArrayFetchIterator(result.collect())
+
+          case plan => style match {
+              case PlainStyle => explainWithPlainStyle(plan)
+              case JsonStyle => explainWithJsonStyle(plan)
+              case UnknownStyle => unknownStyleError(style)
+              case other => throw notSupportedStyleError(other, "Spark SQL")
+            }
+        }
+      }
+    }
+  }
 
   private def explainWithPlainStyle(plan: LogicalPlan): Unit = {
     mode match {

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/PlanOnlyStatement.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/PlanOnlyStatement.scala
@@ -18,7 +18,6 @@
 package org.apache.kyuubi.engine.spark.operation
 
 import java.lang.{Boolean => JBoolean}
-import java.util.concurrent.{TimeoutException, TimeUnit}
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
@@ -39,7 +38,6 @@ import org.apache.kyuubi.operation.PlanOnlyMode.{notSupportedModeError, unknownM
 import org.apache.kyuubi.operation.PlanOnlyStyle.{notSupportedStyleError, unknownStyleError}
 import org.apache.kyuubi.operation.log.OperationLog
 import org.apache.kyuubi.session.Session
-import org.apache.kyuubi.util.ThreadUtils
 import org.apache.kyuubi.util.reflect.DynMethods
 
 /**
@@ -80,20 +78,10 @@ class PlanOnlyStatement(
   override protected def runInternal(): Unit =
     try {
       if (queryTimeout > 0) {
-        val timeoutExecutor =
-          ThreadUtils.newDaemonSingleThreadScheduledExecutor("query-timeout-thread", false)
-        val future = timeoutExecutor.submit(new Runnable {
-          override def run(): Unit = doParsePlan()
-        })
-        try {
-          future.get(queryTimeout, TimeUnit.SECONDS)
-        } catch {
-          case _: TimeoutException =>
-            future.cancel(true)
-            cleanup(OperationState.TIMEOUT)
-        } finally {
-          timeoutExecutor.shutdownNow()
-        }
+        session.sessionManager.operationManager.runWithTimeoutFallback(
+          () => doParsePlan(),
+          () => cleanup(OperationState.TIMEOUT),
+          queryTimeout)
       } else {
         doParsePlan()
       }

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkSQLOperationManager.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkSQLOperationManager.scala
@@ -109,7 +109,7 @@ class SparkSQLOperationManager private (name: String) extends OperationManager(n
                     opHandle)
               }
             case mode =>
-              new PlanOnlyStatement(session, statement, mode, opHandle)
+              new PlanOnlyStatement(session, statement, mode, queryTimeout, opHandle)
           }
         case OperationLanguages.SCALA =>
           val repl = sessionToRepl.getOrElseUpdate(session.handle, KyuubiSparkILoop(spark))

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/OperationManager.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/OperationManager.scala
@@ -17,7 +17,7 @@
 
 package org.apache.kyuubi.operation
 
-import java.util.concurrent.{ScheduledExecutorService, ScheduledFuture, TimeUnit}
+import java.util.concurrent.{ScheduledExecutorService, ScheduledFuture, TimeoutException, TimeUnit}
 
 import scala.collection.JavaConverters._
 
@@ -68,6 +68,22 @@ abstract class OperationManager(name: String) extends AbstractService(name) {
       timeoutScheduler = null
     }
     super.stop()
+  }
+
+  /**
+   * Submit a task to the internal timeout scheduler and run it with a timeout.
+   * If the task execution exceeds the specified timeout, the task will be cancelled
+   * and the provided onTimeout callback will be executed.
+   */
+  def runWithTimeoutFallback(task: Runnable, onTimeout: Runnable, timeoutSeconds: Long): Unit = {
+    val future = timeoutScheduler.submit(task)
+    try {
+      future.get(timeoutSeconds, TimeUnit.SECONDS)
+    } catch {
+      case _: TimeoutException =>
+        future.cancel(true)
+        onTimeout.run()
+    }
   }
 
   /** Schedule a timeout task using the internal scheduler */

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/spark/SparkSqlEngineSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/spark/SparkSqlEngineSuite.scala
@@ -17,8 +17,6 @@
 
 package org.apache.kyuubi.engine.spark
 
-import java.sql.SQLTimeoutException
-
 import org.apache.kyuubi.WithKyuubiServer
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf._
@@ -148,39 +146,6 @@ class SparkSqlEngineSuite extends WithKyuubiServer with HiveJDBCTestHelper {
         "1670404535000/1000,'yyyy-MM-dd HH:mm:ss'),'GMT+08:00')")
       assert(gmt8ResultSet.next())
       assert(gmt8ResultSet.getString(1) === "2022-12-08 01:15:35.0")
-    }
-  }
-
-  test("KYUUBI-7323: Support timeout at PlanOnlyMode") {
-    val tableName = "t_timeout"
-    val sessionConfMap = Map("kyuubi.operation.plan.only.mode=analyze" -> "analyze")
-    withSessionConf(sessionConfMap)(Map.empty)(Map.empty) {
-
-      withJdbcStatement(tableName) { statement =>
-        statement.setQueryTimeout(2)
-        val layers = 30
-
-        val cteBuilder = new StringBuilder()
-        cteBuilder.append("WITH p AS (SELECT dt, tid, count(1) as pv, DENSE_RANK() " +
-          "over(order by dt) as dt_rank FROM t GROUP BY 1, 2), ")
-        cteBuilder.append("test_d1 AS (SELECT dt, tid FROM (SELECT dt, tid, row_number() " +
-          "over(order by pv desc) as r FROM p WHERE dt_rank=1) WHERE r<=100)")
-
-        for (i <- 2 to layers) {
-          cteBuilder.append(s", test_d$i AS ( " +
-            s"SELECT dt, tid FROM (SELECT p.dt, p.tid, row_number() over(order by pv desc) as r " +
-            s"FROM p LEFT JOIN test_d${i - 1} prev ON p.tid = prev.tid " +
-            s"WHERE p.dt_rank=$i AND prev.tid IS NULL) WHERE r<=100 " +
-            s"UNION ALL SELECT dt, tid FROM test_d${i - 1})")
-        }
-
-        val complexSql = cteBuilder.toString() + s" SELECT * FROM test_d$layers"
-
-        val e = intercept[SQLTimeoutException] {
-          statement.executeQuery(complexSql)
-        }
-        assert(e.getMessage.equals("Query timed out after 2 seconds"))
-      }
     }
   }
 

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/spark/SparkSqlEngineSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/spark/SparkSqlEngineSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.kyuubi.engine.spark
 
+import java.sql.SQLTimeoutException
+
 import org.apache.kyuubi.WithKyuubiServer
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf._
@@ -146,6 +148,39 @@ class SparkSqlEngineSuite extends WithKyuubiServer with HiveJDBCTestHelper {
         "1670404535000/1000,'yyyy-MM-dd HH:mm:ss'),'GMT+08:00')")
       assert(gmt8ResultSet.next())
       assert(gmt8ResultSet.getString(1) === "2022-12-08 01:15:35.0")
+    }
+  }
+
+  test("KYUUBI-7323: Support timeout at PlanOnlyMode") {
+    val tableName = "t_timeout"
+    val sessionConfMap = Map("kyuubi.operation.plan.only.mode=analyze" -> "analyze")
+    withSessionConf(sessionConfMap)(Map.empty)(Map.empty) {
+
+      withJdbcStatement(tableName) { statement =>
+        statement.setQueryTimeout(2)
+        val layers = 30
+
+        val cteBuilder = new StringBuilder()
+        cteBuilder.append("WITH p AS (SELECT dt, tid, count(1) as pv, DENSE_RANK() " +
+          "over(order by dt) as dt_rank FROM t GROUP BY 1, 2), ")
+        cteBuilder.append("test_d1 AS (SELECT dt, tid FROM (SELECT dt, tid, row_number() " +
+          "over(order by pv desc) as r FROM p WHERE dt_rank=1) WHERE r<=100)")
+
+        for (i <- 2 to layers) {
+          cteBuilder.append(s", test_d$i AS ( " +
+            s"SELECT dt, tid FROM (SELECT p.dt, p.tid, row_number() over(order by pv desc) as r " +
+            s"FROM p LEFT JOIN test_d${i - 1} prev ON p.tid = prev.tid " +
+            s"WHERE p.dt_rank=$i AND prev.tid IS NULL) WHERE r<=100 " +
+            s"UNION ALL SELECT dt, tid FROM test_d${i - 1})")
+        }
+
+        val complexSql = cteBuilder.toString() + s" SELECT * FROM test_d$layers"
+
+        val e = intercept[SQLTimeoutException] {
+          statement.executeQuery(complexSql)
+        }
+        assert(e.getMessage.equals("Query timed out after 2 seconds"))
+      }
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
close #7323

Support to cancel the `PlanOnlyStatement` when timeout.


### How was this patch tested?
Test by manual, the job group has been canceled, and the driver memory stop increase.
```
26/02/12 10:54:11 INFO PlanOnlyStatement: Processing hive's query[bc48bfb9-2294-4987-aa81-c5ae3f3b39b5]: RUNNING_STATE -> TIMEDOUT_STATE, time taken: 10.007 seconds
26/02/12 10:54:11 INFO PlanOnlyStatement: statementId=bc48bfb9-2294-4987-aa81-c5ae3f3b39b5, operationRunTime=0 ms, operationCpuTime=0 ms
26/02/12 10:54:11 INFO DAGScheduler: Asked to cancel job group bc48bfb9-2294-4987-aa81-c5ae3f3b39b5
26/02/12 10:54:11 INFO DAGScheduler: Asked to cancel job group bc48bfb9-2294-4987-aa81-c5ae3f3b39b5
```


### Was this patch authored or co-authored using generative AI tooling?
NO

