### PR TITLE
Support partition management for HiveTable

### DIFF
--- a/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveConnectorUtils.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveConnectorUtils.scala
@@ -55,9 +55,9 @@ object HiveConnectorUtils extends Logging {
   // Using reflection to construct Cast instances avoids compile-time binding to
   // version-specific default parameter methods, ensuring cross-version compatibility.
   def castExpression(
-                  child: Expression,
-                  dataType: DataType,
-                  timeZoneId: Option[String] = None): Expression = {
+      child: Expression,
+      dataType: DataType,
+      timeZoneId: Option[String] = None): Expression = {
     castCtor.newInstance(child, dataType, timeZoneId)
   }
 

--- a/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveConnectorUtils.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveConnectorUtils.scala
@@ -28,18 +28,38 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
 import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTablePartition}
+import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.connector.catalog.TableChange
 import org.apache.spark.sql.connector.catalog.TableChange._
 import org.apache.spark.sql.execution.command.CommandUtils
 import org.apache.spark.sql.execution.datasources.{PartitionDirectory, PartitionedFile}
 import org.apache.spark.sql.hive.execution.HiveFileFormat
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{ArrayType, MapType, StructField, StructType}
+import org.apache.spark.sql.types.{ArrayType, DataType, MapType, StructField, StructType}
 
 import org.apache.kyuubi.util.reflect.{DynClasses, DynConstructors, DynMethods}
 import org.apache.kyuubi.util.reflect.ReflectUtils.invokeAs
 
 object HiveConnectorUtils extends Logging {
+
+  private val castCtor: DynConstructors.Ctor[Expression] =
+    DynConstructors.builder(classOf[Expression])
+      .impl(
+        "org.apache.spark.sql.catalyst.expressions.Cast",
+        classOf[Expression],
+        classOf[DataType],
+        classOf[Option[_]])
+      .build[Expression]()
+
+  // SPARK-40054, Cast class added a 4th parameter `evalMode` with a default value.
+  // Using reflection to construct Cast instances avoids compile-time binding to
+  // version-specific default parameter methods, ensuring cross-version compatibility.
+  def castExpression(
+                  child: Expression,
+                  dataType: DataType,
+                  timeZoneId: Option[String] = None): Expression = {
+    castCtor.newInstance(child, dataType, timeZoneId)
+  }
 
   def getHiveFileFormat(fileSinkConf: FileSinkDesc): HiveFileFormat =
     Try { // SPARK-43186: 3.5.0

--- a/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveConnectorUtils.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveConnectorUtils.scala
@@ -28,7 +28,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
 import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTablePartition}
-import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.expressions.{Cast, Expression}
 import org.apache.spark.sql.connector.catalog.TableChange
 import org.apache.spark.sql.connector.catalog.TableChange._
 import org.apache.spark.sql.execution.command.CommandUtils
@@ -45,15 +45,13 @@ object HiveConnectorUtils extends Logging {
   private val castCtor: DynConstructors.Ctor[Expression] =
     DynConstructors.builder(classOf[Expression])
       .impl(
-        "org.apache.spark.sql.catalyst.expressions.Cast",
+        classOf[Cast],
         classOf[Expression],
         classOf[DataType],
         classOf[Option[_]])
       .build[Expression]()
 
-  // SPARK-40054, Cast class added a 4th parameter `evalMode` with a default value.
-  // Using reflection to construct Cast instances avoids compile-time binding to
-  // version-specific default parameter methods, ensuring cross-version compatibility.
+  // SPARK-40054, ensuring cross-version compatibility.
   def castExpression(
       child: Expression,
       dataType: DataType,

--- a/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveConnectorUtils.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveConnectorUtils.scala
@@ -51,8 +51,7 @@ object HiveConnectorUtils extends Logging {
         classOf[Option[_]])
       .build[Expression]()
 
-  // Reflection-based constructor lookup to keep compatible
-  // with the Cast constructor signature change introduced by SPARK-40054: 3.4.0.
+  // Compat for Cast ctor signature change in SPARK-40054: 3.4.0.
   def castExpression(
       child: Expression,
       dataType: DataType,

--- a/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveConnectorUtils.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveConnectorUtils.scala
@@ -51,7 +51,8 @@ object HiveConnectorUtils extends Logging {
         classOf[Option[_]])
       .build[Expression]()
 
-  // SPARK-40054, ensuring cross-version compatibility.
+  // Reflection-based constructor lookup to keep compatible
+  // with the Cast constructor signature change introduced by SPARK-40054: 3.4.0.
   def castExpression(
       child: Expression,
       dataType: DataType,

--- a/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveTable.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveTable.scala
@@ -17,6 +17,7 @@
 
 package org.apache.kyuubi.spark.connector.hive
 
+import java.net.URI
 import java.util
 import java.util.Locale
 
@@ -26,8 +27,11 @@ import scala.collection.mutable
 import org.apache.hadoop.fs.Path
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.catalyst.catalog.CatalogTable
-import org.apache.spark.sql.connector.catalog.{SupportsRead, SupportsWrite, Table, TableCapability}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.analysis.NoSuchPartitionException
+import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTablePartition}
+import org.apache.spark.sql.catalyst.expressions.{Cast, GenericInternalRow, Literal}
+import org.apache.spark.sql.connector.catalog.{SupportsPartitionManagement, SupportsRead, SupportsWrite, Table, TableCapability}
 import org.apache.spark.sql.connector.catalog.TableCapability.{BATCH_READ, BATCH_WRITE, OVERWRITE_BY_FILTER, OVERWRITE_DYNAMIC}
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.connector.read.ScanBuilder
@@ -35,7 +39,7 @@ import org.apache.spark.sql.connector.write.{LogicalWriteInfo, WriteBuilder}
 import org.apache.spark.sql.execution.datasources.v2.orc.OrcScanBuilder
 import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScanBuilder
 import org.apache.spark.sql.hive.kyuubi.connector.HiveBridgeHelper.{BucketSpecHelper, LogicalExpressions}
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{StringType, StructType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 import org.apache.kyuubi.spark.connector.hive.KyuubiHiveConnectorConf.{READ_CONVERT_METASTORE_ORC, READ_CONVERT_METASTORE_PARQUET}
@@ -46,7 +50,7 @@ case class HiveTable(
     sparkSession: SparkSession,
     catalogTable: CatalogTable,
     hiveTableCatalog: HiveTableCatalog)
-  extends Table with SupportsRead with SupportsWrite with Logging {
+  extends Table with SupportsRead with SupportsWrite with SupportsPartitionManagement with Logging {
 
   lazy val dataSchema: StructType = catalogTable.dataSchema
 
@@ -111,5 +115,93 @@ case class HiveTable(
 
   override def capabilities(): util.Set[TableCapability] = {
     util.EnumSet.of(BATCH_READ, BATCH_WRITE, OVERWRITE_BY_FILTER, OVERWRITE_DYNAMIC)
+  }
+
+  override def createPartition(ident: InternalRow, properties: util.Map[String, String]): Unit = {
+    val spec = toPartitionSpec(ident)
+    val location = Option(properties.get(HiveTableProperties.LOCATION)).map(new URI(_))
+    val newPart = CatalogTablePartition(
+      spec,
+      catalogTable.storage.copy(locationUri = location),
+      properties.asScala.toMap)
+    hiveTableCatalog.externalCatalog.createPartitions(
+      catalogTable.database,
+      catalogTable.identifier.table,
+      Seq(newPart),
+      ignoreIfExists = false)
+  }
+
+  override def dropPartition(ident: InternalRow): Boolean = {
+    try {
+      hiveTableCatalog.externalCatalog.dropPartitions(
+        catalogTable.database,
+        catalogTable.identifier.table,
+        Seq(toPartitionSpec(ident)),
+        ignoreIfNotExists = false,
+        purge = false,
+        retainData = false)
+      true
+    } catch {
+      case _: NoSuchPartitionException => false
+    }
+  }
+
+  override def replacePartitionMetadata(
+      ident: InternalRow,
+      properties: util.Map[String, String]): Unit = {
+    throw new UnsupportedOperationException("Replace partition is not supported")
+  }
+
+  override def loadPartitionMetadata(ident: InternalRow): util.Map[String, String] = {
+    val spec = toPartitionSpec(ident)
+    val partition = hiveTableCatalog.externalCatalog.getPartition(
+      catalogTable.database,
+      catalogTable.identifier.table,
+      spec)
+    val metadata = new util.HashMap[String, String](partition.parameters.asJava)
+    partition.storage.locationUri.foreach { uri =>
+      metadata.put(HiveTableProperties.LOCATION, uri.toString)
+    }
+    metadata
+  }
+
+  override def listPartitionIdentifiers(
+      names: Array[String],
+      ident: InternalRow): Array[InternalRow] = {
+    val partialSpec = if (names.isEmpty) {
+      None
+    } else {
+      val fields = names.map(partitionSchema(_))
+      val schema = StructType(fields)
+      Some(toPartitionSpec(ident, schema))
+    }
+    hiveTableCatalog.externalCatalog.listPartitions(
+      catalogTable.database,
+      catalogTable.identifier.table,
+      partialSpec).map { part =>
+      val values = partitionSchema.map { field =>
+        val strValue = part.spec(field.name)
+        Cast(Literal(strValue), field.dataType).eval()
+      }
+      new GenericInternalRow(values.toArray)
+    }.toArray
+  }
+
+  private def toPartitionSpec(ident: InternalRow, schema: StructType): Map[String, String] = {
+    require(
+      schema.size == ident.numFields,
+      s"Schema size (${schema.size}) does not match numFields (${ident.numFields})")
+    schema.zipWithIndex.map { case (field, index) =>
+      val value = ident.get(index, field.dataType)
+      val filedValue = Cast(
+        Literal(value, field.dataType),
+        StringType,
+        Some(sparkSession.sessionState.conf.sessionLocalTimeZone)).eval().toString
+      field.name -> filedValue
+    }.toMap
+  }
+
+  private def toPartitionSpec(ident: InternalRow): Map[String, String] = {
+    toPartitionSpec(ident, partitionSchema)
   }
 }

--- a/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveTable.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveTable.scala
@@ -181,7 +181,7 @@ case class HiveTable(
       partialSpec).map { part =>
       val values = partitionSchema.map { field =>
         val strValue = part.spec(field.name)
-        Cast(Literal(strValue), field.dataType).eval()
+        new Cast(Literal(strValue), field.dataType).eval()
       }
       new GenericInternalRow(values.toArray)
     }.toArray
@@ -193,7 +193,7 @@ case class HiveTable(
       s"Schema size (${schema.size}) does not match numFields (${ident.numFields})")
     schema.zipWithIndex.map { case (field, index) =>
       val value = ident.get(index, field.dataType)
-      val filedValue = Cast(
+      val filedValue = new Cast(
         Literal(value, field.dataType),
         StringType,
         Some(sparkSession.sessionState.conf.sessionLocalTimeZone)).eval().toString

--- a/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveTable.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveTable.scala
@@ -193,11 +193,11 @@ case class HiveTable(
       s"Schema size (${schema.size}) does not match numFields (${ident.numFields})")
     schema.zipWithIndex.map { case (field, index) =>
       val value = ident.get(index, field.dataType)
-      val filedValue = HiveConnectorUtils.castExpression(
+      val fieldValue = HiveConnectorUtils.castExpression(
         Literal(value, field.dataType),
         StringType,
         Some(sparkSession.sessionState.conf.sessionLocalTimeZone)).eval().toString
-      field.name -> filedValue
+      field.name -> fieldValue
     }.toMap
   }
 

--- a/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveTable.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveTable.scala
@@ -29,7 +29,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.NoSuchPartitionException
-import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTablePartition}
+import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTablePartition, ExternalCatalogUtils}
 import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, Literal}
 import org.apache.spark.sql.connector.catalog.{SupportsPartitionManagement, SupportsRead, SupportsWrite, Table, TableCapability}
 import org.apache.spark.sql.connector.catalog.TableCapability.{BATCH_READ, BATCH_WRITE, OVERWRITE_BY_FILTER, OVERWRITE_DYNAMIC}
@@ -149,7 +149,7 @@ case class HiveTable(
   override def replacePartitionMetadata(
       ident: InternalRow,
       properties: util.Map[String, String]): Unit = {
-    throw new UnsupportedOperationException("Replace partition is not supported")
+    throw new UnsupportedOperationException("Replace partition metadata is not supported")
   }
 
   override def loadPartitionMetadata(ident: InternalRow): util.Map[String, String] = {
@@ -181,7 +181,11 @@ case class HiveTable(
       partialSpec).map { part =>
       val values = partitionSchema.map { field =>
         val strValue = part.spec(field.name)
-        HiveConnectorUtils.castExpression(Literal(strValue), field.dataType).eval()
+        if (strValue == ExternalCatalogUtils.DEFAULT_PARTITION_NAME) {
+          null
+        } else {
+          HiveConnectorUtils.castExpression(Literal(strValue), field.dataType).eval()
+        }
       }
       new GenericInternalRow(values.toArray)
     }.toArray

--- a/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveTableProperties.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveTableProperties.scala
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.spark.connector.hive
+
+object HiveTableProperties {
+  val LOCATION = "location"
+}

--- a/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/KyuubiHiveTest.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/KyuubiHiveTest.scala
@@ -45,8 +45,6 @@ abstract class KyuubiHiveTest extends QueryTest with Logging {
       SupportsNamespaces.PROP_LOCATION,
       SupportsNamespaces.PROP_OWNER)
 
-  protected val catalogName: String = "hive"
-
   override def beforeEach(): Unit = {
     super.beforeAll()
     getOrCreateSpark()

--- a/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/command/CreateNamespaceSuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/command/CreateNamespaceSuite.scala
@@ -142,7 +142,7 @@ class CreateNamespaceV1Suite extends CreateNamespaceSuiteBase {
 
   val SESSION_CATALOG_NAME: String = "spark_catalog"
 
-  override protected val catalogName: String = SESSION_CATALOG_NAME
+  override protected def catalogName: String = SESSION_CATALOG_NAME
 
   override protected def catalogVersion: String = "V1"
 

--- a/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/command/DDLCommandTestUtils.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/command/DDLCommandTestUtils.scala
@@ -84,8 +84,6 @@ trait DDLCommandTestUtils extends KyuubiHiveTest {
       ns: String,
       tableName: String,
       cat: String = catalogName)(f: String => Unit): Unit = {
-    // scalastyle:off println
-    logInfo(s"${catalogName} catalogVersion is ${catalogVersion}")
     val nsCat = s"$cat.$ns"
     withNamespace(nsCat) {
       sql(s"CREATE NAMESPACE $nsCat")

--- a/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/command/DDLCommandTestUtils.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/command/DDLCommandTestUtils.scala
@@ -35,6 +35,8 @@ trait DDLCommandTestUtils extends KyuubiHiveTest {
   // Name of the command as SQL statement, for instance "SHOW PARTITIONS"
   protected def command: String
 
+  protected def catalogName: String = "hive"
+
   // Overrides the `test` method, and adds a prefix to easily find identify the catalog to which
   // the failed test in logs belongs to.
   override def test(testName: String, testTags: Tag*)(testFun: => Any /* Assertion */ )(implicit
@@ -82,6 +84,8 @@ trait DDLCommandTestUtils extends KyuubiHiveTest {
       ns: String,
       tableName: String,
       cat: String = catalogName)(f: String => Unit): Unit = {
+    // scalastyle:off println
+    logInfo(s"${catalogName} catalogVersion is ${catalogVersion}")
     val nsCat = s"$cat.$ns"
     withNamespace(nsCat) {
       sql(s"CREATE NAMESPACE $nsCat")

--- a/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/command/DropNamespaceSuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/command/DropNamespaceSuite.scala
@@ -107,6 +107,8 @@ trait DropNamespaceSuiteBase extends DDLCommandTestUtils {
 
 class DropNamespaceV2Suite extends DropNamespaceSuiteBase {
 
+  override protected def catalogName: String = "hive"
+
   override protected def catalogVersion: String = "Hive V2"
 
   override protected def commandVersion: String = V2_COMMAND_VERSION
@@ -116,7 +118,7 @@ class DropNamespaceV1Suite extends DropNamespaceSuiteBase {
 
   val SESSION_CATALOG_NAME: String = "spark_catalog"
 
-  override protected val catalogName: String = SESSION_CATALOG_NAME
+  override protected def catalogName: String = SESSION_CATALOG_NAME
 
   override protected def catalogVersion: String = "V1"
 

--- a/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/command/PartitionManagementSuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/command/PartitionManagementSuite.scala
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.spark.connector.hive.command
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.analysis.{NoSuchPartitionsException, PartitionsAlreadyExistException}
+import org.apache.spark.sql.connector.catalog.{Identifier, SupportsPartitionManagement, TableCatalog}
+import org.apache.spark.unsafe.types.UTF8String
+
+import org.apache.kyuubi.spark.connector.hive.command.DDLCommandTestUtils.{V1_COMMAND_VERSION, V2_COMMAND_VERSION}
+
+trait PartitionManagementSuite extends DDLCommandTestUtils {
+  override protected def command: String = "PARTITION MANAGEMENT"
+
+  test("create partition") {
+    withNamespaceAndTable("ns", "tbl") { t =>
+      sql(s"CREATE TABLE $t (id string, year string, month string) PARTITIONED BY (year, month)")
+      sql(s"ALTER TABLE $t ADD PARTITION (year='2023', month='01')")
+      checkAnswer(
+        sql(s"SHOW PARTITIONS $t"),
+        Row("year=2023/month=01") :: Nil)
+      intercept[PartitionsAlreadyExistException] {
+        sql(s"ALTER TABLE $t ADD PARTITION (year='2023', month='01')")
+      }
+    }
+  }
+
+  test("drop partition") {
+    withNamespaceAndTable("ns", "tbl") { t =>
+      sql(s"CREATE TABLE $t (id string, year string, month string) PARTITIONED BY (year, month)")
+      sql(s"ALTER TABLE $t ADD PARTITION (year='2023', month='01')")
+      sql(s"ALTER TABLE $t DROP PARTITION (year='2023', month='01')")
+      checkAnswer(
+        sql(s"SHOW PARTITIONS $t"),
+        Nil)
+      intercept[NoSuchPartitionsException] {
+        sql(s"ALTER TABLE $t DROP PARTITION (year='9999', month='99')")
+      }
+    }
+  }
+
+  test("show partitions") {
+    withNamespaceAndTable("ns", "tbl") { t =>
+      sql(s"CREATE TABLE $t (id string, year string, month string) PARTITIONED BY (year, month)")
+      sql(s"ALTER TABLE $t ADD PARTITION (year='2023', month='01')")
+      sql(s"ALTER TABLE $t ADD PARTITION (year='2023', month='02')")
+      checkAnswer(
+        sql(s"SHOW PARTITIONS $t"),
+        Row("year=2023/month=01") :: Row("year=2023/month=02") :: Nil)
+
+      checkAnswer(
+        sql(s"SHOW PARTITIONS $t PARTITION (year='2023', month='01')"),
+        Row("year=2023/month=01") :: Nil)
+
+      checkAnswer(
+        sql(s"SHOW PARTITIONS $t PARTITION (year='2023')"),
+        Row("year=2023/month=01") :: Row("year=2023/month=02") :: Nil)
+    }
+  }
+}
+
+class PartitionManagementV2Suite extends PartitionManagementSuite {
+  override protected def catalogVersion: String = "Hive V2"
+  override protected def commandVersion: String = V2_COMMAND_VERSION
+
+  test("create partition with location") {
+    withNamespaceAndTable("ns", "tbl") { t =>
+      sql(s"CREATE TABLE $t (id string, year string, month string) PARTITIONED BY (year, month)")
+      val loc = "file:///tmp/kyuubi/hive_catalog_part_loc"
+      sql(s"ALTER TABLE $t ADD PARTITION (year='2023', month='01') LOCATION '$loc'")
+      checkAnswer(
+        sql(s"SHOW PARTITIONS $t"),
+        Row("year=2023/month=01") :: Nil)
+      val catalog = spark.sessionState.catalogManager
+        .catalog(catalogName).asInstanceOf[TableCatalog]
+      val partManagement = catalog.loadTable(Identifier.of(Array("ns"), "tbl"))
+        .asInstanceOf[SupportsPartitionManagement]
+      val partIdent = InternalRow.fromSeq(
+        Seq(UTF8String.fromString("2023"), UTF8String.fromString("01")))
+      val metadata = partManagement.loadPartitionMetadata(partIdent)
+      assert(metadata.containsKey("location"))
+      assert(metadata.get("location").contains("hive_catalog_part_loc"))
+    }
+  }
+}
+
+class PartitionManagementV1Suite extends PartitionManagementSuite {
+  val SESSION_CATALOG_NAME: String = "spark_catalog"
+  override protected val catalogName: String = SESSION_CATALOG_NAME
+  override protected def catalogVersion: String = "V1"
+  override protected def commandVersion: String = V1_COMMAND_VERSION
+}

--- a/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/command/PartitionManagementSuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/command/PartitionManagementSuite.scala
@@ -105,22 +105,4 @@ class PartitionManagementV1Suite extends PartitionManagementSuite {
   override protected val catalogName: String = SESSION_CATALOG_NAME
   override protected def catalogVersion: String = "V1"
   override protected def commandVersion: String = V1_COMMAND_VERSION
-
-  test("create partition with location") {
-    withNamespaceAndTable("ns", "tbl") { t =>
-      sql(s"CREATE TABLE $t (id string, year string, month string) PARTITIONED BY (year, month)")
-      val loc = "file:///tmp/kyuubi/hive_catalog_part_loc"
-      sql(s"ALTER TABLE $t ADD PARTITION (year='2023', month='01') LOCATION '$loc'")
-      checkAnswer(
-        sql(s"SHOW PARTITIONS $t"),
-        Row("year=2023/month=01") :: Nil)
-      val partition = spark.sessionState.catalog.externalCatalog.getPartition(
-        "ns",
-        "tbl",
-        Map("year" -> "2023", "month" -> "01"))
-      val locationUri = partition.storage.locationUri
-      assert(locationUri.isDefined)
-      assert(locationUri.get.toString.contains("hive_catalog_part_loc"))
-    }
-  }
 }

--- a/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/command/PartitionManagementSuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/command/PartitionManagementSuite.scala
@@ -105,4 +105,21 @@ class PartitionManagementV1Suite extends PartitionManagementSuite {
   override protected val catalogName: String = SESSION_CATALOG_NAME
   override protected def catalogVersion: String = "V1"
   override protected def commandVersion: String = V1_COMMAND_VERSION
+
+  test("create partition with location") {
+    withNamespaceAndTable("ns", "tbl") { t =>
+      sql(s"CREATE TABLE $t (id string, year string, month string) PARTITIONED BY (year, month)")
+      val loc = "file:///tmp/kyuubi/hive_catalog_part_loc"
+      sql(s"ALTER TABLE $t ADD PARTITION (year='2023', month='01') LOCATION '$loc'")
+      checkAnswer(
+        sql(s"SHOW PARTITIONS $t"),
+        Row("year=2023/month=01") :: Nil)
+      sql(s"USE $catalogName")
+      val partDesc = sql(s"DESCRIBE FORMATTED ns.tbl PARTITION (year='2023', month='01')")
+      val locationRow = partDesc.collect()
+        .find(row => row.getString(0).trim.equalsIgnoreCase("location"))
+      assert(locationRow.isDefined)
+      assert(locationRow.get.getString(1).contains("hive_catalog_part_loc"))
+    }
+  }
 }

--- a/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/command/PartitionManagementSuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/command/PartitionManagementSuite.scala
@@ -114,12 +114,13 @@ class PartitionManagementV1Suite extends PartitionManagementSuite {
       checkAnswer(
         sql(s"SHOW PARTITIONS $t"),
         Row("year=2023/month=01") :: Nil)
-      sql(s"USE $catalogName")
-      val partDesc = sql(s"DESCRIBE FORMATTED ns.tbl PARTITION (year='2023', month='01')")
-      val locationRow = partDesc.collect()
-        .find(row => row.getString(0).trim.equalsIgnoreCase("location"))
-      assert(locationRow.isDefined)
-      assert(locationRow.get.getString(1).contains("hive_catalog_part_loc"))
+      val partition = spark.sessionState.catalog.externalCatalog.getPartition(
+        "ns",
+        "tbl",
+        Map("year" -> "2023", "month" -> "01"))
+      val locationUri = partition.storage.locationUri
+      assert(locationUri.isDefined)
+      assert(locationUri.get.toString.contains("hive_catalog_part_loc"))
     }
   }
 }

--- a/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/command/PartitionManagementSuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/command/PartitionManagementSuite.scala
@@ -131,28 +131,4 @@ class PartitionManagementV1Suite extends PartitionManagementSuite {
   override protected def catalogName: String = "spark_catalog"
   override protected def catalogVersion: String = "V1"
   override protected def commandVersion: String = V1_COMMAND_VERSION
-
-  test("create partition") {
-    withNamespaceAndTable("ns", "tbl") { t =>
-      sql(
-        s"""CREATE TABLE $t (id string, name string, year int, dt date)
-           |PARTITIONED BY (name, year, dt)""".stripMargin)
-      sql(s"ALTER TABLE $t ADD PARTITION (name='a', year=2023, dt='2023-01-01')")
-      checkAnswer(
-        sql(s"SHOW PARTITIONS $t"),
-        Row("name=a/year=2023/dt=2023-01-01") :: Nil)
-      intercept[PartitionsAlreadyExistException] {
-        sql(s"ALTER TABLE $t ADD PARTITION (name='a', year=2023, dt='2023-01-01')")
-      }
-      sql(s"INSERT INTO $t PARTITION (name=null, year=null, dt=null) VALUES ('1')")
-      checkAnswer(
-        sql(s"SHOW PARTITIONS $t"),
-        Row("name=a/year=2023/dt=2023-01-01") ::
-          Row("name=__HIVE_DEFAULT_PARTITION__/" +
-            "year=__HIVE_DEFAULT_PARTITION__/dt=__HIVE_DEFAULT_PARTITION__") :: Nil)
-      checkAnswer(
-        sql(s"SELECT id, name, year, dt FROM $t WHERE name IS NULL"),
-        Row("1", "__HIVE_DEFAULT_PARTITION__", null, null) :: Nil)
-    }
-  }
 }

--- a/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/command/PartitionManagementSuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/command/PartitionManagementSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.kyuubi.spark.connector.hive.command
 
+import java.io.File
+
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.{NoSuchPartitionsException, PartitionsAlreadyExistException}
@@ -28,49 +30,42 @@ import org.apache.kyuubi.spark.connector.hive.command.DDLCommandTestUtils.{V1_CO
 trait PartitionManagementSuite extends DDLCommandTestUtils {
   override protected def command: String = "PARTITION MANAGEMENT"
 
-  test("create partition") {
-    withNamespaceAndTable("ns", "tbl") { t =>
-      sql(s"CREATE TABLE $t (id string, year string, month string) PARTITIONED BY (year, month)")
-      sql(s"ALTER TABLE $t ADD PARTITION (year='2023', month='01')")
-      checkAnswer(
-        sql(s"SHOW PARTITIONS $t"),
-        Row("year=2023/month=01") :: Nil)
-      intercept[PartitionsAlreadyExistException] {
-        sql(s"ALTER TABLE $t ADD PARTITION (year='2023', month='01')")
-      }
-    }
-  }
-
   test("drop partition") {
     withNamespaceAndTable("ns", "tbl") { t =>
-      sql(s"CREATE TABLE $t (id string, year string, month string) PARTITIONED BY (year, month)")
-      sql(s"ALTER TABLE $t ADD PARTITION (year='2023', month='01')")
-      sql(s"ALTER TABLE $t DROP PARTITION (year='2023', month='01')")
+      sql(
+        s"""CREATE TABLE $t (id string, name string, year int, dt date)
+           |PARTITIONED BY (name, year, dt)""".stripMargin)
+      sql(s"ALTER TABLE $t ADD PARTITION (name='a', year=2023, dt='2023-01-01')")
+      sql(s"ALTER TABLE $t DROP PARTITION (name='a', year=2023, dt='2023-01-01')")
       checkAnswer(
         sql(s"SHOW PARTITIONS $t"),
         Nil)
       intercept[NoSuchPartitionsException] {
-        sql(s"ALTER TABLE $t DROP PARTITION (year='9999', month='99')")
+        sql(s"ALTER TABLE $t DROP PARTITION (name='a', year=9999, dt='9999-12-31')")
       }
     }
   }
 
   test("show partitions") {
     withNamespaceAndTable("ns", "tbl") { t =>
-      sql(s"CREATE TABLE $t (id string, year string, month string) PARTITIONED BY (year, month)")
-      sql(s"ALTER TABLE $t ADD PARTITION (year='2023', month='01')")
-      sql(s"ALTER TABLE $t ADD PARTITION (year='2023', month='02')")
+      sql(
+        s"""CREATE TABLE $t (id string, name string, year int, dt date)
+           |PARTITIONED BY (name, year, dt)""".stripMargin)
+      sql(s"ALTER TABLE $t ADD PARTITION (name='a', year=2023, dt='2023-01-01')")
+      sql(s"ALTER TABLE $t ADD PARTITION (name='a', year=2023, dt='2023-02-01')")
       checkAnswer(
         sql(s"SHOW PARTITIONS $t"),
-        Row("year=2023/month=01") :: Row("year=2023/month=02") :: Nil)
+        Row("name=a/year=2023/dt=2023-01-01") ::
+          Row("name=a/year=2023/dt=2023-02-01") :: Nil)
 
       checkAnswer(
-        sql(s"SHOW PARTITIONS $t PARTITION (year='2023', month='01')"),
-        Row("year=2023/month=01") :: Nil)
+        sql(s"SHOW PARTITIONS $t PARTITION (name='a', year=2023, dt='2023-01-01')"),
+        Row("name=a/year=2023/dt=2023-01-01") :: Nil)
 
       checkAnswer(
-        sql(s"SHOW PARTITIONS $t PARTITION (year='2023')"),
-        Row("year=2023/month=01") :: Row("year=2023/month=02") :: Nil)
+        sql(s"SHOW PARTITIONS $t PARTITION (name='a', year=2023)"),
+        Row("name=a/year=2023/dt=2023-01-01") ::
+          Row("name=a/year=2023/dt=2023-02-01") :: Nil)
     }
   }
 }
@@ -79,30 +74,85 @@ class PartitionManagementV2Suite extends PartitionManagementSuite {
   override protected def catalogVersion: String = "Hive V2"
   override protected def commandVersion: String = V2_COMMAND_VERSION
 
-  test("create partition with location") {
+  test("create partition") {
     withNamespaceAndTable("ns", "tbl") { t =>
-      sql(s"CREATE TABLE $t (id string, year string, month string) PARTITIONED BY (year, month)")
-      val loc = "file:///tmp/kyuubi/hive_catalog_part_loc"
-      sql(s"ALTER TABLE $t ADD PARTITION (year='2023', month='01') LOCATION '$loc'")
+      sql(
+        s"""CREATE TABLE $t (id string, name string, year int, dt date)
+           |PARTITIONED BY (name, year, dt)""".stripMargin)
+      sql(s"ALTER TABLE $t ADD PARTITION (name='a', year=2023, dt='2023-01-01')")
       checkAnswer(
         sql(s"SHOW PARTITIONS $t"),
-        Row("year=2023/month=01") :: Nil)
-      val catalog = spark.sessionState.catalogManager
-        .catalog(catalogName).asInstanceOf[TableCatalog]
-      val partManagement = catalog.loadTable(Identifier.of(Array("ns"), "tbl"))
-        .asInstanceOf[SupportsPartitionManagement]
-      val partIdent = InternalRow.fromSeq(
-        Seq(UTF8String.fromString("2023"), UTF8String.fromString("01")))
-      val metadata = partManagement.loadPartitionMetadata(partIdent)
-      assert(metadata.containsKey("location"))
-      assert(metadata.get("location").contains("hive_catalog_part_loc"))
+        Row("name=a/year=2023/dt=2023-01-01") :: Nil)
+      intercept[PartitionsAlreadyExistException] {
+        sql(s"ALTER TABLE $t ADD PARTITION (name='a', year=2023, dt='2023-01-01')")
+      }
+      sql(s"INSERT INTO $t PARTITION (name=null, year=null, dt=null) VALUES ('1')")
+      checkAnswer(
+        sql(s"SHOW PARTITIONS $t"),
+        Row("name=a/year=2023/dt=2023-01-01") ::
+          Row("name=null/year=null/dt=null") :: Nil)
+      checkAnswer(
+        sql(s"SELECT id, name, year, dt FROM $t WHERE name IS NULL"),
+        Row("1", null, null, null) :: Nil)
+    }
+  }
+
+  test("create partition with location") {
+    withNamespaceAndTable("ns", "tbl") { t =>
+      sql(
+        s"""CREATE TABLE $t (id string, name string, year int, dt date)
+           |PARTITIONED BY (name, year, dt)""".stripMargin)
+      withTempDir { tmpDir =>
+        val loc = new File(tmpDir, "hive_catalog_part_loc").toURI.toString
+        sql(
+          s"ALTER TABLE $t ADD PARTITION (name='a', year=2023, dt='2023-01-01') LOCATION '$loc'")
+        checkAnswer(
+          sql(s"SHOW PARTITIONS $t"),
+          Row("name=a/year=2023/dt=2023-01-01") :: Nil)
+        val catalog = spark.sessionState.catalogManager
+          .catalog(catalogName).asInstanceOf[TableCatalog]
+        val partManagement = catalog.loadTable(Identifier.of(Array("ns"), "tbl"))
+          .asInstanceOf[SupportsPartitionManagement]
+        val partIdent = InternalRow.fromSeq(
+          Seq(
+            UTF8String.fromString("a"),
+            2023,
+            java.sql.Date.valueOf("2023-01-01").toLocalDate.toEpochDay.toInt))
+        val metadata = partManagement.loadPartitionMetadata(partIdent)
+        assert(metadata.containsKey("location"))
+        assert(metadata.get("location").contains("hive_catalog_part_loc"))
+      }
     }
   }
 }
 
 class PartitionManagementV1Suite extends PartitionManagementSuite {
   val SESSION_CATALOG_NAME: String = "spark_catalog"
-  override protected val catalogName: String = SESSION_CATALOG_NAME
+  override protected def catalogName: String = "spark_catalog"
   override protected def catalogVersion: String = "V1"
   override protected def commandVersion: String = V1_COMMAND_VERSION
+
+  test("create partition") {
+    withNamespaceAndTable("ns", "tbl") { t =>
+      sql(
+        s"""CREATE TABLE $t (id string, name string, year int, dt date)
+           |PARTITIONED BY (name, year, dt)""".stripMargin)
+      sql(s"ALTER TABLE $t ADD PARTITION (name='a', year=2023, dt='2023-01-01')")
+      checkAnswer(
+        sql(s"SHOW PARTITIONS $t"),
+        Row("name=a/year=2023/dt=2023-01-01") :: Nil)
+      intercept[PartitionsAlreadyExistException] {
+        sql(s"ALTER TABLE $t ADD PARTITION (name='a', year=2023, dt='2023-01-01')")
+      }
+      sql(s"INSERT INTO $t PARTITION (name=null, year=null, dt=null) VALUES ('1')")
+      checkAnswer(
+        sql(s"SHOW PARTITIONS $t"),
+        Row("name=a/year=2023/dt=2023-01-01") ::
+          Row("name=__HIVE_DEFAULT_PARTITION__/" +
+            "year=__HIVE_DEFAULT_PARTITION__/dt=__HIVE_DEFAULT_PARTITION__") :: Nil)
+      checkAnswer(
+        sql(s"SELECT id, name, year, dt FROM $t WHERE name IS NULL"),
+        Row("1", "__HIVE_DEFAULT_PARTITION__", null, null) :: Nil)
+    }
+  }
 }

--- a/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/command/ShowTablesSuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/command/ShowTablesSuite.scala
@@ -105,7 +105,7 @@ class ShowTablesV1Suite extends ShowTablesSuiteBase {
 
   val SESSION_CATALOG_NAME: String = "spark_catalog"
 
-  override protected val catalogName: String = SESSION_CATALOG_NAME
+  override protected def catalogName: String = SESSION_CATALOG_NAME
 
   override protected def catalogVersion: String = "V1"
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->
The Hive V2 Catalog  did not implement the `SupportsPartitionManagement` interface from Spark's DataSource V2 API. As a result, common partition-related SQL commands would fail ( like `alter table ... add partition ` `show partitions` etc.)

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Add new UT

