### PR TITLE
style: update spotless maven plugin to 3.3, googlejavaformat to 1.35, scalafmt to 3.10

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 3.9.0
+version = 3.10.7
 runner.dialect=scala212
 project.git=true
 

--- a/dev/kyuubi-codecov/pom.xml
+++ b/dev/kyuubi-codecov/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/dev/kyuubi-tpcds/pom.xml
+++ b/dev/kyuubi-tpcds/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/extensions/flink/kyuubi-flink-token-provider/pom.xml
+++ b/extensions/flink/kyuubi-flink-token-provider/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/extensions/server/kyuubi-server-plugin/pom.xml
+++ b/extensions/server/kyuubi-server-plugin/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/extensions/spark/kyuubi-extension-spark-3-3/pom.xml
+++ b/extensions/spark/kyuubi-extension-spark-3-3/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/extensions/spark/kyuubi-extension-spark-3-4/pom.xml
+++ b/extensions/spark/kyuubi-extension-spark-3-4/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/extensions/spark/kyuubi-extension-spark-3-5/pom.xml
+++ b/extensions/spark/kyuubi-extension-spark-3-5/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/extensions/spark/kyuubi-extension-spark-4-0/pom.xml
+++ b/extensions/spark/kyuubi-extension-spark-4-0/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/extensions/spark/kyuubi-extension-spark-4-1/pom.xml
+++ b/extensions/spark/kyuubi-extension-spark-4-1/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/extensions/spark/kyuubi-extension-spark-jdbc-dialect/pom.xml
+++ b/extensions/spark/kyuubi-extension-spark-jdbc-dialect/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/extensions/spark/kyuubi-spark-authz-shaded/pom.xml
+++ b/extensions/spark/kyuubi-spark-authz-shaded/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/extensions/spark/kyuubi-spark-authz/pom.xml
+++ b/extensions/spark/kyuubi-spark-authz/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/extensions/spark/kyuubi-spark-authz/src/main/java/com/kstruct/gethostname4j/Hostname.java
+++ b/extensions/spark/kyuubi-spark-authz/src/main/java/com/kstruct/gethostname4j/Hostname.java
@@ -29,7 +29,9 @@ public class Hostname {
   // set hostname for Ranger client
   public static final String RANGER_CLIENT_HOSTNAME = "RANGER_CLIENT_HOSTNAME";
 
-  /** @return the hostname the of the current machine */
+  /**
+   * @return the hostname the of the current machine
+   */
   public static String getHostname() {
     String hostname = System.getenv(RANGER_CLIENT_HOSTNAME);
     if (isValid(hostname)) return hostname;

--- a/extensions/spark/kyuubi-spark-connector-common/pom.xml
+++ b/extensions/spark/kyuubi-spark-connector-common/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/extensions/spark/kyuubi-spark-connector-hive/pom.xml
+++ b/extensions/spark/kyuubi-spark-connector-hive/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveConnectorUtils.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveConnectorUtils.scala
@@ -103,69 +103,72 @@ object HiveConnectorUtils extends Logging {
           isSplitable,
           maxSplitBytes,
           partitionValues)
-    }.recover { case _: Exception => // SPARK-42821: 4.0.0-preview2
-      val fileStatusWithMetadataClz = DynClasses.builder()
-        .impl("org.apache.spark.sql.execution.datasources.FileStatusWithMetadata")
-        .buildChecked()
-      DynMethods
-        .builder("splitFiles")
-        .impl(
-          "org.apache.spark.sql.execution.PartitionedFileUtil",
-          fileStatusWithMetadataClz,
-          classOf[Boolean],
-          classOf[Long],
-          classOf[InternalRow])
-        .buildChecked()
-        .invokeChecked[Seq[PartitionedFile]](
-          null,
-          file,
-          isSplitable,
-          maxSplitBytes,
-          partitionValues)
-    }.recover { case _: Exception => // SPARK-51185: Spark 3.5.7
-      val fileStatusWithMetadataClz = DynClasses.builder()
-        .impl("org.apache.spark.sql.execution.datasources.FileStatusWithMetadata")
-        .buildChecked()
-      DynMethods
-        .builder("splitFiles")
-        .impl(
-          "org.apache.spark.sql.execution.PartitionedFileUtil",
-          classOf[SparkSession],
-          fileStatusWithMetadataClz,
-          classOf[Path],
-          classOf[Boolean],
-          classOf[Long],
-          classOf[InternalRow])
-        .buildChecked()
-        .invokeChecked[Seq[PartitionedFile]](
-          null,
-          sparkSession,
-          file,
-          filePath,
-          isSplitable,
-          maxSplitBytes,
-          partitionValues)
-    }.recover { case _: Exception => // SPARK-43039: 3.5.0
-      val fileStatusWithMetadataClz = DynClasses.builder()
-        .impl("org.apache.spark.sql.execution.datasources.FileStatusWithMetadata")
-        .buildChecked()
-      DynMethods
-        .builder("splitFiles")
-        .impl(
-          "org.apache.spark.sql.execution.PartitionedFileUtil",
-          classOf[SparkSession],
-          fileStatusWithMetadataClz,
-          classOf[Boolean],
-          classOf[Long],
-          classOf[InternalRow])
-        .buildChecked()
-        .invokeChecked[Seq[PartitionedFile]](
-          null,
-          sparkSession,
-          file,
-          isSplitable,
-          maxSplitBytes,
-          partitionValues)
+    }.recover {
+      case _: Exception => // SPARK-42821: 4.0.0-preview2
+        val fileStatusWithMetadataClz = DynClasses.builder()
+          .impl("org.apache.spark.sql.execution.datasources.FileStatusWithMetadata")
+          .buildChecked()
+        DynMethods
+          .builder("splitFiles")
+          .impl(
+            "org.apache.spark.sql.execution.PartitionedFileUtil",
+            fileStatusWithMetadataClz,
+            classOf[Boolean],
+            classOf[Long],
+            classOf[InternalRow])
+          .buildChecked()
+          .invokeChecked[Seq[PartitionedFile]](
+            null,
+            file,
+            isSplitable,
+            maxSplitBytes,
+            partitionValues)
+    }.recover {
+      case _: Exception => // SPARK-51185: Spark 3.5.7
+        val fileStatusWithMetadataClz = DynClasses.builder()
+          .impl("org.apache.spark.sql.execution.datasources.FileStatusWithMetadata")
+          .buildChecked()
+        DynMethods
+          .builder("splitFiles")
+          .impl(
+            "org.apache.spark.sql.execution.PartitionedFileUtil",
+            classOf[SparkSession],
+            fileStatusWithMetadataClz,
+            classOf[Path],
+            classOf[Boolean],
+            classOf[Long],
+            classOf[InternalRow])
+          .buildChecked()
+          .invokeChecked[Seq[PartitionedFile]](
+            null,
+            sparkSession,
+            file,
+            filePath,
+            isSplitable,
+            maxSplitBytes,
+            partitionValues)
+    }.recover {
+      case _: Exception => // SPARK-43039: 3.5.0
+        val fileStatusWithMetadataClz = DynClasses.builder()
+          .impl("org.apache.spark.sql.execution.datasources.FileStatusWithMetadata")
+          .buildChecked()
+        DynMethods
+          .builder("splitFiles")
+          .impl(
+            "org.apache.spark.sql.execution.PartitionedFileUtil",
+            classOf[SparkSession],
+            fileStatusWithMetadataClz,
+            classOf[Boolean],
+            classOf[Long],
+            classOf[InternalRow])
+          .buildChecked()
+          .invokeChecked[Seq[PartitionedFile]](
+            null,
+            sparkSession,
+            file,
+            isSplitable,
+            maxSplitBytes,
+            partitionValues)
     }.recover { case _: Exception =>
       DynMethods
         .builder("splitFiles")

--- a/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveTableCatalog.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveTableCatalog.scala
@@ -256,53 +256,54 @@ class HiveTableCatalog(sparkSession: SparkSession)
           schemaPreservesCase,
           ignoredProperties,
           viewOriginalText)
-    }.recover { case _: Exception => // Spark 3.5 and previous
-      DynConstructors.builder()
-        .impl(
-          classOf[CatalogTable],
-          classOf[TableIdentifier],
-          classOf[CatalogTableType],
-          classOf[CatalogStorageFormat],
-          classOf[StructType],
-          classOf[Option[String]],
-          classOf[Seq[String]],
-          classOf[Option[BucketSpec]],
-          classOf[String],
-          classOf[Long],
-          classOf[Long],
-          classOf[String],
-          classOf[Map[String, String]],
-          classOf[Option[CatalogStatistics]],
-          classOf[Option[String]],
-          classOf[Option[String]],
-          classOf[Seq[String]],
-          classOf[Boolean],
-          classOf[Boolean],
-          classOf[Map[String, String]],
-          classOf[Option[String]])
-        .buildChecked()
-        .invokeChecked[CatalogTable](
-          null,
-          identifier,
-          tableType,
-          storage,
-          schema,
-          provider,
-          partitionColumnNames,
-          bucketSpec,
-          owner,
-          createTime,
-          lastAccessTime,
-          createVersion,
-          properties,
-          stats,
-          viewText,
-          comment,
-          unsupportedFeatures,
-          tracksPartitionsInCatalog,
-          schemaPreservesCase,
-          ignoredProperties,
-          viewOriginalText)
+    }.recover {
+      case _: Exception => // Spark 3.5 and previous
+        DynConstructors.builder()
+          .impl(
+            classOf[CatalogTable],
+            classOf[TableIdentifier],
+            classOf[CatalogTableType],
+            classOf[CatalogStorageFormat],
+            classOf[StructType],
+            classOf[Option[String]],
+            classOf[Seq[String]],
+            classOf[Option[BucketSpec]],
+            classOf[String],
+            classOf[Long],
+            classOf[Long],
+            classOf[String],
+            classOf[Map[String, String]],
+            classOf[Option[CatalogStatistics]],
+            classOf[Option[String]],
+            classOf[Option[String]],
+            classOf[Seq[String]],
+            classOf[Boolean],
+            classOf[Boolean],
+            classOf[Map[String, String]],
+            classOf[Option[String]])
+          .buildChecked()
+          .invokeChecked[CatalogTable](
+            null,
+            identifier,
+            tableType,
+            storage,
+            schema,
+            provider,
+            partitionColumnNames,
+            bucketSpec,
+            owner,
+            createTime,
+            lastAccessTime,
+            createVersion,
+            properties,
+            stats,
+            viewText,
+            comment,
+            unsupportedFeatures,
+            tracksPartitionsInCatalog,
+            schemaPreservesCase,
+            ignoredProperties,
+            viewOriginalText)
     }.get
   }
 

--- a/extensions/spark/kyuubi-spark-connector-tpcds/pom.xml
+++ b/extensions/spark/kyuubi-spark-connector-tpcds/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/extensions/spark/kyuubi-spark-connector-tpcds/src/main/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSBatchScan.scala
+++ b/extensions/spark/kyuubi-spark-connector-tpcds/src/main/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSBatchScan.scala
@@ -56,8 +56,9 @@ class TPCDSBatchScan(
 
   override def readSchema: StructType = schema
 
-  override def planInputPartitions: Array[InputPartition] =
-    (1 to parallelism).map { i => TPCDSTableChunk(table.getName, scale, parallelism, i) }.toArray
+  override def planInputPartitions: Array[InputPartition] = (1 to parallelism).map { i =>
+    TPCDSTableChunk(table.getName, scale, parallelism, i)
+  }.toArray
 
   def createReaderFactory: PartitionReaderFactory = (partition: InputPartition) => {
     val chuck = partition.asInstanceOf[TPCDSTableChunk]

--- a/extensions/spark/kyuubi-spark-connector-tpcds/src/test/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSTableSuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-tpcds/src/test/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSTableSuite.scala
@@ -142,8 +142,7 @@ class TPCDSTableSuite extends KyuubiFunSuite {
           scanExec.scan.asInstanceOf[TPCDSBatchScan]
       }
       assert(scan.isDefined)
-      val expected =
-        (TPCDSStatisticsUtils.sizeInBytes(table, scale) / maxPartitionBytes).ceil.toInt
+      val expected = (TPCDSStatisticsUtils.sizeInBytes(table, scale) / maxPartitionBytes).ceil.toInt
       assert(scan.get.planInputPartitions.length == expected)
     }
   }

--- a/extensions/spark/kyuubi-spark-connector-tpch/pom.xml
+++ b/extensions/spark/kyuubi-spark-connector-tpch/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/extensions/spark/kyuubi-spark-connector-tpch/src/main/scala/org/apache/kyuubi/spark/connector/tpch/TPCHBatchScan.scala
+++ b/extensions/spark/kyuubi-spark-connector-tpch/src/main/scala/org/apache/kyuubi/spark/connector/tpch/TPCHBatchScan.scala
@@ -66,10 +66,9 @@ class TPCHBatchScan(
 
   override def readSchema: StructType = schema
 
-  override def planInputPartitions: Array[InputPartition] =
-    (1 to parallelism).map { i =>
-      TPCHTableChuck(table.getTableName, scale, parallelism, i)
-    }.toArray
+  override def planInputPartitions: Array[InputPartition] = (1 to parallelism).map { i =>
+    TPCHTableChuck(table.getTableName, scale, parallelism, i)
+  }.toArray
 
   def createReaderFactory: PartitionReaderFactory = (partition: InputPartition) => {
     val chuck = partition.asInstanceOf[TPCHTableChuck]

--- a/extensions/spark/kyuubi-spark-jvm-quake/pom.xml
+++ b/extensions/spark/kyuubi-spark-jvm-quake/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/extensions/spark/kyuubi-spark-lineage-shaded/pom.xml
+++ b/extensions/spark/kyuubi-spark-lineage-shaded/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/extensions/spark/kyuubi-spark-lineage/pom.xml
+++ b/extensions/spark/kyuubi-spark-lineage/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/externals/kyuubi-chat-engine/pom.xml
+++ b/externals/kyuubi-chat-engine/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/externals/kyuubi-download/pom.xml
+++ b/externals/kyuubi-download/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/externals/kyuubi-flink-sql-engine/pom.xml
+++ b/externals/kyuubi-flink-sql-engine/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/externals/kyuubi-hive-sql-engine/pom.xml
+++ b/externals/kyuubi-hive-sql-engine/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/externals/kyuubi-jdbc-engine/pom.xml
+++ b/externals/kyuubi-jdbc-engine/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/externals/kyuubi-spark-sql-engine/pom.xml
+++ b/externals/kyuubi-spark-sql-engine/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/sql/execution/arrow/KyuubiArrowConverters.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/sql/execution/arrow/KyuubiArrowConverters.scala
@@ -298,11 +298,12 @@ object KyuubiArrowConverters extends SQLConfHelper with Logging {
               (!isBatchSizeLimitExceeded && !isRecordLimitExceeded))) {
           val row = rowIter.next()
           arrowWriter.write(row)
-          estimatedBatchSize += (row match {
-            case ur: UnsafeRow => ur.getSizeInBytes
-            // Trying to estimate the size of the current row
-            case _: InternalRow => schema.defaultSize
-          })
+          estimatedBatchSize +=
+            (row match {
+              case ur: UnsafeRow => ur.getSizeInBytes
+              // Trying to estimate the size of the current row
+              case _: InternalRow => schema.defaultSize
+            })
           rowCountInLastBatch += 1
           rowCount += 1
         }

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/SparkArrowbasedOperationSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/SparkArrowbasedOperationSuite.scala
@@ -559,21 +559,23 @@ class SparkArrowbasedOperationSuite extends WithSparkSQLEngine with SparkDataTyp
         errorOnDuplicatedFieldNames,
         largeVarTypes,
         context)
-    }.recover { case _: Exception => // SPARK-43528: Spark 3.5
-      fromBatchIteratorMethod.invokeChecked[Iterator[InternalRow]](
-        arrowConvertersObject,
-        arrowBatchIter,
-        schema,
-        timeZoneId,
-        errorOnDuplicatedFieldNames,
-        context)
-    }.recover { case _: Exception => // for Spark 3.4 or previous
-      fromBatchIteratorMethod.invokeChecked[Iterator[InternalRow]](
-        arrowConvertersObject,
-        arrowBatchIter,
-        schema,
-        timeZoneId,
-        context)
+    }.recover {
+      case _: Exception => // SPARK-43528: Spark 3.5
+        fromBatchIteratorMethod.invokeChecked[Iterator[InternalRow]](
+          arrowConvertersObject,
+          arrowBatchIter,
+          schema,
+          timeZoneId,
+          errorOnDuplicatedFieldNames,
+          context)
+    }.recover {
+      case _: Exception => // for Spark 3.4 or previous
+        fromBatchIteratorMethod.invokeChecked[Iterator[InternalRow]](
+          arrowConvertersObject,
+          arrowBatchIter,
+          schema,
+          timeZoneId,
+          context)
     }.get
 
   class JobCountListener extends SparkListener {

--- a/externals/kyuubi-trino-engine/pom.xml
+++ b/externals/kyuubi-trino-engine/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/integration-tests/kyuubi-flink-it/pom.xml
+++ b/integration-tests/kyuubi-flink-it/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/integration-tests/kyuubi-hive-it/pom.xml
+++ b/integration-tests/kyuubi-hive-it/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/integration-tests/kyuubi-jdbc-it/pom.xml
+++ b/integration-tests/kyuubi-jdbc-it/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/integration-tests/kyuubi-kubernetes-it/pom.xml
+++ b/integration-tests/kyuubi-kubernetes-it/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/integration-tests/kyuubi-trino-it/pom.xml
+++ b/integration-tests/kyuubi-trino-it/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/integration-tests/kyuubi-zookeeper-it/pom.xml
+++ b/integration-tests/kyuubi-zookeeper-it/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/kyuubi-assembly/pom.xml
+++ b/kyuubi-assembly/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>

--- a/kyuubi-common/pom.xml
+++ b/kyuubi-common/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/service/TFrontendServiceSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/service/TFrontendServiceSuite.scala
@@ -422,7 +422,8 @@ class TFrontendServiceSuite extends KyuubiFunSuite {
       val resp4 = client.GetOperationStatus(req2)
       assert(resp4.getStatus.getStatusCode === TStatusCode.SUCCESS_STATUS)
       assert(resp4.getOperationState === TOperationState.ERROR_STATE)
-      assert(resp4.getErrorMessage startsWith "org.apache.kyuubi.KyuubiSQLException:" +
+      assert(resp4.getErrorMessage startsWith
+        "org.apache.kyuubi.KyuubiSQLException:" +
         " noop operation err\n\tat org.apache.kyuubi.KyuubiSQLException")
     }
   }

--- a/kyuubi-ctl/pom.xml
+++ b/kyuubi-ctl/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/kyuubi-events/pom.xml
+++ b/kyuubi-events/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/kyuubi-ha/pom.xml
+++ b/kyuubi-ha/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/zookeeper/ZookeeperDiscoveryClient.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/zookeeper/ZookeeperDiscoveryClient.scala
@@ -330,8 +330,9 @@ class ZookeeperDiscoveryClient(conf: KyuubiConf) extends DiscoveryClient {
     val authenticationMethod = conf.get(KyuubiConf.AUTHENTICATION_METHOD).mkString(",")
     confsToPublish += ("hive.server2.authentication" -> authenticationMethod)
     if (authenticationMethod.equalsIgnoreCase("KERBEROS")) {
-      confsToPublish += ("hive.server2.authentication.kerberos.principal" ->
-        conf.get(KyuubiConf.SERVER_PRINCIPAL).getOrElse(""))
+      confsToPublish +=
+        ("hive.server2.authentication.kerberos.principal" ->
+          conf.get(KyuubiConf.SERVER_PRINCIPAL).getOrElse(""))
     }
     confsToPublish.map { case (k, v) => k + "=" + v }.mkString(";")
   }

--- a/kyuubi-hive-beeline/pom.xml
+++ b/kyuubi-hive-beeline/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/BeeLineCompleter.java
+++ b/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/BeeLineCompleter.java
@@ -29,7 +29,9 @@ import jline.console.completer.Completer;
 class BeeLineCompleter implements Completer {
   private final BeeLine beeLine;
 
-  /** @param beeLine */
+  /**
+   * @param beeLine
+   */
   BeeLineCompleter(BeeLine beeLine) {
     this.beeLine = beeLine;
   }

--- a/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/BeeLineOpts.java
+++ b/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/BeeLineOpts.java
@@ -414,7 +414,9 @@ class BeeLineOpts implements Completer {
     return historyFile;
   }
 
-  /** @param numRows - the number of rows to store in history file */
+  /**
+   * @param numRows - the number of rows to store in history file
+   */
   public void setMaxHistoryRows(int numRows) {
     this.maxHistoryRows = numRows;
   }

--- a/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/CommandHandler.java
+++ b/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/CommandHandler.java
@@ -30,13 +30,19 @@ import jline.console.completer.Completer;
  * {@link #matches(java.lang.String)} method.
  */
 interface CommandHandler {
-  /** @return the name of the command */
+  /**
+   * @return the name of the command
+   */
   public String getName();
 
-  /** @return all the possible names of this command. */
+  /**
+   * @return all the possible names of this command.
+   */
   public String[] getNames();
 
-  /** @return the short help description for this command. */
+  /**
+   * @return the short help description for this command.
+   */
   public String getHelpText();
 
   /**

--- a/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/Commands.java
+++ b/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/Commands.java
@@ -67,7 +67,9 @@ public class Commands {
   private static final int DEFAULT_QUERY_PROGRESS_INTERVAL = 1000;
   private static final int DEFAULT_QUERY_PROGRESS_THREAD_TIMEOUT = 10 * 1000;
 
-  /** @param beeLine */
+  /**
+   * @param beeLine
+   */
   Commands(BeeLine beeLine) {
     this.beeLine = beeLine;
   }

--- a/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/JSONOutputFormat.java
+++ b/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/JSONOutputFormat.java
@@ -39,7 +39,9 @@ public class JSONOutputFormat extends AbstractOutputFormat {
   protected final BeeLine beeLine;
   protected JsonGenerator generator;
 
-  /** @param beeLine */
+  /**
+   * @param beeLine
+   */
   JSONOutputFormat(BeeLine beeLine) {
     this.beeLine = beeLine;
     try {

--- a/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/SQLCompleter.java
+++ b/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/SQLCompleter.java
@@ -90,7 +90,8 @@ class SQLCompleter extends StringsCompleter {
 
     for (StringTokenizer tok = new StringTokenizer(keywords, ", ");
         tok.hasMoreTokens();
-        completions.add(tok.nextToken())) {;
+        completions.add(tok.nextToken())) {
+      ;
     }
 
     // now add the tables and columns from the current connection

--- a/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/TableNameCompletor.java
+++ b/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/TableNameCompletor.java
@@ -29,7 +29,9 @@ import jline.console.completer.StringsCompleter;
 class TableNameCompletor implements Completer {
   private final BeeLine beeLine;
 
-  /** @param beeLine */
+  /**
+   * @param beeLine
+   */
   TableNameCompletor(BeeLine beeLine) {
     this.beeLine = beeLine;
   }

--- a/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/TableOutputFormat.java
+++ b/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/TableOutputFormat.java
@@ -27,7 +27,9 @@ class TableOutputFormat implements OutputFormat {
   private final BeeLine beeLine;
   private final StringBuilder sb = new StringBuilder();
 
-  /** @param beeLine */
+  /**
+   * @param beeLine
+   */
   TableOutputFormat(BeeLine beeLine) {
     this.beeLine = beeLine;
   }

--- a/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/VerticalOutputFormat.java
+++ b/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/VerticalOutputFormat.java
@@ -26,7 +26,9 @@ package org.apache.hive.beeline;
 class VerticalOutputFormat implements OutputFormat {
   private final BeeLine beeLine;
 
-  /** @param beeLine */
+  /**
+   * @param beeLine
+   */
   VerticalOutputFormat(BeeLine beeLine) {
     this.beeLine = beeLine;
   }

--- a/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/XMLAttributeOutputFormat.java
+++ b/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/XMLAttributeOutputFormat.java
@@ -26,7 +26,9 @@ class XMLAttributeOutputFormat extends AbstractOutputFormat {
   private final BeeLine beeLine;
   private final StringBuilder buf = new StringBuilder();
 
-  /** @param beeLine */
+  /**
+   * @param beeLine
+   */
   XMLAttributeOutputFormat(BeeLine beeLine) {
     this.beeLine = beeLine;
   }

--- a/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/XMLElementOutputFormat.java
+++ b/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/XMLElementOutputFormat.java
@@ -25,7 +25,9 @@ package org.apache.hive.beeline;
 class XMLElementOutputFormat extends AbstractOutputFormat {
   private final BeeLine beeLine;
 
-  /** @param beeLine */
+  /**
+   * @param beeLine
+   */
   XMLElementOutputFormat(BeeLine beeLine) {
     this.beeLine = beeLine;
   }

--- a/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/common/util/HiveStringUtils.java
+++ b/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/common/util/HiveStringUtils.java
@@ -78,7 +78,8 @@ public class HiveStringUtils {
         // Jump to the end of current line. When a multiple line query is executed with -e
         // parameter,
         // it is passed in as one line string separated with '\n'
-        for (; index < line.length() && line.charAt(index) != '\n'; ++index) ;
+        for (; index < line.length() && line.charAt(index) != '\n'; ++index)
+          ;
         continue;
       }
 

--- a/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/hs2connection/BeelineSiteParser.java
+++ b/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/hs2connection/BeelineSiteParser.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 public class BeelineSiteParser implements HS2ConnectionFileParser {
   /** Prefix string used for named jdbc uri configs */
   public static final String BEELINE_CONNECTION_NAMED_JDBC_URL_PREFIX = "beeline.hs2.jdbc.url.";
+
   /** Property key used to provide the default named jdbc uri in the config file */
   public static final String DEFAULT_NAMED_JDBC_URL_PROPERTY_KEY = "default";
 
@@ -126,6 +127,7 @@ public class BeelineSiteParser implements HS2ConnectionFileParser {
   public boolean configExists() {
     return (getFileLocation() != null);
   }
+
   /*
    * This method looks in locations specified above and returns the first location where the file
    * exists. If the file does not exist in any one of the locations it returns null

--- a/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/hs2connection/HS2ConnectionFileParser.java
+++ b/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/hs2connection/HS2ConnectionFileParser.java
@@ -27,14 +27,19 @@ import java.util.Properties;
 public interface HS2ConnectionFileParser {
   /** prefix string used for the keys */
   public static final String BEELINE_CONNECTION_PROPERTY_PREFIX = "beeline.hs2.connection.";
+
   /** Property key used to provide the URL prefix for the connection URL */
   public static final String URL_PREFIX_PROPERTY_KEY = "url_prefix";
+
   /** Property key used to provide the default database in the connection URL */
   public static final String DEFAULT_DB_PROPERTY_KEY = "defaultDB";
+
   /** Property key used to provide the hosts in the connection URL */
   public static final String HOST_PROPERTY_KEY = "hosts";
+
   /** Property key used to provide the hive configuration key value pairs in the connection URL */
   public static final String HIVE_CONF_PROPERTY_KEY = "hiveconf";
+
   /** Property key used to provide the hive variables in the connection URL */
   public static final String HIVE_VAR_PROPERTY_KEY = "hivevar";
 
@@ -73,6 +78,9 @@ public interface HS2ConnectionFileParser {
    * @throws BeelineHS2ConnectionFileParseException if there is invalid key with appropriate message
    */
   Properties getConnectionProperties() throws BeelineConfFileParseException;
-  /** @return returns true if the configuration exists else returns false */
+
+  /**
+   * @return returns true if the configuration exists else returns false
+   */
   boolean configExists();
 }

--- a/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/hs2connection/UserHS2ConnectionFileParser.java
+++ b/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/hs2connection/UserHS2ConnectionFileParser.java
@@ -104,6 +104,7 @@ public class UserHS2ConnectionFileParser implements HS2ConnectionFileParser {
   public boolean configExists() {
     return (getFileLocation() != null);
   }
+
   /*
    * This method looks in locations specified above and returns the first location where the file
    * exists. If the file does not exist in any one of the locations it returns null

--- a/kyuubi-hive-jdbc-shaded/pom.xml
+++ b/kyuubi-hive-jdbc-shaded/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/kyuubi-hive-jdbc/pom.xml
+++ b/kyuubi-hive-jdbc/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/KyuubiDriver.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/KyuubiDriver.java
@@ -17,6 +17,8 @@
 
 package org.apache.kyuubi.jdbc;
 
-/** @deprecated Use `KyuubiHiveDriver` instead. */
+/**
+ * @deprecated Use `KyuubiHiveDriver` instead.
+ */
 @Deprecated
 public class KyuubiDriver extends KyuubiHiveDriver {}

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/JdbcColumn.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/JdbcColumn.java
@@ -274,12 +274,12 @@ public class JdbcColumn {
       case TIMESTAMP_WITH_TIMEZONE:
         return columnPrecision(tType, columnAttributes);
 
-        // see
-        // http://download.oracle.com/javase/6/docs/api/constant-values.html#java.lang.Float.MAX_EXPONENT
+      // see
+      // http://download.oracle.com/javase/6/docs/api/constant-values.html#java.lang.Float.MAX_EXPONENT
       case FLOAT:
         return 24; // e.g. -(17#).e-###
-        // see
-        // http://download.oracle.com/javase/6/docs/api/constant-values.html#java.lang.Double.MAX_EXPONENT
+      // see
+      // http://download.oracle.com/javase/6/docs/api/constant-values.html#java.lang.Double.MAX_EXPONENT
       case DOUBLE:
         return 25; // e.g. -(17#).e-####
       case DECIMAL:

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/JdbcUriParseException.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/JdbcUriParseException.java
@@ -23,12 +23,16 @@ public class JdbcUriParseException extends SQLException {
 
   private static final long serialVersionUID = 0;
 
-  /** @param cause (original exception) */
+  /**
+   * @param cause (original exception)
+   */
   public JdbcUriParseException(Throwable cause) {
     super(cause);
   }
 
-  /** @param msg (exception message) */
+  /**
+   * @param msg (exception message)
+   */
   public JdbcUriParseException(String msg) {
     super(msg);
   }

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
@@ -895,12 +895,16 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
     isClosed = false;
   }
 
-  /** @return username from sessConfMap */
+  /**
+   * @return username from sessConfMap
+   */
   private String getUserName() {
     return getSessionValue(AUTH_USER, ANONYMOUS_USER);
   }
 
-  /** @return password from sessConfMap */
+  /**
+   * @return password from sessConfMap
+   */
   private String getPassword() {
     return getSessionValue(AUTH_PASSWD, ANONYMOUS_PASSWD);
   }

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiStatement.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiStatement.java
@@ -48,6 +48,7 @@ public class KyuubiStatement implements SQLStatement, KyuubiLoggable {
   private boolean isOperationComplete = false;
 
   private Map<String, String> properties = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+
   /**
    * We need to keep a reference to the result set to support the following: <code>
    * statement.execute(String sql);

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/Utils.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/Utils.java
@@ -37,12 +37,14 @@ import org.slf4j.LoggerFactory;
 
 public class Utils {
   static final Logger LOG = LoggerFactory.getLogger(Utils.class);
+
   /** The required prefix list for the connection URL. */
   public static final List<String> URL_PREFIX_LIST =
       Arrays.asList("jdbc:hive2://", "jdbc:kyuubi://");
 
   /** If host is provided, without a port. */
   static final String DEFAULT_PORT = "10009";
+
   // To parse the intermediate URI as a Java URI, we'll give a dummy authority(dummyhost:00000).
   // Later, we'll substitute the dummy authority for a resolved authority.
   static final String dummyAuthorityString = "dummyhost:00000";

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/ZooKeeperHiveClientException.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/ZooKeeperHiveClientException.java
@@ -21,12 +21,16 @@ public class ZooKeeperHiveClientException extends Exception {
 
   private static final long serialVersionUID = 0;
 
-  /** @param cause (original exception) */
+  /**
+   * @param cause (original exception)
+   */
   public ZooKeeperHiveClientException(Throwable cause) {
     super(cause);
   }
 
-  /** @param msg (exception message) */
+  /**
+   * @param msg (exception message)
+   */
   public ZooKeeperHiveClientException(String msg) {
     super(msg);
   }

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/auth/HttpAuthUtils.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/auth/HttpAuthUtils.java
@@ -31,7 +31,9 @@ public final class HttpAuthUtils {
   public static final String NEGOTIATE = "Negotiate";
   public static final String BEARER = "Bearer";
 
-  /** @return Stringified Base64 encoded kerberosAuthHeader on success */
+  /**
+   * @return Stringified Base64 encoded kerberosAuthHeader on success
+   */
   public static String getKerberosServiceTicket(
       String serverPrinciple, String host, Subject loggedInSubject) throws Exception {
     String spn = KerberosUtils.canonicalPrincipal(serverPrinciple, host);

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/common/FastHiveDecimalImpl.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/common/FastHiveDecimalImpl.java
@@ -3132,7 +3132,9 @@ public class FastHiveDecimalImpl extends FastHiveDecimal {
     }
   }
 
-  /** @return True when shortValue() will return a correct short. */
+  /**
+   * @return True when shortValue() will return a correct short.
+   */
 
   /**
    * Is the decimal value a short? Range -32,768 to 32,767. Short.MIN_VALUE Short.MAX_VALUE

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/common/HiveIntervalDayTime.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/common/HiveIntervalDayTime.java
@@ -81,7 +81,9 @@ public class HiveIntervalDayTime implements Comparable<HiveIntervalDayTime> {
     return totalSeconds;
   }
 
-  /** @return double representation of the interval day time, accurate to nanoseconds */
+  /**
+   * @return double representation of the interval day time, accurate to nanoseconds
+   */
   public double getDouble() {
     return totalSeconds + nanos / 1000000000;
   }

--- a/kyuubi-metrics/pom.xml
+++ b/kyuubi-metrics/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/kyuubi-rest-client/pom.xml
+++ b/kyuubi-rest-client/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/kyuubi-server/pom.xml
+++ b/kyuubi-server/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
@@ -352,10 +352,12 @@ private[v1] class BatchesResource extends ApiRequestContext with Logging {
       buildBatchFromSession(batchSession)
     }.getOrElse {
       sessionManager.getBatchMetadata(batchId).map { metadata =>
-        val isOperationTerminated = (StringUtils.isNotBlank(metadata.state)
-          && OperationState.isTerminal(OperationState.withName(metadata.state)))
-        val isApplicationTerminated = (StringUtils.isNotBlank(metadata.engineState)
-          && ApplicationState.isTerminated(ApplicationState.withName(metadata.engineState)))
+        val isOperationTerminated =
+          (StringUtils.isNotBlank(metadata.state)
+            && OperationState.isTerminal(OperationState.withName(metadata.state)))
+        val isApplicationTerminated =
+          (StringUtils.isNotBlank(metadata.engineState)
+            && ApplicationState.isTerminated(ApplicationState.withName(metadata.engineState)))
 
         if (!batchInfoInternalRedirect ||
           batchV2Enabled(metadata.requestConf) ||

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/mysql/MySQLDialectHelper.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/mysql/MySQLDialectHelper.scala
@@ -101,8 +101,9 @@ object MySQLDialectHelper {
       "performance_schema" -> "0",
       "query_cache_size" -> "1048576",
       "query_cache_type" -> "OFF",
-      "sql_mode" -> ("ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE," +
-        "NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"),
+      "sql_mode" ->
+        ("ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE," +
+          "NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"),
       "system_time_zone" -> "UTC",
       "time_zone" -> "SYSTEM",
       "transaction_isolation" -> "REPEATABLE-READ",

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/mysql/authentication/MySQLNativePassword.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/mysql/authentication/MySQLNativePassword.scala
@@ -66,6 +66,7 @@ class MySQLNativePassword {
     xor(passwordSha1, secretSha1)
   }
 
-  private def xor(input: Array[Byte], secret: Array[Byte]): Array[Byte] =
-    (input zip secret).map { case (b1, b2) => (b1 ^ b2).toByte }
+  private def xor(input: Array[Byte], secret: Array[Byte]): Array[Byte] = (input zip secret).map {
+    case (b1, b2) => (b1 ^ b2).toByte
+  }
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiBatchSession.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiBatchSession.scala
@@ -165,10 +165,11 @@ class KyuubiBatchSession(
         Map(KyuubiConf.KUBERNETES_CONTEXT.key -> context)
       }.getOrElse(Map.empty) ++ appMgrInfo.kubernetesInfo.namespace.map { namespace =>
         Map(KyuubiConf.KUBERNETES_NAMESPACE.key -> namespace)
-      }.getOrElse(Map.empty) ++ (batchJobSubmissionOp.builder match {
-        case builder: SparkProcessBuilder => builder.appendPodNameConf(optimizedConf)
-        case _ => Map.empty[String, String]
-      })
+      }.getOrElse(Map.empty) ++
+        (batchJobSubmissionOp.builder match {
+          case builder: SparkProcessBuilder => builder.appendPodNameConf(optimizedConf)
+          case _ => Map.empty[String, String]
+        })
     }
 
     (metadata, fromRecovery) match {

--- a/kyuubi-util-scala/pom.xml
+++ b/kyuubi-util-scala/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/kyuubi-util/pom.xml
+++ b/kyuubi-util/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/kyuubi-zookeeper/pom.xml
+++ b/kyuubi-zookeeper/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.kyuubi</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -248,8 +248,7 @@
         <maven.plugin.scalatest.exclude.tags>org.scalatest.tags.Slow</maven.plugin.scalatest.exclude.tags>
         <maven.plugin.scalatest.include.tags></maven.plugin.scalatest.include.tags>
         <maven.plugin.scalatest.debug.enabled>false</maven.plugin.scalatest.debug.enabled>
-        <!-- TODO: Once we drop support for Java 8, we can consider upgrade spotless.version to 2.43.0. -->
-        <maven.plugin.spotless.version>2.30.0</maven.plugin.spotless.version>
+        <maven.plugin.spotless.version>3.3.0</maven.plugin.spotless.version>
         <maven.plugin.surefire.version>3.2.1</maven.plugin.surefire.version>
         <maven.plugin.jacoco.version>0.8.11</maven.plugin.jacoco.version>
         <maven.plugin.scalastyle.version>1.0.0</maven.plugin.scalastyle.version>
@@ -268,13 +267,12 @@
         <!-- Package to use when relocating shaded classes. -->
         <kyuubi.shade.packageName>org.apache.kyuubi.shade</kyuubi.shade.packageName>
 
-        <!-- Needed for Spotless style check.
-             TODO: Once we drop support for Java 8, we can consider upgrade googlejavaformat.version to 1.22.0 or above. -->
-        <spotless.java.googlejavaformat.version>1.7</spotless.java.googlejavaformat.version>
+        <!-- Needed for Spotless style check. -->
+        <spotless.java.googlejavaformat.version>1.34.1</spotless.java.googlejavaformat.version>
         <spotless.python.includes></spotless.python.includes>
         <spotless.python.black.version>22.3.0</spotless.python.black.version>
         <!-- Please also update .scalafmt.conf when you change it here -->
-        <spotless.scala.scalafmt.version>3.9.0</spotless.scala.scalafmt.version>
+        <spotless.scala.scalafmt.version>3.10.7</spotless.scala.scalafmt.version>
 
         <distMgmtReleaseId>apache.releases.https</distMgmtReleaseId>
         <distMgmtReleaseName>Apache Release Distribution Repository</distMgmtReleaseName>
@@ -1950,21 +1948,6 @@
             </activation>
             <properties>
                 <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-        </profile>
-
-        <profile>
-            <id>java-21</id>
-            <activation>
-                <jdk>21</jdk>
-            </activation>
-            <properties>
-                <!-- TODO: The current version of spotless(2.30.0) and google-java-format(1.7)
-                           does not support Java 21, but new version produces different outputs.
-                           Re-evaluate once we dropped support for Java 8. -->
-                <maven.plugin.spotless.version>2.43.0</maven.plugin.spotless.version>
-                <spotless.check.skip>true</spotless.check.skip>
-                <spotless.java.googlejavaformat.version>1.22.0</spotless.java.googlejavaformat.version>
             </properties>
         </profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -268,7 +268,7 @@
         <kyuubi.shade.packageName>org.apache.kyuubi.shade</kyuubi.shade.packageName>
 
         <!-- Needed for Spotless style check. -->
-        <spotless.java.googlejavaformat.version>1.34.1</spotless.java.googlejavaformat.version>
+        <spotless.java.googlejavaformat.version>1.35.0</spotless.java.googlejavaformat.version>
         <spotless.python.includes></spotless.python.includes>
         <spotless.python.black.version>22.3.0</spotless.python.black.version>
         <!-- Please also update .scalafmt.conf when you change it here -->

--- a/pom.xml
+++ b/pom.xml
@@ -248,7 +248,7 @@
         <maven.plugin.scalatest.exclude.tags>org.scalatest.tags.Slow</maven.plugin.scalatest.exclude.tags>
         <maven.plugin.scalatest.include.tags></maven.plugin.scalatest.include.tags>
         <maven.plugin.scalatest.debug.enabled>false</maven.plugin.scalatest.debug.enabled>
-        <maven.plugin.spotless.version>3.3.0</maven.plugin.spotless.version>
+        <maven.plugin.spotless.version>3.2.1</maven.plugin.spotless.version>
         <maven.plugin.surefire.version>3.2.1</maven.plugin.surefire.version>
         <maven.plugin.jacoco.version>0.8.11</maven.plugin.jacoco.version>
         <maven.plugin.scalastyle.version>1.0.0</maven.plugin.scalastyle.version>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->
As JDK 8 support dropped for development since 1.11.0, we are now able to use JDK 17+ for code sytle linting.
- update spotless maven plugin to 3.3
- update googlejavaformat to 1.35
- update scalafmt to 3.10
- remove 'jdk-21' profile for disabling Java style checks

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

