### PR TITLE
[Bug] Fix mapping for DECIMAL type to BigDecimal in JdbcColumn

### DIFF
--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/JdbcColumn.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/JdbcColumn.java
@@ -19,7 +19,7 @@ package org.apache.kyuubi.jdbc.hive;
 
 import static java.sql.Types.*;
 
-import java.math.BigInteger;
+import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.SQLException;
 import java.sql.Timestamp;
@@ -126,7 +126,7 @@ public class JdbcColumn {
       case TIMESTAMP_WITH_TIMEZONE:
         return TimestampTZ.class.getName();
       case DECIMAL:
-        return BigInteger.class.getName();
+        return BigDecimal.class.getName();
       case BINARY:
         return byte[].class.getName();
       case OTHER:


### PR DESCRIPTION
### Why are the changes needed?

In JDBC/Java, SQL DECIMAL/NUMERIC must map to `java.math.BigDecimal` to preserve precision and scale. The current implementation maps DECIMAL to `java.math.BigInteger`, which drops fractional parts and causes type mismatches.

### How was this patch tested?

Existing tests passing indicates no regressions.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Trae AI (GPT-5-high)
