### PR TITLE
[KYUUBI #7407] STGroup free to avoid OOM Kill

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/ldap/Query.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/ldap/Query.scala
@@ -128,7 +128,7 @@ object Query {
     def build: Query = {
       validate()
       val filter: String = createFilter
-      // Unload template cache after render to avoid CompliedST/STToken retntion
+      // Unload template cache after render to avoid CompiledST/STToken retention
       Option(filterTemplate.groupThatCreatedThisInstance).foreach(_.unload())
       updateControls()
       new Query(filter, controls)

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/ldap/Query.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/ldap/Query.scala
@@ -25,6 +25,9 @@ import org.stringtemplate.v4.{ST, STGroup}
 /**
  * The object that encompasses all components of a Directory Service search query.
  *
+ * The caller must and can only call each [[filter]] and [[build]] once,
+ * otherwise [[ST]] internal cache may leak and cause heap OOM.
+ *
  * @see [[LdapSearch]]
  */
 object Query {

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/ldap/Query.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/ldap/Query.scala
@@ -40,6 +40,7 @@ object Query {
    * A builder of the [[Query]].
    */
   final class QueryBuilder {
+
     /** The [[STGroup]] used only for this builder's filter template; unloaded in [[build]]. */
     private var filterTemplateGroup: Option[STGroup] = None
     private var filterTemplate: ST = _
@@ -116,7 +117,7 @@ object Query {
       require(filterTemplate != null, "filter is required for LDAP search query")
     }
 
-    private def createFilter: String = filterTemplate.render
+    private def createFilter(): String = filterTemplate.render()
 
     private def updateControls(): Unit = {
       if (!returningAttributes.isEmpty) controls.setReturningAttributes(
@@ -130,7 +131,7 @@ object Query {
      */
     def build: Query = {
       validate()
-      val filter: String = createFilter
+      val filter: String = createFilter()
       // Unload template cache after render to avoid CompiledST/STToken retention
       filterTemplateGroup.foreach(_.unload())
       updateControls()

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/ldap/Query.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/ldap/Query.scala
@@ -40,6 +40,8 @@ object Query {
    * A builder of the [[Query]].
    */
   final class QueryBuilder {
+    /** The [[STGroup]] used only for this builder's filter template; unloaded in [[build]]. */
+    private var filterTemplateGroup: Option[STGroup] = None
     private var filterTemplate: ST = _
     private val controls: SearchControls = {
       val _controls = new SearchControls
@@ -57,6 +59,7 @@ object Query {
      */
     def filter(filterTemplate: String): Query.QueryBuilder = {
       val group = new STGroup()
+      this.filterTemplateGroup = Some(group)
       this.filterTemplate = new ST(group, filterTemplate)
       this
     }
@@ -129,7 +132,7 @@ object Query {
       validate()
       val filter: String = createFilter
       // Unload template cache after render to avoid CompiledST/STToken retention
-      Option(filterTemplate.groupThatCreatedThisInstance).foreach(_.unload())
+      filterTemplateGroup.foreach(_.unload())
       updateControls()
       new Query(filter, controls)
     }

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/ldap/Query.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/ldap/Query.scala
@@ -20,7 +20,7 @@ package org.apache.kyuubi.service.authentication.ldap
 import java.util
 import javax.naming.directory.SearchControls
 
-import org.stringtemplate.v4.ST
+import org.stringtemplate.v4.{ST, STGroup}
 
 /**
  * The object that encompasses all components of a Directory Service search query.
@@ -56,7 +56,8 @@ object Query {
      * @return the current instance of the builder
      */
     def filter(filterTemplate: String): Query.QueryBuilder = {
-      this.filterTemplate = new ST(filterTemplate)
+      val group = new STGroup()
+      this.filterTemplate = new ST(group, filterTemplate)
       this
     }
 
@@ -127,6 +128,8 @@ object Query {
     def build: Query = {
       validate()
       val filter: String = createFilter
+      // Unload template cache after render to avoid CompliedST/STToken retntion
+      Option(filterTemplate.groupThatCreatedThisInstance).foreach(_.unload())
       updateControls()
       new Query(filter, controls)
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->


When LDAP Authentication is used ST Token is created and saved in the cache, but it is never freed up.
This is causing continuous increase in heap usage, eventually causing out-of-memory for kyuubi server pods.

This changes is added to clear ST Tokens. Also ST Group is added to avoid any race condition during clean up.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

This patch was tested in our customer environment. We observed there's no more continuous heap increase after the fix.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

Cursor auto-complete feature was used.