### PR TITLE
Added try-catch block in REST batch v2 openBatchSession

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiBatchService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiBatchService.scala
@@ -149,7 +149,7 @@ class KyuubiBatchService(
                     ex)
               }
             }
-            // sleep 1 second to avoid excessive retries during transient network/DB failures 
+            // sleep 1 second to avoid excessive retries during transient network/DB failures
             Thread.sleep(1000)
         }
       }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiBatchService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiBatchService.scala
@@ -60,57 +60,79 @@ class KyuubiBatchService(
   }
 
   override def start(): Unit = {
+    val UNINITIALIZED_BATCH_ID = "UNINITIALIZED_BATCH_ID"
     assert(running.compareAndSet(false, true))
     val submitTask: Runnable = () => {
       restFrontend.waitForServerStarted()
       while (running.get) {
-        metadataManager.pickBatchForSubmitting(kyuubiInstance) match {
-          case None => Thread.sleep(1000)
-          case Some(metadata) =>
-            val batchId = metadata.identifier
-            info(s"$batchId is picked for submission.")
-            val batchSession = sessionManager.createBatchSession(
-              metadata.username,
-              "anonymous",
-              metadata.ipAddress,
-              metadata.requestConf,
-              metadata.engineType,
-              Option(metadata.requestName),
-              metadata.resource,
-              metadata.className,
-              metadata.requestArgs,
-              Some(metadata),
-              fromRecovery = false)
-            sessionManager.openBatchSession(batchSession)
-            var submitted = false
-            while (!submitted) { // block until batch job submitted
-              submitted = metadataManager.getBatchSessionMetadata(batchId) match {
-                case Some(metadata) if OperationState.isTerminal(metadata.opState) =>
-                  true
-                case Some(metadata) if metadata.opState == OperationState.RUNNING =>
-                  metadata.appState match {
-                    // app that is not submitted to resource manager
-                    case None | Some(ApplicationState.NOT_FOUND) => false
-                    // app that is pending in resource manager while the local startup
-                    // process is alive. For example, in Spark YARN cluster mode, if set
-                    // spark.yarn.submit.waitAppCompletion=false, the local spark-submit
-                    // process exits immediately once Application goes ACCEPTED status,
-                    // even no resource could be allocated for the AM container.
-                    case Some(ApplicationState.PENDING) if batchSession.startupProcessAlive =>
-                      false
-                    // not sure, added for safe
-                    case Some(ApplicationState.UNKNOWN) => false
-                    case _ => true
-                  }
-                case Some(_) =>
-                  false
-                case None =>
-                  error(s"$batchId does not existed in metastore, assume it is finished")
-                  true
+        var batchId = UNINITIALIZED_BATCH_ID
+        try {
+          metadataManager.pickBatchForSubmitting(kyuubiInstance) match {
+            case None => Thread.sleep(1000)
+            case Some(metadata) =>
+              batchId = metadata.identifier
+              info(s"$batchId is picked for submission.")
+              val batchSession = sessionManager.createBatchSession(
+                metadata.username,
+                "anonymous",
+                metadata.ipAddress,
+                metadata.requestConf,
+                metadata.engineType,
+                Option(metadata.requestName),
+                metadata.resource,
+                metadata.className,
+                metadata.requestArgs,
+                Some(metadata),
+                fromRecovery = false)
+              sessionManager.openBatchSession(batchSession)
+              var submitted = false
+              while (!submitted) { // block until batch job submitted
+                submitted = metadataManager.getBatchSessionMetadata(batchId) match {
+                  case Some(metadata) if OperationState.isTerminal(metadata.opState) =>
+                    true
+                  case Some(metadata) if metadata.opState == OperationState.RUNNING =>
+                    metadata.appState match {
+                      // app that is not submitted to resource manager
+                      case None | Some(ApplicationState.NOT_FOUND) => false
+                      // app that is pending in resource manager while the local startup
+                      // process is alive. For example, in Spark YARN cluster mode, if set
+                      // spark.yarn.submit.waitAppCompletion=false, the local spark-submit
+                      // process exits immediately once Application goes ACCEPTED status,
+                      // even no resource could be allocated for the AM container.
+                      case Some(ApplicationState.PENDING) if batchSession.startupProcessAlive =>
+                        false
+                      // not sure, added for safe
+                      case Some(ApplicationState.UNKNOWN) => false
+                      case _ => true
+                    }
+                  case Some(_) =>
+                    false
+                  case None =>
+                    error(s"$batchId does not existed in metastore, assume it is finished")
+                    true
+                }
+                if (!submitted) Thread.sleep(1000)
               }
-              if (!submitted) Thread.sleep(1000)
+              info(s"$batchId is submitted or finished.")
+          }
+        } catch {
+          // GEICO: If the batch session is not opened,
+          // reinitialize the batch state to ERROR
+          // This can be due to a DB error or connection limits
+          case e: Exception =>
+            if (batchId == UNINITIALIZED_BATCH_ID) {
+              error(s"Error picking batch for submission", e)
+            } else {
+              error(s"Error opening batch session for $batchId", e)
+              try {
+                metadataManager.failScheduledBatch(batchId)
+                info(s"$batchId is marked as ERROR")
+              } catch {
+                case ex: Exception =>
+                  error(s"Unable to modify metadata for $batchId to ERROR", ex)
+              }
             }
-            info(s"$batchId is submitted or finished.")
+            Thread.sleep(1000)
         }
       }
     }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiBatchService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiBatchService.scala
@@ -125,7 +125,10 @@ class KyuubiBatchService(
                 metadataManager.failScheduledBatch(batchId)
               } catch {
                 case ex: Exception =>
-                  error(s"Unable to modify metadata for $batchId to ERROR", ex)
+                  error(
+                    s"Unable to modify metadata for $batchId to ERROR; " +
+                      "an administrator may need to reset the batch state manually.",
+                    ex)
               }
             }
             throw e
@@ -140,9 +143,14 @@ class KyuubiBatchService(
                 metadataManager.failScheduledBatch(batchId)
               } catch {
                 case ex: Exception =>
-                  error(s"Unable to modify metadata for $batchId to ERROR", ex)
+                  error(
+                    s"Unable to modify metadata for $batchId to ERROR; " +
+                      "an administrator may need to reset the batch state manually.",
+                    ex)
               }
             }
+            // sleep 1 second to avoid excessive retries during transient network/DB failures 
+            Thread.sleep(1000)
         }
       }
     }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiBatchService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiBatchService.scala
@@ -108,7 +108,7 @@ class KyuubiBatchService(
                   case Some(_) =>
                     false
                   case None =>
-                    error(s"$batchId does not existed in metastore, assume it is finished")
+                    error(s"$batchId does not exist in metastore, assume it is finished")
                     true
                 }
                 if (!submitted) Thread.sleep(1000)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiBatchService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiBatchService.scala
@@ -116,6 +116,19 @@ class KyuubiBatchService(
               info(s"$batchId is submitted or finished.")
           }
         } catch {
+          case e: InterruptedException =>
+            if (batchId == UNINITIALIZED_BATCH_ID) {
+              error(s"Interrupted while picking batch for submission", e)
+            } else {
+              error(s"Interrupted while opening batch session for $batchId", e)
+              try {
+                metadataManager.failScheduledBatch(batchId)
+              } catch {
+                case ex: Exception =>
+                  error(s"Unable to modify metadata for $batchId to ERROR", ex)
+              }
+            }
+            throw e
           // If the batch session failed to open, reinitialize the batch state to ERROR
           // This can be due to a DB error or batch_connection_limits exceeded
           case e: Exception =>

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiBatchService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiBatchService.scala
@@ -143,7 +143,6 @@ class KyuubiBatchService(
                   error(s"Unable to modify metadata for $batchId to ERROR", ex)
               }
             }
-            Thread.sleep(1000)
         }
       }
     }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiBatchService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiBatchService.scala
@@ -111,14 +111,12 @@ class KyuubiBatchService(
                     error(s"$batchId does not existed in metastore, assume it is finished")
                     true
                 }
-                if (!submitted) Thread.sleep(1000)
-              }
+                if (!submitted) Thread.sleep(1000)              }
               info(s"$batchId is submitted or finished.")
           }
         } catch {
-          // GEICO: If the batch session is not opened,
-          // reinitialize the batch state to ERROR
-          // This can be due to a DB error or connection limits
+          // If the batch session failed to open, reinitialize the batch state to ERROR
+          // This can be due to a DB error or batch_connection_limits exceeded
           case e: Exception =>
             if (batchId == UNINITIALIZED_BATCH_ID) {
               error(s"Error picking batch for submission", e)
@@ -126,7 +124,6 @@ class KyuubiBatchService(
               error(s"Error opening batch session for $batchId", e)
               try {
                 metadataManager.failScheduledBatch(batchId)
-                info(s"$batchId is marked as ERROR")
               } catch {
                 case ex: Exception =>
                   error(s"Unable to modify metadata for $batchId to ERROR", ex)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiBatchService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiBatchService.scala
@@ -111,7 +111,8 @@ class KyuubiBatchService(
                     error(s"$batchId does not existed in metastore, assume it is finished")
                     true
                 }
-                if (!submitted) Thread.sleep(1000)              }
+                if (!submitted) Thread.sleep(1000)
+              }
               info(s"$batchId is submitted or finished.")
           }
         } catch {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/MetadataManager.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/MetadataManager.scala
@@ -181,6 +181,10 @@ class MetadataManager extends AbstractService("MetadataManager") {
     _metadataStore.transformMetadataState(batchId, "INITIALIZED", "CANCELED")
   }
 
+  def failScheduledBatch(batchId: String): Boolean = {
+    _metadataStore.transformMetadataState(batchId, "PENDING", "ERROR")
+  }
+
   def getBatchesRecoveryMetadata(
       state: String,
       kyuubiInstance: String,

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/jdbc/JDBCMetadataStore.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/jdbc/JDBCMetadataStore.scala
@@ -235,7 +235,7 @@ class JDBCMetadataStore(conf: KyuubiConf) extends MetadataStore with Logging {
       targetState: String): Boolean = {
     val query = s"UPDATE $METADATA_TABLE SET state = ? WHERE identifier = ? AND state = ?"
     JdbcUtils.withConnection { connection =>
-      withUpdateCount(connection, query, fromState, identifier, targetState) { updateCount =>
+      withUpdateCount(connection, query, targetState, identifier, fromState) { updateCount =>
         updateCount == 1
       }
     }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
@@ -110,9 +110,9 @@ class BatchesV2ResourceSuite extends BatchesResourceSuiteBase {
         assert(batchInfoResponse.getStatus == 200)
         val batchInfo = batchInfoResponse.readEntity(classOf[Batch])
         assert(
-          batchInfo.getState === "INITIALIZED",
-          "Batch should remain INITIALIZED after openBatchSession failed and catch block ran " +
-            "(failScheduledBatch only transitions PENDING->ERROR)")
+          batchInfo.getState === "ERROR",
+           "Batch should eventually become ERROR after being picked and failed by the " +
+             "catch path, rather than remaining stuck in PENDING")
       }
 
       sessionManager.metadataManager = originalMetadataManager

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
@@ -44,6 +44,7 @@ import org.apache.kyuubi.operation.{BatchJobSubmission, OperationState}
 import org.apache.kyuubi.operation.OperationState.OperationState
 import org.apache.kyuubi.server.KyuubiRestFrontendService
 import org.apache.kyuubi.server.http.util.HttpAuthUtils.{basicAuthorizationHeader, AUTHORIZATION_HEADER}
+import org.apache.kyuubi.server.metadata.MetadataManager
 import org.apache.kyuubi.server.metadata.api.{Metadata, MetadataFilter}
 import org.apache.kyuubi.service.authentication.{AnonymousAuthenticationProviderImpl, AuthUtils}
 import org.apache.kyuubi.session.{KyuubiBatchSession, KyuubiSessionManager, SessionHandle, SessionType}
@@ -70,6 +71,72 @@ class BatchesV2ResourceSuite extends BatchesResourceSuiteBase {
     super.afterEach()
     sessionManager.allSessions().foreach { session =>
       Utils.tryLogNonFatalError { sessionManager.closeSession(session.handle) }
+    }
+  }
+
+  test("KyuubiBatchService catch block when openBatchSession fails during metadata update") {
+    val sessionManager = fe.be.sessionManager.asInstanceOf[KyuubiSessionManager]
+    val realMetadataManager = sessionManager.metadataManager.get
+
+    val wrapperMetadataManager = new MetadataManager {
+      override def updateMetadata(metadata: Metadata, asyncRetryOnError: Boolean = true): Unit = {
+        throw new RuntimeException("test metadata update failure")
+      }
+      override def insertMetadata(metadata: Metadata, asyncRetryOnError: Boolean = true): Unit = {
+        realMetadataManager.insertMetadata(metadata, asyncRetryOnError)
+      }
+      override def getBatch(batchId: String) = realMetadataManager.getBatch(batchId)
+    }
+    wrapperMetadataManager.initialize(sessionManager.getConf)
+
+    val originalMetadataManager = sessionManager.metadataManager
+    try {
+      sessionManager.metadataManager = Some(wrapperMetadataManager)
+
+      val requestObj = newSparkBatchRequest(Map("spark.master" -> "local"))
+      val response = webTarget.path("api/v1/batches")
+        .request(MediaType.APPLICATION_JSON_TYPE)
+        .header(AUTHORIZATION_HEADER, basicAuthorizationHeader("anonymous"))
+        .post(Entity.entity(requestObj, MediaType.APPLICATION_JSON_TYPE))
+      assert(response.getStatus == 200)
+      val batch = response.readEntity(classOf[Batch])
+      val batchId = batch.getId
+      assert(batch.getState === "INITIALIZED")
+
+      eventually(timeout(15.seconds), interval(1.second)) {
+        val batchInfoResponse = webTarget.path(s"api/v1/batches/$batchId")
+          .request(MediaType.APPLICATION_JSON_TYPE)
+          .header(AUTHORIZATION_HEADER, basicAuthorizationHeader("anonymous"))
+          .get()
+        assert(batchInfoResponse.getStatus == 200)
+        val batchInfo = batchInfoResponse.readEntity(classOf[Batch])
+        assert(
+          batchInfo.getState === "INITIALIZED",
+          "Batch should remain INITIALIZED after openBatchSession failed and catch block ran " +
+            "(failScheduledBatch only transitions PENDING->ERROR)")
+      }
+
+      sessionManager.metadataManager = originalMetadataManager
+
+      val requestObj2 = newSparkBatchRequest(Map("spark.master" -> "local"))
+      val response2 = webTarget.path("api/v1/batches")
+        .request(MediaType.APPLICATION_JSON_TYPE)
+        .header(AUTHORIZATION_HEADER, basicAuthorizationHeader("anonymous"))
+        .post(Entity.entity(requestObj2, MediaType.APPLICATION_JSON_TYPE))
+      assert(response2.getStatus == 200)
+      val batch2Id = response2.readEntity(classOf[Batch]).getId
+      eventually(timeout(30.seconds), interval(1.second)) {
+        val batch2InfoResponse = webTarget.path(s"api/v1/batches/$batch2Id")
+          .request(MediaType.APPLICATION_JSON_TYPE)
+          .header(AUTHORIZATION_HEADER, basicAuthorizationHeader("anonymous"))
+          .get()
+        val batch2Info = batch2InfoResponse.readEntity(classOf[Batch])
+        assert(
+          batch2Info.getState === "PENDING" || batch2Info.getState === "RUNNING",
+          "Second batch should be processed (batch service still running after catch)")
+      }
+    } finally {
+      sessionManager.metadataManager = originalMetadataManager
     }
   }
 }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
@@ -87,7 +87,6 @@ class BatchesV2ResourceSuite extends BatchesResourceSuiteBase {
       }
       override def getBatch(batchId: String) = realMetadataManager.getBatch(batchId)
     }
-    wrapperMetadataManager.initialize(sessionManager.getConf)
 
     val originalMetadataManager = sessionManager.metadataManager
     try {

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
@@ -111,8 +111,8 @@ class BatchesV2ResourceSuite extends BatchesResourceSuiteBase {
         val batchInfo = batchInfoResponse.readEntity(classOf[Batch])
         assert(
           batchInfo.getState === "ERROR",
-           "Batch should eventually become ERROR after being picked and failed by the " +
-             "catch path, rather than remaining stuck in PENDING")
+          "Batch should eventually become ERROR after being picked and failed by the " +
+            "catch path, rather than remaining stuck in PENDING")
       }
 
       sessionManager.metadataManager = originalMetadataManager


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->

In Kyuubi Batch v2 version, Batch Service creates `batchExecutor` to submit a batch job. However, when `openBatchSession` fails, the executor dies and never recovers.

This results in a jobs stuck at PENDING state and no executor to submit any jobs at INITIALIZED state.

This PR added error handling logic to handle openBatchSession.

This also fixes `withUpdateCount` call changes fromState to targetState.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Tested in our environment, openBatchSession exceptions like connections per user or DB connection error no longer leaves jobs stuck at PENDING state. Instead all those jobs are labeled as ERROR.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

Test case and bug finding were assisted with Cursor agent.