### PR TITLE
[KYUUBI #7424] Periodically delete pod stuck at FailedMount state

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -1441,7 +1441,7 @@ object KyuubiConf {
       .checkValues(KubernetesApplicationStateSource)
       .createWithDefault(KubernetesApplicationStateSource.POD.toString)
 
-  // GEICO: Configuration for checking and deleting pods stuck in FailedMount loop
+  // Configuration for checking and deleting pods stuck in FailedMount loop
   // Kubernetes will retry ~every 2 minutes,
   // Thus 30 count correspond to (30*2)/60 = 1 hours
   val KUBERNETES_POD_FAILED_MOUNT_LOOP_THRESHOLD: ConfigEntry[Int] =

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -1441,6 +1441,34 @@ object KyuubiConf {
       .checkValues(KubernetesApplicationStateSource)
       .createWithDefault(KubernetesApplicationStateSource.POD.toString)
 
+  // GEICO: Configuration for checking and deleting pods stuck in FailedMount loop
+  // Kubernetes will retry ~every 2 minutes,
+  // Thus 30 count correspond to (30*2)/60 = 1 hours
+  val KUBERNETES_POD_FAILED_MOUNT_LOOP_THRESHOLD: ConfigEntry[Int] =
+    buildConf("kyuubi.kubernetes.pod.failed.mount.loop.threshold")
+      .serverOnly
+      .doc("The threshold for the number of failed mount loop to trigger pod deletion")
+      .version("1.11.0")
+      .intConf
+      .createWithDefault(30)
+
+  val KUBERNETES_POD_FAILED_MOUNT_LOOP_CHECK_ENABLED: ConfigEntry[Boolean] =
+    buildConf("kyuubi.kubernetes.pod.failed.mount.loop.check.enabled")
+      .serverOnly
+      .doc("Whether to periodically check Pending pods for FailedMount " +
+        "loops and delete them when exceeding the threshold.")
+      .version("1.11.0")
+      .booleanConf
+      .createWithDefault(true)
+
+  val KUBERNETES_POD_FAILED_MOUNT_LOOP_CHECK_INTERVAL: ConfigEntry[Long] =
+    buildConf("kyuubi.kubernetes.pod.failed.mount.loop.check.interval")
+      .serverOnly
+      .doc("Interval for periodically checking Pending pods for FailedMount loops.")
+      .version("1.11.0")
+      .timeConf
+      .createWithDefault(60 * 60 * 1000)
+
   object KubernetesApplicationStateSource extends Enumeration {
     type KubernetesApplicationStateSource = Value
     val POD, CONTAINER = Value

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -1616,7 +1616,7 @@ object KyuubiConf {
       .checkValues(KubernetesApplicationStateSource)
       .createWithDefault(KubernetesApplicationStateSource.POD.toString)
 
-  // GEICO: Configuration for checking and deleting pods stuck in FailedMount loop
+  // Configuration for checking and deleting pods stuck in FailedMount loop
   // Kubernetes will retry ~every 2 minutes,
   // Thus 30 count correspond to (30*2)/60 = 1 hours
   val KUBERNETES_POD_FAILED_MOUNT_LOOP_THRESHOLD: ConfigEntry[Int] =

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -1621,7 +1621,8 @@ object KyuubiConf {
   // Thus 30 count correspond to (30*2)/60 = 1 hours
   val KUBERNETES_POD_FAILED_MOUNT_LOOP_THRESHOLD: ConfigEntry[Int] =
     buildConf("kyuubi.kubernetes.pod.failed.mount.loop.threshold")
-      .serverOnly
+      .audience(SERVER)
+      .immutable
       .doc("The threshold for the number of failed mount loop to trigger pod deletion")
       .version("1.11.0")
       .intConf
@@ -1629,7 +1630,8 @@ object KyuubiConf {
 
   val KUBERNETES_POD_FAILED_MOUNT_LOOP_CHECK_ENABLED: ConfigEntry[Boolean] =
     buildConf("kyuubi.kubernetes.pod.failed.mount.loop.check.enabled")
-      .serverOnly
+      .audience(SERVER)
+      .immutable
       .doc("Whether to periodically check Pending pods for FailedMount " +
         "loops and delete them when exceeding the threshold.")
       .version("1.11.0")
@@ -1638,7 +1640,8 @@ object KyuubiConf {
 
   val KUBERNETES_POD_FAILED_MOUNT_LOOP_CHECK_INTERVAL: ConfigEntry[Long] =
     buildConf("kyuubi.kubernetes.pod.failed.mount.loop.check.interval")
-      .serverOnly
+      .audience(SERVER)
+      .immutable
       .doc("Interval for periodically checking Pending pods for FailedMount loops.")
       .version("1.11.0")
       .timeConf

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -1616,6 +1616,34 @@ object KyuubiConf {
       .checkValues(KubernetesApplicationStateSource)
       .createWithDefault(KubernetesApplicationStateSource.POD.toString)
 
+  // GEICO: Configuration for checking and deleting pods stuck in FailedMount loop
+  // Kubernetes will retry ~every 2 minutes,
+  // Thus 30 count correspond to (30*2)/60 = 1 hours
+  val KUBERNETES_POD_FAILED_MOUNT_LOOP_THRESHOLD: ConfigEntry[Int] =
+    buildConf("kyuubi.kubernetes.pod.failed.mount.loop.threshold")
+      .serverOnly
+      .doc("The threshold for the number of failed mount loop to trigger pod deletion")
+      .version("1.11.0")
+      .intConf
+      .createWithDefault(30)
+
+  val KUBERNETES_POD_FAILED_MOUNT_LOOP_CHECK_ENABLED: ConfigEntry[Boolean] =
+    buildConf("kyuubi.kubernetes.pod.failed.mount.loop.check.enabled")
+      .serverOnly
+      .doc("Whether to periodically check Pending pods for FailedMount " +
+        "loops and delete them when exceeding the threshold.")
+      .version("1.11.0")
+      .booleanConf
+      .createWithDefault(true)
+
+  val KUBERNETES_POD_FAILED_MOUNT_LOOP_CHECK_INTERVAL: ConfigEntry[Long] =
+    buildConf("kyuubi.kubernetes.pod.failed.mount.loop.check.interval")
+      .serverOnly
+      .doc("Interval for periodically checking Pending pods for FailedMount loops.")
+      .version("1.11.0")
+      .timeConf
+      .createWithDefault(60 * 60 * 1000)
+
   object KubernetesApplicationStateSource extends Enumeration {
     type KubernetesApplicationStateSource = Value
     val POD, CONTAINER = Value

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
@@ -224,7 +224,7 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
       "cleanup-failed-mount-loop-pod-thread")
     initializeKubernetesClient(kyuubiConf)
 
-    // GEICO: start a periodic FailedMount checker for Pending pods
+    // start a periodic FailedMount checker for Pending pods
     if (kyuubiConf.get(KyuubiConf.KUBERNETES_POD_FAILED_MOUNT_LOOP_CHECK_ENABLED)) {
       val interval = kyuubiConf.get(KyuubiConf.KUBERNETES_POD_FAILED_MOUNT_LOOP_CHECK_INTERVAL)
       failedMountLoopPeriodicChecker = ThreadUtils.newDaemonSingleThreadScheduledExecutor(
@@ -653,7 +653,7 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
     }
   }
 
-  // GEICO: Check if pod is stuck at failedMount Loop
+  // Check if pod is stuck at failedMount Loop
   private def checkPodFailedMountLoop(
       kubernetesInfo: KubernetesInfo,
       pod: Pod): Unit = {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
@@ -60,6 +60,9 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
   private def allowedNamespaces: Set[String] =
     kyuubiConf.get(KyuubiConf.KUBERNETES_NAMESPACE_ALLOW_LIST)
 
+  private def failedMountLoopThreshold: Int =
+    kyuubiConf.get(KyuubiConf.KUBERNETES_POD_FAILED_MOUNT_LOOP_THRESHOLD)
+
   private def appStateSource: KubernetesApplicationStateSource =
     KubernetesApplicationStateSource.withName(
       kyuubiConf.get(KyuubiConf.KUBERNETES_APPLICATION_STATE_SOURCE))
@@ -84,6 +87,10 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
   private var cleanupCanceledAppPodExecutor: ThreadPoolExecutor = _
 
   private var kubernetesClientInitializeCleanupTerminatedPodExecutor: ThreadPoolExecutor = _
+  
+  private var cleanupFailedMountLoopPodExecutor: ThreadPoolExecutor = _
+
+  private var failedMountLoopPeriodicChecker: ScheduledExecutorService = _
 
   private def getOrCreateKubernetesClient(kubernetesInfo: KubernetesInfo): KubernetesClient = {
     checkKubernetesInfo(kubernetesInfo)
@@ -213,7 +220,50 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
     kubernetesClientInitializeCleanupTerminatedPodExecutor =
       ThreadUtils.newDaemonCachedThreadPool(
         "kubernetes-client-initialize-cleanup-terminated-pod-thread")
+    cleanupFailedMountLoopPodExecutor = ThreadUtils.newDaemonCachedThreadPool(
+      "cleanup-failed-mount-loop-pod-thread")
     initializeKubernetesClient(kyuubiConf)
+
+    // GEICO: start a periodic FailedMount checker for Pending pods
+    if (kyuubiConf.get(KyuubiConf.KUBERNETES_POD_FAILED_MOUNT_LOOP_CHECK_ENABLED)) {
+      val interval = kyuubiConf.get(KyuubiConf.KUBERNETES_POD_FAILED_MOUNT_LOOP_CHECK_INTERVAL)
+      failedMountLoopPeriodicChecker = ThreadUtils.newDaemonSingleThreadScheduledExecutor(
+        "failed-mount-loop-periodic-checker")
+      ThreadUtils.scheduleTolerableRunnableWithFixedDelay(
+        failedMountLoopPeriodicChecker,
+        new Runnable {
+          override def run(): Unit = Utils.tryLogNonFatalError {
+            try {
+              // Iterate over known applications and check Pending pods for FailedMount loops
+              appInfoStore.asScala.foreach { case (_, (kubernetesInfo, appInfo)) =>
+                if (appInfo.state == ApplicationState.PENDING) {
+                  val client = getOrCreateKubernetesClient(kubernetesInfo)
+                  val podNameOpt = appInfo.podName
+                  val podOpt = podNameOpt
+                    .flatMap { name => Option(client.pods().withName(name).get()) }
+                    .orElse {
+                      Option(client.pods()
+                        .withLabel(LABEL_KYUUBI_UNIQUE_KEY, appInfo.name)
+                        .list())
+                        .flatMap(l => Option(l.getItems)).map(_.asScala.headOption).flatten
+                    }
+                  podOpt.foreach { pod =>
+                    // Reuse the existing logic through checkPodFailedMountLoop
+                    checkPodFailedMountLoop(
+                      kubernetesInfo,
+                      pod)
+                  }
+                }
+              }
+            } catch {
+              case NonFatal(e) => warn("Periodic FailedMount checker encountered an error", e)
+            }
+          }
+        },
+        1 * 60 * 1000,
+        interval,
+        TimeUnit.MILLISECONDS)
+    }
   }
 
   private[kyuubi] def getKubernetesClientInitializeInfo(
@@ -377,6 +427,15 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
     if (kubernetesClientInitializeCleanupTerminatedPodExecutor != null) {
       ThreadUtils.shutdown(kubernetesClientInitializeCleanupTerminatedPodExecutor)
       kubernetesClientInitializeCleanupTerminatedPodExecutor = null
+    }
+    if (cleanupFailedMountLoopPodExecutor != null) {
+      ThreadUtils.shutdown(cleanupFailedMountLoopPodExecutor)
+      cleanupFailedMountLoopPodExecutor = null
+    }
+
+    if (failedMountLoopPeriodicChecker != null) {
+      ThreadUtils.shutdown(failedMountLoopPeriodicChecker)
+      failedMountLoopPeriodicChecker = null
     }
   }
 
@@ -592,6 +651,37 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
         }
       })
     }
+  }
+
+  // GEICO: Check if pod is stuck at failedMount Loop
+  private def checkPodFailedMountLoop(
+      kubernetesInfo: KubernetesInfo,
+      pod: Pod): Unit = {
+    cleanupFailedMountLoopPodExecutor.submit(new Runnable {
+      override def run(): Unit = Utils.tryLogNonFatalError {
+        val kyuubiUniqueKey = pod.getMetadata.getLabels.get(LABEL_KYUUBI_UNIQUE_KEY)
+        val client = getOrCreateKubernetesClient(kubernetesInfo)
+        val ns = Option(pod.getMetadata.getNamespace).getOrElse(client.getNamespace)
+        val events = client.v1().events().inNamespace(ns)
+          .withField("involvedObject.kind", "Pod")
+          .withField("involvedObject.name", pod.getMetadata.getName)
+          .list()
+          .getItems.asScala.toList
+
+        val hasFailedMount = events.exists { event =>
+          val reasonMatches = Option(event.getReason)
+            .exists(_.contains("FailedMount"))
+          val count = Option(event.getCount).getOrElse(0).asInstanceOf[Int]
+          reasonMatches && (count >= failedMountLoopThreshold)
+        }
+        if (hasFailedMount) {
+          warn(s"[$kubernetesInfo] Detected FailedMount for pod " +
+            s" exceeding the threshold of $failedMountLoopThreshold, " +
+            s"${pod.getMetadata.getName}, deleting pod")
+          deletePod(kubernetesInfo, pod.getMetadata.getName, kyuubiUniqueKey)
+        }
+      }
+    })
   }
 }
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
@@ -87,7 +87,7 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
   private var cleanupCanceledAppPodExecutor: ThreadPoolExecutor = _
 
   private var kubernetesClientInitializeCleanupTerminatedPodExecutor: ThreadPoolExecutor = _
-  
+
   private var cleanupFailedMountLoopPodExecutor: ThreadPoolExecutor = _
 
   private var failedMountLoopPeriodicChecker: ScheduledExecutorService = _

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
@@ -88,7 +88,7 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
   private var cleanupCanceledAppPodExecutor: ExecutorService = _
 
   private var kubernetesClientInitializeCleanupTerminatedPodExecutor: ThreadPoolExecutor = _
-  
+
   private var cleanupFailedMountLoopPodExecutor: ThreadPoolExecutor = _
 
   private var failedMountLoopPeriodicChecker: ScheduledExecutorService = _

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
@@ -87,7 +87,7 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
 
   private var cleanupCanceledAppPodExecutor: ExecutorService = _
 
-  private var cleanupFailedMountLoopPodExecutor: ThreadPoolExecutor = _
+  private var cleanupFailedMountLoopPodExecutor: ExecutorService = _
 
   private var failedMountLoopPeriodicChecker: ScheduledExecutorService = _
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
@@ -639,7 +639,7 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
     }
   }
 
-  // GEICO: Check if pod is stuck at failedMount Loop
+  // Check if pod is stuck at failedMount Loop
   private def checkPodFailedMountLoop(
       kubernetesInfo: KubernetesInfo,
       pod: Pod): Unit = {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
@@ -60,6 +60,9 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
   private def allowedNamespaces: Set[String] =
     kyuubiConf.get(KyuubiConf.KUBERNETES_NAMESPACE_ALLOW_LIST)
 
+  private def failedMountLoopThreshold: Int =
+    kyuubiConf.get(KyuubiConf.KUBERNETES_POD_FAILED_MOUNT_LOOP_THRESHOLD)
+
   private def appStateSource: KubernetesApplicationStateSource =
     KubernetesApplicationStateSource.withName(
       kyuubiConf.get(KyuubiConf.KUBERNETES_APPLICATION_STATE_SOURCE))
@@ -83,6 +86,12 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
   private var expireCleanUpTriggerCacheExecutor: ScheduledExecutorService = _
 
   private var cleanupCanceledAppPodExecutor: ExecutorService = _
+
+  private var kubernetesClientInitializeCleanupTerminatedPodExecutor: ThreadPoolExecutor = _
+  
+  private var cleanupFailedMountLoopPodExecutor: ThreadPoolExecutor = _
+
+  private var failedMountLoopPeriodicChecker: ScheduledExecutorService = _
 
   private def getOrCreateKubernetesClient(kubernetesInfo: KubernetesInfo): KubernetesClient = {
     checkKubernetesInfo(kubernetesInfo)
@@ -180,7 +189,50 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
     } else {
       ThreadUtils.newDaemonCachedThreadPool("cleanup-canceled-app-pod-thread")
     }
+    kubernetesClientInitializeCleanupTerminatedPodExecutor =
+      ThreadUtils.newDaemonCachedThreadPool(
+        "kubernetes-client-initialize-cleanup-terminated-pod-thread")
+    cleanupFailedMountLoopPodExecutor = ThreadUtils.newDaemonCachedThreadPool(
+      "cleanup-failed-mount-loop-pod-thread")
     initializeKubernetesClient(kyuubiConf)
+
+    if (kyuubiConf.get(KyuubiConf.KUBERNETES_POD_FAILED_MOUNT_LOOP_CHECK_ENABLED)) {
+      val interval = kyuubiConf.get(KyuubiConf.KUBERNETES_POD_FAILED_MOUNT_LOOP_CHECK_INTERVAL)
+      failedMountLoopPeriodicChecker = ThreadUtils.newDaemonSingleThreadScheduledExecutor(
+        "failed-mount-loop-periodic-checker")
+      ThreadUtils.scheduleTolerableRunnableWithFixedDelay(
+        failedMountLoopPeriodicChecker,
+        new Runnable {
+          override def run(): Unit = Utils.tryLogNonFatalError {
+            try {
+              appInfoStore.asScala.foreach { case (_, (kubernetesInfo, appInfo)) =>
+                if (appInfo.state == ApplicationState.PENDING) {
+                  val client = getOrCreateKubernetesClient(kubernetesInfo)
+                  val podNameOpt = appInfo.podName
+                  val podOpt = podNameOpt
+                    .flatMap { name => Option(client.pods().withName(name).get()) }
+                    .orElse {
+                      Option(client.pods()
+                        .withLabel(LABEL_KYUUBI_UNIQUE_KEY, appInfo.name)
+                        .list())
+                        .flatMap(l => Option(l.getItems)).map(_.asScala.headOption).flatten
+                    }
+                  podOpt.foreach { pod =>
+                    checkPodFailedMountLoop(
+                      kubernetesInfo,
+                      pod)
+                  }
+                }
+              }
+            } catch {
+              case NonFatal(e) => warn("Periodic FailedMount checker encountered an error", e)
+            }
+          }
+        },
+        1 * 60 * 1000,
+        interval,
+        TimeUnit.MILLISECONDS)
+    }
   }
 
   private[kyuubi] def getKubernetesClientInitializeInfo(
@@ -351,6 +403,20 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
     if (cleanupCanceledAppPodExecutor != null) {
       ThreadUtils.shutdown(cleanupCanceledAppPodExecutor)
       cleanupCanceledAppPodExecutor = null
+    }
+
+    if (kubernetesClientInitializeCleanupTerminatedPodExecutor != null) {
+      ThreadUtils.shutdown(kubernetesClientInitializeCleanupTerminatedPodExecutor)
+      kubernetesClientInitializeCleanupTerminatedPodExecutor = null
+    }
+    if (cleanupFailedMountLoopPodExecutor != null) {
+      ThreadUtils.shutdown(cleanupFailedMountLoopPodExecutor)
+      cleanupFailedMountLoopPodExecutor = null
+    }
+
+    if (failedMountLoopPeriodicChecker != null) {
+      ThreadUtils.shutdown(failedMountLoopPeriodicChecker)
+      failedMountLoopPeriodicChecker = null
     }
   }
 
@@ -571,6 +637,37 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
         }
       })
     }
+  }
+
+  // GEICO: Check if pod is stuck at failedMount Loop
+  private def checkPodFailedMountLoop(
+      kubernetesInfo: KubernetesInfo,
+      pod: Pod): Unit = {
+    cleanupFailedMountLoopPodExecutor.submit(new Runnable {
+      override def run(): Unit = Utils.tryLogNonFatalError {
+        val kyuubiUniqueKey = pod.getMetadata.getLabels.get(LABEL_KYUUBI_UNIQUE_KEY)
+        val client = getOrCreateKubernetesClient(kubernetesInfo)
+        val ns = Option(pod.getMetadata.getNamespace).getOrElse(client.getNamespace)
+        val events = client.v1().events().inNamespace(ns)
+          .withField("involvedObject.kind", "Pod")
+          .withField("involvedObject.name", pod.getMetadata.getName)
+          .list()
+          .getItems.asScala.toList
+
+        val hasFailedMount = events.exists { event =>
+          val reasonMatches = Option(event.getReason)
+            .exists(_.contains("FailedMount"))
+          val count = Option(event.getCount).getOrElse(0).asInstanceOf[Int]
+          reasonMatches && (count >= failedMountLoopThreshold)
+        }
+        if (hasFailedMount) {
+          warn(s"[$kubernetesInfo] Detected FailedMount for pod " +
+            s" exceeding the threshold of $failedMountLoopThreshold, " +
+            s"${pod.getMetadata.getName}, deleting pod")
+          deletePod(kubernetesInfo, pod.getMetadata.getName, kyuubiUniqueKey)
+        }
+      }
+    })
   }
 }
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
@@ -87,8 +87,6 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
 
   private var cleanupCanceledAppPodExecutor: ExecutorService = _
 
-  private var kubernetesClientInitializeCleanupTerminatedPodExecutor: ThreadPoolExecutor = _
-
   private var cleanupFailedMountLoopPodExecutor: ThreadPoolExecutor = _
 
   private var failedMountLoopPeriodicChecker: ScheduledExecutorService = _
@@ -189,9 +187,6 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
     } else {
       ThreadUtils.newDaemonCachedThreadPool("cleanup-canceled-app-pod-thread")
     }
-    kubernetesClientInitializeCleanupTerminatedPodExecutor =
-      ThreadUtils.newDaemonCachedThreadPool(
-        "kubernetes-client-initialize-cleanup-terminated-pod-thread")
     cleanupFailedMountLoopPodExecutor = ThreadUtils.newDaemonCachedThreadPool(
       "cleanup-failed-mount-loop-pod-thread")
     initializeKubernetesClient(kyuubiConf)
@@ -405,10 +400,6 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
       cleanupCanceledAppPodExecutor = null
     }
 
-    if (kubernetesClientInitializeCleanupTerminatedPodExecutor != null) {
-      ThreadUtils.shutdown(kubernetesClientInitializeCleanupTerminatedPodExecutor)
-      kubernetesClientInitializeCleanupTerminatedPodExecutor = null
-    }
     if (cleanupFailedMountLoopPodExecutor != null) {
       ThreadUtils.shutdown(cleanupFailedMountLoopPodExecutor)
       cleanupFailedMountLoopPodExecutor = null


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->

When kyuubi server pod crashes, some spark driver pod may stuck at FailedMount state. 
This PR adds periodic check to clean up these pods.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Deployed and Tested in our environment. We were able to observe FailedMount pods do get deleted after configured time.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

Yes Cursor was used.