### PR TITLE
Support fetchOrientation parameter in OperationRestApi.getOperationLog 

### DIFF
--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/OperationRestApi.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/OperationRestApi.java
@@ -52,9 +52,14 @@ public class OperationRestApi {
   }
 
   public OperationLog getOperationLog(String operationHandleStr, int maxRows) {
+    return getOperationLog(operationHandleStr, null, maxRows);
+  }
+
+  public OperationLog getOperationLog(String operationHandleStr, String fetchOrientation, Integer maxRows) {
     String path = String.format("%s/%s/log", API_BASE_PATH, operationHandleStr);
     Map<String, Object> params = new HashMap<>();
-    params.put("maxrows", maxRows);
+    if (fetchOrientation != null) params.put("fetchorientation", fetchOrientation);
+    if (maxRows != null) params.put("maxrows", maxRows);
     return this.getClient().get(path, params, OperationLog.class, client.getAuthHeader());
   }
 

--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/OperationRestApi.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/OperationRestApi.java
@@ -55,7 +55,8 @@ public class OperationRestApi {
     return getOperationLog(operationHandleStr, null, maxRows);
   }
 
-  public OperationLog getOperationLog(String operationHandleStr, String fetchOrientation, Integer maxRows) {
+  public OperationLog getOperationLog(
+      String operationHandleStr, String fetchOrientation, Integer maxRows) {
     String path = String.format("%s/%s/log", API_BASE_PATH, operationHandleStr);
     Map<String, Object> params = new HashMap<>();
     if (fetchOrientation != null) params.put("fetchorientation", fetchOrientation);

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/rest/client/OperationRestApiSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/rest/client/OperationRestApiSuite.scala
@@ -85,6 +85,12 @@ class OperationRestApiSuite extends RestClientTestHelper {
         _.contains("select \"test_value\", 1, 0.32d, true")))
       assert(logRowSet.getRowCount === 10)
 
+      val logRowSetWithOrientation =
+        operationRestApi.getOperationLog(statementHandleStr, "FETCH_FIRST", 10)
+      assert(logRowSetWithOrientation.getLogRowSet.asScala.exists(
+        _.contains("select \"test_value\", 1, 0.32d, true")))
+      assert(logRowSetWithOrientation.getRowCount === 10)
+
       val resultRowSet = operationRestApi.getNextRowSet(statementHandleStr)
       assert("test_value".equals(resultRowSet.getRows.asScala.head.getFields.asScala.head.getValue))
       assert(resultRowSet.getRowCount == 1)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->
  The current getOperationLog method in OperationRestApi does not support the fetchOrientation parameter, which limits the client's ability to control the fetch direction (e.g., FETCH_NEXT, FETCH_FIRST) when retrieving operation logs. This change adds an overloaded method that accepts
  fetchOrientation, while keeping the original method signature for backward compatibility.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
  - Existing tests should pass as the original method signature is preserved via method overloading.
  - Manual verification by calling the new API with and without fetchOrientation.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
