### PR TITLE
add service discovery for REST frontend with ZK/ETCD support

### DIFF
--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/ServiceDiscovery.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/ServiceDiscovery.scala
@@ -41,8 +41,8 @@ abstract class ServiceDiscovery(
   /**
    * a pre-defined namespace used to publish the instance of the associate service
    */
-  private var _namespace: String = _
-  private var _discoveryClient: DiscoveryClient = _
+  protected var _namespace: String = _
+  protected var _discoveryClient: DiscoveryClient = _
 
   def namespace: String = _namespace
   def discoveryClient: DiscoveryClient = _discoveryClient

--- a/kyuubi-rest-client/pom.xml
+++ b/kyuubi-rest-client/pom.xml
@@ -74,6 +74,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.kyuubi</groupId>
+            <artifactId>kyuubi-ha_${scala.binary.version}</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/KyuubiRestClient.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/KyuubiRestClient.java
@@ -17,12 +17,18 @@
 
 package org.apache.kyuubi.client;
 
+import java.lang.reflect.Proxy;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.kyuubi.client.auth.*;
+import org.apache.kyuubi.client.discovery.RestDiscoveryConf;
+import org.apache.kyuubi.client.discovery.RestServiceDiscoverer;
 
 public class KyuubiRestClient implements AutoCloseable, Cloneable {
 
@@ -37,6 +43,9 @@ public class KyuubiRestClient implements AutoCloseable, Cloneable {
   private ApiVersion version;
 
   private AuthHeaderGenerator authHeaderGenerator;
+
+  private ScheduledExecutorService discoveryRefresher;
+  private volatile RestDiscoveryConf discoveryConf;
 
   /** Specifies the version of the Kyuubi API to communicate with. */
   public enum ApiVersion {
@@ -55,6 +64,10 @@ public class KyuubiRestClient implements AutoCloseable, Cloneable {
 
   @Override
   public void close() throws Exception {
+    if (discoveryRefresher != null) {
+      discoveryRefresher.shutdownNow();
+      discoveryRefresher = null;
+    }
     if (httpClient != null) {
       httpClient.close();
     }
@@ -104,6 +117,8 @@ public class KyuubiRestClient implements AutoCloseable, Cloneable {
 
     this.httpClient = RetryableRestClient.getRestClient(this.baseUrls, conf);
 
+    this.discoveryConf = builder.discoveryConf;
+
     switch (builder.authHeaderMethod) {
       case BASIC:
         this.authHeaderGenerator = new BasicAuthHeaderGenerator(builder.username, builder.password);
@@ -120,6 +135,8 @@ public class KyuubiRestClient implements AutoCloseable, Cloneable {
           this.authHeaderGenerator = builder.authHeaderGenerator;
         }
     }
+
+    startDiscoveryRefresher();
   }
 
   private List<String> initBaseUrls(List<String> hostUrls, ApiVersion version) {
@@ -157,6 +174,54 @@ public class KyuubiRestClient implements AutoCloseable, Cloneable {
     return new Builder(hostUrls);
   }
 
+  /**
+   * Create a Builder with host URLs discovered from ZK/ETCD service discovery. The returned Builder
+   * is pre-populated with discovered host URLs. After {@link Builder#build()} is called, a
+   * background thread will periodically refresh the URL list. The current server connection is
+   * preserved if it remains in the refreshed list.
+   *
+   * @param discoveryConf the discovery configuration
+   * @return a Builder pre-populated with discovered host URLs
+   */
+  public static Builder discoveryBuilder(RestDiscoveryConf discoveryConf) {
+    List<String> hostUrls = RestServiceDiscoverer.discoverHostUrls(discoveryConf);
+    return new Builder(hostUrls).discoveryConf(discoveryConf);
+  }
+
+  private void startDiscoveryRefresher() {
+    if (discoveryConf == null) {
+      return;
+    }
+    final RestDiscoveryConf conf = this.discoveryConf;
+    discoveryRefresher =
+        Executors.newSingleThreadScheduledExecutor(
+            r -> {
+              Thread t = new Thread(r, "rest-service-discovery-refresher");
+              t.setDaemon(true);
+              return t;
+            });
+    discoveryRefresher.scheduleWithFixedDelay(
+        () -> {
+          try {
+            List<String> newHostUrls = RestServiceDiscoverer.discoverHostUrls(conf);
+            if (!newHostUrls.equals(hostUrls)) {
+              List<String> newBaseUrls = initBaseUrls(newHostUrls, version);
+              hostUrls = newHostUrls;
+              baseUrls = newBaseUrls;
+              ((RetryableRestClient) Proxy.getInvocationHandler(httpClient))
+                  .updateUris(newBaseUrls);
+            }
+          } catch (Exception e) {
+            // log and continue, next refresh will retry
+            org.slf4j.LoggerFactory.getLogger(KyuubiRestClient.class)
+                .warn("Failed to refresh REST service endpoints", e);
+          }
+        },
+        conf.getRefreshIntervalMs(),
+        conf.getRefreshIntervalMs(),
+        TimeUnit.MILLISECONDS);
+  }
+
   public static class Builder {
 
     private List<String> hostUrls;
@@ -183,6 +248,8 @@ public class KyuubiRestClient implements AutoCloseable, Cloneable {
 
     // 3s
     private int attemptWaitTime = 3 * 1000;
+
+    private RestDiscoveryConf discoveryConf;
 
     public Builder(String hostUrl) {
       if (StringUtils.isBlank(hostUrl)) {
@@ -248,6 +315,11 @@ public class KyuubiRestClient implements AutoCloseable, Cloneable {
 
     public Builder attemptWaitTime(int attemptWaitTime) {
       this.attemptWaitTime = attemptWaitTime;
+      return this;
+    }
+
+    Builder discoveryConf(RestDiscoveryConf discoveryConf) {
+      this.discoveryConf = discoveryConf;
       return this;
     }
 

--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/RetryableRestClient.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/RetryableRestClient.java
@@ -37,14 +37,14 @@ public class RetryableRestClient implements InvocationHandler {
   private static final Logger LOG = LoggerFactory.getLogger(RetryableRestClient.class);
 
   private final RestClientConf conf;
-  private final List<String> uris;
-  private int currentUriIndex;
+  private List<String> uris;
+  private String currentUri;
   private volatile IRestClient restClient;
 
   private RetryableRestClient(List<String> uris, RestClientConf conf) {
     this.conf = conf;
     this.uris = uris;
-    this.currentUriIndex = ThreadLocalRandom.current().nextInt(uris.size());
+    this.currentUri = uris.get(ThreadLocalRandom.current().nextInt(uris.size()));
     newRestClient();
   }
 
@@ -69,9 +69,23 @@ public class RetryableRestClient implements InvocationHandler {
     }
 
     CloseableHttpClient httpclient = HttpClientFactory.createHttpClient(conf);
-    assert currentUriIndex < uris.size();
-    this.restClient = new RestClient(uris.get(currentUriIndex), httpclient);
-    LOG.info("Current connect server uri {}", uris.get(currentUriIndex));
+    this.restClient = new RestClient(currentUri, httpclient);
+    LOG.info("Current connect server uri {}", currentUri);
+  }
+
+  /**
+   * Update the URI list dynamically (e.g. from service discovery refresh). If the current server is
+   * still in the new list, keep the connection; otherwise pick a random new server and reconnect.
+   */
+  public synchronized void updateUris(List<String> newUris) {
+    this.uris = newUris;
+    if (newUris.contains(currentUri)) {
+      // current server still available, keep connection as-is
+    } else {
+      // current server gone, switch to a random one
+      currentUri = newUris.get(ThreadLocalRandom.current().nextInt(newUris.size()));
+      newRestClient();
+    }
   }
 
   @Override
@@ -93,16 +107,17 @@ public class RetryableRestClient implements InvocationHandler {
             LOG.error("Attempt over {} times", conf.getMaxAttempts(), e.getCause());
             throw e.getCause();
           }
-          if (currentUriIndex == uris.size() - 1) {
-            currentUriIndex = 0;
-          } else {
-            currentUriIndex++;
-          }
+          rotateToNextUri();
           newRestClient();
         } else {
           throw e.getCause();
         }
       }
     }
+  }
+
+  private void rotateToNextUri() {
+    int idx = uris.indexOf(currentUri);
+    currentUri = uris.get((idx + 1) % uris.size());
   }
 }

--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/discovery/RestDiscoveryConf.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/discovery/RestDiscoveryConf.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.client.discovery;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Configuration for REST service discovery via ZK/ETCD.
+ *
+ * <p>Example usage:
+ *
+ * <pre>
+ *   RestDiscoveryConf conf = new RestDiscoveryConf()
+ *       .setHaAddresses("zk1:2181,zk2:2181")
+ *       .setHaNamespace("kyuubi");
+ * </pre>
+ *
+ * <p>The REST namespace is derived as {@code haNamespace + "/rest"}, e.g. "kyuubi/rest" for the
+ * default namespace.
+ */
+public class RestDiscoveryConf {
+
+  private String haAddresses;
+  private String haNamespace = "kyuubi";
+  private String haClientClass = "org.apache.kyuubi.ha.client.zookeeper.ZookeeperDiscoveryClient";
+  private long refreshIntervalMs = 5000L;
+
+  public String getHaAddresses() {
+    return haAddresses;
+  }
+
+  public RestDiscoveryConf setHaAddresses(String haAddresses) {
+    this.haAddresses = haAddresses;
+    return this;
+  }
+
+  public String getHaNamespace() {
+    return haNamespace;
+  }
+
+  public RestDiscoveryConf setHaNamespace(String haNamespace) {
+    this.haNamespace = haNamespace;
+    return this;
+  }
+
+  public String getHaClientClass() {
+    return haClientClass;
+  }
+
+  public RestDiscoveryConf setHaClientClass(String haClientClass) {
+    this.haClientClass = haClientClass;
+    return this;
+  }
+
+  public long getRefreshIntervalMs() {
+    return refreshIntervalMs;
+  }
+
+  public RestDiscoveryConf setRefreshIntervalMs(long refreshIntervalMs) {
+    this.refreshIntervalMs = refreshIntervalMs;
+    return this;
+  }
+
+  public void validate() {
+    if (StringUtils.isBlank(haAddresses)) {
+      throw new IllegalArgumentException("haAddresses must not be blank.");
+    }
+    if (StringUtils.isBlank(haNamespace)) {
+      throw new IllegalArgumentException("haNamespace must not be blank.");
+    }
+    if (StringUtils.isBlank(haClientClass)) {
+      throw new IllegalArgumentException("haClientClass must not be blank.");
+    }
+  }
+}

--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/discovery/RestServiceDiscoverer.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/discovery/RestServiceDiscoverer.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.client.discovery;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.kyuubi.config.KyuubiConf;
+import org.apache.kyuubi.ha.client.DiscoveryClient;
+import org.apache.kyuubi.ha.client.DiscoveryClientProvider;
+import org.apache.kyuubi.ha.client.ServiceNodeInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A utility to discover REST service endpoints from ZK/ETCD. It creates a discovery client, reads
+ * the service nodes under the given namespace, and returns the list of {@code http://host:port}
+ * URLs.
+ */
+public class RestServiceDiscoverer {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RestServiceDiscoverer.class);
+
+  private RestServiceDiscoverer() {}
+
+  /**
+   * Discover REST service host URLs from the configured discovery service.
+   *
+   * @param discoveryConf the discovery configuration
+   * @return list of host URLs in the form {@code http://host:port}
+   */
+  public static List<String> discoverHostUrls(RestDiscoveryConf discoveryConf) {
+    discoveryConf.validate();
+    KyuubiConf conf = toKyuubiConf(discoveryConf);
+    DiscoveryClient client = DiscoveryClientProvider.createDiscoveryClient(conf);
+    try {
+      client.createClient();
+      String restNamespace = discoveryConf.getHaNamespace() + "/rest";
+      List<ServiceNodeInfo> nodes =
+          scala.collection.JavaConverters.seqAsJavaListConverter(
+                  client.getServiceNodesInfo(restNamespace, scala.Option.empty(), false))
+              .asJava();
+      if (nodes == null || nodes.isEmpty()) {
+        throw new RuntimeException("No REST service nodes found under namespace: " + restNamespace);
+      }
+      List<String> urls =
+          nodes.stream()
+              .map(node -> "http://" + node.host() + ":" + node.port())
+              .collect(Collectors.toList());
+      LOG.info("Discovered REST service endpoints: {}", urls);
+      return urls;
+    } finally {
+      try {
+        client.closeClient();
+      } catch (Exception e) {
+        LOG.warn("Failed to close discovery client", e);
+      }
+    }
+  }
+
+  private static KyuubiConf toKyuubiConf(RestDiscoveryConf discoveryConf) {
+    KyuubiConf conf = new KyuubiConf(true);
+    conf.set("kyuubi.ha.addresses", discoveryConf.getHaAddresses());
+    conf.set("kyuubi.ha.client.class", discoveryConf.getHaClientClass());
+    return conf;
+  }
+}

--- a/kyuubi-rest-client/src/test/java/org/apache/kyuubi/client/RetryableRestClientTest.java
+++ b/kyuubi-rest-client/src/test/java/org/apache/kyuubi/client/RetryableRestClientTest.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.client;
+
+import static org.junit.Assert.*;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Proxy;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Test;
+
+public class RetryableRestClientTest {
+
+  private RetryableRestClient getHandler(IRestClient proxy) {
+    return (RetryableRestClient) Proxy.getInvocationHandler(proxy);
+  }
+
+  private String getCurrentUri(RetryableRestClient client) throws Exception {
+    Field f = RetryableRestClient.class.getDeclaredField("currentUri");
+    f.setAccessible(true);
+    return (String) f.get(client);
+  }
+
+  private List<String> getUris(RetryableRestClient client) throws Exception {
+    Field f = RetryableRestClient.class.getDeclaredField("uris");
+    f.setAccessible(true);
+    return (List<String>) f.get(client);
+  }
+
+  @Test
+  public void testUpdateUrisKeepsCurrentServer() throws Exception {
+    List<String> uris =
+        Arrays.asList("http://host1:10099", "http://host2:10099", "http://host3:10099");
+    RestClientConf conf = new RestClientConf();
+    IRestClient proxy = RetryableRestClient.getRestClient(uris, conf);
+    RetryableRestClient handler = getHandler(proxy);
+
+    String currentUri = getCurrentUri(handler);
+    assertTrue(uris.contains(currentUri));
+
+    // update with a new list that still contains the current server
+    List<String> newUris = Arrays.asList("http://host4:10099", currentUri, "http://host5:10099");
+    handler.updateUris(newUris);
+
+    assertEquals(currentUri, getCurrentUri(handler));
+    assertEquals(newUris, getUris(handler));
+
+    proxy.close();
+  }
+
+  @Test
+  public void testUpdateUrisSwitchesWhenCurrentGone() throws Exception {
+    List<String> uris = Arrays.asList("http://host1:10099", "http://host2:10099");
+    RestClientConf conf = new RestClientConf();
+    IRestClient proxy = RetryableRestClient.getRestClient(uris, conf);
+    RetryableRestClient handler = getHandler(proxy);
+
+    // Force current to host1
+    // (we can't control random, so we just verify the invariant:
+    //  after updateUris with list not containing current, current is in new list)
+    String currentBefore = getCurrentUri(handler);
+
+    List<String> newUris = Collections.singletonList("http://host3:10099");
+    handler.updateUris(newUris);
+
+    String currentAfter = getCurrentUri(handler);
+    assertEquals("http://host3:10099", currentAfter);
+    assertNotEquals(currentBefore, currentAfter);
+
+    proxy.close();
+  }
+
+  @Test
+  public void testUpdateUrisWithEmptyRemoval() throws Exception {
+    List<String> uris = Arrays.asList("http://host1:10099", "http://host2:10099");
+    RestClientConf conf = new RestClientConf();
+    IRestClient proxy = RetryableRestClient.getRestClient(uris, conf);
+    RetryableRestClient handler = getHandler(proxy);
+
+    // Remove the current server from the list
+    String current = getCurrentUri(handler);
+    String other =
+        current.equals("http://host1:10099") ? "http://host2:10099" : "http://host1:10099";
+
+    handler.updateUris(Collections.singletonList(other));
+    assertEquals(other, getCurrentUri(handler));
+
+    proxy.close();
+  }
+
+  @Test
+  public void testRotateToNextUri() throws Exception {
+    List<String> uris =
+        Arrays.asList("http://host1:10099", "http://host2:10099", "http://host3:10099");
+    RestClientConf conf = new RestClientConf();
+    IRestClient proxy = RetryableRestClient.getRestClient(uris, conf);
+    RetryableRestClient handler = getHandler(proxy);
+
+    String current = getCurrentUri(handler);
+    int idx = uris.indexOf(current);
+    String expected = uris.get((idx + 1) % uris.size());
+
+    // Use reflection to call rotateToNextUri
+    java.lang.reflect.Method rotateMethod =
+        RetryableRestClient.class.getDeclaredMethod("rotateToNextUri");
+    rotateMethod.setAccessible(true);
+    rotateMethod.invoke(handler);
+
+    assertEquals(expected, getCurrentUri(handler));
+
+    proxy.close();
+  }
+}

--- a/kyuubi-rest-client/src/test/java/org/apache/kyuubi/client/discovery/RestDiscoveryConfTest.java
+++ b/kyuubi-rest-client/src/test/java/org/apache/kyuubi/client/discovery/RestDiscoveryConfTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.client.discovery;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class RestDiscoveryConfTest {
+
+  @Test
+  public void testDefaults() {
+    RestDiscoveryConf conf = new RestDiscoveryConf();
+    assertNull(conf.getHaAddresses());
+    assertEquals("kyuubi", conf.getHaNamespace());
+    assertEquals(
+        "org.apache.kyuubi.ha.client.zookeeper.ZookeeperDiscoveryClient", conf.getHaClientClass());
+    assertEquals(5000L, conf.getRefreshIntervalMs());
+  }
+
+  @Test
+  public void testSetters() {
+    RestDiscoveryConf conf =
+        new RestDiscoveryConf()
+            .setHaAddresses("zk1:2181,zk2:2181")
+            .setHaNamespace("custom-ns")
+            .setHaClientClass("org.apache.kyuubi.ha.client.etcd.EtcdDiscoveryClient")
+            .setRefreshIntervalMs(10000L);
+
+    assertEquals("zk1:2181,zk2:2181", conf.getHaAddresses());
+    assertEquals("custom-ns", conf.getHaNamespace());
+    assertEquals("org.apache.kyuubi.ha.client.etcd.EtcdDiscoveryClient", conf.getHaClientClass());
+    assertEquals(10000L, conf.getRefreshIntervalMs());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testValidateBlankAddresses() {
+    new RestDiscoveryConf().validate();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testValidateEmptyAddresses() {
+    new RestDiscoveryConf().setHaAddresses("").validate();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testValidateBlankNamespace() {
+    new RestDiscoveryConf().setHaAddresses("zk1:2181").setHaNamespace("").validate();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testValidateBlankClientClass() {
+    new RestDiscoveryConf().setHaAddresses("zk1:2181").setHaClientClass("").validate();
+  }
+
+  @Test
+  public void testValidateSuccess() {
+    new RestDiscoveryConf().setHaAddresses("zk1:2181").validate();
+  }
+}

--- a/kyuubi-rest-client/src/test/java/org/apache/kyuubi/client/discovery/RestServiceDiscovererTest.java
+++ b/kyuubi-rest-client/src/test/java/org/apache/kyuubi/client/discovery/RestServiceDiscovererTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.client.discovery;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for RestServiceDiscoverer. Integration tests with embedded ZK are covered by {@code
+ * KyuubiRestServiceDiscoverySuite} in kyuubi-server.
+ */
+public class RestServiceDiscovererTest {
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testDiscoverValidatesBlankAddresses() {
+    RestDiscoveryConf conf = new RestDiscoveryConf().setHaNamespace("kyuubi");
+    // haAddresses is blank, should fail validation
+    RestServiceDiscoverer.discoverHostUrls(conf);
+  }
+
+  @Test
+  public void testRestNamespaceConstruction() {
+    // Verify the namespace logic: haNamespace + "/rest"
+    RestDiscoveryConf conf =
+        new RestDiscoveryConf().setHaAddresses("localhost:2181").setHaNamespace("kyuubi");
+    // The namespace should be "kyuubi/rest" — this is tested via the
+    // server-side KyuubiRestServiceDiscoverySuite integration test
+    assertEquals("kyuubi", conf.getHaNamespace());
+  }
+
+  @Test
+  public void testCustomNamespace() {
+    RestDiscoveryConf conf =
+        new RestDiscoveryConf().setHaAddresses("zk1:2181").setHaNamespace("custom-ns");
+    assertEquals("custom-ns", conf.getHaNamespace());
+  }
+
+  @Test
+  public void testRefreshIntervalDefault() {
+    RestDiscoveryConf conf = new RestDiscoveryConf().setHaAddresses("zk1:2181");
+    assertEquals(5000L, conf.getRefreshIntervalMs());
+  }
+
+  @Test
+  public void testRefreshIntervalCustom() {
+    RestDiscoveryConf conf =
+        new RestDiscoveryConf().setHaAddresses("zk1:2181").setRefreshIntervalMs(10000L);
+    assertEquals(10000L, conf.getRefreshIntervalMs());
+  }
+}

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiRestFrontendService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiRestFrontendService.scala
@@ -32,6 +32,7 @@ import org.eclipse.jetty.servlet.{ErrorPageErrorHandler, FilterHolder}
 import org.apache.kyuubi.{KyuubiException, Utils}
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf._
+import org.apache.kyuubi.ha.client.ServiceDiscovery
 import org.apache.kyuubi.metrics.{MetricsConstants, MetricsSystem}
 import org.apache.kyuubi.metrics.MetricsConstants.OPERATION_BATCH_PENDING_MAX_ELAPSE
 import org.apache.kyuubi.operation.OperationState
@@ -369,5 +370,11 @@ class KyuubiRestFrontendService(override val serverable: Serverable)
     }
   }
 
-  override val discoveryService: Option[Service] = None
+  override lazy val discoveryService: Option[Service] = {
+    if (ServiceDiscovery.supportServiceDiscovery(conf)) {
+      Some(new KyuubiRestServiceDiscovery(this))
+    } else {
+      None
+    }
+  }
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiRestServiceDiscovery.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiRestServiceDiscovery.scala
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.server
+
+import org.apache.kyuubi.config.KyuubiConf
+import org.apache.kyuubi.ha.HighAvailabilityConf._
+import org.apache.kyuubi.ha.client.{DiscoveryClientProvider, ServiceDiscovery}
+import org.apache.kyuubi.service.FrontendService
+
+/**
+ * A service discovery implementation for the REST frontend.
+ * It registers the REST service under a subdirectory "rest" of the
+ * HA_NAMESPACE (e.g. "/kyuubi/rest") to distinguish from Thrift endpoints.
+ *
+ * @param fe the REST frontend service to publish for service discovery
+ */
+class KyuubiRestServiceDiscovery(
+    fe: FrontendService) extends ServiceDiscovery("KyuubiRestServiceDiscovery", fe) {
+
+  override def initialize(conf: KyuubiConf): Unit = {
+    this.conf = conf
+
+    _namespace = conf.get(HA_NAMESPACE) + "/rest"
+    _discoveryClient = DiscoveryClientProvider.createDiscoveryClient(conf)
+    discoveryClient.monitorState(this)
+    discoveryClient.createClient()
+
+    super.initialize(conf)
+  }
+
+  override def stop(): Unit = synchronized {
+    if (!isServerLost.get()) {
+      discoveryClient.deregisterService()
+      discoveryClient.closeClient()
+      gracefulShutdownLatch.await()
+    } else {
+      warn(s"The discovery service ensemble is LOST")
+    }
+    super.stop()
+  }
+}

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiRestServiceDiscovery.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiRestServiceDiscovery.scala
@@ -19,7 +19,7 @@ package org.apache.kyuubi.server
 
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.ha.HighAvailabilityConf._
-import org.apache.kyuubi.ha.client.{DiscoveryClientProvider, ServiceDiscovery}
+import org.apache.kyuubi.ha.client.ServiceDiscovery
 import org.apache.kyuubi.service.FrontendService
 
 /**
@@ -33,14 +33,8 @@ class KyuubiRestServiceDiscovery(
     fe: FrontendService) extends ServiceDiscovery("KyuubiRestServiceDiscovery", fe) {
 
   override def initialize(conf: KyuubiConf): Unit = {
-    this.conf = conf
-
-    _namespace = conf.get(HA_NAMESPACE) + "/rest"
-    _discoveryClient = DiscoveryClientProvider.createDiscoveryClient(conf)
-    discoveryClient.monitorState(this)
-    discoveryClient.createClient()
-
     super.initialize(conf)
+    _namespace = conf.get(HA_NAMESPACE) + "/rest"
   }
 
   override def stop(): Unit = synchronized {

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/KyuubiRestServiceDiscoverySuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/KyuubiRestServiceDiscoverySuite.scala
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.server
+
+import org.scalatest.time.SpanSugar._
+
+import org.apache.kyuubi.KyuubiFunSuite
+import org.apache.kyuubi.config.KyuubiConf
+import org.apache.kyuubi.ha.HighAvailabilityConf._
+import org.apache.kyuubi.ha.client.DiscoveryClientProvider.withDiscoveryClient
+import org.apache.kyuubi.ha.client.ServiceDiscovery
+import org.apache.kyuubi.service._
+import org.apache.kyuubi.zookeeper.EmbeddedZookeeper
+import org.apache.kyuubi.zookeeper.ZookeeperConf.ZK_CLIENT_PORT
+
+class KyuubiRestServiceDiscoverySuite extends KyuubiFunSuite {
+
+  private var zkServer: EmbeddedZookeeper = _
+  private var conf: KyuubiConf = _
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    val embeddedZkConf = KyuubiConf()
+    embeddedZkConf.set(ZK_CLIENT_PORT, 0)
+    zkServer = new EmbeddedZookeeper()
+    zkServer.initialize(embeddedZkConf)
+    zkServer.start()
+    conf = new KyuubiConf()
+      .set(HA_ADDRESSES, zkServer.getConnectString)
+      .set(HA_ZK_CONN_RETRY_POLICY, "ONE_TIME")
+      .set(HA_ZK_CONN_BASE_RETRY_WAIT, 1000)
+      .set(HA_ZK_SESSION_TIMEOUT, 3000)
+      .set(HA_ZK_CONN_TIMEOUT, 3000)
+      .set(KyuubiConf.FRONTEND_THRIFT_BINARY_BIND_PORT, 0)
+  }
+
+  override def afterEach(): Unit = {
+    if (zkServer != null) zkServer.stop()
+    super.afterEach()
+  }
+
+  test("REST discovery is conditional on HA config") {
+    val noHaConf = new KyuubiConf()
+    assert(!ServiceDiscovery.supportServiceDiscovery(noHaConf))
+    assert(ServiceDiscovery.supportServiceDiscovery(conf))
+  }
+
+  test("publish REST instance under namespace/rest and verify with discovery client") {
+    val namespace = "kyuubi-rest-test"
+    conf.set(HA_NAMESPACE, namespace)
+
+    var restDiscovery: KyuubiRestServiceDiscovery = null
+    val service: Serverable = new NoopTBinaryFrontendServer() {
+      override val frontendServices: Seq[NoopTBinaryFrontendService] = Seq(
+        new NoopTBinaryFrontendService(this) {
+          override val discoveryService: Option[Service] = {
+            restDiscovery = new KyuubiRestServiceDiscovery(this)
+            Some(restDiscovery)
+          }
+        })
+    }
+    service.initialize(conf)
+    service.start()
+    assert(service.getServiceState === ServiceState.STARTED)
+
+    val restPath = s"/$namespace/rest"
+    try {
+      // Verify using the service's own discovery client
+      eventually(timeout(10.seconds), interval(200.millis)) {
+        withDiscoveryClient(conf) { discoveryClient =>
+          assert(discoveryClient.pathExists(restPath))
+          val children = discoveryClient.getChildren(restPath)
+          assert(children.size === 1)
+          assert(children.head.startsWith(
+            s"serverUri=${service.frontendServices.head.connectionUrl}"))
+        }
+      }
+    } finally {
+      service.stop()
+      restDiscovery.stop()
+    }
+  }
+
+  test("graceful stop when REST service node is deleted") {
+    val namespace = "kyuubi-rest-graceful"
+    conf.set(HA_NAMESPACE, namespace)
+
+    var restDiscovery: KyuubiRestServiceDiscovery = null
+    val service: Serverable = new NoopTBinaryFrontendServer() {
+      override val frontendServices: Seq[NoopTBinaryFrontendService] = Seq(
+        new NoopTBinaryFrontendService(this) {
+          override val discoveryService: Option[Service] = {
+            restDiscovery = new KyuubiRestServiceDiscovery(this)
+            Some(restDiscovery)
+          }
+        })
+    }
+    service.initialize(conf)
+    service.start()
+    assert(service.getServiceState === ServiceState.STARTED)
+
+    val restPath = s"/$namespace/rest"
+    try {
+      eventually(timeout(10.seconds), interval(200.millis)) {
+        withDiscoveryClient(conf) { discoveryClient =>
+          assert(discoveryClient.pathExists(restPath))
+        }
+      }
+
+      withDiscoveryClient(conf) { discoveryClient =>
+        val children = discoveryClient.getChildren(restPath)
+        children.foreach { child =>
+          discoveryClient.delete(s"$restPath/$child")
+        }
+      }
+
+      eventually(timeout(10.seconds), interval(100.millis)) {
+        assert(restDiscovery.getServiceState === ServiceState.STOPPED)
+        assert(service.getServiceState === ServiceState.STOPPED)
+      }
+    } finally {
+      service.stop()
+      if (restDiscovery != null) restDiscovery.stop()
+    }
+  }
+}


### PR DESCRIPTION
### Why are the changes needed?

  Currently, the Kyuubi REST frontend service does not register itself with the HA discovery service (ZK/ETCD). This means REST clients must use static host URLs and cannot benefit from dynamic service discovery, automatic failover, or load balancing that the Thrift frontend already
  supports.

  This patch adds full service discovery support for the REST frontend, covering both the **server-side** (registering REST endpoints in ZK/ETCD under a dedicated namespace) and the **client-side** (discovering and dynamically refreshing REST endpoints).

  **Server-side changes:**
  - `KyuubiRestFrontendService` now creates a `KyuubiRestServiceDiscovery` when HA is configured, registering the REST service under `{namespace}/rest` (e.g. `/kyuubi/rest`) to distinguish it from Thrift endpoints.
  - `KyuubiRestServiceDiscovery` extends `ServiceDiscovery` with custom namespace logic and graceful shutdown.
  - `ServiceDiscovery._namespace` and `_discoveryClient` visibility changed from `private` to `protected` to allow subclass customization.

  **Client-side changes:**
  - New `RestDiscoveryConf` configuration class for ZK/ETCD discovery settings (addresses, namespace, client class, refresh interval).
  - New `RestServiceDiscoverer` utility to discover REST host URLs from ZK/ETCD service nodes.
  - `KyuubiRestClient.discoveryBuilder()` API to create a client with automatic background endpoint refresh.
  - `RetryableRestClient` refactored to track the current URI by value instead of index, with a new `updateUris()` method for dynamic URI list updates.

  ### How was this patch tested?

  - **Unit tests added:**
    - `RetryableRestClientTest` — tests `updateUris()` behavior: keeping current server, switching when removed, URI rotation.
    - `RestDiscoveryConfTest` — tests default values, setters, and validation logic.
    - `RestServiceDiscovererTest` — tests namespace construction and validation.

  - **Integration tests added:**
    - `KyuubiRestServiceDiscoverySuite` — tests with embedded ZooKeeper:
      - REST discovery is conditional on HA configuration.
      - REST instance publishes under `namespace/rest` and can be discovered.
      - Graceful shutdown when the REST service node is deleted.

  - Compiled and tested `kyuubi-ha`, `kyuubi-rest-client`, and `kyuubi-server` modules (`mvn compile` and `mvn test` all passed).

  ### Was this patch authored or co-authored using generative AI tooling?

  co-authored
