### PR TITLE
[DOC] Update Apache Paimon references after graduation

### DIFF
--- a/docs/connector/flink/paimon.rst
+++ b/docs/connector/flink/paimon.rst
@@ -13,48 +13,48 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 
-Apache Paimon (Incubating)
-==========================
+Apache Paimon
+=============
 
-`Apache Paimon (Incubating)`_ is a streaming data lake platform that supports high-speed data ingestion, change data tracking, and efficient real-time analytics.
+`Apache Paimon`_ is a streaming data lake platform that supports high-speed data ingestion, change data tracking, and efficient real-time analytics.
 
 .. tip::
-   This article assumes that you have mastered the basic knowledge and operation of `Apache Paimon (Incubating)`_.
+   This article assumes that you have mastered the basic knowledge and operation of `Apache Paimon`_.
    For the knowledge not mentioned in this article,
    you can obtain it from its `Official Documentation`_.
 
-By using kyuubi, we can run SQL queries towards Apache Paimon (Incubating) which is more
+By using kyuubi, we can run SQL queries towards Apache Paimon which is more
 convenient, easy to understand, and easy to expand than directly using flink.
 
-Apache Paimon (Incubating) Integration
---------------------------------------
+Apache Paimon Integration
+-------------------------
 
-To enable the integration of kyuubi flink sql engine and Apache Paimon (Incubating), you need to:
+To enable the integration of kyuubi flink sql engine and Apache Paimon, you need to:
 
-- Referencing the Apache Paimon (Incubating) :ref:`dependencies<flink-paimon-deps>`
+- Referencing the Apache Paimon :ref:`dependencies<flink-paimon-deps>`
 
 .. _flink-paimon-deps:
 
 Dependencies
 ************
 
-The **classpath** of kyuubi flink sql engine with Apache Paimon (Incubating) supported consists of
+The **classpath** of kyuubi flink sql engine with Apache Paimon supported consists of
 
 1. kyuubi-flink-sql-engine-\ |release|\ _2.12.jar, the engine jar deployed with a Kyuubi distribution
 2. a copy of flink distribution
-3. paimon-flink-<version>.jar (example: paimon-flink-1.18-0.8.1.jar), which can be found in the `Apache Paimon (Incubating) Supported Engines Flink`_
+3. paimon-flink-<version>.jar (example: paimon-flink-1.18-0.8.1.jar), which can be found in the `Apache Paimon Supported Engines Flink`_
 4. flink-shaded-hadoop-2-uber-<version>.jar, which code can be found in the `Pre-bundled Hadoop Jar`_
 
-In order to make the Apache Paimon (Incubating) packages visible for the runtime classpath of engines, you need to:
+In order to make the Apache Paimon packages visible for the runtime classpath of engines, you need to:
 
-1. Put the Apache Paimon (Incubating) packages into ``$FLINK_HOME/lib`` directly
+1. Put the Apache Paimon packages into ``$FLINK_HOME/lib`` directly
 2. Setting the HADOOP_CLASSPATH environment variable or copy the `Pre-bundled Hadoop Jar`_ to flink/lib.
 
 .. warning::
-   Please mind the compatibility of different Apache Paimon (Incubating) and Flink versions, which can be confirmed on the page of `Apache Paimon (Incubating) multi engine support`_.
+   Please mind the compatibility of different Apache Paimon and Flink versions, which can be confirmed on the page of `Apache Paimon multi engine support`_.
 
-Apache Paimon (Incubating) Operations
--------------------------------------
+Apache Paimon Operations
+------------------------
 
 Taking ``CREATE CATALOG`` as a example,
 
@@ -103,8 +103,8 @@ Taking ``Rescale Bucket`` as a example,
    INSERT OVERWRITE my_table PARTITION (dt = '2022-01-01');
 
 
-.. _Apache Paimon (Incubating): https://paimon.apache.org/
+.. _Apache Paimon: https://paimon.apache.org/
 .. _Official Documentation: https://paimon.apache.org/docs/master/
-.. _Apache Paimon (Incubating) Supported Engines Flink: https://paimon.apache.org/docs/master/engines/flink/#preparing-paimon-jar-file
+.. _Apache Paimon Supported Engines Flink: https://paimon.apache.org/docs/master/engines/flink/#preparing-paimon-jar-file
 .. _Pre-bundled Hadoop Jar: https://flink.apache.org/downloads/#additional-components
-.. _Apache Paimon (Incubating) multi engine support: https://paimon.apache.org/docs/master/engines/overview/
+.. _Apache Paimon multi engine support: https://paimon.apache.org/docs/master/engines/overview/

--- a/docs/connector/hive/paimon.rst
+++ b/docs/connector/hive/paimon.rst
@@ -13,26 +13,26 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 
-Apache Paimon (Incubating)
-==========================
+Apache Paimon
+=============
 
-`Apache Paimon (Incubating)`_ is a streaming data lake platform that supports high-speed data ingestion, change data tracking and efficient real-time analytics.
+`Apache Paimon`_ is a streaming data lake platform that supports high-speed data ingestion, change data tracking and efficient real-time analytics.
 
 .. tip::
-   This article assumes that you have mastered the basic knowledge and operation of `Apache Paimon (Incubating)`_.
-   For the knowledge about Apache Paimon (Incubating) not mentioned in this article,
+   This article assumes that you have mastered the basic knowledge and operation of `Apache Paimon`_.
+   For the knowledge about Apache Paimon not mentioned in this article,
    you can obtain it from its `Official Documentation`_.
 
-By using Kyuubi, we can run SQL queries towards Apache Paimon (Incubating) which is more
+By using Kyuubi, we can run SQL queries towards Apache Paimon which is more
 convenient, easy to understand, and easy to expand than directly using
-Hive to manipulate Apache Paimon (Incubating).
+Hive to manipulate Apache Paimon.
 
-Apache Paimon (Incubating) Integration
---------------------------------------
+Apache Paimon Integration
+-------------------------
 
-To enable the integration of kyuubi hive sql engine and Apache Paimon (Incubating), you need to:
+To enable the integration of kyuubi hive sql engine and Apache Paimon, you need to:
 
-- Referencing the Apache Paimon (Incubating) :ref:`dependencies<hive-paimon-deps>`
+- Referencing the Apache Paimon :ref:`dependencies<hive-paimon-deps>`
 - Setting the environment variable :ref:`configurations<hive-paimon-conf>`
 
 .. _hive-paimon-deps:
@@ -44,7 +44,7 @@ The **classpath** of kyuubi hive sql engine with Iceberg supported consists of
 
 1. kyuubi-hive-sql-engine-\ |release|\ _2.12.jar, the engine jar deployed with a Kyuubi distribution
 2. a copy of hive distribution
-3. paimon-hive-connector-<hive.binary.version>-<paimon.version>.jar (example: paimon-hive-connector-3.1-0.4-SNAPSHOT.jar), which can be found in the `Apache Paimon (Incubating) Supported Engines Hive`_
+3. paimon-hive-connector-<hive.binary.version>-<paimon.version>.jar (example: paimon-hive-connector-3.1-0.4-SNAPSHOT.jar), which can be found in the `Apache Paimon Supported Engines Hive`_
 
 In order to make the Hive packages visible for the runtime classpath of engines, we can use one of these methods:
 
@@ -60,7 +60,7 @@ In order to make the Hive packages visible for the runtime classpath of engines,
     ``org.apache.hive.com.esotericsoftware.kryo.kryoexception: unable to find class.``
 
 .. warning::
-   Please mind the compatibility of different Apache Paimon (Incubating) and Hive versions, which can be confirmed on the page of `Apache Paimon (Incubating) multi engine support`_.
+   Please mind the compatibility of different Apache Paimon and Hive versions, which can be confirmed on the page of `Apache Paimon multi engine support`_.
 
 .. _hive-paimon-conf:
 
@@ -69,12 +69,12 @@ Configurations
 
 If you are using HDFS, make sure that the environment variable HADOOP_HOME or HADOOP_CONF_DIR is set.
 
-Apache Paimon (Incubating) Operations
--------------------------------------
+Apache Paimon Operations
+------------------------
 
-Apache Paimon (Incubating) only supports only reading table store tables through Hive.
+Apache Paimon only supports only reading table store tables through Hive.
 A common scenario is to write data with Spark or Flink and read data with Hive.
-You can follow this document `Apache Paimon (Incubating) Quick Start with Paimon Hive Catalog`_  to write data to a table which can also be accessed directly from Hive.
+You can follow this document `Apache Paimon Quick Start with Paimon Hive Catalog`_  to write data to a table which can also be accessed directly from Hive.
 and then use Kyuubi Hive SQL engine to query the table with the following SQL ``SELECT`` statement.
 
 Taking ``Query Data`` as an example,
@@ -93,8 +93,8 @@ Taking ``Query External Table`` as an example,
 
     SELECT a, b FROM test_table ORDER BY a;
 
-.. _Apache Paimon (Incubating): https://paimon.apache.org/
+.. _Apache Paimon: https://paimon.apache.org/
 .. _Official Documentation: https://paimon.apache.org/docs/master/
-.. _Apache Paimon (Incubating) Quick Start with Paimon Hive Catalog: https://paimon.apache.org/docs/master/engines/hive/#quick-start-with-paimon-hive-catalog
-.. _Apache Paimon (Incubating) Supported Engines Hive: https://paimon.apache.org/docs/master/engines/hive/
-.. _Apache Paimon (Incubating) multi engine support: https://paimon.apache.org/docs/master/engines/overview/
+.. _Apache Paimon Quick Start with Paimon Hive Catalog: https://paimon.apache.org/docs/master/engines/hive/#quick-start-with-paimon-hive-catalog
+.. _Apache Paimon Supported Engines Hive: https://paimon.apache.org/docs/master/engines/hive/
+.. _Apache Paimon multi engine support: https://paimon.apache.org/docs/master/engines/overview/

--- a/docs/connector/spark/index.rst
+++ b/docs/connector/spark/index.rst
@@ -23,7 +23,7 @@ By default, it provides accessibility to hive warehouses with various file forma
 supported, such as parquet, orc, json, etc.
 
 Also，it can easily integrate with other third-party libraries, such as Hudi,
-Iceberg, Delta Lake, Kudu, Apache Paimon (Incubating), HBase，Cassandra, etc.
+Iceberg, Delta Lake, Kudu, Apache Paimon, HBase，Cassandra, etc.
 
 We also provide sample data sources like TDC-DS, TPC-H for testing and benchmarking
 purpose.

--- a/docs/connector/spark/paimon.rst
+++ b/docs/connector/spark/paimon.rst
@@ -13,27 +13,27 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 
-Apache Paimon (Incubating)
-==========================
+Apache Paimon
+=============
 
-`Apache Paimon (Incubating)`_ is a streaming data lake platform that supports high-speed data ingestion, change data tracking and efficient real-time analytics.
+`Apache Paimon`_ is a streaming data lake platform that supports high-speed data ingestion, change data tracking and efficient real-time analytics.
 
 .. tip::
-   This article assumes that you have mastered the basic knowledge and operation of `Apache Paimon (Incubating)`_.
-   For the knowledge about Apache Paimon (Incubating) not mentioned in this article,
+   This article assumes that you have mastered the basic knowledge and operation of `Apache Paimon`_.
+   For the knowledge about Apache Paimon not mentioned in this article,
    you can obtain it from its `Official Documentation`_.
 
-By using kyuubi, we can run SQL queries towards Apache Paimon (Incubating) which is more
+By using kyuubi, we can run SQL queries towards Apache Paimon which is more
 convenient, easy to understand, and easy to expand than directly using
-spark to manipulate Apache Paimon (Incubating).
+spark to manipulate Apache Paimon.
 
-Apache Paimon (Incubating) Integration
---------------------------------------
+Apache Paimon Integration
+-------------------------
 
-To enable the integration of Kyuubi Spark SQL engine and Apache Paimon (Incubating) through
+To enable the integration of Kyuubi Spark SQL engine and Apache Paimon through
 Spark DataSource V2 API, you need to:
 
-- Referencing the Apache Paimon (Incubating) :ref:`dependencies<spark-paimon-deps>`
+- Referencing the Apache Paimon :ref:`dependencies<spark-paimon-deps>`
 - Setting the Spark extension and catalog :ref:`configurations<spark-paimon-conf>`
 
 .. _spark-paimon-deps:
@@ -41,34 +41,34 @@ Spark DataSource V2 API, you need to:
 Dependencies
 ************
 
-The **classpath** of Kyuubi Spark SQL engine with Apache Paimon (Incubating) consists of
+The **classpath** of Kyuubi Spark SQL engine with Apache Paimon consists of
 
 1. kyuubi-spark-sql-engine-\ |release|\ _2.12.jar, the engine jar deployed with a Kyuubi distribution
 2. a copy of Spark distribution
-3. paimon-spark-<version>.jar (example: paimon-spark-3.5-0.8.1.jar), which can be found in the `Apache Paimon (Incubating) Supported Engines Spark3`_
+3. paimon-spark-<version>.jar (example: paimon-spark-3.5-0.8.1.jar), which can be found in the `Apache Paimon Supported Engines Spark3`_
 
-In order to make the Apache Paimon (Incubating) packages visible for the runtime classpath of engines, we can use one of these methods:
+In order to make the Apache Paimon packages visible for the runtime classpath of engines, we can use one of these methods:
 
-1. Put the Apache Paimon (Incubating) packages into ``$SPARK_HOME/jars`` directly
+1. Put the Apache Paimon packages into ``$SPARK_HOME/jars`` directly
 2. Set ``spark.jars=/path/to/paimon-spark-<version>.jar``
 
 .. warning::
-   Please mind the compatibility of different Apache Paimon (Incubating) and Spark versions, which can be confirmed on the page of `Apache Paimon (Incubating) multi engine support`_.
+   Please mind the compatibility of different Apache Paimon and Spark versions, which can be confirmed on the page of `Apache Paimon multi engine support`_.
 
 .. _spark-paimon-conf:
 
 Configurations
 **************
 
-To activate functionality of Apache Paimon (Incubating), we can set the following configurations:
+To activate functionality of Apache Paimon, we can set the following configurations:
 
 .. code-block:: properties
 
    spark.sql.catalog.paimon=org.apache.paimon.spark.SparkCatalog
    spark.sql.catalog.paimon.warehouse=file:/tmp/paimon
 
-Apache Paimon (Incubating) Operations
--------------------------------------
+Apache Paimon Operations
+------------------------
 
 
 Taking ``CREATE NAMESPACE`` as a example,
@@ -105,7 +105,7 @@ Taking ``INSERT`` as a example,
 
 
 
-.. _Apache Paimon (Incubating): https://paimon.apache.org/
+.. _Apache Paimon: https://paimon.apache.org/
 .. _Official Documentation: https://paimon.apache.org/docs/master/
-.. _Apache Paimon (Incubating) Supported Engines Spark3: https://paimon.apache.org/docs/master/engines/spark3/
-.. _Apache Paimon (Incubating) multi engine support: https://paimon.apache.org/docs/master/engines/overview/
+.. _Apache Paimon Supported Engines Spark3: https://paimon.apache.org/docs/master/engines/spark3/
+.. _Apache Paimon multi engine support: https://paimon.apache.org/docs/master/engines/overview/

--- a/docs/connector/trino/paimon.rst
+++ b/docs/connector/trino/paimon.rst
@@ -13,26 +13,26 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 
-Apache Paimon (Incubating)
-==========================
+Apache Paimon
+=============
 
-`Apache Paimon (Incubating)`_ is a streaming data lake platform that supports high-speed data ingestion, change data tracking and efficient real-time analytics.
+`Apache Paimon`_ is a streaming data lake platform that supports high-speed data ingestion, change data tracking and efficient real-time analytics.
 
 .. tip::
-   This article assumes that you have mastered the basic knowledge and operation of `Apache Paimon (Incubating)`_.
-   For the knowledge about Apache Paimon (Incubating) not mentioned in this article,
+   This article assumes that you have mastered the basic knowledge and operation of `Apache Paimon`_.
+   For the knowledge about Apache Paimon not mentioned in this article,
    you can obtain it from its `Official Documentation`_.
 
-By using kyuubi, we can run SQL queries towards Apache Paimon (Incubating) which is more
+By using kyuubi, we can run SQL queries towards Apache Paimon which is more
 convenient, easy to understand, and easy to expand than directly using
-trino to manipulate Apache Paimon (Incubating).
+trino to manipulate Apache Paimon.
 
-Apache Paimon (Incubating) Integration
---------------------------------------
+Apache Paimon Integration
+-------------------------
 
-To enable the integration of kyuubi trino sql engine and Apache Paimon (Incubating), you need to:
+To enable the integration of kyuubi trino sql engine and Apache Paimon, you need to:
 
-- Referencing the Apache Paimon (Incubating) :ref:`dependencies<trino-paimon-deps>`
+- Referencing the Apache Paimon :ref:`dependencies<trino-paimon-deps>`
 - Setting the trino extension and catalog :ref:`configurations<trino-paimon-conf>`
 
 .. _trino-paimon-deps:
@@ -40,27 +40,27 @@ To enable the integration of kyuubi trino sql engine and Apache Paimon (Incubati
 Dependencies
 ************
 
-The **classpath** of kyuubi trino sql engine with Apache Paimon (Incubating) supported consists of
+The **classpath** of kyuubi trino sql engine with Apache Paimon supported consists of
 
 1. kyuubi-trino-sql-engine-\ |release|\ _2.12.jar, the engine jar deployed with a Kyuubi distribution
 2. a copy of trino distribution
 3. paimon-trino-<version>.jar (example: paimon-trino-0.2.jar), which code can be found in the `Source Code`_
 4. flink-shaded-hadoop-2-uber-<version>.jar, which code can be found in the `Pre-bundled Hadoop`_
 
-In order to make the Apache Paimon (Incubating) packages visible for the runtime classpath of engines, you need to:
+In order to make the Apache Paimon packages visible for the runtime classpath of engines, you need to:
 
-1. Build the paimon-trino-<version>.jar by reference to `Apache Paimon (Incubating) Trino README`_
+1. Build the paimon-trino-<version>.jar by reference to `Apache Paimon Trino README`_
 2. Put the paimon-trino-<version>.jar and flink-shaded-hadoop-2-uber-<version>.jar packages into ``$TRINO_SERVER_HOME/plugin/tablestore`` directly
 
 .. warning::
-   Please mind the compatibility of different Apache Paimon (Incubating) and Trino versions, which can be confirmed on the page of `Apache Paimon (Incubating) multi engine support`_.
+   Please mind the compatibility of different Apache Paimon and Trino versions, which can be confirmed on the page of `Apache Paimon multi engine support`_.
 
 .. _trino-paimon-conf:
 
 Configurations
 **************
 
-To activate functionality of Apache Paimon (Incubating), we can set the following configurations:
+To activate functionality of Apache Paimon, we can set the following configurations:
 
 Catalogs are registered by creating a catalog properties file in the $TRINO_SERVER_HOME/etc/catalog directory.
 For example, create $TRINO_SERVER_HOME/etc/catalog/tablestore.properties with the following contents to mount the tablestore connector as the tablestore catalog:
@@ -70,12 +70,12 @@ For example, create $TRINO_SERVER_HOME/etc/catalog/tablestore.properties with th
    connector.name=tablestore
    warehouse=file:///tmp/warehouse
 
-Apache Paimon (Incubating) Operations
--------------------------------------
+Apache Paimon Operations
+------------------------
 
-Apache Paimon (Incubating) supports reading table store tables through Trino.
+Apache Paimon supports reading table store tables through Trino.
 A common scenario is to write data with Spark or Flink and read data with Trino.
-You can follow this document `Apache Paimon (Incubating) Engines Flink Quick Start`_  to write data to a table store table
+You can follow this document `Apache Paimon Engines Flink Quick Start`_  to write data to a table store table
 and then use kyuubi trino sql engine to query the table with the following SQL ``SELECT`` statement.
 
 
@@ -83,10 +83,10 @@ and then use kyuubi trino sql engine to query the table with the following SQL `
 
    SELECT * FROM tablestore.default.t1
 
-.. _Apache Paimon (Incubating): https://paimon.apache.org/
-.. _Apache Paimon (Incubating) multi engine support: https://paimon.apache.org/docs/master/engines/overview/
-.. _Apache Paimon (Incubating) Engines Flink Quick Start: https://paimon.apache.org/docs/master/engines/flink/#quick-start
+.. _Apache Paimon: https://paimon.apache.org/
+.. _Apache Paimon multi engine support: https://paimon.apache.org/docs/master/engines/overview/
+.. _Apache Paimon Engines Flink Quick Start: https://paimon.apache.org/docs/master/engines/flink/#quick-start
 .. _Official Documentation: https://paimon.apache.org/docs/master/
 .. _Source Code: https://github.com/JingsongLi/paimon-trino
 .. _Pre-bundled Hadoop: https://flink.apache.org/downloads/#additional-components
-.. _Apache Paimon (Incubating) Trino README: https://github.com/JingsongLi/paimon-trino#readme
+.. _Apache Paimon Trino README: https://github.com/JingsongLi/paimon-trino#readme

--- a/docs/connector/trino/paimon.rst
+++ b/docs/connector/trino/paimon.rst
@@ -89,4 +89,4 @@ and then use kyuubi trino sql engine to query the table with the following SQL `
 .. _Official Documentation: https://paimon.apache.org/docs/master/
 .. _Source Code: https://github.com/JingsongLi/paimon-trino
 .. _Pre-bundled Hadoop: https://flink.apache.org/downloads/#additional-components
-.. _Apache Paimon Trino README: https://github.com/JingsongLi/paimon-trino#readme
+.. _Apache Paimon Trino README: https://github.com/apache/paimon-trino

--- a/docs/connector/trino/paimon.rst
+++ b/docs/connector/trino/paimon.rst
@@ -87,6 +87,6 @@ and then use kyuubi trino sql engine to query the table with the following SQL `
 .. _Apache Paimon multi engine support: https://paimon.apache.org/docs/master/engines/overview/
 .. _Apache Paimon Engines Flink Quick Start: https://paimon.apache.org/docs/master/engines/flink/#quick-start
 .. _Official Documentation: https://paimon.apache.org/docs/master/
-.. _Source Code: https://github.com/JingsongLi/paimon-trino
+.. _Source Code: https://github.com/apache/paimon-trino
 .. _Pre-bundled Hadoop: https://flink.apache.org/downloads/#additional-components
 .. _Apache Paimon Trino README: https://github.com/apache/paimon-trino


### PR DESCRIPTION
### Why are the changes needed?
The PR removes "(Incubating)" from the Apache Paimon references and it's needed to keep documentation up to date.
See [Apache Software Foundation Announces New Top-Level Project Apache® Paimon](https://news.apache.org/foundation/entry/apache-software-foundation-announces-new-top-level-project-apache-paimon).


### How was this patch tested?
Built the documentation with the following command and verified the text:
```shell
make html
```


### Was this patch authored or co-authored using generative AI tooling?
No

