### PR TITLE
[KYUUBI #7443] Fix NullPointerException when configuring the wrong SPARK_HOME

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
@@ -111,13 +111,20 @@ class SparkProcessBuilder(
   }
 
   private[kyuubi] def extractSparkCoreScalaVersion(fileNames: Iterable[String]): String = {
-    fileNames.collectFirst { case SPARK_CORE_SCALA_VERSION_REGEX(scalaVersion) => scalaVersion }
+    Option(fileNames).getOrElse(Iterable.empty)
+      .collectFirst { case SPARK_CORE_SCALA_VERSION_REGEX(scalaVersion) => scalaVersion }
       .getOrElse(throw new KyuubiException("Failed to extract Scala version from spark-core jar"))
   }
 
   override protected val engineScalaBinaryVersion: String = {
     env.get("SPARK_SCALA_VERSION").filter(StringUtils.isNotBlank).getOrElse {
-      extractSparkCoreScalaVersion(Paths.get(sparkHome, "jars").toFile.list())
+      val jarsDir = Paths.get(sparkHome, "jars").toFile
+      val fileNames = Option(jarsDir.list()).getOrElse {
+        throw new KyuubiException(
+          s"Failed to list jars under $sparkHome, please check if SPARK_HOME is configured " +
+            "correctly and the jars directory exists")
+      }
+      extractSparkCoreScalaVersion(fileNames)
     }
   }
 

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilderSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilderSuite.scala
@@ -422,6 +422,70 @@ class SparkProcessBuilderSuite extends KerberizedTestHelper with MockitoSugar {
     }
   }
 
+  test("Fix NullPointerException when SPARK_HOME is invalid") {
+    val notFoundMsg = "Failed to extract Scala version"
+    val listFailMsg = "Failed to list jars"
+
+    def newConf(sparkHome: String): KyuubiConf = {
+      KyuubiConf(false)
+        .set("kyuubi.engineEnv.SPARK_HOME", sparkHome)
+        .set("kyuubi.engineEnv.SPARK_SCALA_VERSION", "")
+    }
+
+    // case 1: SPARK_HOME does not exists
+    val nonExistentHome = Paths.get(
+      Utils.createTempDir("invalid-spark-home").toString,
+      s"not-exist-${UUID.randomUUID()}").toString
+    val nonExistentErr = intercept[KyuubiException] {
+      new SparkProcessBuilder("kentyao", true, newConf(nonExistentHome))
+    }
+    assert(!nonExistentErr.getMessage.contains("NullPointerException"))
+    assert(nonExistentErr.getMessage.contains(listFailMsg))
+
+    // case 2: SPARK_HOME exists but the `jars` subdirectory is missing
+    val homeWithoutJarsDir = Utils.createTempDir("spark-home-no-jars-dir")
+    val withoutJarsErr = intercept[KyuubiException] {
+      new SparkProcessBuilder("kentyao", true, newConf(homeWithoutJarsDir.toString))
+    }
+    assert(!withoutJarsErr.getMessage.contains("NullPointerException"))
+    assert(withoutJarsErr.getMessage.contains(listFailMsg))
+
+    // case 3: SPARK_HOME exists, but the `jars` is a regular file instead of a directory
+    val homeWithJarsAsFile = Utils.createTempDir("spark-home-jars-as-file")
+    Files.createFile(homeWithJarsAsFile.resolve("jars"))
+    val jarsAsFileErr = intercept[KyuubiException] {
+      new SparkProcessBuilder("kentyao", true, newConf(homeWithJarsAsFile.toString))
+    }
+    assert(!jarsAsFileErr.getMessage.contains("NullPointerException"))
+    assert(jarsAsFileErr.getMessage.contains(listFailMsg))
+
+    // case 4: SPARK_HOME exists, but the `jars` is an empty directory
+    val homeWithEmptyJars = Utils.createTempDir("spark-home-empty-jars")
+    Files.createDirectory(homeWithEmptyJars.resolve("jars"))
+    val emptyJarsHomeErr = intercept[KyuubiException] {
+      new SparkProcessBuilder("kentyao", true, newConf(homeWithEmptyJars.toString))
+    }
+    assert(!emptyJarsHomeErr.getMessage.contains("NullPointerException"))
+    assert(emptyJarsHomeErr.getMessage.contains(notFoundMsg))
+
+    // case 5: SPARK_HOME exists, but the `jars` does not contain any spark-core jar
+    val homeWithoutCoreJar = Utils.createTempDir("spark-home-no-core")
+    val noCoreJarsDir = Files.createDirectory(homeWithoutCoreJar.resolve("jars"))
+    Files.createFile(noCoreJarsDir.resolve("hadoop-common-3.3.4.jar"))
+    Files.createFile(noCoreJarsDir.resolve("scala-library-2.12.18.jar"))
+    val noCoreErr = intercept[KyuubiException] {
+      new SparkProcessBuilder("kentyao", true, newConf(homeWithoutCoreJar.toString))
+    }
+    assert(!noCoreErr.getMessage.contains("NullPointerException"))
+    assert(noCoreErr.getMessage.contains(notFoundMsg))
+
+    // case 6: SPARK_HOME exists, and the `jars` contains spark-core jar
+    val validSparkHome = Utils.createTempDir("spark-home-valid")
+    val validJarsDir = Files.createDirectory(validSparkHome.resolve("jars"))
+    Files.createFile(validJarsDir.resolve("spark-core_2.12-3.5.0.jar"))
+    new SparkProcessBuilder("kentyao", true, newConf(validSparkHome.toString))
+  }
+
   test("match scala version of spark home") {
     Seq(
       "spark-3.2.4-bin-hadoop3.2",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->
Fix NullPointerException when configuring the wrong SPARK_HOME. For example: 
```
bin/kyuubi-beeline \
  -u 'jdbc:kyuubi://localhost:10009/default' \
  --conf kyuubi.engineEnv.SPARK_HOME=/path/of/not/exist
```

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
1. Unit test
2. Manual test

### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Partially assisted by Claude Code (Claude Opus 4.7) for unit test.
