### PR TITLE
[CI] Enable Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 4


### PR DESCRIPTION
### Why are the changes needed?
These changes are needed to be compliant with [ASF GitHub Actions Policy](https://infra.apache.org/github-actions-policy.html).
The implementation follows instructions at [Dependabot for Dependency Management](https://infra.apache.org/dependabot.html) page.

Related to [[Umbrella] Ensure GitHub Actions compliance with ASF Policy #7456](https://github.com/apache/kyuubi/issues/7456).


### How was this patch tested?
Review.


### Was this patch authored or co-authored using generative AI tooling?
No

