### PR TITLE
[CI] Set default max-parallel value for all matrices

### DIFF
--- a/.github/workflows/gluten.yml
+++ b/.github/workflows/gluten.yml
@@ -96,6 +96,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
+      max-parallel: 15
       matrix:
         spark: [ '3.5' ]
     steps:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -149,6 +149,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
+      max-parallel: 15
       matrix:
         scala:
           - '2.13'
@@ -384,6 +385,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
+      max-parallel: 15
       matrix:
         java: [ 8 ]
         comment: [ "normal" ]

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,6 +27,7 @@ jobs:
     if: ${{ startsWith(github.repository, 'apache/') }}
     runs-on: ubuntu-24.04
     strategy:
+      max-parallel: 15
       matrix:
         profiles:
           - '-Pscala-2.13 -Pspark-master -pl externals/kyuubi-spark-sql-engine -am'

--- a/.github/workflows/publish-snapshot-nexus.yml
+++ b/.github/workflows/publish-snapshot-nexus.yml
@@ -27,6 +27,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
+      max-parallel: 15
       matrix:
         branch:
           - master

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -40,6 +40,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
+      max-parallel: 15
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
     env:

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -32,6 +32,7 @@ jobs:
     name: Style check
     runs-on: ubuntu-24.04
     strategy:
+      max-parallel: 15
       matrix:
         profiles:
           - '-Pflink-provided,hive-provided,spark-provided,spark-3.5,spark-3.4,spark-3.3,tpcds,kubernetes-it'


### PR DESCRIPTION
### Why are the changes needed?
These changes are needed to ensure compliancy with [ASF GitHub Actions Policy](https://infra.apache.org/github-actions-policy.html).
The default value is set to `15`, which is the recommended job concurrency level.
All other matrices already have specified `max-parallel` value.

Similar PR: https://github.com/apache/airflow/pull/61954

Related to [[Umbrella] Ensure GitHub Actions compliance with ASF Policy #7456](https://github.com/apache/kyuubi/issues/7456).


### How was this patch tested?
Review.


### Was this patch authored or co-authored using generative AI tooling?
No

