### PR TITLE
[KYUUBI #6815] fix jdbc oracle engine NUMBER(20,0) type problem

### DIFF
--- a/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/oracle/OracleSchemaHelper.scala
+++ b/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/oracle/OracleSchemaHelper.scala
@@ -25,7 +25,7 @@ class OracleSchemaHelper extends SchemaHelper {
   override protected def toTTypeDesc(sqlType: Int, precision: Int, scale: Int): TTypeDesc = {
     sqlType match {
       // case for int, returns NUMERIC type in Oracle JDBC
-      case Types.NUMERIC if scale == 0 =>
+      case Types.NUMERIC if scale == 0 && (precision > 0 && precision <= 9) =>
         super.toTTypeDesc(Types.INTEGER, precision, scale)
       // except for int
       case Types.NUMERIC =>

--- a/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/oracle/OracleTRowSetGenerator.scala
+++ b/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/oracle/OracleTRowSetGenerator.scala
@@ -34,9 +34,10 @@ class OracleTRowSetGenerator extends DefaultJdbcTRowSetGenerator {
   }
 
   override def getColumnType(schema: Seq[Column], ordinal: Int): Int = {
-    schema(ordinal).sqlType match {
+    val col = schema(ordinal)
+    col.sqlType match {
       // case for int, returns NUMERIC type in Oracle JDBC
-      case Types.NUMERIC if schema(ordinal).scale == 0 =>
+      case Types.NUMERIC if col.scale == 0 && (col.precision > 0 && col.precision <= 9) =>
         Types.INTEGER
       case Types.NUMERIC =>
         Types.DECIMAL


### PR DESCRIPTION
### Why are the changes needed?
when oracle column type is NUMBER(20,0), and value is 530924057810571264， query tips Integer cast exception
This PR adds Column precision length check，only length <= 9 can be cast to Integer.

### How was this patch tested?
Deployed and Tested in our environment. use kyuubi 1.11.1 jdbc engine proxy oracle, data can be queried normally.

### Was this patch authored or co-authored using generative AI tooling?
No.
