### PR TITLE
[KYUUBI #7473] Migrate Java tests from JUnit 4 to JUnit 5

### DIFF
--- a/externals/kyuubi-data-agent-engine/pom.xml
+++ b/externals/kyuubi-data-agent-engine/pom.xml
@@ -168,8 +168,8 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/datasource/DataSourceFactoryAuthTest.java
+++ b/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/datasource/DataSourceFactoryAuthTest.java
@@ -17,7 +17,10 @@
 
 package org.apache.kyuubi.engine.dataagent.datasource;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.zaxxer.hikari.HikariDataSource;
 import java.io.File;
@@ -25,8 +28,8 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.Statement;
 import javax.sql.DataSource;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 /** Tests for DataSourceFactory. Uses real SQLite. */
 public class DataSourceFactoryAuthTest {
@@ -34,7 +37,7 @@ public class DataSourceFactoryAuthTest {
   private DataSource ds;
   private File tmpFile;
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (ds instanceof HikariDataSource) {
       ((HikariDataSource) ds).close();
@@ -136,13 +139,21 @@ public class DataSourceFactoryAuthTest {
     tmpFile2.delete();
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testNullJdbcUrlThrows() {
-    DataSourceFactory.create(null);
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          DataSourceFactory.create(null);
+        });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testEmptyJdbcUrlThrows() {
-    DataSourceFactory.create("");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          DataSourceFactory.create("");
+        });
   }
 }

--- a/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/datasource/DataSourceFactoryAuthTest.java
+++ b/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/datasource/DataSourceFactoryAuthTest.java
@@ -18,6 +18,7 @@
 package org.apache.kyuubi.engine.dataagent.datasource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -73,7 +74,7 @@ public class DataSourceFactoryAuthTest {
 
     ds = DataSourceFactory.create("jdbc:sqlite:" + tmpFile.getAbsolutePath(), "testuser");
     assertNotNull(ds);
-    assertTrue(ds instanceof HikariDataSource);
+    assertInstanceOf(HikariDataSource.class, ds);
     assertEquals("testuser", ((HikariDataSource) ds).getUsername());
   }
 

--- a/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/datasource/JdbcDialectTest.java
+++ b/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/datasource/JdbcDialectTest.java
@@ -18,11 +18,10 @@
 package org.apache.kyuubi.engine.dataagent.datasource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.kyuubi.engine.dataagent.datasource.dialect.GenericDialect;
 import org.junit.jupiter.api.Test;
@@ -106,7 +105,7 @@ public class JdbcDialectTest {
   public void testUnknownReturnsGenericDialectWithName() {
     JdbcDialect d = JdbcDialect.fromUrl("jdbc:postgresql://localhost:5432/db");
     assertNotNull(d);
-    assertTrue(d instanceof GenericDialect);
+    assertInstanceOf(GenericDialect.class, d);
     assertEquals("postgresql", d.datasourceName());
   }
 
@@ -114,12 +113,7 @@ public class JdbcDialectTest {
   public void testGenericDialectQuoteIdentifierUnsupported() {
     JdbcDialect d = JdbcDialect.fromUrl("jdbc:clickhouse://localhost:8123");
     assertEquals("clickhouse", d.datasourceName());
-    try {
-      d.quoteIdentifier("col");
-      fail("expected UnsupportedOperationException");
-    } catch (UnsupportedOperationException expected) {
-      // ok
-    }
+    assertThrows(UnsupportedOperationException.class, () -> d.quoteIdentifier("col"));
   }
 
   // --- qualify tests ---

--- a/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/datasource/JdbcDialectTest.java
+++ b/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/datasource/JdbcDialectTest.java
@@ -17,10 +17,15 @@
 
 package org.apache.kyuubi.engine.dataagent.datasource;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.kyuubi.engine.dataagent.datasource.dialect.GenericDialect;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JdbcDialectTest {
 
@@ -157,10 +162,14 @@ public class JdbcDialectTest {
     assertEquals("\"t\"", d.qualify(TableRef.of("t")));
   }
 
-  @Test(expected = UnsupportedOperationException.class)
+  @Test
   public void testGenericQualifyThrows() {
-    JdbcDialect d = JdbcDialect.fromUrl("jdbc:clickhouse://localhost:8123");
-    d.qualify(TableRef.of("db", "t"));
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> {
+          JdbcDialect d = JdbcDialect.fromUrl("jdbc:clickhouse://localhost:8123");
+          d.qualify(TableRef.of("db", "t"));
+        });
   }
 
   @Test

--- a/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/datasource/TableRefTest.java
+++ b/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/datasource/TableRefTest.java
@@ -17,10 +17,13 @@
 
 package org.apache.kyuubi.engine.dataagent.datasource;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TableRefTest {
 
@@ -62,19 +65,31 @@ public class TableRefTest {
 
   // --- Validation ---
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testNullTableThrows() {
-    TableRef.of(null);
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          TableRef.of(null);
+        });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testEmptyTableThrows() {
-    TableRef.of("");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          TableRef.of("");
+        });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testNullTableInThreeArgThrows() {
-    TableRef.of("cat", "sch", null);
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          TableRef.of("cat", "sch", null);
+        });
   }
 
   @Test
@@ -146,8 +161,12 @@ public class TableRefTest {
     assertEquals("orders", ref.getTable());
   }
 
-  @Test(expected = Exception.class)
+  @Test
   public void testDeserializeMissingTableThrows() throws Exception {
-    JSON.readValue("{\"schema\":\"mydb\"}", TableRef.class);
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSON.readValue("{\"schema\":\"mydb\"}", TableRef.class);
+        });
   }
 }

--- a/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/mysql/DataSourceFactoryTest.java
+++ b/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/mysql/DataSourceFactoryTest.java
@@ -18,12 +18,13 @@
 package org.apache.kyuubi.engine.dataagent.mysql;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import com.zaxxer.hikari.HikariDataSource;
 import java.sql.Connection;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Statement;
 import javax.sql.DataSource;
 import org.apache.kyuubi.engine.dataagent.datasource.DataSourceFactory;
@@ -51,11 +52,16 @@ public class DataSourceFactoryTest extends WithMySQLContainer {
   @Test
   public void testCreateWithWrongPassword() {
     DataSource ds = DataSourceFactory.create(mysql.getJdbcUrl(), "root", "wrong_password");
-    try (Connection conn = ds.getConnection()) {
-      fail("Expected exception for wrong password");
-    } catch (Exception e) {
-      // HikariCP wraps MySQL auth error — just verify we get an exception.
-      // The exception chain should contain the MySQL access-denied message.
+    try {
+      Exception e =
+          assertThrows(
+              SQLException.class,
+              () -> {
+                Connection conn = ds.getConnection();
+                conn.close();
+              });
+      // HikariCP wraps MySQL auth error; verify the chain carries the MySQL access-denied
+      // message.
       String fullMsg = getFullExceptionMessage(e);
       assertTrue(
           fullMsg.contains("Access denied") || fullMsg.contains("password"),

--- a/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/mysql/DataSourceFactoryTest.java
+++ b/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/mysql/DataSourceFactoryTest.java
@@ -17,7 +17,9 @@
 
 package org.apache.kyuubi.engine.dataagent.mysql;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.zaxxer.hikari.HikariDataSource;
 import java.sql.Connection;
@@ -25,7 +27,7 @@ import java.sql.ResultSet;
 import java.sql.Statement;
 import javax.sql.DataSource;
 import org.apache.kyuubi.engine.dataagent.datasource.DataSourceFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Integration tests for {@link DataSourceFactory} against a real MySQL instance. */
 public class DataSourceFactoryTest extends WithMySQLContainer {
@@ -56,8 +58,8 @@ public class DataSourceFactoryTest extends WithMySQLContainer {
       // The exception chain should contain the MySQL access-denied message.
       String fullMsg = getFullExceptionMessage(e);
       assertTrue(
-          "Expected auth error, got: " + fullMsg,
-          fullMsg.contains("Access denied") || fullMsg.contains("password"));
+          fullMsg.contains("Access denied") || fullMsg.contains("password"),
+          "Expected auth error, got: " + fullMsg);
     } finally {
       if (ds instanceof HikariDataSource) {
         ((HikariDataSource) ds).close();

--- a/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/mysql/DialectTest.java
+++ b/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/mysql/DialectTest.java
@@ -17,7 +17,10 @@
 
 package org.apache.kyuubi.engine.dataagent.mysql;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.kyuubi.engine.dataagent.datasource.JdbcDialect;
 import org.apache.kyuubi.engine.dataagent.datasource.dialect.MySQLDialect;
@@ -25,15 +28,15 @@ import org.apache.kyuubi.engine.dataagent.prompt.SystemPromptBuilder;
 import org.apache.kyuubi.engine.dataagent.tool.ToolContext;
 import org.apache.kyuubi.engine.dataagent.tool.sql.RunSelectQueryTool;
 import org.apache.kyuubi.engine.dataagent.tool.sql.SqlQueryArgs;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /** Integration tests for {@link MySQLDialect} end-to-end with a real MySQL instance. */
 public class DialectTest extends WithMySQLContainer {
 
   private static RunSelectQueryTool selectTool;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() {
     selectTool = new RunSelectQueryTool(dataSource, 30);
   }
@@ -86,6 +89,6 @@ public class DialectTest extends WithMySQLContainer {
   public void testPromptBuilderWithMySQLDatasource() {
     JdbcDialect dialect = JdbcDialect.fromUrl(mysql.getJdbcUrl());
     String prompt = SystemPromptBuilder.create().datasource(dialect.datasourceName()).build();
-    assertTrue("Prompt should mention mysql dialect", prompt.toLowerCase().contains("mysql"));
+    assertTrue(prompt.toLowerCase().contains("mysql"), "Prompt should mention mysql dialect");
   }
 }

--- a/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/mysql/DialectTest.java
+++ b/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/mysql/DialectTest.java
@@ -19,6 +19,7 @@ package org.apache.kyuubi.engine.dataagent.mysql;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -45,7 +46,7 @@ public class DialectTest extends WithMySQLContainer {
   public void testDialectFromUrl() {
     JdbcDialect dialect = JdbcDialect.fromUrl(mysql.getJdbcUrl());
     assertNotNull(dialect);
-    assertTrue(dialect instanceof MySQLDialect);
+    assertInstanceOf(MySQLDialect.class, dialect);
     assertEquals("mysql", dialect.datasourceName());
   }
 

--- a/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/mysql/RunMutationQueryTest.java
+++ b/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/mysql/RunMutationQueryTest.java
@@ -17,10 +17,11 @@
 
 package org.apache.kyuubi.engine.dataagent.mysql;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Integration tests for run_mutation_query tool against a real MySQL instance. All calls go through
@@ -28,7 +29,7 @@ import org.junit.Test;
  */
 public class RunMutationQueryTest extends WithMySQLContainer {
 
-  @Before
+  @BeforeEach
   public void setUp() {
     exec("DROP TABLE IF EXISTS mutation_test");
     exec(

--- a/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/mysql/RunSelectQueryTest.java
+++ b/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/mysql/RunSelectQueryTest.java
@@ -17,10 +17,11 @@
 
 package org.apache.kyuubi.engine.dataagent.mysql;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Integration tests for run_select_query tool against a real MySQL instance. All calls go through
@@ -28,7 +29,7 @@ import org.junit.Test;
  */
 public class RunSelectQueryTest extends WithMySQLContainer {
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() {
     exec(
         "CREATE TABLE IF NOT EXISTS select_test ("
@@ -68,23 +69,23 @@ public class RunSelectQueryTest extends WithMySQLContainer {
     String result = select("SELECT id AS user_id, name AS user_name FROM select_test LIMIT 1");
     assertFalse(result.startsWith("Error:"));
     assertTrue(
-        "header should contain alias 'user_id', got:\n" + result, result.contains("user_id"));
+        result.contains("user_id"), "header should contain alias 'user_id', got:\n" + result);
     assertTrue(
-        "header should contain alias 'user_name', got:\n" + result, result.contains("user_name"));
+        result.contains("user_name"), "header should contain alias 'user_name', got:\n" + result);
     assertFalse(
-        "header should NOT leak the base column name 'id', got:\n" + result,
-        result.contains("| id |") || result.contains("| id "));
+        result.contains("| id |") || result.contains("| id "),
+        "header should NOT leak the base column name 'id', got:\n" + result);
   }
 
   @Test
   public void testMySQLTypes() {
     String result = select("SELECT * FROM select_test WHERE id = 1");
     assertFalse(result.startsWith("Error:"));
-    assertTrue("DECIMAL value", result.contains("99.123456789"));
-    assertTrue("DATE value", result.contains("1990-01-15"));
-    assertTrue("DATETIME value", result.contains("2024-06-01"));
-    assertTrue("DOUBLE value", result.contains("88.5"));
-    assertTrue("ENUM value", result.contains("ACTIVE"));
+    assertTrue(result.contains("99.123456789"), "DECIMAL value");
+    assertTrue(result.contains("1990-01-15"), "DATE value");
+    assertTrue(result.contains("2024-06-01"), "DATETIME value");
+    assertTrue(result.contains("88.5"), "DOUBLE value");
+    assertTrue(result.contains("ACTIVE"), "ENUM value");
   }
 
   @Test
@@ -172,6 +173,6 @@ public class RunSelectQueryTest extends WithMySQLContainer {
 
     String result = select("SELECT val FROM pipe_test WHERE id = 1");
     assertFalse(result.startsWith("Error:"));
-    assertTrue("Pipe should be escaped for markdown table", result.contains("a\\|b\\|c"));
+    assertTrue(result.contains("a\\|b\\|c"), "Pipe should be escaped for markdown table");
   }
 }

--- a/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/mysql/ToolExecutionTest.java
+++ b/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/mysql/ToolExecutionTest.java
@@ -17,12 +17,13 @@
 
 package org.apache.kyuubi.engine.dataagent.mysql;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.kyuubi.engine.dataagent.tool.ToolRegistry;
 import org.apache.kyuubi.engine.dataagent.tool.sql.RunSelectQueryTool;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Integration tests for ToolRegistry-level behavior and cross-tool workflows against a real MySQL
@@ -32,7 +33,7 @@ import org.junit.Test;
  */
 public class ToolExecutionTest extends WithMySQLContainer {
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() {
     exec(
         "CREATE TABLE IF NOT EXISTS workflow_test ("
@@ -112,10 +113,10 @@ public class ToolExecutionTest extends WithMySQLContainer {
     long elapsed = System.currentTimeMillis() - start;
 
     // Must not block for 60 seconds
-    assertTrue("Should return within 10s, took " + elapsed + "ms", elapsed < 10_000);
+    assertTrue(elapsed < 10_000, "Should return within 10s, took " + elapsed + "ms");
     // Either JDBC timeout or ToolRegistry timeout fires
     assertTrue(
-        "Expected timeout or interrupted sleep, got: " + result,
-        result.contains("timed out") || result.startsWith("Error:") || result.contains("1"));
+        result.contains("timed out") || result.startsWith("Error:") || result.contains("1"),
+        "Expected timeout or interrupted sleep, got: " + result);
   }
 }

--- a/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/mysql/WithMySQLContainer.java
+++ b/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/mysql/WithMySQLContainer.java
@@ -26,8 +26,8 @@ import java.sql.Statement;
 import org.apache.kyuubi.engine.dataagent.tool.ToolRegistry;
 import org.apache.kyuubi.engine.dataagent.tool.sql.RunMutationQueryTool;
 import org.apache.kyuubi.engine.dataagent.tool.sql.RunSelectQueryTool;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.testcontainers.mysql.MySQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -48,7 +48,7 @@ public abstract class WithMySQLContainer {
   protected static HikariDataSource dataSource;
   protected static ToolRegistry registry;
 
-  @BeforeClass
+  @BeforeAll
   public static void startContainer() {
     DockerImageName imageName =
         DockerImageName.parse(MYSQL_IMAGE).asCompatibleSubstituteFor("mysql");
@@ -74,7 +74,7 @@ public abstract class WithMySQLContainer {
     registry.register(new RunMutationQueryTool(dataSource, QUERY_TIMEOUT_SECONDS));
   }
 
-  @AfterClass
+  @AfterAll
   public static void stopContainer() {
     if (registry != null) {
       registry.close();

--- a/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/prompt/SystemPromptBuilderTest.java
+++ b/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/prompt/SystemPromptBuilderTest.java
@@ -17,10 +17,13 @@
 
 package org.apache.kyuubi.engine.dataagent.prompt;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SystemPromptBuilderTest {
 
@@ -90,8 +93,8 @@ public class SystemPromptBuilderTest {
   @Test
   public void testDatasourceReplacesNotAppends() {
     String prompt = SystemPromptBuilder.create().datasource("sqlite").datasource("spark").build();
-    assertTrue("Last datasource wins", prompt.contains("Spark SQL"));
-    assertFalse("Previous datasource replaced", prompt.contains("SQLite SQL compatibility"));
+    assertTrue(prompt.contains("Spark SQL"), "Last datasource wins");
+    assertFalse(prompt.contains("SQLite SQL compatibility"), "Previous datasource replaced");
   }
 
   @Test
@@ -113,9 +116,13 @@ public class SystemPromptBuilderTest {
     assertTrue(prompt.contains("MySQL"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testLoadResourceThrowsOnMissing() {
-    SystemPromptBuilder.loadResource("nonexistent-resource");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          SystemPromptBuilder.loadResource("nonexistent-resource");
+        });
   }
 
   @Test

--- a/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/provider/echo/EchoProviderTest.java
+++ b/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/provider/echo/EchoProviderTest.java
@@ -17,7 +17,10 @@
 
 package org.apache.kyuubi.engine.dataagent.provider.echo;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,7 +30,7 @@ import org.apache.kyuubi.engine.dataagent.runtime.event.AgentEvent;
 import org.apache.kyuubi.engine.dataagent.runtime.event.ContentComplete;
 import org.apache.kyuubi.engine.dataagent.runtime.event.ContentDelta;
 import org.apache.kyuubi.engine.dataagent.runtime.event.EventType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Smoke tests for EchoProvider — verify event stream structure and content echo. */
 public class EchoProviderTest {
@@ -41,7 +44,7 @@ public class EchoProviderTest {
     provider.run("session-1", new ProviderRunRequest("What is Kyuubi?"), events::add);
     provider.close("session-1");
 
-    assertFalse("Should emit events", events.isEmpty());
+    assertFalse(events.isEmpty(), "Should emit events");
 
     // Verify event type sequence: AGENT_START -> STEP_START -> CONTENT_DELTA... ->
     //   CONTENT_COMPLETE -> STEP_END -> AGENT_FINISH
@@ -66,6 +69,6 @@ public class EchoProviderTest {
     }
     assertNotNull(complete);
     assertEquals(complete, deltas.toString());
-    assertTrue("Should echo the question", complete.contains("What is Kyuubi?"));
+    assertTrue(complete.contains("What is Kyuubi?"), "Should echo the question");
   }
 }

--- a/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/runtime/ConversationMemoryTest.java
+++ b/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/runtime/ConversationMemoryTest.java
@@ -17,12 +17,12 @@
 
 package org.apache.kyuubi.engine.dataagent.runtime;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.openai.models.chat.completions.ChatCompletionMessageParam;
 import com.openai.models.chat.completions.ChatCompletionUserMessageParam;
 import java.util.Collections;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ConversationMemoryTest {
 
@@ -40,8 +40,8 @@ public class ConversationMemoryTest {
             ChatCompletionUserMessageParam.builder().content("summary").build());
     memory.replaceHistory(Collections.singletonList(summary));
 
-    assertEquals("lastTotalTokens reset after compaction", 0L, memory.getLastTotalTokens());
-    assertEquals("cumulative totals preserved", 300L, memory.getCumulativePromptTokens());
-    assertEquals("cumulative totals preserved", 430L, memory.getCumulativeTotalTokens());
+    assertEquals(0L, memory.getLastTotalTokens(), "lastTotalTokens reset after compaction");
+    assertEquals(300L, memory.getCumulativePromptTokens(), "cumulative totals preserved");
+    assertEquals(430L, memory.getCumulativeTotalTokens(), "cumulative totals preserved");
   }
 }

--- a/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/runtime/ReactAgentLiveTest.java
+++ b/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/runtime/ReactAgentLiveTest.java
@@ -17,8 +17,10 @@
 
 package org.apache.kyuubi.engine.dataagent.runtime;
 
-import static org.junit.Assert.*;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.openai.client.OpenAIClient;
 import com.openai.client.okhttp.OpenAIOkHttpClient;
@@ -41,9 +43,9 @@ import org.apache.kyuubi.engine.dataagent.runtime.middleware.ToolResultOffloadMi
 import org.apache.kyuubi.engine.dataagent.tool.ToolRegistry;
 import org.apache.kyuubi.engine.dataagent.tool.sql.RunMutationQueryTool;
 import org.apache.kyuubi.engine.dataagent.tool.sql.RunSelectQueryTool;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.sqlite.SQLiteDataSource;
 
 /**
@@ -66,14 +68,14 @@ public class ReactAgentLiveTest {
   private final List<File> tempFiles = new ArrayList<>();
   private OpenAIClient client;
 
-  @Before
+  @BeforeEach
   public void setUp() {
-    assumeTrue("DATA_AGENT_OPENAI_API_KEY not set, skipping live tests", !API_KEY.isEmpty());
-    assumeTrue("DATA_AGENT_OPENAI_ENDPOINT not set, skipping live tests", !BASE_URL.isEmpty());
+    assumeTrue(!API_KEY.isEmpty(), "DATA_AGENT_OPENAI_API_KEY not set, skipping live tests");
+    assumeTrue(!BASE_URL.isEmpty(), "DATA_AGENT_OPENAI_ENDPOINT not set, skipping live tests");
     client = OpenAIOkHttpClient.builder().apiKey(API_KEY).baseUrl(BASE_URL).build();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     tempFiles.forEach(File::delete);
   }
@@ -101,8 +103,8 @@ public class ReactAgentLiveTest {
             .map(e -> ((ContentDelta) e).text())
             .collect(Collectors.toList());
 
-    assertTrue("Expected multiple ContentDelta events", deltas.size() > 1);
-    assertFalse("Streamed text should not be empty", String.join("", deltas).isEmpty());
+    assertTrue(deltas.size() > 1, "Expected multiple ContentDelta events");
+    assertFalse(String.join("", deltas).isEmpty(), "Streamed text should not be empty");
     assertTrue(events.stream().anyMatch(e -> e instanceof StepStart));
     assertTrue(events.stream().anyMatch(e -> e instanceof ContentComplete));
     assertTrue(events.get(events.size() - 1) instanceof AgentFinish);
@@ -146,14 +148,14 @@ public class ReactAgentLiveTest {
             .map(e -> (ToolResult) e)
             .collect(Collectors.toList());
 
-    assertFalse("Agent should have called at least one tool", toolCalls.isEmpty());
-    assertFalse("Agent should have received tool results", toolResults.isEmpty());
-    assertTrue("Tool calls should not error", toolResults.stream().noneMatch(ToolResult::isError));
+    assertFalse(toolCalls.isEmpty(), "Agent should have called at least one tool");
+    assertFalse(toolResults.isEmpty(), "Agent should have received tool results");
+    assertTrue(toolResults.stream().noneMatch(ToolResult::isError), "Tool calls should not error");
 
     // Verify SQL query was called
     assertTrue(
-        "Agent should execute at least one SQL query",
-        toolCalls.stream().anyMatch(tc -> "run_select_query".equals(tc.toolName())));
+        toolCalls.stream().anyMatch(tc -> "run_select_query".equals(tc.toolName())),
+        "Agent should execute at least one SQL query");
 
     // Verify final answer mentions "Electronics" (highest revenue)
     List<String> completions =
@@ -163,13 +165,13 @@ public class ReactAgentLiveTest {
             .collect(Collectors.toList());
     String lastAnswer = completions.get(completions.size() - 1);
     assertTrue(
-        "Final answer should mention Electronics, got: " + lastAnswer,
-        lastAnswer.toLowerCase().contains("electronics"));
+        lastAnswer.toLowerCase().contains("electronics"),
+        "Final answer should mention Electronics, got: " + lastAnswer);
 
     // Verify agent finished successfully
     AgentEvent last = events.get(events.size() - 1);
     assertTrue(last instanceof AgentFinish);
-    assertTrue("Should take multiple steps", ((AgentFinish) last).totalSteps() > 1);
+    assertTrue(((AgentFinish) last).totalSteps() > 1, "Should take multiple steps");
   }
 
   @Test
@@ -196,11 +198,10 @@ public class ReactAgentLiveTest {
     agent.run(new AgentInvocation("How many orders are there in total?"), memory, events1::add);
 
     assertTrue(
-        "Turn 1 should query the database",
         events1.stream()
             .anyMatch(
-                e ->
-                    e instanceof ToolCall && "run_select_query".equals(((ToolCall) e).toolName())));
+                e -> e instanceof ToolCall && "run_select_query".equals(((ToolCall) e).toolName())),
+        "Turn 1 should query the database");
     assertTrue(events1.get(events1.size() - 1) instanceof AgentFinish);
 
     // Turn 2: follow-up relying on conversation context
@@ -209,17 +210,16 @@ public class ReactAgentLiveTest {
         new AgentInvocation("Now show me only orders above 500 dollars."), memory, events2::add);
 
     assertTrue(
-        "Turn 2 should also query the database",
         events2.stream()
             .anyMatch(
-                e ->
-                    e instanceof ToolCall && "run_select_query".equals(((ToolCall) e).toolName())));
+                e -> e instanceof ToolCall && "run_select_query".equals(((ToolCall) e).toolName())),
+        "Turn 2 should also query the database");
     assertTrue(events2.get(events2.size() - 1) instanceof AgentFinish);
 
     // Verify memory accumulated across both turns
     assertTrue(
-        "Memory should contain messages from both turns, got " + memory.getHistory().size(),
-        memory.getHistory().size() > 4);
+        memory.getHistory().size() > 4,
+        "Memory should contain messages from both turns, got " + memory.getHistory().size());
   }
 
   @Test
@@ -288,23 +288,23 @@ public class ReactAgentLiveTest {
     }
 
     assertTrue(
-        "Agent should have run a select query first",
-        toolCalls.stream().anyMatch(tc -> "run_select_query".equals(tc.toolName())));
+        toolCalls.stream().anyMatch(tc -> "run_select_query".equals(tc.toolName())),
+        "Agent should have run a select query first");
 
     // The SELECT returned 800 rows, which must trip the offload threshold.
     assertTrue(
-        "Expected at least one offload preview marker in tool results",
-        toolResults.stream().anyMatch(tr -> tr.output().contains("Tool output truncated")));
+        toolResults.stream().anyMatch(tr -> tr.output().contains("Tool output truncated")),
+        "Expected at least one offload preview marker in tool results");
 
     assertTrue(
-        "Agent should have used grep_tool_output or read_tool_output after seeing"
-            + " the offload preview; actual tool calls: "
-            + toolCalls.stream().map(ToolCall::toolName).collect(Collectors.toList()),
         toolCalls.stream()
             .anyMatch(
                 tc ->
                     "grep_tool_output".equals(tc.toolName())
-                        || "read_tool_output".equals(tc.toolName())));
+                        || "read_tool_output".equals(tc.toolName())),
+        "Agent should have used grep_tool_output or read_tool_output after seeing"
+            + " the offload preview; actual tool calls: "
+            + toolCalls.stream().map(ToolCall::toolName).collect(Collectors.toList()));
 
     String finalAnswer =
         events.stream()
@@ -313,8 +313,8 @@ public class ReactAgentLiveTest {
             .reduce((a, b) -> b)
             .orElse("");
     assertTrue(
-        "Final answer should contain the needle note 'the-answer-is-42', got: " + finalAnswer,
-        finalAnswer.contains("the-answer-is-42"));
+        finalAnswer.contains("the-answer-is-42"),
+        "Final answer should contain the needle note 'the-answer-is-42', got: " + finalAnswer);
   }
 
   @Test
@@ -371,17 +371,17 @@ public class ReactAgentLiveTest {
             .filter(e -> e instanceof ApprovalRequest)
             .map(e -> (ApprovalRequest) e)
             .collect(Collectors.toList());
-    assertFalse("Expected at least one ApprovalRequest", approvals.isEmpty());
+    assertFalse(approvals.isEmpty(), "Expected at least one ApprovalRequest");
     assertTrue(
-        "ApprovalRequest should target run_mutation_query",
-        approvals.stream().anyMatch(a -> "run_mutation_query".equals(a.toolName())));
+        approvals.stream().anyMatch(a -> "run_mutation_query".equals(a.toolName())),
+        "ApprovalRequest should target run_mutation_query");
 
     // Mutation must have actually executed — check the DB directly.
     try (Connection conn = ds.getConnection();
         Statement stmt = conn.createStatement();
         java.sql.ResultSet rs = stmt.executeQuery("SELECT value FROM counters WHERE name='hits'")) {
       assertTrue(rs.next());
-      assertEquals("Counter should be 1 after approved mutation", 1, rs.getInt(1));
+      assertEquals(1, rs.getInt(1), "Counter should be 1 after approved mutation");
     }
 
     String finalAnswer =
@@ -390,7 +390,7 @@ public class ReactAgentLiveTest {
             .map(e -> ((ContentComplete) e).fullText())
             .reduce((a, b) -> b)
             .orElse("");
-    assertTrue("Final answer should mention 1, got: " + finalAnswer, finalAnswer.contains("1"));
+    assertTrue(finalAnswer.contains("1"), "Final answer should mention 1, got: " + finalAnswer);
   }
 
   @Test
@@ -440,15 +440,15 @@ public class ReactAgentLiveTest {
     }
 
     assertTrue(
-        "Expected at least one ApprovalRequest",
-        events.stream().anyMatch(e -> e instanceof ApprovalRequest));
+        events.stream().anyMatch(e -> e instanceof ApprovalRequest),
+        "Expected at least one ApprovalRequest");
 
     // DB must be untouched.
     try (Connection conn = ds.getConnection();
         Statement stmt = conn.createStatement();
         java.sql.ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM counters")) {
       assertTrue(rs.next());
-      assertTrue("Counters rows must survive denied mutation", rs.getInt(1) > 0);
+      assertTrue(rs.getInt(1) > 0, "Counters rows must survive denied mutation");
     }
 
     // LLM should tell the user the operation didn't go through. Loose lexical check to
@@ -461,14 +461,14 @@ public class ReactAgentLiveTest {
             .orElse("")
             .toLowerCase();
     assertTrue(
-        "Final answer should indicate the deletion was refused/denied/not executed, got: "
-            + finalAnswer,
         finalAnswer.contains("den")
             || finalAnswer.contains("reject")
             || finalAnswer.contains("not ")
             || finalAnswer.contains("refus")
             || finalAnswer.contains("unable")
-            || finalAnswer.contains("could not"));
+            || finalAnswer.contains("could not"),
+        "Final answer should indicate the deletion was refused/denied/not executed, got: "
+            + finalAnswer);
   }
 
   // --- Helpers ---

--- a/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/runtime/ReactAgentLiveTest.java
+++ b/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/runtime/ReactAgentLiveTest.java
@@ -19,8 +19,9 @@ package org.apache.kyuubi.engine.dataagent.runtime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import com.openai.client.OpenAIClient;
 import com.openai.client.okhttp.OpenAIOkHttpClient;
@@ -36,7 +37,14 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.apache.kyuubi.engine.dataagent.prompt.SystemPromptBuilder;
-import org.apache.kyuubi.engine.dataagent.runtime.event.*;
+import org.apache.kyuubi.engine.dataagent.runtime.event.AgentEvent;
+import org.apache.kyuubi.engine.dataagent.runtime.event.AgentFinish;
+import org.apache.kyuubi.engine.dataagent.runtime.event.ApprovalRequest;
+import org.apache.kyuubi.engine.dataagent.runtime.event.ContentComplete;
+import org.apache.kyuubi.engine.dataagent.runtime.event.ContentDelta;
+import org.apache.kyuubi.engine.dataagent.runtime.event.StepStart;
+import org.apache.kyuubi.engine.dataagent.runtime.event.ToolCall;
+import org.apache.kyuubi.engine.dataagent.runtime.event.ToolResult;
 import org.apache.kyuubi.engine.dataagent.runtime.middleware.ApprovalMiddleware;
 import org.apache.kyuubi.engine.dataagent.runtime.middleware.LoggingMiddleware;
 import org.apache.kyuubi.engine.dataagent.runtime.middleware.ToolResultOffloadMiddleware;
@@ -70,8 +78,8 @@ public class ReactAgentLiveTest {
 
   @BeforeEach
   public void setUp() {
-    assumeTrue(!API_KEY.isEmpty(), "DATA_AGENT_OPENAI_API_KEY not set, skipping live tests");
-    assumeTrue(!BASE_URL.isEmpty(), "DATA_AGENT_OPENAI_ENDPOINT not set, skipping live tests");
+    assumeFalse(API_KEY.isEmpty(), "DATA_AGENT_OPENAI_API_KEY not set, skipping live tests");
+    assumeFalse(BASE_URL.isEmpty(), "DATA_AGENT_OPENAI_ENDPOINT not set, skipping live tests");
     client = OpenAIOkHttpClient.builder().apiKey(API_KEY).baseUrl(BASE_URL).build();
   }
 
@@ -107,7 +115,7 @@ public class ReactAgentLiveTest {
     assertFalse(String.join("", deltas).isEmpty(), "Streamed text should not be empty");
     assertTrue(events.stream().anyMatch(e -> e instanceof StepStart));
     assertTrue(events.stream().anyMatch(e -> e instanceof ContentComplete));
-    assertTrue(events.get(events.size() - 1) instanceof AgentFinish);
+    assertInstanceOf(AgentFinish.class, events.get(events.size() - 1));
     assertEquals(2, memory.getHistory().size()); // user + assistant
   }
 
@@ -170,8 +178,8 @@ public class ReactAgentLiveTest {
 
     // Verify agent finished successfully
     AgentEvent last = events.get(events.size() - 1);
-    assertTrue(last instanceof AgentFinish);
-    assertTrue(((AgentFinish) last).totalSteps() > 1, "Should take multiple steps");
+    AgentFinish finish = assertInstanceOf(AgentFinish.class, last);
+    assertTrue(finish.totalSteps() > 1, "Should take multiple steps");
   }
 
   @Test
@@ -202,7 +210,7 @@ public class ReactAgentLiveTest {
             .anyMatch(
                 e -> e instanceof ToolCall && "run_select_query".equals(((ToolCall) e).toolName())),
         "Turn 1 should query the database");
-    assertTrue(events1.get(events1.size() - 1) instanceof AgentFinish);
+    assertInstanceOf(AgentFinish.class, events1.get(events1.size() - 1));
 
     // Turn 2: follow-up relying on conversation context
     List<AgentEvent> events2 = new CopyOnWriteArrayList<>();
@@ -214,7 +222,7 @@ public class ReactAgentLiveTest {
             .anyMatch(
                 e -> e instanceof ToolCall && "run_select_query".equals(((ToolCall) e).toolName())),
         "Turn 2 should also query the database");
-    assertTrue(events2.get(events2.size() - 1) instanceof AgentFinish);
+    assertInstanceOf(AgentFinish.class, events2.get(events2.size() - 1));
 
     // Verify memory accumulated across both turns
     assertTrue(

--- a/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/runtime/ToolOutputStoreTest.java
+++ b/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/runtime/ToolOutputStoreTest.java
@@ -17,19 +17,20 @@
 
 package org.apache.kyuubi.engine.dataagent.runtime;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ToolOutputStoreTest {
 
   private ToolOutputStore store;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     store = ToolOutputStore.create();
   }
@@ -42,11 +43,11 @@ public class ToolOutputStoreTest {
     assertTrue(Files.exists(p));
 
     String out = store.read("sess1", p.toString(), 10, 5);
-    assertTrue(out, out.contains("lines 11-15 of"));
-    assertTrue(out, out.contains("row11"));
-    assertTrue(out, out.contains("row15"));
-    assertFalse(out, out.contains("row16"));
-    assertFalse(out, out.contains("row10"));
+    assertTrue(out.contains("lines 11-15 of"), out);
+    assertTrue(out.contains("row11"), out);
+    assertTrue(out.contains("row15"), out);
+    assertFalse(out.contains("row16"), out);
+    assertFalse(out.contains("row10"), out);
   }
 
   @Test
@@ -55,9 +56,9 @@ public class ToolOutputStoreTest {
     Path p = store.write("sess1", "call1", content);
 
     String out = store.grep("sess1", p.toString(), "apple", 10);
-    assertTrue(out, out.contains("1:apple"));
-    assertTrue(out, out.contains("4:apple pie"));
-    assertFalse(out, out.contains("banana"));
+    assertTrue(out.contains("1:apple"), out);
+    assertTrue(out.contains("4:apple pie"), out);
+    assertFalse(out.contains("banana"), out);
   }
 
   @Test
@@ -67,17 +68,17 @@ public class ToolOutputStoreTest {
     Path p = store.write("sess1", "call1", sb.toString());
 
     String out = store.grep("sess1", p.toString(), "hit", 3);
-    assertTrue(out, out.contains("[3 matches]"));
-    assertTrue(out, out.contains("1:hit"));
-    assertTrue(out, out.contains("3:hit"));
-    assertFalse("should stop after 3 matches", out.contains("4:hit"));
+    assertTrue(out.contains("[3 matches]"), out);
+    assertTrue(out.contains("1:hit"), out);
+    assertTrue(out.contains("3:hit"), out);
+    assertFalse(out.contains("4:hit"), "should stop after 3 matches");
   }
 
   @Test
   public void grepInvalidRegexReturnsError() throws IOException {
     Path p = store.write("sess1", "call1", "x\n");
     String out = store.grep("sess1", p.toString(), "[", 10);
-    assertTrue(out, out.startsWith("Error:"));
+    assertTrue(out.startsWith("Error:"), out);
   }
 
   @Test
@@ -86,16 +87,16 @@ public class ToolOutputStoreTest {
     assertTrue(Files.exists(victim));
 
     String out = store.read("attacker", victim.toString(), 0, 10);
-    assertTrue(out, out.startsWith("Error:"));
-    assertFalse(out, out.contains("top secret"));
+    assertTrue(out.startsWith("Error:"), out);
+    assertFalse(out.contains("top secret"), out);
   }
 
   @Test
   public void grepRejectsCrossSessionPath() throws IOException {
     Path victim = store.write("victim", "secret_call", "api_key=xyz\n");
     String out = store.grep("attacker", victim.toString(), "api_key", 10);
-    assertTrue(out, out.startsWith("Error:"));
-    assertFalse(out, out.contains("xyz"));
+    assertTrue(out.startsWith("Error:"), out);
+    assertFalse(out.contains("xyz"), out);
   }
 
   @Test
@@ -111,6 +112,6 @@ public class ToolOutputStoreTest {
 
     assertFalse(Files.exists(p1));
     assertFalse(Files.exists(p2));
-    assertTrue("other sessions untouched", Files.exists(p3));
+    assertTrue(Files.exists(p3), "other sessions untouched");
   }
 }

--- a/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/runtime/event/EventTest.java
+++ b/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/runtime/event/EventTest.java
@@ -20,8 +20,8 @@ package org.apache.kyuubi.engine.dataagent.runtime.event;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -56,12 +56,7 @@ public class EventTest {
     Map<String, Object> args = new HashMap<>();
     args.put("key", "value");
     ToolCall event = new ToolCall("tc-1", "tool", args);
-    try {
-      event.toolArgs().put("new", "entry");
-      fail("Should throw on modification");
-    } catch (UnsupportedOperationException expected) {
-      // expected
-    }
+    assertThrows(UnsupportedOperationException.class, () -> event.toolArgs().put("new", "entry"));
   }
 
   @Test
@@ -91,12 +86,7 @@ public class EventTest {
     Map<String, Object> args = new HashMap<>();
     args.put("key", "value");
     ApprovalRequest event = new ApprovalRequest("req-1", "tc-1", "tool", args, ToolRiskLevel.SAFE);
-    try {
-      event.toolArgs().put("new", "entry");
-      fail("Should throw on modification");
-    } catch (UnsupportedOperationException expected) {
-      // expected
-    }
+    assertThrows(UnsupportedOperationException.class, () -> event.toolArgs().put("new", "entry"));
   }
 
   @Test

--- a/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/runtime/event/EventTest.java
+++ b/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/runtime/event/EventTest.java
@@ -17,12 +17,16 @@
 
 package org.apache.kyuubi.engine.dataagent.runtime.event;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.kyuubi.engine.dataagent.tool.ToolRiskLevel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class EventTest {
 
@@ -122,7 +126,7 @@ public class EventTest {
     EventType[] values = EventType.values();
     java.util.Set<String> names = new java.util.HashSet<>();
     for (EventType type : values) {
-      assertTrue("Duplicate SSE name: " + type.sseEventName(), names.add(type.sseEventName()));
+      assertTrue(names.add(type.sseEventName()), "Duplicate SSE name: " + type.sseEventName());
     }
     assertEquals(11, values.length);
   }

--- a/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/runtime/middleware/ApprovalMiddlewareTest.java
+++ b/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/runtime/middleware/ApprovalMiddlewareTest.java
@@ -17,7 +17,8 @@
 
 package org.apache.kyuubi.engine.dataagent.runtime.middleware;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -37,15 +38,15 @@ import org.apache.kyuubi.engine.dataagent.tool.AgentTool;
 import org.apache.kyuubi.engine.dataagent.tool.ToolContext;
 import org.apache.kyuubi.engine.dataagent.tool.ToolRegistry;
 import org.apache.kyuubi.engine.dataagent.tool.ToolRiskLevel;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ApprovalMiddlewareTest {
 
   private ToolRegistry registry;
   private List<AgentEvent> emittedEvents;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     registry = new ToolRegistry(30);
     registry.register(safeTool("safe_tool"));
@@ -64,7 +65,7 @@ public class ApprovalMiddlewareTest {
         Decision.Kind.PROCEED, mw.beforeToolCall(ctx, invocation("tc1", "dangerous_tool")).kind());
     assertEquals(
         Decision.Kind.PROCEED, mw.beforeToolCall(ctx, invocation("tc2", "safe_tool")).kind());
-    assertTrue("No approval events should be emitted", emittedEvents.isEmpty());
+    assertTrue(emittedEvents.isEmpty(), "No approval events should be emitted");
   }
 
   // --- Normal mode: safe auto-approved, destructive needs approval ---
@@ -98,7 +99,7 @@ public class ApprovalMiddlewareTest {
           exec.submit(() -> mw.beforeToolCall(ctx, invocation("tc1", "dangerous_tool")));
 
       // Wait for the approval request event
-      assertTrue("Approval event should be emitted", eventEmitted.await(2, TimeUnit.SECONDS));
+      assertTrue(eventEmitted.await(2, TimeUnit.SECONDS), "Approval event should be emitted");
       assertEquals(1, emittedEvents.size());
       assertEquals(EventType.APPROVAL_REQUEST, emittedEvents.get(0).eventType());
 
@@ -109,9 +110,9 @@ public class ApprovalMiddlewareTest {
       // Approve
       assertTrue(mw.resolve(req.requestId(), true));
       assertEquals(
-          "Approved tool should proceed",
           Decision.Kind.PROCEED,
-          future.get(2, TimeUnit.SECONDS).kind());
+          future.get(2, TimeUnit.SECONDS).kind(),
+          "Approved tool should proceed");
     } finally {
       exec.shutdownNow();
     }
@@ -192,7 +193,7 @@ public class ApprovalMiddlewareTest {
 
       // Don't resolve — let it time out
       Decision<ToolInvocation> decision = future.get(5, TimeUnit.SECONDS);
-      assertEquals("Timeout should produce a denial", Decision.Kind.ABORT, decision.kind());
+      assertEquals(Decision.Kind.ABORT, decision.kind(), "Timeout should produce a denial");
       assertTrue(decision.reason().contains("timed out"));
     } finally {
       exec.shutdownNow();
@@ -223,7 +224,7 @@ public class ApprovalMiddlewareTest {
       mw.onStop();
 
       Decision<ToolInvocation> decision = future.get(2, TimeUnit.SECONDS);
-      assertEquals("onStop should unblock with a denial", Decision.Kind.ABORT, decision.kind());
+      assertEquals(Decision.Kind.ABORT, decision.kind(), "onStop should unblock with a denial");
     } finally {
       exec.shutdownNow();
     }

--- a/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/runtime/middleware/CompactionMiddlewareLiveTest.java
+++ b/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/runtime/middleware/CompactionMiddlewareLiveTest.java
@@ -19,7 +19,7 @@ package org.apache.kyuubi.engine.dataagent.runtime.middleware;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import com.openai.client.OpenAIClient;
 import com.openai.client.okhttp.OpenAIOkHttpClient;
@@ -49,8 +49,8 @@ public class CompactionMiddlewareLiveTest {
 
   @BeforeEach
   public void setUp() {
-    assumeTrue(!API_KEY.isEmpty(), "DATA_AGENT_OPENAI_API_KEY not set, skipping live tests");
-    assumeTrue(!BASE_URL.isEmpty(), "DATA_AGENT_OPENAI_ENDPOINT not set, skipping live tests");
+    assumeFalse(API_KEY.isEmpty(), "DATA_AGENT_OPENAI_API_KEY not set, skipping live tests");
+    assumeFalse(BASE_URL.isEmpty(), "DATA_AGENT_OPENAI_ENDPOINT not set, skipping live tests");
     client = OpenAIOkHttpClient.builder().apiKey(API_KEY).baseUrl(BASE_URL).build();
   }
 

--- a/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/runtime/middleware/CompactionMiddlewareLiveTest.java
+++ b/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/runtime/middleware/CompactionMiddlewareLiveTest.java
@@ -17,8 +17,9 @@
 
 package org.apache.kyuubi.engine.dataagent.runtime.middleware;
 
-import static org.junit.Assert.*;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.openai.client.OpenAIClient;
 import com.openai.client.okhttp.OpenAIOkHttpClient;
@@ -28,8 +29,8 @@ import java.util.List;
 import org.apache.kyuubi.engine.dataagent.runtime.AgentRunContext;
 import org.apache.kyuubi.engine.dataagent.runtime.ApprovalMode;
 import org.apache.kyuubi.engine.dataagent.runtime.ConversationMemory;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Live integration test for {@link CompactionMiddleware}: exercises the full compaction path
@@ -46,10 +47,10 @@ public class CompactionMiddlewareLiveTest {
 
   private OpenAIClient client;
 
-  @Before
+  @BeforeEach
   public void setUp() {
-    assumeTrue("DATA_AGENT_OPENAI_API_KEY not set, skipping live tests", !API_KEY.isEmpty());
-    assumeTrue("DATA_AGENT_OPENAI_ENDPOINT not set, skipping live tests", !BASE_URL.isEmpty());
+    assumeTrue(!API_KEY.isEmpty(), "DATA_AGENT_OPENAI_API_KEY not set, skipping live tests");
+    assumeTrue(!BASE_URL.isEmpty(), "DATA_AGENT_OPENAI_ENDPOINT not set, skipping live tests");
     client = OpenAIOkHttpClient.builder().apiKey(API_KEY).baseUrl(BASE_URL).build();
   }
 
@@ -83,7 +84,7 @@ public class CompactionMiddlewareLiveTest {
     Decision<List<ChatCompletionMessageParam>> decision =
         mw.beforeLlmCall(ctx, memory.buildLlmMessages());
 
-    assertEquals("expected compaction to fire", Decision.Kind.REPLACE, decision.kind());
+    assertEquals(Decision.Kind.REPLACE, decision.kind(), "expected compaction to fire");
 
     // History got rewritten: [summary user msg] + kept tail.
     List<ChatCompletionMessageParam> hist = memory.getHistory();
@@ -91,12 +92,12 @@ public class CompactionMiddlewareLiveTest {
     assertTrue(hist.get(0).isUser());
     String first = hist.get(0).asUser().content().text().orElse("");
     assertTrue(
-        "summary message should be wrapped in <conversation_summary>",
-        first.contains("<conversation_summary>"));
+        first.contains("<conversation_summary>"),
+        "summary message should be wrapped in <conversation_summary>");
 
     // The LLM was told to emit 8 markdown sections; sanity-check a couple show up.
     assertTrue(
-        "summary should contain '## User Intent' section",
-        first.contains("## User Intent") || first.contains("User Intent"));
+        first.contains("## User Intent") || first.contains("User Intent"),
+        "summary should contain '## User Intent' section");
   }
 }

--- a/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/runtime/middleware/CompactionMiddlewareTest.java
+++ b/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/runtime/middleware/CompactionMiddlewareTest.java
@@ -17,7 +17,8 @@
 
 package org.apache.kyuubi.engine.dataagent.runtime.middleware;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.openai.client.OpenAIClient;
 import com.openai.client.okhttp.OpenAIOkHttpClient;
@@ -36,8 +37,8 @@ import java.util.Set;
 import org.apache.kyuubi.engine.dataagent.runtime.AgentRunContext;
 import org.apache.kyuubi.engine.dataagent.runtime.ApprovalMode;
 import org.apache.kyuubi.engine.dataagent.runtime.ConversationMemory;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests that exercise only the deterministic, LLM-free parts of {@link CompactionMiddleware}:
@@ -69,7 +70,7 @@ public class CompactionMiddlewareTest {
   private ConversationMemory memory;
   private AgentRunContext ctx;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     memory = new ConversationMemory();
     memory.setSystemPrompt("SYS");
@@ -125,8 +126,8 @@ public class CompactionMiddlewareTest {
     CompactionMiddleware.Split s = CompactionMiddleware.computeSplit(history, 4);
     assertNoOrphanToolResult(s.kept);
     // Verify the tc1 pair really did end up in kept, not old.
-    assertTrue("a3(tc1) must be in kept", containsToolCallId(s.kept, "tc1"));
-    assertTrue("tool_result(tc1) must be in kept", containsToolCallIdAsResult(s.kept, "tc1"));
+    assertTrue(containsToolCallId(s.kept, "tc1"), "a3(tc1) must be in kept");
+    assertTrue(containsToolCallIdAsResult(s.kept, "tc1"), "tool_result(tc1) must be in kept");
   }
 
   @Test
@@ -314,8 +315,8 @@ public class CompactionMiddlewareTest {
     for (ChatCompletionMessageParam m : msgs) {
       if (m.isTool()) {
         assertTrue(
-            "tool_result id=" + m.asTool().toolCallId() + " has no matching tool_call",
-            issued.contains(m.asTool().toolCallId()));
+            issued.contains(m.asTool().toolCallId()),
+            "tool_result id=" + m.asTool().toolCallId() + " has no matching tool_call");
       }
     }
   }

--- a/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/runtime/middleware/ToolResultOffloadMiddlewareTest.java
+++ b/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/runtime/middleware/ToolResultOffloadMiddlewareTest.java
@@ -17,7 +17,9 @@
 
 package org.apache.kyuubi.engine.dataagent.runtime.middleware;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collections;
 import org.apache.kyuubi.engine.dataagent.runtime.AgentRunContext;
@@ -25,9 +27,9 @@ import org.apache.kyuubi.engine.dataagent.runtime.ApprovalMode;
 import org.apache.kyuubi.engine.dataagent.runtime.ConversationMemory;
 import org.apache.kyuubi.engine.dataagent.tool.output.GrepToolOutputTool;
 import org.apache.kyuubi.engine.dataagent.tool.output.ReadToolOutputTool;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ToolResultOffloadMiddlewareTest {
 
@@ -35,7 +37,7 @@ public class ToolResultOffloadMiddlewareTest {
   private AgentRunContext ctxWithSession;
   private AgentRunContext ctxNoSession;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     mw = new ToolResultOffloadMiddleware();
     ctxWithSession =
@@ -43,7 +45,7 @@ public class ToolResultOffloadMiddlewareTest {
     ctxNoSession = new AgentRunContext(new ConversationMemory(), ApprovalMode.AUTO_APPROVE, null);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     mw.onStop();
   }
@@ -64,12 +66,12 @@ public class ToolResultOffloadMiddlewareTest {
         replacement(
             mw.afterToolCall(ctxWithSession, invocation("run_select_query"), sb.toString()));
 
-    assertTrue(out, out.contains("Tool output truncated"));
-    assertTrue(out, out.contains("Saved to:"));
-    assertTrue(out, out.contains(ReadToolOutputTool.NAME));
-    assertTrue(out, out.contains(GrepToolOutputTool.NAME));
-    assertTrue(out, out.contains("row0"));
-    assertTrue(out, out.contains("row599"));
+    assertTrue(out.contains("Tool output truncated"), out);
+    assertTrue(out.contains("Saved to:"), out);
+    assertTrue(out.contains(ReadToolOutputTool.NAME), out);
+    assertTrue(out.contains(GrepToolOutputTool.NAME), out);
+    assertTrue(out.contains("row0"), out);
+    assertTrue(out.contains("row599"), out);
   }
 
   @Test
@@ -83,7 +85,7 @@ public class ToolResultOffloadMiddlewareTest {
     String out =
         replacement(
             mw.afterToolCall(ctxWithSession, invocation("run_select_query"), sb.toString()));
-    assertTrue(out, out.contains("Tool output truncated"));
+    assertTrue(out.contains("Tool output truncated"), out);
   }
 
   @Test
@@ -105,9 +107,9 @@ public class ToolResultOffloadMiddlewareTest {
     StringBuilder sb = new StringBuilder();
     for (int i = 0; i < 1000; i++) sb.append("row").append(i).append('\n');
     assertEquals(
-        "without sessionId, cannot offload safely — pass through",
         Decision.Kind.PROCEED,
-        mw.afterToolCall(ctxNoSession, invocation("run_select_query"), sb.toString()).kind());
+        mw.afterToolCall(ctxNoSession, invocation("run_select_query"), sb.toString()).kind(),
+        "without sessionId, cannot offload safely — pass through");
   }
 
   @Test
@@ -143,7 +145,7 @@ public class ToolResultOffloadMiddlewareTest {
 
   private static String replacement(Decision<String> decision) {
     assertEquals(
-        "expected REPLACE but got " + decision.kind(), Decision.Kind.REPLACE, decision.kind());
+        Decision.Kind.REPLACE, decision.kind(), "expected REPLACE but got " + decision.kind());
     return decision.replacement();
   }
 

--- a/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/tool/ToolRegistryThreadSafetyTest.java
+++ b/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/tool/ToolRegistryThreadSafetyTest.java
@@ -17,7 +17,9 @@
 
 package org.apache.kyuubi.engine.dataagent.tool;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.openai.models.ChatModel;
 import com.openai.models.chat.completions.ChatCompletionCreateParams;
@@ -26,7 +28,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Thread safety tests for ToolRegistry. Uses real tool implementations. */
 public class ToolRegistryThreadSafetyTest {
@@ -91,7 +93,7 @@ public class ToolRegistryThreadSafetyTest {
 
     pool.shutdown();
     assertTrue(pool.awaitTermination(10, TimeUnit.SECONDS));
-    assertEquals("Should have no errors from concurrent access", 0, errors.get());
+    assertEquals(0, errors.get(), "Should have no errors from concurrent access");
     assertFalse(registry.isEmpty());
   }
 

--- a/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/tool/ToolSchemaGeneratorTest.java
+++ b/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/tool/ToolSchemaGeneratorTest.java
@@ -20,6 +20,7 @@ package org.apache.kyuubi.engine.dataagent.tool;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -133,7 +134,7 @@ public class ToolSchemaGeneratorTest {
     Map<String, Object> schema = ToolSchemaGenerator.generateSchema(NoRequiredArgs.class);
     @SuppressWarnings("unchecked")
     List<String> required = (List<String>) schema.get("required");
-    assertTrue(required == null || required.isEmpty());
+    assertNull(required);
   }
 
   @Test

--- a/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/tool/ToolSchemaGeneratorTest.java
+++ b/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/tool/ToolSchemaGeneratorTest.java
@@ -17,14 +17,17 @@
 
 package org.apache.kyuubi.engine.dataagent.tool;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import java.util.List;
 import java.util.Map;
 import org.apache.kyuubi.engine.dataagent.tool.sql.SqlQueryArgs;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ToolSchemaGeneratorTest {
 
@@ -43,7 +46,7 @@ public class ToolSchemaGeneratorTest {
     @SuppressWarnings("unchecked")
     Map<String, Object> sqlProp = (Map<String, Object>) props.get("sql");
     assertEquals("string", sqlProp.get("type"));
-    assertNotNull("sql should have a description", sqlProp.get("description"));
+    assertNotNull(sqlProp.get("description"), "sql should have a description");
 
     @SuppressWarnings("unchecked")
     List<String> required = (List<String>) schema.get("required");
@@ -106,8 +109,8 @@ public class ToolSchemaGeneratorTest {
     @SuppressWarnings("unchecked")
     List<String> required = (List<String>) schema.get("required");
     assertNotNull(required);
-    assertTrue("stringField should be required", required.contains("stringField"));
-    assertFalse("intField should not be required", required.contains("intField"));
+    assertTrue(required.contains("stringField"), "stringField should be required");
+    assertFalse(required.contains("intField"), "intField should not be required");
   }
 
   // --- Edge cases ---
@@ -136,7 +139,7 @@ public class ToolSchemaGeneratorTest {
   @Test
   public void testSchemaDoesNotContainDollarSchema() {
     Map<String, Object> schema = ToolSchemaGenerator.generateSchema(AllTypesArgs.class);
-    assertFalse("$schema key should be stripped", schema.containsKey("$schema"));
+    assertFalse(schema.containsKey("$schema"), "$schema key should be stripped");
   }
 
   public static class ArrayArgs {
@@ -157,14 +160,14 @@ public class ToolSchemaGeneratorTest {
   @SuppressWarnings("unchecked")
   private static String getType(Map<String, Object> props, String fieldName) {
     Map<String, Object> prop = (Map<String, Object>) props.get(fieldName);
-    assertNotNull("Property " + fieldName + " should exist", prop);
+    assertNotNull(prop, "Property " + fieldName + " should exist");
     return (String) prop.get("type");
   }
 
   @SuppressWarnings("unchecked")
   private static String getDescription(Map<String, Object> props, String fieldName) {
     Map<String, Object> prop = (Map<String, Object>) props.get(fieldName);
-    assertNotNull("Property " + fieldName + " should exist", prop);
+    assertNotNull(prop, "Property " + fieldName + " should exist");
     return (String) prop.get("description");
   }
 }

--- a/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/tool/ToolTest.java
+++ b/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/tool/ToolTest.java
@@ -17,7 +17,9 @@
 
 package org.apache.kyuubi.engine.dataagent.tool;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.openai.models.ChatModel;
 import com.openai.models.chat.completions.ChatCompletionCreateParams;
@@ -30,15 +32,15 @@ import java.util.Collections;
 import java.util.List;
 import org.apache.kyuubi.engine.dataagent.tool.sql.RunMutationQueryTool;
 import org.apache.kyuubi.engine.dataagent.tool.sql.RunSelectQueryTool;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.sqlite.SQLiteDataSource;
 
 public class ToolTest {
 
   private final List<File> tempFiles = new ArrayList<>();
 
-  @After
+  @AfterEach
   public void cleanup() {
     tempFiles.forEach(File::delete);
   }
@@ -63,8 +65,8 @@ public class ToolTest {
 
     List<String> names = new ArrayList<>();
     tools.forEach(t -> names.add(t.asFunction().function().name()));
-    assertTrue("Missing run_select_query", names.contains("run_select_query"));
-    assertTrue("Missing run_mutation_query", names.contains("run_mutation_query"));
+    assertTrue(names.contains("run_select_query"), "Missing run_select_query");
+    assertTrue(names.contains("run_mutation_query"), "Missing run_mutation_query");
   }
 
   @Test
@@ -76,7 +78,7 @@ public class ToolTest {
 
     String result =
         registry.executeTool("run_select_query", "{\"sql\": \"SELECT COUNT(*) FROM users\"}");
-    assertTrue("Expected count of 3, got: " + result, result.contains("3"));
+    assertTrue(result.contains("3"), "Expected count of 3, got: " + result);
   }
 
   @Test
@@ -121,9 +123,9 @@ public class ToolTest {
     long start = System.currentTimeMillis();
     String result = registry.executeTool("slow_tool", "{}");
     long elapsed = System.currentTimeMillis() - start;
-    assertTrue("Should contain timeout error", result.contains("timed out"));
-    assertTrue("Should contain tool name", result.contains("slow_tool"));
-    assertTrue("Should finish within ~3s (timeout=2s)", elapsed < 5000);
+    assertTrue(result.contains("timed out"), "Should contain timeout error");
+    assertTrue(result.contains("slow_tool"), "Should contain tool name");
+    assertTrue(elapsed < 5000, "Should finish within ~3s (timeout=2s)");
   }
 
   @Test

--- a/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/tool/sql/RunMutationQueryToolTest.java
+++ b/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/tool/sql/RunMutationQueryToolTest.java
@@ -17,7 +17,9 @@
 
 package org.apache.kyuubi.engine.dataagent.tool.sql;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.sql.Connection;
@@ -26,9 +28,9 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.kyuubi.engine.dataagent.tool.ToolContext;
 import org.apache.kyuubi.engine.dataagent.tool.ToolRiskLevel;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.sqlite.SQLiteDataSource;
 
 /** Tests for RunMutationQueryTool. Uses real SQLite — no mocks. */
@@ -40,14 +42,14 @@ public class RunMutationQueryToolTest {
   private RunMutationQueryTool tool;
   private final List<File> tempFiles = new ArrayList<>();
 
-  @Before
+  @BeforeEach
   public void setUp() {
     ds = createDataSource();
     setupTable(ds);
     tool = new RunMutationQueryTool(ds, TEST_TIMEOUT_SECONDS);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     tempFiles.forEach(File::delete);
   }

--- a/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/tool/sql/RunSelectQueryToolTest.java
+++ b/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/tool/sql/RunSelectQueryToolTest.java
@@ -17,7 +17,8 @@
 
 package org.apache.kyuubi.engine.dataagent.tool.sql;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.sql.Connection;
@@ -25,9 +26,9 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.kyuubi.engine.dataagent.tool.ToolContext;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.sqlite.SQLiteDataSource;
 
 /** Tests for RunSelectQueryTool. Uses real SQLite — no mocks. */
@@ -39,14 +40,14 @@ public class RunSelectQueryToolTest {
   private RunSelectQueryTool tool;
   private final List<File> tempFiles = new ArrayList<>();
 
-  @Before
+  @BeforeEach
   public void setUp() {
     ds = createDataSource();
     setupLargeTable(ds);
     tool = new RunSelectQueryTool(ds, TEST_TIMEOUT_SECONDS);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     tempFiles.forEach(File::delete);
   }
@@ -206,7 +207,7 @@ public class RunSelectQueryToolTest {
     SqlQueryArgs args = new SqlQueryArgs();
     args.sql = "SELECT val FROM pipe_test";
     String result = tool.execute(ToolContext.EMPTY, args);
-    assertTrue("Pipe should be escaped for markdown table", result.contains("a\\|b\\|c"));
+    assertTrue(result.contains("a\\|b\\|c"), "Pipe should be escaped for markdown table");
   }
 
   // --- Error formatting ---
@@ -227,7 +228,7 @@ public class RunSelectQueryToolTest {
     String result = tool.execute(ToolContext.EMPTY, args);
     assertTrue(result.startsWith("Error:"));
     long newlines = result.chars().filter(c -> c == '\n').count();
-    assertTrue("Error should be concise (<=2 newlines), got " + newlines, newlines <= 2);
+    assertTrue(newlines <= 2, "Error should be concise (<=2 newlines), got " + newlines);
   }
 
   // --- Query timeout ---
@@ -316,8 +317,8 @@ public class RunSelectQueryToolTest {
     SqlQueryArgs args = new SqlQueryArgs();
     args.sql = "SELECT * FROM large_table";
     String result = timeoutTool.execute(ToolContext.EMPTY, args);
-    assertTrue("Expected error on timeout", result.startsWith("Error:"));
-    assertTrue("Expected timeout message", result.contains("timed out"));
+    assertTrue(result.startsWith("Error:"), "Expected error on timeout");
+    assertTrue(result.contains("timed out"), "Expected timeout message");
   }
 
   // --- Helpers ---

--- a/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/tool/sql/SqlReadOnlyCheckerTest.java
+++ b/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/tool/sql/SqlReadOnlyCheckerTest.java
@@ -17,9 +17,10 @@
 
 package org.apache.kyuubi.engine.dataagent.tool.sql;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SqlReadOnlyCheckerTest {
 

--- a/kyuubi-hive-beeline/pom.xml
+++ b/kyuubi-hive-beeline/pom.xml
@@ -118,8 +118,8 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/KyuubiBeeLineTest.java
+++ b/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/KyuubiBeeLineTest.java
@@ -18,14 +18,14 @@
 
 package org.apache.hive.beeline;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import org.apache.kyuubi.util.reflect.DynFields;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/KyuubiBeeLineTest.java
+++ b/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/KyuubiBeeLineTest.java
@@ -19,6 +19,7 @@
 package org.apache.hive.beeline;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -70,7 +71,7 @@ public class KyuubiBeeLineTest {
     String[] args1 = {"-h"};
     kyuubiBeeLine.initArgs(args1);
     String output = printStream.getOutput();
-    assert output.contains("--python-mode                   Execute python code/script.");
+    assertTrue(output.contains("--python-mode                   Execute python code/script."));
   }
 
   @Test
@@ -84,12 +85,12 @@ public class KyuubiBeeLineTest {
     String[] args2 = {"--python-mode", "-f", "test.sql"};
     kyuubiBeeLine.initArgs(args2);
     assertTrue(kyuubiBeeLine.isPythonMode());
-    assert kyuubiBeeLine.getOpts().getScriptFile().equals("test.sql");
+    assertEquals("test.sql", kyuubiBeeLine.getOpts().getScriptFile());
     kyuubiBeeLine.setPythonMode(false);
 
     String[] args3 = {"-u", "badUrl"};
     kyuubiBeeLine.initArgs(args3);
-    assertTrue(!kyuubiBeeLine.isPythonMode());
+    assertFalse(kyuubiBeeLine.isPythonMode());
     kyuubiBeeLine.setPythonMode(false);
   }
 

--- a/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/KyuubiCommandsTest.java
+++ b/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/KyuubiCommandsTest.java
@@ -18,12 +18,12 @@
 
 package org.apache.hive.beeline;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.util.List;
 import jline.console.ConsoleReader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class KyuubiCommandsTest {
@@ -40,8 +40,8 @@ public class KyuubiCommandsTest {
     String line = commands.handleMultiLineCmd(pythonSnippets);
 
     List<String> cmdList = commands.getCmdList(line, false);
-    assertEquals(cmdList.size(), 1);
-    assertEquals(cmdList.get(0), pythonSnippets);
+    assertEquals(1, cmdList.size());
+    assertEquals(pythonSnippets, cmdList.get(0));
   }
 
   @Test
@@ -56,16 +56,16 @@ public class KyuubiCommandsTest {
     KyuubiCommands commands = new KyuubiCommands(beeline);
     String line = commands.handleMultiLineCmd(snippets);
     List<String> cmdList = commands.getCmdList(line, false);
-    assertEquals(cmdList.size(), 2);
-    assertEquals(cmdList.get(0), "select 1");
-    assertEquals(cmdList.get(1), "\nselect 2");
+    assertEquals(2, cmdList.size());
+    assertEquals("select 1", cmdList.get(0));
+    assertEquals("\nselect 2", cmdList.get(1));
 
     // see HIVE-15820: comment at the head of beeline -e
     snippets = "--comments1\nselect 2;--comments2";
     Mockito.when(reader.readLine()).thenReturn(snippets);
     line = commands.handleMultiLineCmd(snippets);
     cmdList = commands.getCmdList(line, false);
-    assertEquals(cmdList.size(), 1);
-    assertEquals(cmdList.get(0), "select 2");
+    assertEquals(1, cmdList.size());
+    assertEquals("select 2", cmdList.get(0));
   }
 }

--- a/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestBeeLineExceptionHandling.java
+++ b/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestBeeLineExceptionHandling.java
@@ -17,9 +17,10 @@
  */
 package org.apache.hive.beeline;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.sql.SQLException;
 import org.apache.kyuubi.shaded.thrift.transport.TTransportException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class TestBeeLineExceptionHandling {
@@ -36,9 +37,9 @@ public class TestBeeLineExceptionHandling {
     @Override
     boolean error(String log) {
       if (logCount == 0) {
-        Assertions.assertEquals(loc(expectedLoc), log);
+        assertEquals(loc(expectedLoc), log);
       } else {
-        Assertions.assertEquals(
+        assertEquals(
             "Error: org.apache.kyuubi.shaded.thrift.transport.TTransportException "
                 + "(state=,code=0)",
             log);

--- a/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestBeeLineExceptionHandling.java
+++ b/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestBeeLineExceptionHandling.java
@@ -18,9 +18,9 @@
 package org.apache.hive.beeline;
 
 import java.sql.SQLException;
-import junit.framework.Assert;
 import org.apache.kyuubi.shaded.thrift.transport.TTransportException;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TestBeeLineExceptionHandling {
 
@@ -36,9 +36,9 @@ public class TestBeeLineExceptionHandling {
     @Override
     boolean error(String log) {
       if (logCount == 0) {
-        Assert.assertEquals(loc(expectedLoc), log);
+        Assertions.assertEquals(loc(expectedLoc), log);
       } else {
-        Assert.assertEquals(
+        Assertions.assertEquals(
             "Error: org.apache.kyuubi.shaded.thrift.transport.TTransportException "
                 + "(state=,code=0)",
             log);

--- a/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestBeeLineHistory.java
+++ b/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestBeeLineHistory.java
@@ -18,13 +18,14 @@
 
 package org.apache.hive.beeline;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.lang.reflect.Method;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -63,7 +64,7 @@ public class TestBeeLineHistory {
     beeline.dispatch("!history");
     String output = os.toString("UTF-8");
     int numHistories = output.split("\n").length;
-    Assertions.assertEquals(10, numHistories);
+    assertEquals(10, numHistories);
     beeline.close();
   }
 
@@ -81,8 +82,8 @@ public class TestBeeLineHistory {
     beeline.dispatch("!history");
     String output = os.toString("UTF-8");
     String[] tmp = output.split("\n");
-    Assertions.assertEquals("1     : select 1;", tmp[0]);
-    Assertions.assertEquals("10    : select 10;", tmp[9]);
+    assertEquals("1     : select 1;", tmp[0]);
+    assertEquals("10    : select 10;", tmp[9]);
     beeline.close();
   }
 

--- a/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestBeeLineHistory.java
+++ b/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestBeeLineHistory.java
@@ -81,8 +81,8 @@ public class TestBeeLineHistory {
     beeline.dispatch("!history");
     String output = os.toString("UTF-8");
     String[] tmp = output.split("\n");
-    Assertions.assertTrue(tmp[0].equals("1     : select 1;"));
-    Assertions.assertTrue(tmp[9].equals("10    : select 10;"));
+    Assertions.assertEquals("1     : select 1;", tmp[0]);
+    Assertions.assertEquals("10    : select 10;", tmp[9]);
     beeline.close();
   }
 

--- a/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestBeeLineHistory.java
+++ b/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestBeeLineHistory.java
@@ -23,17 +23,17 @@ import java.io.File;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.lang.reflect.Method;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /** TestBeeLineHistory - executes tests of the !history command of BeeLine */
 public class TestBeeLineHistory {
 
   private static final String fileName = System.getProperty("java.io.tmpdir") + "/history";
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeTests() throws Exception {
     PrintWriter writer = new PrintWriter(fileName);
     writer.println("select 1;");
@@ -63,7 +63,7 @@ public class TestBeeLineHistory {
     beeline.dispatch("!history");
     String output = os.toString("UTF-8");
     int numHistories = output.split("\n").length;
-    Assert.assertEquals(10, numHistories);
+    Assertions.assertEquals(10, numHistories);
     beeline.close();
   }
 
@@ -81,12 +81,12 @@ public class TestBeeLineHistory {
     beeline.dispatch("!history");
     String output = os.toString("UTF-8");
     String[] tmp = output.split("\n");
-    Assert.assertTrue(tmp[0].equals("1     : select 1;"));
-    Assert.assertTrue(tmp[9].equals("10    : select 10;"));
+    Assertions.assertTrue(tmp[0].equals("1     : select 1;"));
+    Assertions.assertTrue(tmp[9].equals("10    : select 10;"));
     beeline.close();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterTests() throws Exception {
     File file = new File(fileName);
     file.delete();

--- a/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestBeeLineOpts.java
+++ b/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestBeeLineOpts.java
@@ -20,8 +20,8 @@ package org.apache.hive.beeline;
 import static org.mockito.Mockito.*;
 
 import java.io.*;
-import junit.framework.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TestBeeLineOpts {
   @Test
@@ -30,6 +30,6 @@ public class TestBeeLineOpts {
     when(mockBeeLine.isBeeLine()).thenReturn(true);
     when(mockBeeLine.getReflector()).thenReturn(new Reflector(mockBeeLine));
     BeeLineOpts beeLineOpts = new BeeLineOpts(mockBeeLine, System.getProperties());
-    Assert.assertFalse(beeLineOpts.propertyNamesSet().contains("conf"));
+    Assertions.assertFalse(beeLineOpts.propertyNamesSet().contains("conf"));
   }
 }

--- a/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestBeeLineOpts.java
+++ b/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestBeeLineOpts.java
@@ -17,10 +17,10 @@
  */
 package org.apache.hive.beeline;
 
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-import java.io.*;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class TestBeeLineOpts {
@@ -30,6 +30,6 @@ public class TestBeeLineOpts {
     when(mockBeeLine.isBeeLine()).thenReturn(true);
     when(mockBeeLine.getReflector()).thenReturn(new Reflector(mockBeeLine));
     BeeLineOpts beeLineOpts = new BeeLineOpts(mockBeeLine, System.getProperties());
-    Assertions.assertFalse(beeLineOpts.propertyNamesSet().contains("conf"));
+    assertFalse(beeLineOpts.propertyNamesSet().contains("conf"));
   }
 }

--- a/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestBeelineArgParsing.java
+++ b/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestBeelineArgParsing.java
@@ -123,8 +123,8 @@ public class TestBeelineArgParsing {
           "-u", "url", "-n", "name", "-p", "password", "-d", "driver", "-a", "authType"
         };
     assertEquals(0, bl.initArgs(args));
-    assertTrue(bl.connectArgs.equals("url name password driver"));
-    assertTrue(bl.getOpts().getAuthType().equals("authType"));
+    assertEquals("url name password driver", bl.connectArgs);
+    assertEquals("authType", bl.getOpts().getAuthType());
   }
 
   @Test
@@ -153,8 +153,8 @@ public class TestBeelineArgParsing {
     bl.initArgs(args);
     System.out.println(bl.connectArgs);
     // Password file contents are trimmed of trailing whitespaces and newlines
-    assertTrue(bl.connectArgs.equals("url name mypass driver"));
-    assertTrue(bl.getOpts().getAuthType().equals("authType"));
+    assertEquals("url name mypass driver", bl.connectArgs);
+    assertEquals("authType", bl.getOpts().getAuthType());
     passFile.delete();
   }
 
@@ -165,7 +165,7 @@ public class TestBeelineArgParsing {
     String args[] =
         new String[] {"-u", "url", "-u", "url2", "-n", "name", "-p", "password", "-d", "driver"};
     assertEquals(0, bl.initArgs(args));
-    assertTrue(bl.connectArgs.equals("url name password driver"));
+    assertEquals("url name password driver", bl.connectArgs);
   }
 
   @Test
@@ -187,7 +187,7 @@ public class TestBeelineArgParsing {
           "select2"
         };
     assertEquals(0, bl.initArgs(args));
-    assertTrue(bl.connectArgs.equals("url name password driver"));
+    assertEquals("url name password driver", bl.connectArgs);
     assertTrue(bl.queries.contains("select1"));
     assertTrue(bl.queries.contains("select2"));
   }
@@ -220,13 +220,13 @@ public class TestBeelineArgParsing {
           "f=fvalue"
         };
     assertEquals(0, bl.initArgs(args));
-    assertTrue(bl.connectArgs.equals("url name password driver"));
-    assertTrue(bl.getOpts().getHiveConfVariables().get("a").equals("avalue"));
-    assertTrue(bl.getOpts().getHiveConfVariables().get("b").equals("bvalue"));
-    assertTrue(bl.getOpts().getHiveVariables().get("c").equals("cvalue"));
-    assertTrue(bl.getOpts().getHiveVariables().get("d").equals("dvalue"));
-    assertTrue(bl.getOpts().getHiveConfVariables().get("e").equals("evalue"));
-    assertTrue(bl.getOpts().getHiveConfVariables().get("f").equals("fvalue"));
+    assertEquals("url name password driver", bl.connectArgs);
+    assertEquals("avalue", bl.getOpts().getHiveConfVariables().get("a"));
+    assertEquals("bvalue", bl.getOpts().getHiveConfVariables().get("b"));
+    assertEquals("cvalue", bl.getOpts().getHiveVariables().get("c"));
+    assertEquals("dvalue", bl.getOpts().getHiveVariables().get("d"));
+    assertEquals("evalue", bl.getOpts().getHiveConfVariables().get("e"));
+    assertEquals("fvalue", bl.getOpts().getHiveConfVariables().get("f"));
   }
 
   @Test
@@ -247,7 +247,7 @@ public class TestBeelineArgParsing {
           "--truncateTable"
         };
     assertEquals(0, bl.initArgs(args));
-    assertTrue(bl.connectArgs.equals("url name password driver"));
+    assertEquals("url name password driver", bl.connectArgs);
     assertTrue(bl.getOpts().getAutoCommit());
     assertTrue(bl.getOpts().getVerbose());
     assertTrue(bl.getOpts().getTruncateTable());
@@ -297,8 +297,8 @@ public class TestBeelineArgParsing {
           "-u", "url", "-n", "name", "-p", "password", "-d", "driver", "-f", "myscript"
         };
     assertEquals(0, bl.initArgs(args));
-    assertTrue(bl.connectArgs.equals("url name password driver"));
-    assertTrue(bl.getOpts().getScriptFile().equals("myscript"));
+    assertEquals("url name password driver", bl.connectArgs);
+    assertEquals("myscript", bl.getOpts().getScriptFile());
   }
 
   /** Test beeline with -f and -e simultaneously */
@@ -408,7 +408,7 @@ public class TestBeelineArgParsing {
     TestBeeline bl = new TestBeeline();
     String args[] = new String[] {"--property-file", "props"};
     assertEquals(0, bl.initArgs(args));
-    assertTrue(bl.properties.get(0).equals("props"));
+    assertEquals("props", bl.properties.get(0));
     bl.close();
   }
 
@@ -418,7 +418,7 @@ public class TestBeelineArgParsing {
     TestBeeline bl = new TestBeeline();
     String args[] = new String[] {"--maxHistoryRows=100"};
     assertEquals(0, bl.initArgs(args));
-    assertTrue(bl.getOpts().getMaxHistoryRows() == 100);
+    assertEquals(100, bl.getOpts().getMaxHistoryRows());
     bl.close();
   }
 }

--- a/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestBeelineArgParsing.java
+++ b/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestBeelineArgParsing.java
@@ -18,7 +18,11 @@
 
 package org.apache.hive.beeline;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -28,43 +32,24 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.apache.hive.beeline.common.HiveTestUtils;
 import org.apache.kyuubi.util.JavaUtils;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Unit test for Beeline arg parser. */
-@RunWith(Parameterized.class)
 public class TestBeelineArgParsing {
   private static final Logger LOG = LoggerFactory.getLogger(TestBeelineArgParsing.class.getName());
 
   private static final String dummyDriverClazzName = "DummyDriver";
-
-  private String connectionString;
-  private String driverClazzName;
-  private String driverJarFileName;
-  private boolean defaultSupported;
-
-  public TestBeelineArgParsing(
-      String connectionString,
-      String driverClazzName,
-      String driverJarFileName,
-      boolean defaultSupported) {
-    this.connectionString = connectionString;
-    this.driverClazzName = driverClazzName;
-    this.driverJarFileName = driverJarFileName;
-    this.defaultSupported = defaultSupported;
-  }
 
   public class TestBeeline extends BeeLine {
 
@@ -97,8 +82,7 @@ public class TestBeelineArgParsing {
     }
   }
 
-  @Parameters(name = "{1}")
-  public static Collection<Object[]> data() throws IOException, InterruptedException {
+  public static Stream<Arguments> data() throws IOException, InterruptedException {
     // generate the dummy driver by using txt file
     String u = HiveTestUtils.getFileFromClasspath("DummyDriver.txt");
     Map<File, String> extraContent = new HashMap<>();
@@ -121,16 +105,14 @@ public class TestBeelineArgParsing {
             .toAbsolutePath()
             .toString();
 
-    return Arrays.asList(
-        new Object[][] {
-          {
+    return Stream.of(
+        Arguments.of(
             "jdbc:postgresql://host:5432/testdb",
             "org.postgresql.Driver",
             postgresqlJdbcDriverPath,
-            true
-          },
-          {"jdbc:dummy://host:5432/testdb", dummyDriverClazzName, pathToDummyDriver, false}
-        });
+            true),
+        Arguments.of(
+            "jdbc:dummy://host:5432/testdb", dummyDriverClazzName, pathToDummyDriver, false));
   }
 
   @Test
@@ -140,9 +122,9 @@ public class TestBeelineArgParsing {
         new String[] {
           "-u", "url", "-n", "name", "-p", "password", "-d", "driver", "-a", "authType"
         };
-    org.junit.Assert.assertEquals(0, bl.initArgs(args));
-    Assert.assertTrue(bl.connectArgs.equals("url name password driver"));
-    Assert.assertTrue(bl.getOpts().getAuthType().equals("authType"));
+    assertEquals(0, bl.initArgs(args));
+    assertTrue(bl.connectArgs.equals("url name password driver"));
+    assertTrue(bl.getOpts().getAuthType().equals("authType"));
   }
 
   @Test
@@ -171,8 +153,8 @@ public class TestBeelineArgParsing {
     bl.initArgs(args);
     System.out.println(bl.connectArgs);
     // Password file contents are trimmed of trailing whitespaces and newlines
-    Assert.assertTrue(bl.connectArgs.equals("url name mypass driver"));
-    Assert.assertTrue(bl.getOpts().getAuthType().equals("authType"));
+    assertTrue(bl.connectArgs.equals("url name mypass driver"));
+    assertTrue(bl.getOpts().getAuthType().equals("authType"));
     passFile.delete();
   }
 
@@ -182,8 +164,8 @@ public class TestBeelineArgParsing {
     TestBeeline bl = new TestBeeline();
     String args[] =
         new String[] {"-u", "url", "-u", "url2", "-n", "name", "-p", "password", "-d", "driver"};
-    Assert.assertEquals(0, bl.initArgs(args));
-    Assert.assertTrue(bl.connectArgs.equals("url name password driver"));
+    assertEquals(0, bl.initArgs(args));
+    assertTrue(bl.connectArgs.equals("url name password driver"));
   }
 
   @Test
@@ -204,10 +186,10 @@ public class TestBeelineArgParsing {
           "-e",
           "select2"
         };
-    Assert.assertEquals(0, bl.initArgs(args));
-    Assert.assertTrue(bl.connectArgs.equals("url name password driver"));
-    Assert.assertTrue(bl.queries.contains("select1"));
-    Assert.assertTrue(bl.queries.contains("select2"));
+    assertEquals(0, bl.initArgs(args));
+    assertTrue(bl.connectArgs.equals("url name password driver"));
+    assertTrue(bl.queries.contains("select1"));
+    assertTrue(bl.queries.contains("select2"));
   }
 
   /** Test setting hive conf and hive vars with --hiveconf, --hivevar and --conf */
@@ -237,14 +219,14 @@ public class TestBeelineArgParsing {
           "--conf",
           "f=fvalue"
         };
-    Assert.assertEquals(0, bl.initArgs(args));
-    Assert.assertTrue(bl.connectArgs.equals("url name password driver"));
-    Assert.assertTrue(bl.getOpts().getHiveConfVariables().get("a").equals("avalue"));
-    Assert.assertTrue(bl.getOpts().getHiveConfVariables().get("b").equals("bvalue"));
-    Assert.assertTrue(bl.getOpts().getHiveVariables().get("c").equals("cvalue"));
-    Assert.assertTrue(bl.getOpts().getHiveVariables().get("d").equals("dvalue"));
-    Assert.assertTrue(bl.getOpts().getHiveConfVariables().get("e").equals("evalue"));
-    Assert.assertTrue(bl.getOpts().getHiveConfVariables().get("f").equals("fvalue"));
+    assertEquals(0, bl.initArgs(args));
+    assertTrue(bl.connectArgs.equals("url name password driver"));
+    assertTrue(bl.getOpts().getHiveConfVariables().get("a").equals("avalue"));
+    assertTrue(bl.getOpts().getHiveConfVariables().get("b").equals("bvalue"));
+    assertTrue(bl.getOpts().getHiveVariables().get("c").equals("cvalue"));
+    assertTrue(bl.getOpts().getHiveVariables().get("d").equals("dvalue"));
+    assertTrue(bl.getOpts().getHiveConfVariables().get("e").equals("evalue"));
+    assertTrue(bl.getOpts().getHiveConfVariables().get("f").equals("fvalue"));
   }
 
   @Test
@@ -264,11 +246,11 @@ public class TestBeelineArgParsing {
           "--verbose",
           "--truncateTable"
         };
-    Assert.assertEquals(0, bl.initArgs(args));
-    Assert.assertTrue(bl.connectArgs.equals("url name password driver"));
-    Assert.assertTrue(bl.getOpts().getAutoCommit());
-    Assert.assertTrue(bl.getOpts().getVerbose());
-    Assert.assertTrue(bl.getOpts().getTruncateTable());
+    assertEquals(0, bl.initArgs(args));
+    assertTrue(bl.connectArgs.equals("url name password driver"));
+    assertTrue(bl.getOpts().getAutoCommit());
+    assertTrue(bl.getOpts().getVerbose());
+    assertTrue(bl.getOpts().getTruncateTable());
   }
 
   @Test
@@ -276,15 +258,15 @@ public class TestBeelineArgParsing {
     TestBeeline bl = new TestBeeline();
     String[] args = {};
     bl.initArgs(args);
-    Assert.assertTrue(bl.getOpts().getAutoCommit());
+    assertTrue(bl.getOpts().getAutoCommit());
 
     args = new String[] {"--autoCommit=false"};
     bl.initArgs(args);
-    Assert.assertFalse(bl.getOpts().getAutoCommit());
+    assertFalse(bl.getOpts().getAutoCommit());
 
     args = new String[] {"--autoCommit=true"};
     bl.initArgs(args);
-    Assert.assertTrue(bl.getOpts().getAutoCommit());
+    assertTrue(bl.getOpts().getAutoCommit());
     bl.close();
   }
 
@@ -292,18 +274,18 @@ public class TestBeelineArgParsing {
   public void testBeelineShowDbInPromptOptsDefault() throws Exception {
     TestBeeline bl = new TestBeeline();
     String args[] = new String[] {"-u", "url"};
-    Assert.assertEquals(0, bl.initArgs(args));
-    Assert.assertFalse(bl.getOpts().getShowDbInPrompt());
-    Assert.assertEquals("", bl.getFormattedDb());
+    assertEquals(0, bl.initArgs(args));
+    assertFalse(bl.getOpts().getShowDbInPrompt());
+    assertEquals("", bl.getFormattedDb());
   }
 
   @Test
   public void testBeelineShowDbInPromptOptsTrue() throws Exception {
     TestBeeline bl = new TestBeeline();
     String args[] = new String[] {"-u", "url", "--showDbInPrompt=true"};
-    Assert.assertEquals(0, bl.initArgs(args));
-    Assert.assertTrue(bl.getOpts().getShowDbInPrompt());
-    Assert.assertEquals(" (default)", bl.getFormattedDb());
+    assertEquals(0, bl.initArgs(args));
+    assertTrue(bl.getOpts().getShowDbInPrompt());
+    assertEquals(" (default)", bl.getFormattedDb());
   }
 
   /** Test setting script file with -f option. */
@@ -314,9 +296,9 @@ public class TestBeelineArgParsing {
         new String[] {
           "-u", "url", "-n", "name", "-p", "password", "-d", "driver", "-f", "myscript"
         };
-    Assert.assertEquals(0, bl.initArgs(args));
-    Assert.assertTrue(bl.connectArgs.equals("url name password driver"));
-    Assert.assertTrue(bl.getOpts().getScriptFile().equals("myscript"));
+    assertEquals(0, bl.initArgs(args));
+    assertTrue(bl.connectArgs.equals("url name password driver"));
+    assertTrue(bl.getOpts().getScriptFile().equals("myscript"));
   }
 
   /** Test beeline with -f and -e simultaneously */
@@ -324,7 +306,7 @@ public class TestBeelineArgParsing {
   public void testCommandAndFileSimultaneously() throws Exception {
     TestBeeline bl = new TestBeeline();
     String args[] = new String[] {"-e", "myselect", "-f", "myscript"};
-    Assert.assertEquals(1, bl.initArgs(args));
+    assertEquals(1, bl.initArgs(args));
   }
 
   /** Test beeline with multiple initfiles in -i. */
@@ -332,10 +314,10 @@ public class TestBeelineArgParsing {
   public void testMultipleInitFiles() {
     TestBeeline bl = new TestBeeline();
     String[] args = new String[] {"-i", "/url/to/file1", "-i", "/url/to/file2"};
-    Assert.assertEquals(0, bl.initArgs(args));
+    assertEquals(0, bl.initArgs(args));
     String[] files = bl.getOpts().getInitFiles();
-    Assert.assertEquals("/url/to/file1", files[0]);
-    Assert.assertEquals("/url/to/file2", files[1]);
+    assertEquals("/url/to/file1", files[0]);
+    assertEquals("/url/to/file2", files[1]);
   }
 
   /** Displays the usage. */
@@ -343,8 +325,8 @@ public class TestBeelineArgParsing {
   public void testHelp() throws Exception {
     TestBeeline bl = new TestBeeline();
     String args[] = new String[] {"--help"};
-    Assert.assertEquals(0, bl.initArgs(args));
-    Assert.assertEquals(true, bl.getOpts().isHelpAsked());
+    assertEquals(0, bl.initArgs(args));
+    assertEquals(true, bl.getOpts().isHelpAsked());
   }
 
   /** Displays the usage. */
@@ -352,35 +334,46 @@ public class TestBeelineArgParsing {
   public void testUnmatchedArgs() throws Exception {
     TestBeeline bl = new TestBeeline();
     String args[] = new String[] {"-u", "url", "-n"};
-    Assert.assertEquals(-1, bl.initArgs(args));
+    assertEquals(-1, bl.initArgs(args));
   }
 
-  @Test
-  public void testAddLocalJar() throws Exception {
+  @ParameterizedTest(name = "{1}")
+  @MethodSource("data")
+  public void testAddLocalJar(
+      String connectionString,
+      String driverClazzName,
+      String driverJarFileName,
+      boolean defaultSupported)
+      throws Exception {
     TestBeeline bl = new TestBeeline();
-    Assert.assertNull(bl.findLocalDriver(connectionString));
+    assertNull(bl.findLocalDriver(connectionString));
 
     LOG.info("Add " + driverJarFileName + " for the driver class " + driverClazzName);
 
     bl.addLocalJar(driverJarFileName);
     bl.addlocaldrivername(driverClazzName);
-    Assert.assertEquals(bl.findLocalDriver(connectionString).getClass().getName(), driverClazzName);
+    assertEquals(driverClazzName, bl.findLocalDriver(connectionString).getClass().getName());
   }
 
-  @Test
-  public void testAddLocalJarWithoutAddDriverClazz() throws Exception {
+  @ParameterizedTest(name = "{1}")
+  @MethodSource("data")
+  public void testAddLocalJarWithoutAddDriverClazz(
+      String connectionString,
+      String driverClazzName,
+      String driverJarFileName,
+      boolean defaultSupported)
+      throws Exception {
     TestBeeline bl = new TestBeeline();
 
     LOG.info("Add " + driverJarFileName + " for the driver class " + driverClazzName);
-    assertTrue("expected to exists: " + driverJarFileName, new File(driverJarFileName).exists());
+    assertTrue(new File(driverJarFileName).exists(), "expected to exists: " + driverJarFileName);
     bl.addLocalJar(driverJarFileName);
     if (!defaultSupported) {
-      Assert.assertNull(bl.findLocalDriver(connectionString));
+      assertNull(bl.findLocalDriver(connectionString));
     } else {
       // no need to add for the default supported local jar driver
-      Assert.assertNotNull(bl.findLocalDriver(connectionString));
-      Assert.assertEquals(
-          bl.findLocalDriver(connectionString).getClass().getName(), driverClazzName);
+      assertNotNull(bl.findLocalDriver(connectionString));
+      assertEquals(driverClazzName, bl.findLocalDriver(connectionString).getClass().getName());
     }
   }
 
@@ -406,7 +399,7 @@ public class TestBeelineArgParsing {
     bl.initArgs(args);
     bl.close();
     String errContents = new String(Files.readAllBytes(Paths.get(errFile.toString())));
-    Assert.assertTrue(errContents.contains(BeeLine.PASSWD_MASK));
+    assertTrue(errContents.contains(BeeLine.PASSWD_MASK));
   }
 
   /** Test property file parameter option. */
@@ -414,8 +407,8 @@ public class TestBeelineArgParsing {
   public void testPropertyFile() throws Exception {
     TestBeeline bl = new TestBeeline();
     String args[] = new String[] {"--property-file", "props"};
-    Assert.assertEquals(0, bl.initArgs(args));
-    Assert.assertTrue(bl.properties.get(0).equals("props"));
+    assertEquals(0, bl.initArgs(args));
+    assertTrue(bl.properties.get(0).equals("props"));
     bl.close();
   }
 
@@ -424,8 +417,8 @@ public class TestBeelineArgParsing {
   public void testMaxHistoryRows() throws Exception {
     TestBeeline bl = new TestBeeline();
     String args[] = new String[] {"--maxHistoryRows=100"};
-    Assert.assertEquals(0, bl.initArgs(args));
-    Assert.assertTrue(bl.getOpts().getMaxHistoryRows() == 100);
+    assertEquals(0, bl.initArgs(args));
+    assertTrue(bl.getOpts().getMaxHistoryRows() == 100);
     bl.close();
   }
 }

--- a/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestBeelineArgParsing.java
+++ b/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestBeelineArgParsing.java
@@ -326,7 +326,7 @@ public class TestBeelineArgParsing {
     TestBeeline bl = new TestBeeline();
     String args[] = new String[] {"--help"};
     assertEquals(0, bl.initArgs(args));
-    assertEquals(true, bl.getOpts().isHelpAsked());
+    assertTrue(bl.getOpts().isHelpAsked());
   }
 
   /** Displays the usage. */

--- a/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestBufferedRows.java
+++ b/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestBufferedRows.java
@@ -17,13 +17,13 @@
  */
 package org.apache.hive.beeline;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.invocation.InvocationOnMock;
@@ -59,7 +59,7 @@ public class TestBufferedRows {
     while (bfRows.hasNext()) {
       Rows.Row row = (Rows.Row) bfRows.next();
       for (int colSize : row.sizes) {
-        Assertions.assertTrue(colSize <= mockBeeLineOpts.getMaxColumnWidth());
+        assertTrue(colSize <= mockBeeLineOpts.getMaxColumnWidth());
       }
     }
   }

--- a/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestBufferedRows.java
+++ b/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestBufferedRows.java
@@ -23,8 +23,8 @@ import static org.mockito.Mockito.when;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -59,7 +59,7 @@ public class TestBufferedRows {
     while (bfRows.hasNext()) {
       Rows.Row row = (Rows.Row) bfRows.next();
       for (int colSize : row.sizes) {
-        Assert.assertTrue(colSize <= mockBeeLineOpts.getMaxColumnWidth());
+        Assertions.assertTrue(colSize <= mockBeeLineOpts.getMaxColumnWidth());
       }
     }
   }

--- a/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestClientCommandHookFactory.java
+++ b/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestClientCommandHookFactory.java
@@ -17,13 +17,15 @@
  */
 package org.apache.hive.beeline;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -50,40 +52,40 @@ public class TestClientCommandHookFactory {
   @Test
   public void testGetHookBeeLineWithShowDbInPrompt() {
     BeeLine beeLine = setupMockData(true, true);
-    Assertions.assertNull(ClientCommandHookFactory.get().getHook(beeLine, "set a;"));
-    Assertions.assertNull(ClientCommandHookFactory.get().getHook(beeLine, "set a=b;"));
-    Assertions.assertTrue(
-        ClientCommandHookFactory.get().getHook(beeLine, "USE a.b")
-            instanceof ClientCommandHookFactory.UseCommandHook);
-    Assertions.assertTrue(
-        ClientCommandHookFactory.get().getHook(beeLine, "coNNect a.b")
-            instanceof ClientCommandHookFactory.ConnectCommandHook);
-    Assertions.assertTrue(
-        ClientCommandHookFactory.get().getHook(beeLine, "gO 1")
-            instanceof ClientCommandHookFactory.GoCommandHook);
-    Assertions.assertNull(ClientCommandHookFactory.get().getHook(beeLine, "g"));
+    assertNull(ClientCommandHookFactory.get().getHook(beeLine, "set a;"));
+    assertNull(ClientCommandHookFactory.get().getHook(beeLine, "set a=b;"));
+    assertInstanceOf(
+        ClientCommandHookFactory.UseCommandHook.class,
+        ClientCommandHookFactory.get().getHook(beeLine, "USE a.b"));
+    assertInstanceOf(
+        ClientCommandHookFactory.ConnectCommandHook.class,
+        ClientCommandHookFactory.get().getHook(beeLine, "coNNect a.b"));
+    assertInstanceOf(
+        ClientCommandHookFactory.GoCommandHook.class,
+        ClientCommandHookFactory.get().getHook(beeLine, "gO 1"));
+    assertNull(ClientCommandHookFactory.get().getHook(beeLine, "g"));
   }
 
   @Test
   public void testGetHookBeeLineWithoutShowDbInPrompt() {
     BeeLine beeLine = setupMockData(true, false);
-    Assertions.assertNull(ClientCommandHookFactory.get().getHook(beeLine, "set a;"));
-    Assertions.assertNull(ClientCommandHookFactory.get().getHook(beeLine, "set a=b;"));
-    Assertions.assertNull(ClientCommandHookFactory.get().getHook(beeLine, "USE a.b"));
-    Assertions.assertNull(ClientCommandHookFactory.get().getHook(beeLine, "coNNect a.b"));
-    Assertions.assertNull(ClientCommandHookFactory.get().getHook(beeLine, "gO 1"));
-    Assertions.assertNull(ClientCommandHookFactory.get().getHook(beeLine, "g"));
+    assertNull(ClientCommandHookFactory.get().getHook(beeLine, "set a;"));
+    assertNull(ClientCommandHookFactory.get().getHook(beeLine, "set a=b;"));
+    assertNull(ClientCommandHookFactory.get().getHook(beeLine, "USE a.b"));
+    assertNull(ClientCommandHookFactory.get().getHook(beeLine, "coNNect a.b"));
+    assertNull(ClientCommandHookFactory.get().getHook(beeLine, "gO 1"));
+    assertNull(ClientCommandHookFactory.get().getHook(beeLine, "g"));
   }
 
   @Test
   public void testUseHook() {
     BeeLine beeLine = setupMockData(true, true);
     ClientHook hook = ClientCommandHookFactory.get().getHook(beeLine, "USE newDatabase1");
-    Assertions.assertTrue(hook instanceof ClientCommandHookFactory.UseCommandHook);
+    assertInstanceOf(ClientCommandHookFactory.UseCommandHook.class, hook);
     hook.postHook(beeLine);
     ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
     verify(beeLine).setCurrentDatabase(argument.capture());
-    Assertions.assertEquals("newDatabase1", argument.getValue());
+    assertEquals("newDatabase1", argument.getValue());
   }
 
   @Test
@@ -92,21 +94,21 @@ public class TestClientCommandHookFactory {
     ClientHook hook =
         ClientCommandHookFactory.get()
             .getHook(beeLine, "coNNect jdbc:hive2://localhost:10000/newDatabase2 a a");
-    Assertions.assertTrue(hook instanceof ClientCommandHookFactory.ConnectCommandHook);
+    assertInstanceOf(ClientCommandHookFactory.ConnectCommandHook.class, hook);
     hook.postHook(beeLine);
     ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
     verify(beeLine).setCurrentDatabase(argument.capture());
-    Assertions.assertEquals("newDatabase2", argument.getValue());
+    assertEquals("newDatabase2", argument.getValue());
   }
 
   @Test
   public void testGoHook() {
     BeeLine beeLine = setupMockData(true, true);
     ClientHook hook = ClientCommandHookFactory.get().getHook(beeLine, "go 1");
-    Assertions.assertTrue(hook instanceof ClientCommandHookFactory.GoCommandHook);
+    assertInstanceOf(ClientCommandHookFactory.GoCommandHook.class, hook);
     hook.postHook(beeLine);
     ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
     verify(beeLine).setCurrentDatabase(argument.capture());
-    Assertions.assertEquals("newDatabase", argument.getValue());
+    assertEquals("newDatabase", argument.getValue());
   }
 }

--- a/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestClientCommandHookFactory.java
+++ b/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestClientCommandHookFactory.java
@@ -23,8 +23,8 @@ import static org.mockito.Mockito.when;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import junit.framework.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 public class TestClientCommandHookFactory {
@@ -50,40 +50,40 @@ public class TestClientCommandHookFactory {
   @Test
   public void testGetHookBeeLineWithShowDbInPrompt() {
     BeeLine beeLine = setupMockData(true, true);
-    Assert.assertNull(ClientCommandHookFactory.get().getHook(beeLine, "set a;"));
-    Assert.assertNull(ClientCommandHookFactory.get().getHook(beeLine, "set a=b;"));
-    Assert.assertTrue(
+    Assertions.assertNull(ClientCommandHookFactory.get().getHook(beeLine, "set a;"));
+    Assertions.assertNull(ClientCommandHookFactory.get().getHook(beeLine, "set a=b;"));
+    Assertions.assertTrue(
         ClientCommandHookFactory.get().getHook(beeLine, "USE a.b")
             instanceof ClientCommandHookFactory.UseCommandHook);
-    Assert.assertTrue(
+    Assertions.assertTrue(
         ClientCommandHookFactory.get().getHook(beeLine, "coNNect a.b")
             instanceof ClientCommandHookFactory.ConnectCommandHook);
-    Assert.assertTrue(
+    Assertions.assertTrue(
         ClientCommandHookFactory.get().getHook(beeLine, "gO 1")
             instanceof ClientCommandHookFactory.GoCommandHook);
-    Assert.assertNull(ClientCommandHookFactory.get().getHook(beeLine, "g"));
+    Assertions.assertNull(ClientCommandHookFactory.get().getHook(beeLine, "g"));
   }
 
   @Test
   public void testGetHookBeeLineWithoutShowDbInPrompt() {
     BeeLine beeLine = setupMockData(true, false);
-    Assert.assertNull(ClientCommandHookFactory.get().getHook(beeLine, "set a;"));
-    Assert.assertNull(ClientCommandHookFactory.get().getHook(beeLine, "set a=b;"));
-    Assert.assertNull(ClientCommandHookFactory.get().getHook(beeLine, "USE a.b"));
-    Assert.assertNull(ClientCommandHookFactory.get().getHook(beeLine, "coNNect a.b"));
-    Assert.assertNull(ClientCommandHookFactory.get().getHook(beeLine, "gO 1"));
-    Assert.assertNull(ClientCommandHookFactory.get().getHook(beeLine, "g"));
+    Assertions.assertNull(ClientCommandHookFactory.get().getHook(beeLine, "set a;"));
+    Assertions.assertNull(ClientCommandHookFactory.get().getHook(beeLine, "set a=b;"));
+    Assertions.assertNull(ClientCommandHookFactory.get().getHook(beeLine, "USE a.b"));
+    Assertions.assertNull(ClientCommandHookFactory.get().getHook(beeLine, "coNNect a.b"));
+    Assertions.assertNull(ClientCommandHookFactory.get().getHook(beeLine, "gO 1"));
+    Assertions.assertNull(ClientCommandHookFactory.get().getHook(beeLine, "g"));
   }
 
   @Test
   public void testUseHook() {
     BeeLine beeLine = setupMockData(true, true);
     ClientHook hook = ClientCommandHookFactory.get().getHook(beeLine, "USE newDatabase1");
-    Assert.assertTrue(hook instanceof ClientCommandHookFactory.UseCommandHook);
+    Assertions.assertTrue(hook instanceof ClientCommandHookFactory.UseCommandHook);
     hook.postHook(beeLine);
     ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
     verify(beeLine).setCurrentDatabase(argument.capture());
-    Assert.assertEquals("newDatabase1", argument.getValue());
+    Assertions.assertEquals("newDatabase1", argument.getValue());
   }
 
   @Test
@@ -92,21 +92,21 @@ public class TestClientCommandHookFactory {
     ClientHook hook =
         ClientCommandHookFactory.get()
             .getHook(beeLine, "coNNect jdbc:hive2://localhost:10000/newDatabase2 a a");
-    Assert.assertTrue(hook instanceof ClientCommandHookFactory.ConnectCommandHook);
+    Assertions.assertTrue(hook instanceof ClientCommandHookFactory.ConnectCommandHook);
     hook.postHook(beeLine);
     ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
     verify(beeLine).setCurrentDatabase(argument.capture());
-    Assert.assertEquals("newDatabase2", argument.getValue());
+    Assertions.assertEquals("newDatabase2", argument.getValue());
   }
 
   @Test
   public void testGoHook() {
     BeeLine beeLine = setupMockData(true, true);
     ClientHook hook = ClientCommandHookFactory.get().getHook(beeLine, "go 1");
-    Assert.assertTrue(hook instanceof ClientCommandHookFactory.GoCommandHook);
+    Assertions.assertTrue(hook instanceof ClientCommandHookFactory.GoCommandHook);
     hook.postHook(beeLine);
     ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
     verify(beeLine).setCurrentDatabase(argument.capture());
-    Assert.assertEquals("newDatabase", argument.getValue());
+    Assertions.assertEquals("newDatabase", argument.getValue());
   }
 }

--- a/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestCommands.java
+++ b/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestCommands.java
@@ -19,10 +19,10 @@
 package org.apache.hive.beeline;
 
 import static org.apache.hive.beeline.common.util.HiveStringUtils.removeComments;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestCommands {
 

--- a/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestIncrementalRows.java
+++ b/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestIncrementalRows.java
@@ -18,6 +18,7 @@
 
 package org.apache.hive.beeline;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -26,7 +27,6 @@ import static org.mockito.Mockito.when;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
@@ -75,7 +75,7 @@ public class TestIncrementalRows {
 
     convertedIr.next();
     String row = convertedIr.next().toString();
-    Assertions.assertEquals("[MMM]", row);
+    assertEquals("[MMM]", row);
   }
 
   @Test
@@ -91,7 +91,7 @@ public class TestIncrementalRows {
 
     convertedIr.next();
     String row = convertedIr.next().toString();
-    Assertions.assertEquals("[[77, 77, 77]]", row);
+    assertEquals("[[77, 77, 77]]", row);
   }
 
   public void initNrOfResultSetCalls(final int iter) throws SQLException {

--- a/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestIncrementalRows.java
+++ b/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestIncrementalRows.java
@@ -26,9 +26,9 @@ import static org.mockito.Mockito.when;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -39,7 +39,7 @@ public class TestIncrementalRows {
   private Integer incrementalBufferRows = 5;
   private ResultSet mockResultSet;
 
-  @Before
+  @BeforeEach
   public void init() throws SQLException {
 
     // Mock BeeLineOpts
@@ -75,7 +75,7 @@ public class TestIncrementalRows {
 
     convertedIr.next();
     String row = convertedIr.next().toString();
-    Assert.assertEquals("[MMM]", row);
+    Assertions.assertEquals("[MMM]", row);
   }
 
   @Test
@@ -91,7 +91,7 @@ public class TestIncrementalRows {
 
     convertedIr.next();
     String row = convertedIr.next().toString();
-    Assert.assertEquals("[[77, 77, 77]]", row);
+    Assertions.assertEquals("[[77, 77, 77]]", row);
   }
 
   public void initNrOfResultSetCalls(final int iter) throws SQLException {

--- a/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestJSONFileOutputFormat.java
+++ b/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestJSONFileOutputFormat.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hive.beeline;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -27,8 +27,8 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Types;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
@@ -56,7 +56,7 @@ public class TestJSONFileOutputFormat {
     assertEquals(expResult, captureOutput.getValue());
   }
 
-  @Before
+  @BeforeEach
   public void setupMockData() throws SQLException {
     mockResultSet = mock(ResultSet.class);
     ResultSetMetaData mockResultSetMetaData = mock(ResultSetMetaData.class);

--- a/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestJSONOutputFormat.java
+++ b/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestJSONOutputFormat.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hive.beeline;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -27,8 +27,8 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Types;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
@@ -58,7 +58,7 @@ public class TestJSONOutputFormat {
     assertEquals(expResult, captureOutput.getValue());
   }
 
-  @Before
+  @BeforeEach
   public void setupMockData() throws SQLException {
     mockResultSet = mock(ResultSet.class);
     ResultSetMetaData mockResultSetMetaData = mock(ResultSetMetaData.class);

--- a/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestShutdownHook.java
+++ b/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestShutdownHook.java
@@ -18,9 +18,10 @@
 
 package org.apache.hive.beeline;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class TestShutdownHook {
@@ -32,9 +33,9 @@ public class TestShutdownHook {
     DatabaseConnections dbConnections = beeline.getDatabaseConnections();
     dbConnections.setConnection(new DatabaseConnection(beeline, null, null, null));
     dbConnections.setConnection(new DatabaseConnection(beeline, null, null, null));
-    Assertions.assertEquals(2, dbConnections.size());
+    assertEquals(2, dbConnections.size());
     beeline.setOutputStream(ops);
     beeline.getShutdownHook().run();
-    Assertions.assertEquals(0, dbConnections.size());
+    assertEquals(0, dbConnections.size());
   }
 }

--- a/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestShutdownHook.java
+++ b/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestShutdownHook.java
@@ -20,8 +20,8 @@ package org.apache.hive.beeline;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TestShutdownHook {
   @Test
@@ -32,9 +32,9 @@ public class TestShutdownHook {
     DatabaseConnections dbConnections = beeline.getDatabaseConnections();
     dbConnections.setConnection(new DatabaseConnection(beeline, null, null, null));
     dbConnections.setConnection(new DatabaseConnection(beeline, null, null, null));
-    Assert.assertEquals(2, dbConnections.size());
+    Assertions.assertEquals(2, dbConnections.size());
     beeline.setOutputStream(ops);
     beeline.getShutdownHook().run();
-    Assert.assertEquals(0, dbConnections.size());
+    Assertions.assertEquals(0, dbConnections.size());
   }
 }

--- a/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestTableOutputFormat.java
+++ b/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/TestTableOutputFormat.java
@@ -15,7 +15,7 @@
  */
 package org.apache.hive.beeline;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -23,7 +23,7 @@ import java.io.PrintStream;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;

--- a/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/hs2connection/TestKyuubiConfFileParser.java
+++ b/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/hs2connection/TestKyuubiConfFileParser.java
@@ -17,13 +17,13 @@
  */
 package org.apache.hive.beeline.hs2connection;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.Properties;
 import org.apache.kyuubi.util.JavaUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestKyuubiConfFileParser {
 

--- a/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/hs2connection/TestUserHS2ConnectionFileParser.java
+++ b/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/hs2connection/TestUserHS2ConnectionFileParser.java
@@ -17,12 +17,14 @@
  */
 package org.apache.hive.beeline.hs2connection;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.hive.beeline.common.HiveTestUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class TestUserHS2ConnectionFileParser {
@@ -62,7 +64,7 @@ public class TestUserHS2ConnectionFileParser {
   public void testParseNoAuthentication() throws BeelineHS2ConnectionFileParseException {
     String url = getParsedUrlFromConfigFile("test-hs2-connection-config-noauth.xml");
     String expectedUrl = "jdbc:hive2://localhost:10000/default;user=hive";
-    Assertions.assertEquals(expectedUrl, url, "Expected " + expectedUrl + " got " + url);
+    assertEquals(expectedUrl, url, "Expected " + expectedUrl + " got " + url);
   }
 
   @Test
@@ -70,7 +72,7 @@ public class TestUserHS2ConnectionFileParser {
     String url = getParsedUrlFromConfigFile("test-hs2-connection-zookeeper-config.xml");
     String expectedUrl =
         "jdbc:hive2://zk-node-1:10000,zk-node-2:10001,zk-node-3:10004/default;serviceDiscoveryMode=zookeeper;zooKeeperNamespace=hiveserver2";
-    Assertions.assertEquals(expectedUrl, url, "Expected " + expectedUrl + " got " + url);
+    assertEquals(expectedUrl, url, "Expected " + expectedUrl + " got " + url);
   }
 
   @Test
@@ -78,7 +80,7 @@ public class TestUserHS2ConnectionFileParser {
     String url = getParsedUrlFromConfigFile("test-hs2-conn-conf-kerberos-nossl.xml");
     String expectedUrl =
         "jdbc:hive2://localhost:10000/default;principal=hive/dummy-hostname@domain.com;ssl=false";
-    Assertions.assertEquals(expectedUrl, url, "Expected " + expectedUrl + " got " + url);
+    assertEquals(expectedUrl, url, "Expected " + expectedUrl + " got " + url);
   }
 
   @Test
@@ -87,7 +89,7 @@ public class TestUserHS2ConnectionFileParser {
     String expectedUrl =
         "jdbc:hive2://localhost:10000/default;principal=hive/dummy-hostname@domain.com;ssl=true;"
             + "sslTrustStore=test/truststore;trustStorePassword=testTruststorePassword";
-    Assertions.assertEquals(expectedUrl, url, "Expected " + expectedUrl + " got " + url);
+    assertEquals(expectedUrl, url, "Expected " + expectedUrl + " got " + url);
   }
 
   @Test
@@ -96,7 +98,7 @@ public class TestUserHS2ConnectionFileParser {
     String expectedUrl =
         "jdbc:hive2://localhost:10000/default;httpPath=testHTTPPath;principal=hive/dummy-hostname@domain.com;"
             + "ssl=true;sslTrustStore=test/truststore;transportMode=http;trustStorePassword=testTruststorePassword";
-    Assertions.assertEquals(expectedUrl, url, "Expected " + expectedUrl + " got " + url);
+    assertEquals(expectedUrl, url, "Expected " + expectedUrl + " got " + url);
   }
 
   @Test
@@ -104,7 +106,7 @@ public class TestUserHS2ConnectionFileParser {
     String url = getParsedUrlFromConfigFile("test-hs2-connection-conf-list.xml");
     String expectedUrl =
         "jdbc:hive2://localhost:10000/default;user=hive?hive.cli.print.current.db=false#testVarName1=value1";
-    Assertions.assertEquals(expectedUrl, url, "Expected " + expectedUrl + " got " + url);
+    assertEquals(expectedUrl, url, "Expected " + expectedUrl + " got " + url);
   }
 
   @Test
@@ -113,7 +115,7 @@ public class TestUserHS2ConnectionFileParser {
     String expectedUrl =
         "jdbc:hive2://localhost:10000/default;user=hive?hive.cli.print.current.db=true;"
             + "hive.cli.print.header=true#testVarName1=value1;testVarName2=value2";
-    Assertions.assertEquals(expectedUrl, url, "Expected " + expectedUrl + " got " + url);
+    assertEquals(expectedUrl, url, "Expected " + expectedUrl + " got " + url);
   }
 
   /*
@@ -126,7 +128,7 @@ public class TestUserHS2ConnectionFileParser {
     testLocations.add(LOCATION_3);
     UserHS2ConnectionFileParser testHS2ConfigManager =
         new UserHS2ConnectionFileParser(testLocations);
-    Assertions.assertTrue(testHS2ConfigManager.getConnectionProperties().isEmpty());
+    assertTrue(testHS2ConfigManager.getConnectionProperties().isEmpty());
   }
 
   /*
@@ -140,8 +142,9 @@ public class TestUserHS2ConnectionFileParser {
     testLocations.add(LOCATION_3);
     UserHS2ConnectionFileParser testHS2ConfigManager =
         new UserHS2ConnectionFileParser(testLocations);
-    Assertions.assertTrue(
-        LOCATION_1.equals(testHS2ConfigManager.getFileLocation()),
+    assertEquals(
+        LOCATION_1,
+        testHS2ConfigManager.getFileLocation(),
         "File location " + LOCATION_1 + " was not returned");
   }
 
@@ -156,8 +159,9 @@ public class TestUserHS2ConnectionFileParser {
     testLocations.add(LOCATION_3);
     UserHS2ConnectionFileParser testHS2ConfigManager =
         new UserHS2ConnectionFileParser(testLocations);
-    Assertions.assertTrue(
-        LOCATION_3.equals(testHS2ConfigManager.getFileLocation()),
+    assertEquals(
+        LOCATION_3,
+        testHS2ConfigManager.getFileLocation(),
         "File location " + LOCATION_3 + " was not returned");
   }
 
@@ -174,8 +178,9 @@ public class TestUserHS2ConnectionFileParser {
     testLocations.add(LOCATION_3);
     UserHS2ConnectionFileParser testHS2ConfigManager =
         new UserHS2ConnectionFileParser(testLocations);
-    Assertions.assertTrue(
-        LOCATION_2.equals(testHS2ConfigManager.getFileLocation()),
+    assertEquals(
+        LOCATION_2,
+        testHS2ConfigManager.getFileLocation(),
         "File location " + LOCATION_2 + " was not returned");
   }
 

--- a/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/hs2connection/TestUserHS2ConnectionFileParser.java
+++ b/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/hs2connection/TestUserHS2ConnectionFileParser.java
@@ -21,9 +21,9 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.hive.beeline.common.HiveTestUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TestUserHS2ConnectionFileParser {
   private final String LOCATION_1 =
@@ -46,7 +46,7 @@ public class TestUserHS2ConnectionFileParser {
 
   List<String> testLocations = new ArrayList<>();
 
-  @After
+  @AfterEach
   public void cleanUp() {
     try {
       deleteFile(LOCATION_1);
@@ -62,7 +62,7 @@ public class TestUserHS2ConnectionFileParser {
   public void testParseNoAuthentication() throws BeelineHS2ConnectionFileParseException {
     String url = getParsedUrlFromConfigFile("test-hs2-connection-config-noauth.xml");
     String expectedUrl = "jdbc:hive2://localhost:10000/default;user=hive";
-    Assert.assertTrue("Expected " + expectedUrl + " got " + url, expectedUrl.equals(url));
+    Assertions.assertTrue(expectedUrl.equals(url), "Expected " + expectedUrl + " got " + url);
   }
 
   @Test
@@ -70,7 +70,7 @@ public class TestUserHS2ConnectionFileParser {
     String url = getParsedUrlFromConfigFile("test-hs2-connection-zookeeper-config.xml");
     String expectedUrl =
         "jdbc:hive2://zk-node-1:10000,zk-node-2:10001,zk-node-3:10004/default;serviceDiscoveryMode=zookeeper;zooKeeperNamespace=hiveserver2";
-    Assert.assertTrue("Expected " + expectedUrl + " got " + url, expectedUrl.equals(url));
+    Assertions.assertTrue(expectedUrl.equals(url), "Expected " + expectedUrl + " got " + url);
   }
 
   @Test
@@ -78,7 +78,7 @@ public class TestUserHS2ConnectionFileParser {
     String url = getParsedUrlFromConfigFile("test-hs2-conn-conf-kerberos-nossl.xml");
     String expectedUrl =
         "jdbc:hive2://localhost:10000/default;principal=hive/dummy-hostname@domain.com;ssl=false";
-    Assert.assertTrue("Expected " + expectedUrl + " got " + url, expectedUrl.equals(url));
+    Assertions.assertTrue(expectedUrl.equals(url), "Expected " + expectedUrl + " got " + url);
   }
 
   @Test
@@ -87,7 +87,7 @@ public class TestUserHS2ConnectionFileParser {
     String expectedUrl =
         "jdbc:hive2://localhost:10000/default;principal=hive/dummy-hostname@domain.com;ssl=true;"
             + "sslTrustStore=test/truststore;trustStorePassword=testTruststorePassword";
-    Assert.assertTrue("Expected " + expectedUrl + " got " + url, expectedUrl.equals(url));
+    Assertions.assertTrue(expectedUrl.equals(url), "Expected " + expectedUrl + " got " + url);
   }
 
   @Test
@@ -96,7 +96,7 @@ public class TestUserHS2ConnectionFileParser {
     String expectedUrl =
         "jdbc:hive2://localhost:10000/default;httpPath=testHTTPPath;principal=hive/dummy-hostname@domain.com;"
             + "ssl=true;sslTrustStore=test/truststore;transportMode=http;trustStorePassword=testTruststorePassword";
-    Assert.assertTrue("Expected " + expectedUrl + " got " + url, expectedUrl.equals(url));
+    Assertions.assertTrue(expectedUrl.equals(url), "Expected " + expectedUrl + " got " + url);
   }
 
   @Test
@@ -104,7 +104,7 @@ public class TestUserHS2ConnectionFileParser {
     String url = getParsedUrlFromConfigFile("test-hs2-connection-conf-list.xml");
     String expectedUrl =
         "jdbc:hive2://localhost:10000/default;user=hive?hive.cli.print.current.db=false#testVarName1=value1";
-    Assert.assertTrue("Expected " + expectedUrl + " got " + url, expectedUrl.equals(url));
+    Assertions.assertTrue(expectedUrl.equals(url), "Expected " + expectedUrl + " got " + url);
   }
 
   @Test
@@ -113,7 +113,7 @@ public class TestUserHS2ConnectionFileParser {
     String expectedUrl =
         "jdbc:hive2://localhost:10000/default;user=hive?hive.cli.print.current.db=true;"
             + "hive.cli.print.header=true#testVarName1=value1;testVarName2=value2";
-    Assert.assertTrue("Expected " + expectedUrl + " got " + url, expectedUrl.equals(url));
+    Assertions.assertTrue(expectedUrl.equals(url), "Expected " + expectedUrl + " got " + url);
   }
 
   /*
@@ -126,7 +126,7 @@ public class TestUserHS2ConnectionFileParser {
     testLocations.add(LOCATION_3);
     UserHS2ConnectionFileParser testHS2ConfigManager =
         new UserHS2ConnectionFileParser(testLocations);
-    Assert.assertTrue(testHS2ConfigManager.getConnectionProperties().isEmpty());
+    Assertions.assertTrue(testHS2ConfigManager.getConnectionProperties().isEmpty());
   }
 
   /*
@@ -140,9 +140,9 @@ public class TestUserHS2ConnectionFileParser {
     testLocations.add(LOCATION_3);
     UserHS2ConnectionFileParser testHS2ConfigManager =
         new UserHS2ConnectionFileParser(testLocations);
-    Assert.assertTrue(
-        "File location " + LOCATION_1 + " was not returned",
-        LOCATION_1.equals(testHS2ConfigManager.getFileLocation()));
+    Assertions.assertTrue(
+        LOCATION_1.equals(testHS2ConfigManager.getFileLocation()),
+        "File location " + LOCATION_1 + " was not returned");
   }
 
   /*
@@ -156,9 +156,9 @@ public class TestUserHS2ConnectionFileParser {
     testLocations.add(LOCATION_3);
     UserHS2ConnectionFileParser testHS2ConfigManager =
         new UserHS2ConnectionFileParser(testLocations);
-    Assert.assertTrue(
-        "File location " + LOCATION_3 + " was not returned",
-        LOCATION_3.equals(testHS2ConfigManager.getFileLocation()));
+    Assertions.assertTrue(
+        LOCATION_3.equals(testHS2ConfigManager.getFileLocation()),
+        "File location " + LOCATION_3 + " was not returned");
   }
 
   /*
@@ -174,9 +174,9 @@ public class TestUserHS2ConnectionFileParser {
     testLocations.add(LOCATION_3);
     UserHS2ConnectionFileParser testHS2ConfigManager =
         new UserHS2ConnectionFileParser(testLocations);
-    Assert.assertTrue(
-        "File location " + LOCATION_2 + " was not returned",
-        LOCATION_2.equals(testHS2ConfigManager.getFileLocation()));
+    Assertions.assertTrue(
+        LOCATION_2.equals(testHS2ConfigManager.getFileLocation()),
+        "File location " + LOCATION_2 + " was not returned");
   }
 
   private String getParsedUrlFromConfigFile(String filename)

--- a/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/hs2connection/TestUserHS2ConnectionFileParser.java
+++ b/kyuubi-hive-beeline/src/test/java/org/apache/hive/beeline/hs2connection/TestUserHS2ConnectionFileParser.java
@@ -62,7 +62,7 @@ public class TestUserHS2ConnectionFileParser {
   public void testParseNoAuthentication() throws BeelineHS2ConnectionFileParseException {
     String url = getParsedUrlFromConfigFile("test-hs2-connection-config-noauth.xml");
     String expectedUrl = "jdbc:hive2://localhost:10000/default;user=hive";
-    Assertions.assertTrue(expectedUrl.equals(url), "Expected " + expectedUrl + " got " + url);
+    Assertions.assertEquals(expectedUrl, url, "Expected " + expectedUrl + " got " + url);
   }
 
   @Test
@@ -70,7 +70,7 @@ public class TestUserHS2ConnectionFileParser {
     String url = getParsedUrlFromConfigFile("test-hs2-connection-zookeeper-config.xml");
     String expectedUrl =
         "jdbc:hive2://zk-node-1:10000,zk-node-2:10001,zk-node-3:10004/default;serviceDiscoveryMode=zookeeper;zooKeeperNamespace=hiveserver2";
-    Assertions.assertTrue(expectedUrl.equals(url), "Expected " + expectedUrl + " got " + url);
+    Assertions.assertEquals(expectedUrl, url, "Expected " + expectedUrl + " got " + url);
   }
 
   @Test
@@ -78,7 +78,7 @@ public class TestUserHS2ConnectionFileParser {
     String url = getParsedUrlFromConfigFile("test-hs2-conn-conf-kerberos-nossl.xml");
     String expectedUrl =
         "jdbc:hive2://localhost:10000/default;principal=hive/dummy-hostname@domain.com;ssl=false";
-    Assertions.assertTrue(expectedUrl.equals(url), "Expected " + expectedUrl + " got " + url);
+    Assertions.assertEquals(expectedUrl, url, "Expected " + expectedUrl + " got " + url);
   }
 
   @Test
@@ -87,7 +87,7 @@ public class TestUserHS2ConnectionFileParser {
     String expectedUrl =
         "jdbc:hive2://localhost:10000/default;principal=hive/dummy-hostname@domain.com;ssl=true;"
             + "sslTrustStore=test/truststore;trustStorePassword=testTruststorePassword";
-    Assertions.assertTrue(expectedUrl.equals(url), "Expected " + expectedUrl + " got " + url);
+    Assertions.assertEquals(expectedUrl, url, "Expected " + expectedUrl + " got " + url);
   }
 
   @Test
@@ -96,7 +96,7 @@ public class TestUserHS2ConnectionFileParser {
     String expectedUrl =
         "jdbc:hive2://localhost:10000/default;httpPath=testHTTPPath;principal=hive/dummy-hostname@domain.com;"
             + "ssl=true;sslTrustStore=test/truststore;transportMode=http;trustStorePassword=testTruststorePassword";
-    Assertions.assertTrue(expectedUrl.equals(url), "Expected " + expectedUrl + " got " + url);
+    Assertions.assertEquals(expectedUrl, url, "Expected " + expectedUrl + " got " + url);
   }
 
   @Test
@@ -104,7 +104,7 @@ public class TestUserHS2ConnectionFileParser {
     String url = getParsedUrlFromConfigFile("test-hs2-connection-conf-list.xml");
     String expectedUrl =
         "jdbc:hive2://localhost:10000/default;user=hive?hive.cli.print.current.db=false#testVarName1=value1";
-    Assertions.assertTrue(expectedUrl.equals(url), "Expected " + expectedUrl + " got " + url);
+    Assertions.assertEquals(expectedUrl, url, "Expected " + expectedUrl + " got " + url);
   }
 
   @Test
@@ -113,7 +113,7 @@ public class TestUserHS2ConnectionFileParser {
     String expectedUrl =
         "jdbc:hive2://localhost:10000/default;user=hive?hive.cli.print.current.db=true;"
             + "hive.cli.print.header=true#testVarName1=value1;testVarName2=value2";
-    Assertions.assertTrue(expectedUrl.equals(url), "Expected " + expectedUrl + " got " + url);
+    Assertions.assertEquals(expectedUrl, url, "Expected " + expectedUrl + " got " + url);
   }
 
   /*

--- a/kyuubi-hive-jdbc/pom.xml
+++ b/kyuubi-hive-jdbc/pom.xml
@@ -123,8 +123,8 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/kyuubi-hive-jdbc/src/test/java/org/apache/kyuubi/jdbc/hive/KyuubiStatementTest.java
+++ b/kyuubi-hive-jdbc/src/test/java/org/apache/kyuubi/jdbc/hive/KyuubiStatementTest.java
@@ -17,10 +17,11 @@
  */
 package org.apache.kyuubi.jdbc.hive;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.sql.SQLException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class KyuubiStatementTest {
 
@@ -41,17 +42,25 @@ public class KyuubiStatementTest {
     }
   }
 
-  @Test(expected = SQLException.class)
+  @Test
   public void testSetFetchSize3() throws SQLException {
-    try (KyuubiStatement stmt = new KyuubiStatement(null, null, null)) {
-      stmt.setFetchSize(-1);
-    }
+    assertThrows(
+        SQLException.class,
+        () -> {
+          try (KyuubiStatement stmt = new KyuubiStatement(null, null, null)) {
+            stmt.setFetchSize(-1);
+          }
+        });
   }
 
-  @Test(expected = SQLException.class)
+  @Test
   public void testaddBatch() throws SQLException {
-    try (KyuubiStatement stmt = new KyuubiStatement(null, null, null)) {
-      stmt.addBatch(null);
-    }
+    assertThrows(
+        SQLException.class,
+        () -> {
+          try (KyuubiStatement stmt = new KyuubiStatement(null, null, null)) {
+            stmt.addBatch(null);
+          }
+        });
   }
 }

--- a/kyuubi-hive-jdbc/src/test/java/org/apache/kyuubi/jdbc/hive/TestJdbcDriver.java
+++ b/kyuubi-hive-jdbc/src/test/java/org/apache/kyuubi/jdbc/hive/TestJdbcDriver.java
@@ -18,7 +18,7 @@
 
 package org.apache.kyuubi.jdbc.hive;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -26,45 +26,33 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Arrays;
-import java.util.Collection;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class TestJdbcDriver {
   private static File file = null;
-  private String input;
-  private String expected;
 
-  public TestJdbcDriver(String input, String expected) throws Exception {
-    this.input = input;
-    this.expected = expected;
+  static Stream<Arguments> data() {
+    return Stream.of(
+        // Here are some positive cases which can be executed as below :
+        Arguments.of("show databases;show tables;", "show databases,show tables"),
+        Arguments.of(" show\n\r  tables;", "show tables"),
+        Arguments.of("show databases; show\ntables;", "show databases,show tables"),
+        Arguments.of("show    tables;", "show    tables"),
+        Arguments.of("show tables ;", "show tables"),
+        // Here are some negative cases as below :
+        Arguments.of("show tables", ","),
+        Arguments.of("show tables show tables;", "show tables show tables"),
+        Arguments.of("show tab les;", "show tab les"),
+        Arguments.of("#show tables; show\n tables;", "tables"),
+        Arguments.of("show tab les;show tables;", "show tab les,show tables"));
   }
 
-  @Parameters
-  public static Collection<Object[]> data() {
-    return Arrays.asList(
-        new Object[][] {
-          // Here are some positive cases which can be executed as below :
-          {"show databases;show tables;", "show databases,show tables"},
-          {" show\n\r  tables;", "show tables"},
-          {"show databases; show\ntables;", "show databases,show tables"},
-          {"show    tables;", "show    tables"},
-          {"show tables ;", "show tables"},
-          // Here are some negative cases as below :
-          {"show tables", ","},
-          {"show tables show tables;", "show tables show tables"},
-          {"show tab les;", "show tab les"},
-          {"#show tables; show\n tables;", "tables"},
-          {"show tab les;show tables;", "show tab les,show tables"}
-        });
-  }
-
-  @BeforeClass
+  @BeforeAll
   public static void setUpBeforeClass() throws Exception {
     file = new File(System.getProperty("user.dir") + File.separator + "Init.sql");
     if (!file.exists()) {
@@ -72,15 +60,16 @@ public class TestJdbcDriver {
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanUpAfterClass() throws Exception {
     if (file != null) {
       Files.deleteIfExists(file.toPath());
     }
   }
 
-  @Test
-  public void testParseInitFile() throws IOException {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testParseInitFile(String input, String expected) throws IOException {
     try (BufferedWriter bw = new BufferedWriter(new FileWriter(file))) {
       bw.write(input);
       bw.flush();

--- a/kyuubi-hive-jdbc/src/test/java/org/apache/kyuubi/jdbc/hive/TestKyuubiPreparedStatement.java
+++ b/kyuubi-hive-jdbc/src/test/java/org/apache/kyuubi/jdbc/hive/TestKyuubiPreparedStatement.java
@@ -17,7 +17,8 @@
  */
 package org.apache.kyuubi.jdbc.hive;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -25,8 +26,8 @@ import static org.mockito.Mockito.when;
 import java.sql.SQLException;
 import org.apache.kyuubi.shaded.hive.service.rpc.thrift.*;
 import org.apache.kyuubi.shaded.hive.service.rpc.thrift.TCLIService.Iface;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -41,7 +42,7 @@ public class TestKyuubiPreparedStatement {
   private TStatus tStatus_SUCCESS = new TStatus(TStatusCode.SUCCESS_STATUS);
   @Mock private TOperationHandle tOperationHandle;
 
-  @Before
+  @BeforeEach
   public void before() throws Exception {
     MockitoAnnotations.initMocks(this);
     when(tExecStatementResp.getStatus()).thenReturn(tStatus_SUCCESS);
@@ -77,11 +78,16 @@ public class TestKyuubiPreparedStatement {
     ps.execute();
   }
 
-  @Test(expected = SQLException.class)
+  @Test
   public void unsetArgument() throws Exception {
-    String sql = "select 1 from x where a=?";
-    KyuubiPreparedStatement ps = new KyuubiPreparedStatement(connection, client, sessHandle, sql);
-    ps.execute();
+    assertThrows(
+        SQLException.class,
+        () -> {
+          String sql = "select 1 from x where a=?";
+          KyuubiPreparedStatement ps =
+              new KyuubiPreparedStatement(connection, client, sessHandle, sql);
+          ps.execute();
+        });
   }
 
   @Test

--- a/kyuubi-hive-jdbc/src/test/java/org/apache/kyuubi/jdbc/hive/UtilsTest.java
+++ b/kyuubi-hive-jdbc/src/test/java/org/apache/kyuubi/jdbc/hive/UtilsTest.java
@@ -20,6 +20,7 @@ package org.apache.kyuubi.jdbc.hive;
 
 import static org.apache.kyuubi.jdbc.hive.Utils.extractURLComponents;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
 import java.io.UnsupportedEncodingException;
@@ -129,7 +130,7 @@ public class UtilsTest {
   @Test
   public void testGetVersion() {
     Pattern pattern = Pattern.compile("^\\d+\\.\\d+\\.\\d+.*");
-    assert pattern.matcher(Utils.getVersion()).matches();
+    assertTrue(pattern.matcher(Utils.getVersion()).matches());
   }
 
   @Test

--- a/kyuubi-hive-jdbc/src/test/java/org/apache/kyuubi/jdbc/hive/UtilsTest.java
+++ b/kyuubi-hive-jdbc/src/test/java/org/apache/kyuubi/jdbc/hive/UtilsTest.java
@@ -19,81 +19,69 @@
 package org.apache.kyuubi.jdbc.hive;
 
 import static org.apache.kyuubi.jdbc.hive.Utils.extractURLComponents;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.common.collect.ImmutableMap;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 import java.util.regex.Pattern;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class UtilsTest {
 
-  private String expectedHost;
-  private String expectedPort;
-  private String expectedCatalog;
-  private String expectedDb;
-  private Map<String, String> expectedHiveConf;
-  private String uri;
-
-  @Parameterized.Parameters
-  public static Collection<Object[]> data() throws UnsupportedEncodingException {
-    return Arrays.asList(
-        new Object[][] {
-          {
+  static Stream<Arguments> data() throws UnsupportedEncodingException {
+    return Stream.of(
+        Arguments.of(
             "localhost",
             "10009",
             null,
             "db",
             new ImmutableMap.Builder<String, String>().put("k2", "v2").build(),
-            "jdbc:hive2:///db;k1=v1?k2=v2#k3=v3"
-          },
-          {
+            "jdbc:hive2:///db;k1=v1?k2=v2#k3=v3"),
+        Arguments.of(
             "localhost",
             "10009",
             null,
             "default",
             new ImmutableMap.Builder<String, String>().build(),
-            "jdbc:hive2:///"
-          },
-          {
+            "jdbc:hive2:///"),
+        Arguments.of(
             "localhost",
             "10009",
             null,
             "default",
             new ImmutableMap.Builder<String, String>().build(),
-            "jdbc:kyuubi://"
-          },
-          {
+            "jdbc:kyuubi://"),
+        Arguments.of(
             "localhost",
             "10009",
             null,
             "default",
             new ImmutableMap.Builder<String, String>().build(),
-            "jdbc:hive2://"
-          },
-          {
+            "jdbc:hive2://"),
+        Arguments.of(
             "hostname",
             "10018",
             null,
             "db",
             new ImmutableMap.Builder<String, String>().put("k2", "v2").build(),
-            "jdbc:hive2://hostname:10018/db;k1=v1?k2=v2#k3=v3"
-          },
-          {
+            "jdbc:hive2://hostname:10018/db;k1=v1?k2=v2#k3=v3"),
+        Arguments.of(
             "hostname",
             "10018",
             "catalog",
             "db",
             new ImmutableMap.Builder<String, String>().put("k2", "v2").build(),
-            "jdbc:hive2://hostname:10018/catalog/db;k1=v1?k2=v2#k3=v3"
-          },
-          {
+            "jdbc:hive2://hostname:10018/catalog/db;k1=v1?k2=v2#k3=v3"),
+        Arguments.of(
             "hostname",
             "10018",
             "catalog",
@@ -107,9 +95,8 @@ public class UtilsTest {
                         "k2=v2;k3=-Xmx2g -XX:+PrintGCDetails -XX:HeapDumpPath=/heap.hprof",
                         StandardCharsets.UTF_8.toString())
                     .replaceAll("\\+", "%20")
-                + "#k4=v4"
-          },
-          {
+                + "#k4=v4"),
+        Arguments.of(
             "hostname",
             "10018",
             "catalog",
@@ -118,28 +105,19 @@ public class UtilsTest {
                 .put("k2", "v2")
                 .put("k3", "hostname:10018")
                 .build(),
-            "jdbc:hive2://hostname:10018/catalog/db;k1=v1?k2=v2;k3=hostname:10018"
-          }
-        });
+            "jdbc:hive2://hostname:10018/catalog/db;k1=v1?k2=v2;k3=hostname:10018"));
   }
 
-  public UtilsTest(
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testExtractURLComponents(
       String expectedHost,
       String expectedPort,
       String expectedCatalog,
       String expectedDb,
       Map<String, String> expectedHiveConf,
-      String uri) {
-    this.expectedHost = expectedHost;
-    this.expectedPort = expectedPort;
-    this.expectedCatalog = expectedCatalog;
-    this.expectedDb = expectedDb;
-    this.expectedHiveConf = expectedHiveConf;
-    this.uri = uri;
-  }
-
-  @Test
-  public void testExtractURLComponents() throws JdbcUriParseException {
+      String uri)
+      throws JdbcUriParseException {
     JdbcConnectionParams jdbcConnectionParams1 = extractURLComponents(uri, new Properties());
     assertEquals(expectedHost, jdbcConnectionParams1.getHost());
     assertEquals(Integer.parseInt(expectedPort), jdbcConnectionParams1.getPort());
@@ -230,9 +208,9 @@ public class UtilsTest {
     assertEquals("JWT", authFromParseProperty);
     assertEquals("JWT", authFromExtract);
     assertEquals(
-        "parsePropertyFromUrl and extractURLComponents should return the same auth value",
         authFromExtract,
-        authFromParseProperty);
+        authFromParseProperty,
+        "parsePropertyFromUrl and extractURLComponents should return the same auth value");
 
     // Verify query string parameters are correctly parsed
     assertEquals("clusterA", params.getHiveConfs().get("kyuubi.session.cluster"));

--- a/kyuubi-hive-jdbc/src/test/java/org/apache/kyuubi/jdbc/hive/ZooKeeperHiveClientHelperTest.java
+++ b/kyuubi-hive-jdbc/src/test/java/org/apache/kyuubi/jdbc/hive/ZooKeeperHiveClientHelperTest.java
@@ -19,38 +19,24 @@
 package org.apache.kyuubi.jdbc.hive;
 
 import static org.apache.kyuubi.jdbc.hive.Utils.extractURLComponents;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Properties;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
-@RunWith(Parameterized.class)
 public class ZooKeeperHiveClientHelperTest {
 
-  private String uri;
-
-  @Parameterized.Parameters
-  public static Collection<String[]> data() {
-    return Arrays.asList(
-        new String[][] {
-          {"jdbc:hive2://hostname:10018/db;zooKeeperNamespace=zookeeper/namespace"},
-          {"jdbc:hive2://hostname:10018/db;zooKeeperNamespace=/zookeeper/namespace"},
-          {"jdbc:hive2://hostname:10018/db;zooKeeperNamespace=zookeeper/namespace/"},
-          {"jdbc:hive2://hostname:10018/db;zooKeeperNamespace=/zookeeper/namespace/"},
-          {"jdbc:hive2://hostname:10018/db;zooKeeperNamespace=///zookeeper/namespace///"}
-        });
-  }
-
-  public ZooKeeperHiveClientHelperTest(String uri) {
-    this.uri = uri;
-  }
-
-  @Test
-  public void testGetZooKeeperNamespace() throws JdbcUriParseException {
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "jdbc:hive2://hostname:10018/db;zooKeeperNamespace=zookeeper/namespace",
+        "jdbc:hive2://hostname:10018/db;zooKeeperNamespace=/zookeeper/namespace",
+        "jdbc:hive2://hostname:10018/db;zooKeeperNamespace=zookeeper/namespace/",
+        "jdbc:hive2://hostname:10018/db;zooKeeperNamespace=/zookeeper/namespace/",
+        "jdbc:hive2://hostname:10018/db;zooKeeperNamespace=///zookeeper/namespace///"
+      })
+  public void testGetZooKeeperNamespace(String uri) throws JdbcUriParseException {
     JdbcConnectionParams jdbcConnectionParams = extractURLComponents(uri, new Properties());
     assertEquals(
         "zookeeper/namespace",

--- a/kyuubi-rest-client/pom.xml
+++ b/kyuubi-rest-client/pom.xml
@@ -90,8 +90,8 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/kyuubi-rest-client/src/test/java/org/apache/kyuubi/client/BatchRestClientTest.java
+++ b/kyuubi-rest-client/src/test/java/org/apache/kyuubi/client/BatchRestClientTest.java
@@ -18,8 +18,9 @@
 package org.apache.kyuubi.client;
 
 import static org.apache.kyuubi.client.RestClientTestUtils.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.kyuubi.client.api.v1.dto.Batch;
 import org.apache.kyuubi.client.api.v1.dto.BatchRequest;
@@ -29,9 +30,9 @@ import org.apache.kyuubi.client.api.v1.dto.OperationLog;
 import org.apache.kyuubi.client.api.v1.dto.ReassignBatchRequest;
 import org.apache.kyuubi.client.api.v1.dto.ReassignBatchResponse;
 import org.apache.kyuubi.client.exception.KyuubiRestException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class BatchRestClientTest {
 
@@ -43,7 +44,7 @@ public class BatchRestClientTest {
   private KerberizedTestHelper kerberizedTestHelper;
   private ServerTestHelper serverTestHelper;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     kerberizedTestHelper = new KerberizedTestHelper();
     serverTestHelper = new ServerTestHelper();
@@ -69,7 +70,7 @@ public class BatchRestClientTest {
     basicBatchRestApi = new BatchRestApi(basicClient);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     kerberizedTestHelper.stop();
     serverTestHelper.stop();
@@ -77,26 +78,34 @@ public class BatchRestClientTest {
     basicClient.close();
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testEmptyHostUrl() {
-    KyuubiRestClient.builder("")
-        .authHeaderMethod(KyuubiRestClient.AuthHeaderMethod.BASIC)
-        .username("test")
-        .password("test")
-        .build();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          KyuubiRestClient.builder("")
+              .authHeaderMethod(KyuubiRestClient.AuthHeaderMethod.BASIC)
+              .username("test")
+              .password("test")
+              .build();
+        });
   }
 
-  @Test(expected = KyuubiRestException.class)
+  @Test
   public void testInvalidUrl() {
-    KyuubiRestClient basicClient =
-        KyuubiRestClient.builder("https://localhost:8443")
-            .authHeaderMethod(KyuubiRestClient.AuthHeaderMethod.BASIC)
-            .username("test")
-            .password("test")
-            .build();
-    BatchRestApi invalidBasicBatchRestApi = new BatchRestApi(basicClient);
+    assertThrows(
+        KyuubiRestException.class,
+        () -> {
+          KyuubiRestClient basicClient =
+              KyuubiRestClient.builder("https://localhost:8443")
+                  .authHeaderMethod(KyuubiRestClient.AuthHeaderMethod.BASIC)
+                  .username("test")
+                  .password("test")
+                  .build();
+          BatchRestApi invalidBasicBatchRestApi = new BatchRestApi(basicClient);
 
-    invalidBasicBatchRestApi.getBatchById("fake");
+          invalidBasicBatchRestApi.getBatchById("fake");
+        });
   }
 
   @Test
@@ -115,18 +124,18 @@ public class BatchRestClientTest {
     Batch expectedBatch = generateTestBatch();
     Batch result = noPasswordBasicBatchRestApi.createBatch(batchRequest);
 
-    assertEquals(result.getId(), expectedBatch.getId());
-    assertEquals(result.getUser(), expectedBatch.getUser());
-    assertEquals(result.getBatchType(), expectedBatch.getBatchType());
-    assertEquals(result.getName(), expectedBatch.getName());
-    assertEquals(result.getAppStartTime(), expectedBatch.getAppStartTime());
-    assertEquals(result.getAppId(), expectedBatch.getAppId());
-    assertEquals(result.getAppUrl(), expectedBatch.getAppUrl());
-    assertEquals(result.getAppState(), expectedBatch.getAppState());
-    assertEquals(result.getAppDiagnostic(), expectedBatch.getAppDiagnostic());
-    assertEquals(result.getState(), expectedBatch.getState());
-    assertEquals(result.getCreateTime(), expectedBatch.getCreateTime());
-    assertEquals(result.getEndTime(), expectedBatch.getEndTime());
+    assertEquals(expectedBatch.getId(), result.getId());
+    assertEquals(expectedBatch.getUser(), result.getUser());
+    assertEquals(expectedBatch.getBatchType(), result.getBatchType());
+    assertEquals(expectedBatch.getName(), result.getName());
+    assertEquals(expectedBatch.getAppStartTime(), result.getAppStartTime());
+    assertEquals(expectedBatch.getAppId(), result.getAppId());
+    assertEquals(expectedBatch.getAppUrl(), result.getAppUrl());
+    assertEquals(expectedBatch.getAppState(), result.getAppState());
+    assertEquals(expectedBatch.getAppDiagnostic(), result.getAppDiagnostic());
+    assertEquals(expectedBatch.getState(), result.getState());
+    assertEquals(expectedBatch.getCreateTime(), result.getCreateTime());
+    assertEquals(expectedBatch.getEndTime(), result.getEndTime());
   }
 
   @Test
@@ -144,18 +153,18 @@ public class BatchRestClientTest {
     Batch expectedBatch = generateTestBatch();
     Batch result = anonymousBasicBatchRestApi.createBatch(batchRequest);
 
-    assertEquals(result.getId(), expectedBatch.getId());
-    assertEquals(result.getUser(), expectedBatch.getUser());
-    assertEquals(result.getBatchType(), expectedBatch.getBatchType());
-    assertEquals(result.getName(), expectedBatch.getName());
-    assertEquals(result.getAppStartTime(), expectedBatch.getAppStartTime());
-    assertEquals(result.getAppId(), expectedBatch.getAppId());
-    assertEquals(result.getAppUrl(), expectedBatch.getAppUrl());
-    assertEquals(result.getAppState(), expectedBatch.getAppState());
-    assertEquals(result.getAppDiagnostic(), expectedBatch.getAppDiagnostic());
-    assertEquals(result.getState(), expectedBatch.getState());
-    assertEquals(result.getCreateTime(), expectedBatch.getCreateTime());
-    assertEquals(result.getEndTime(), expectedBatch.getEndTime());
+    assertEquals(expectedBatch.getId(), result.getId());
+    assertEquals(expectedBatch.getUser(), result.getUser());
+    assertEquals(expectedBatch.getBatchType(), result.getBatchType());
+    assertEquals(expectedBatch.getName(), result.getName());
+    assertEquals(expectedBatch.getAppStartTime(), result.getAppStartTime());
+    assertEquals(expectedBatch.getAppId(), result.getAppId());
+    assertEquals(expectedBatch.getAppUrl(), result.getAppUrl());
+    assertEquals(expectedBatch.getAppState(), result.getAppState());
+    assertEquals(expectedBatch.getAppDiagnostic(), result.getAppDiagnostic());
+    assertEquals(expectedBatch.getState(), result.getState());
+    assertEquals(expectedBatch.getCreateTime(), result.getCreateTime());
+    assertEquals(expectedBatch.getEndTime(), result.getEndTime());
   }
 
   @Test
@@ -167,27 +176,27 @@ public class BatchRestClientTest {
     Batch expectedBatch = generateTestBatch();
     Batch result = spnegoBatchRestApi.createBatch(batchRequest);
 
-    assertEquals(result.getId(), expectedBatch.getId());
-    assertEquals(result.getBatchType(), expectedBatch.getBatchType());
-    assertEquals(result.getState(), expectedBatch.getState());
+    assertEquals(expectedBatch.getId(), result.getId());
+    assertEquals(expectedBatch.getBatchType(), result.getBatchType());
+    assertEquals(expectedBatch.getState(), result.getState());
 
     // test basic auth
     BatchTestServlet.setAuthSchema(BASIC_AUTH);
     BatchTestServlet.allowAnonymous(false);
     result = basicBatchRestApi.createBatch(batchRequest);
 
-    assertEquals(result.getId(), expectedBatch.getId());
-    assertEquals(result.getUser(), expectedBatch.getUser());
-    assertEquals(result.getBatchType(), expectedBatch.getBatchType());
-    assertEquals(result.getName(), expectedBatch.getName());
-    assertEquals(result.getAppStartTime(), expectedBatch.getAppStartTime());
-    assertEquals(result.getAppId(), expectedBatch.getAppId());
-    assertEquals(result.getAppUrl(), expectedBatch.getAppUrl());
-    assertEquals(result.getAppState(), expectedBatch.getAppState());
-    assertEquals(result.getAppDiagnostic(), expectedBatch.getAppDiagnostic());
-    assertEquals(result.getState(), expectedBatch.getState());
-    assertEquals(result.getCreateTime(), expectedBatch.getCreateTime());
-    assertEquals(result.getEndTime(), expectedBatch.getEndTime());
+    assertEquals(expectedBatch.getId(), result.getId());
+    assertEquals(expectedBatch.getUser(), result.getUser());
+    assertEquals(expectedBatch.getBatchType(), result.getBatchType());
+    assertEquals(expectedBatch.getName(), result.getName());
+    assertEquals(expectedBatch.getAppStartTime(), result.getAppStartTime());
+    assertEquals(expectedBatch.getAppId(), result.getAppId());
+    assertEquals(expectedBatch.getAppUrl(), result.getAppUrl());
+    assertEquals(expectedBatch.getAppState(), result.getAppState());
+    assertEquals(expectedBatch.getAppDiagnostic(), result.getAppDiagnostic());
+    assertEquals(expectedBatch.getState(), result.getState());
+    assertEquals(expectedBatch.getCreateTime(), result.getCreateTime());
+    assertEquals(expectedBatch.getEndTime(), result.getEndTime());
   }
 
   @Test
@@ -198,9 +207,9 @@ public class BatchRestClientTest {
     Batch expectedBatch = generateTestBatch();
     Batch result = spnegoBatchRestApi.getBatchById("71535");
 
-    assertEquals(result.getId(), expectedBatch.getId());
-    assertEquals(result.getBatchType(), expectedBatch.getBatchType());
-    assertEquals(result.getState(), expectedBatch.getState());
+    assertEquals(expectedBatch.getId(), result.getId());
+    assertEquals(expectedBatch.getBatchType(), result.getBatchType());
+    assertEquals(expectedBatch.getState(), result.getState());
 
     // test basic auth
     BatchTestServlet.setAuthSchema(BASIC_AUTH);
@@ -208,18 +217,18 @@ public class BatchRestClientTest {
 
     result = basicBatchRestApi.getBatchById("71535");
 
-    assertEquals(result.getId(), expectedBatch.getId());
-    assertEquals(result.getUser(), expectedBatch.getUser());
-    assertEquals(result.getBatchType(), expectedBatch.getBatchType());
-    assertEquals(result.getName(), expectedBatch.getName());
-    assertEquals(result.getAppStartTime(), expectedBatch.getAppStartTime());
-    assertEquals(result.getAppId(), expectedBatch.getAppId());
-    assertEquals(result.getAppUrl(), expectedBatch.getAppUrl());
-    assertEquals(result.getAppState(), expectedBatch.getAppState());
-    assertEquals(result.getAppDiagnostic(), expectedBatch.getAppDiagnostic());
-    assertEquals(result.getState(), expectedBatch.getState());
-    assertEquals(result.getCreateTime(), expectedBatch.getCreateTime());
-    assertEquals(result.getEndTime(), expectedBatch.getEndTime());
+    assertEquals(expectedBatch.getId(), result.getId());
+    assertEquals(expectedBatch.getUser(), result.getUser());
+    assertEquals(expectedBatch.getBatchType(), result.getBatchType());
+    assertEquals(expectedBatch.getName(), result.getName());
+    assertEquals(expectedBatch.getAppStartTime(), result.getAppStartTime());
+    assertEquals(expectedBatch.getAppId(), result.getAppId());
+    assertEquals(expectedBatch.getAppUrl(), result.getAppUrl());
+    assertEquals(expectedBatch.getAppState(), result.getAppState());
+    assertEquals(expectedBatch.getAppDiagnostic(), result.getAppDiagnostic());
+    assertEquals(expectedBatch.getState(), result.getState());
+    assertEquals(expectedBatch.getCreateTime(), result.getCreateTime());
+    assertEquals(expectedBatch.getEndTime(), result.getEndTime());
   }
 
   @Test

--- a/kyuubi-rest-client/src/test/java/org/apache/kyuubi/client/util/VersionUtilsTest.java
+++ b/kyuubi-rest-client/src/test/java/org/apache/kyuubi/client/util/VersionUtilsTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.kyuubi.client.util;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 
@@ -25,6 +27,6 @@ public class VersionUtilsTest {
   @Test
   public void testGetClientVersion() {
     Pattern pattern = Pattern.compile("^\\d+\\.\\d+\\.\\d+.*");
-    assert pattern.matcher(VersionUtils.getVersion()).matches();
+    assertTrue(pattern.matcher(VersionUtils.getVersion()).matches());
   }
 }

--- a/kyuubi-rest-client/src/test/java/org/apache/kyuubi/client/util/VersionUtilsTest.java
+++ b/kyuubi-rest-client/src/test/java/org/apache/kyuubi/client/util/VersionUtilsTest.java
@@ -18,7 +18,7 @@
 package org.apache.kyuubi.client.util;
 
 import java.util.regex.Pattern;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class VersionUtilsTest {
 

--- a/kyuubi-util/pom.xml
+++ b/kyuubi-util/pom.xml
@@ -37,8 +37,8 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/kyuubi-util/src/test/java/org/apache/kyuubi/util/JavaUtilsTest.java
+++ b/kyuubi-util/src/test/java/org/apache/kyuubi/util/JavaUtilsTest.java
@@ -19,13 +19,13 @@
 
 package org.apache.kyuubi.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.net.InetAddress;
 import java.net.SocketException;
 import java.net.UnknownHostException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JavaUtilsTest {
 

--- a/kyuubi-util/src/test/java/org/apache/kyuubi/util/UuidUtilsTest.java
+++ b/kyuubi-util/src/test/java/org/apache/kyuubi/util/UuidUtilsTest.java
@@ -19,10 +19,11 @@
 
 package org.apache.kyuubi.util;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.UUID;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class UuidUtilsTest {
 
@@ -39,15 +40,23 @@ public class UuidUtilsTest {
     assertEquals(2, uuid.variant());
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void generateUUIDv7NegativeTimestamp() {
-    long value = -0xFEDCBA987654L;
-    UuidUtils.generateUUIDv7(value);
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          long value = -0xFEDCBA987654L;
+          UuidUtils.generateUUIDv7(value);
+        });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void generateUUIDv7GreaterThan48BitsTimestamp() {
-    long value = 1L << 48;
-    UuidUtils.generateUUIDv7(value);
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          long value = 1L << 48;
+          UuidUtils.generateUUIDv7(value);
+        });
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
         <jetcd.version>0.7.7</jetcd.version>
         <jetty.version>9.4.57.v20241219</jetty.version>
         <jline.version>2.14.6</jline.version>
-        <junit.jupiter.version>5.11.4</junit.jupiter.version>
+        <junit.jupiter.version>5.14.4</junit.jupiter.version>
         <kafka.version>3.9.2</kafka.version>
         <!-- 6.14.0 requires Jackson 2.19.0+
              https://github.com/fabric8io/kubernetes-client/releases/tag/v6.14.0 -->

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
         <jetcd.version>0.7.7</jetcd.version>
         <jetty.version>9.4.57.v20241219</jetty.version>
         <jline.version>2.14.6</jline.version>
-        <junit.version>4.13.2</junit.version>
+        <junit.jupiter.version>5.11.4</junit.jupiter.version>
         <kafka.version>3.9.2</kafka.version>
         <!-- 6.14.0 requires Jackson 2.19.0+
              https://github.com/fabric8io/kubernetes-client/releases/tag/v6.14.0 -->
@@ -854,9 +854,11 @@
             </dependency>
 
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>${junit.version}</version>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit.jupiter.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
### Why are the changes needed?

Closes #7473.

JUnit 4 has been in maintenance mode since 4.13.2 (Feb 2021); modern Java test deps (Mockito 5, Testcontainers, etc.) target JUnit 5. Our usage is shallow (no `@Rule` / `@ClassRule` / `Theories`), so the migration is mostly mechanical.

Migrates all five modules with Java tests: `kyuubi-rest-client`, `kyuubi-util`, `kyuubi-hive-jdbc`, `kyuubi-hive-beeline`, and `externals/kyuubi-data-agent-engine`. Drops the direct `junit:junit` dependency and `junit.version` property from the root pom; transitive exclusions are kept. `junit-jupiter` is pinned to the latest stable, 5.14.4.

### How was this patch tested?

`build/mvn -Pfast test -pl <module> -am` on each of the five modules — all green. `kyuubi-data-agent-engine` has 7 live tests skipped via `Assumptions.assumeTrue` (require an external LLM API). `dev/reformat` clean.

### Was this patch authored or co-authored using generative AI tooling?

Assisted-by: Claude:claude-opus-4-7
