### PR TITLE
[CI] Add ASF allowlist check workflow

### DIFF
--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -37,7 +37,7 @@ permissions:
 
 jobs:
   asf-allowlist-check:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -1,0 +1,45 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: ASF Allowlist Check
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+      - branch-*
+    paths:
+      - ".github/**"
+  push:
+    branches:
+      - master
+      - branch-*
+    paths:
+      - ".github/**"
+
+permissions:
+  contents: read
+
+jobs:
+  asf-allowlist-check:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: apache/infrastructure-actions/allowlist-check@main

--- a/.github/workflows/publish-snapshot-docker.yml
+++ b/.github/workflows/publish-snapshot-docker.yml
@@ -40,7 +40,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and Push Kyuubi Docker Image
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f	# v7.1.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           # build cache on Github Actions, See: https://docs.docker.com/build/cache/backends/gha/#using-dockerbuild-push-action
           cache-from: type=gha


### PR DESCRIPTION
### Why are the changes needed?
These changes are needed to ensure compliancy with [ASF GitHub Actions Policy](https://infra.apache.org/github-actions-policy.html).

The workflow verifies all `uses:` refs in a project's workflow files are on the ASF Infrastructure [approved allowlist](https://github.com/apache/infrastructure-actions/blob/d3e898ebd3169ee0a078359ff8434a09cd081375/approved_patterns.yml).
It catches violations before merge, preventing the silent CI failures that occur when an action is not on the org-level allowlist.
See more details [here](https://github.com/apache/infrastructure-actions/blob/d3e898ebd3169ee0a078359ff8434a09cd081375/allowlist-check/README.md).

Related to [[Umbrella] Ensure GitHub Actions compliance with ASF Policy #7456](https://github.com/apache/kyuubi/issues/7456).

Similar PRs:
 - https://github.com/apache/airflow/pull/64450
 - https://github.com/apache/iceberg/pull/15797
 - https://github.com/apache/hive/pull/6417


### How was this patch tested?
Review.


### Was this patch authored or co-authored using generative AI tooling?
No
