### PR TITLE
[CI] Run "Docs" workflow for documentation changes only

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,9 @@ on:
   pull_request:
     branches:
       - master
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
 
 concurrency:
   group: docs-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -24,12 +24,14 @@ on:
       - branch-*
     paths-ignore:
       - 'docs/**'
+      - '.github/workflows/docs.yml'
   pull_request:
     branches:
       - master
       - branch-*
     paths-ignore:
       - 'docs/**'
+      - '.github/workflows/docs.yml'
 
 concurrency:
   group: test-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -24,12 +24,14 @@ on:
       - branch-*
     paths-ignore:
       - 'docs/**'
+      - '.github/workflows/docs.yml'
   pull_request:
     branches:
       - master
       - branch-*
     paths-ignore:
       - 'docs/**'
+      - '.github/workflows/docs.yml'
 
 concurrency:
   group: python-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
### Why are the changes needed?
These changes are needed to prevent unnecessary `Docs` workflow runs by ensuring they only trigger when files in `docs/**` or the workflow itself are changed.

Also updated `.github/workflows/master.yml` and `.github/workflows/python.yml` to ignore changes in `.github/workflows/docs.yml`, preventing redundant triggers of the main test suites when only documentation workflow updated.


### How was this patch tested?
Review/CI


### Was this patch authored or co-authored using generative AI tooling?
No
