### PR TITLE
[KUBERNETES] Parse app error from spark.exit-exception pod annotation

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
@@ -599,6 +599,9 @@ object KubernetesApplicationOperation extends Logging {
   val LABEL_KYUUBI_UNIQUE_KEY = "kyuubi-unique-tag"
   private val SPARK_APP_ID_LABEL = "spark-app-selector"
   private val SPARK_APP_NAME_LABEL = "spark-app-name"
+  // Annotation set by Spark 4.1+ (spark.kubernetes.driver.annotateExitException=true)
+  // containing the stringified exit exception for the driver pod.
+  private[engine] val SPARK_EXIT_EXCEPTION_ANNOTATION = "spark.exit-exception"
   val KUBERNETES_SERVICE_HOST = "KUBERNETES_SERVICE_HOST"
   val KUBERNETES_SERVICE_PORT = "KUBERNETES_SERVICE_PORT"
   val SPARK_UI_PORT_NAME = "spark-ui"
@@ -659,6 +662,8 @@ object KubernetesApplicationOperation extends Logging {
       case Some(containerAppState) => containerAppState
       case None => podAppState
     }
+    val sparkExitException = Option(pod.getMetadata.getAnnotations)
+      .flatMap(a => Option(a.get(SPARK_EXIT_EXCEPTION_ANNOTATION)))
     val applicationError = {
       if (ApplicationState.isFailed(
           applicationState,
@@ -668,9 +673,10 @@ object KubernetesApplicationOperation extends Logging {
             "Pod" -> podName,
             "PodStatus" -> pod.getStatus,
             "Container" -> appStateContainer,
-            "ContainerStatus" -> cs)
+            "ContainerStatus" -> cs) ++ sparkExitException.map("ExitException" -> _)
         }.getOrElse {
-          Map("Pod" -> podName, "PodStatus" -> pod.getStatus)
+          Map("Pod" -> podName, "PodStatus" -> pod.getStatus) ++
+            sparkExitException.map("ExitException" -> _)
         }
         Some(JsonUtils.toJson(errorMap.asJava))
       } else {

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/KubernetesApplicationOperationSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/KubernetesApplicationOperationSuite.scala
@@ -17,11 +17,15 @@
 
 package org.apache.kyuubi.engine
 
-import io.fabric8.kubernetes.api.model.{ContainerState, ContainerStateWaiting}
+import java.util.Collections
+
+import io.fabric8.kubernetes.api.model.{ContainerState, ContainerStateWaiting, ObjectMeta, Pod, PodStatus}
 
 import org.apache.kyuubi.{KyuubiException, KyuubiFunSuite}
 import org.apache.kyuubi.config.KyuubiConf
+import org.apache.kyuubi.config.KyuubiConf.KubernetesApplicationStateSource
 import org.apache.kyuubi.engine.ApplicationState.{FAILED, PENDING}
+import org.apache.kyuubi.engine.KubernetesResourceEventTypes
 
 class KubernetesApplicationOperationSuite extends KyuubiFunSuite {
 
@@ -144,6 +148,48 @@ class KubernetesApplicationOperationSuite extends KyuubiFunSuite {
       val result = KubernetesApplicationOperation.containerStateToApplicationState(containerState)
       assert(result === PENDING)
     }
+  }
+
+  test("parse spark.exit-exception annotation from failed pod") {
+    val exitMsg =
+      "java.lang.OutOfMemoryError: Java heap space\n\tat com.example.Foo.bar(Foo.java:42)"
+
+    def buildPod(phase: String, annotations: java.util.Map[String, String]): Pod = {
+      val meta = new ObjectMeta()
+      meta.setName("spark-driver-pod")
+      meta.setAnnotations(annotations)
+      val status = new PodStatus()
+      status.setPhase(phase)
+      val pod = new Pod()
+      pod.setMetadata(meta)
+      pod.setStatus(status)
+      pod
+    }
+
+    val podWithAnnotation = buildPod(
+      "Failed",
+      Collections.singletonMap(
+        KubernetesApplicationOperation.SPARK_EXIT_EXCEPTION_ANNOTATION,
+        exitMsg))
+    val (state, error) = KubernetesApplicationOperation.toApplicationStateAndError(
+      podWithAnnotation,
+      KubernetesApplicationStateSource.POD,
+      "spark-kubernetes-driver",
+      KubernetesResourceEventTypes.UPDATE)
+    assert(state === FAILED)
+    assert(error.isDefined)
+    assert(error.get.contains("ExitException"))
+    assert(error.get.contains("OutOfMemoryError"))
+
+    // Without annotation the error JSON should not contain ExitException
+    val podNoAnnotation = buildPod("Failed", Collections.emptyMap())
+    val (_, errorNoAnnotation) = KubernetesApplicationOperation.toApplicationStateAndError(
+      podNoAnnotation,
+      KubernetesApplicationStateSource.POD,
+      "spark-kubernetes-driver",
+      KubernetesResourceEventTypes.UPDATE)
+    assert(errorNoAnnotation.isDefined)
+    assert(!errorNoAnnotation.get.contains("ExitException"))
   }
 
   test("containerStateToApplicationState failure reasons and empty reason") {


### PR DESCRIPTION
## Why are the changes needed?

Spark 4.1 introduced `spark.kubernetes.driver.annotateExitException` ([SPARK-52068](https://github.com/apache/spark/pull/52068)). When enabled, Spark annotates the driver pod with `spark.exit-exception` containing the stringified exit exception. Unlike YARN's diagnostics field, Kubernetes has no native equivalent, so users currently must inspect logs to find the root cause of a failure.

This PR teaches Kyuubi to read the `spark.exit-exception` annotation and include it as `ExitException` in the application error JSON. The enriched error is surfaced through the batch REST API (`appDiagnostic`) and the session exception message in `EngineRef`, making the root cause visible without log inspection.

## How was this patch tested?

Added a unit test in `KubernetesApplicationOperationSuite` that:
- Builds a `Failed` pod with the `spark.exit-exception` annotation set and asserts the error JSON contains `ExitException` with the annotation value.
- Builds a `Failed` pod without the annotation and asserts the existing error JSON format is unchanged (backward compatible).

## Was this patch authored or co-authored using generative AI tooling?

Assisted-by: Claude:claude-sonnet-4-6