### PR TITLE
[KYUUBI #7488][SERVER] Fix canceled batch reporting stale RUNNING application state

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
@@ -437,6 +437,17 @@ class BatchJobSubmission(
             // kill success and we can change state safely
             // note that, the batch operation state should never be closed
             setState(OperationState.CANCELED)
+            // re-poll the resource manager so the persisted application state reflects the kill
+            // rather than the last-seen (e.g. RUNNING) state; otherwise polling stops after close
+            // and the stale state would be reported by the REST API forever.
+            _applicationInfo = currentApplicationInfo()
+            _applicationInfo.filterNot(app => ApplicationState.isTerminated(app.state)).foreach {
+              app =>
+                withOperationLog(info(s"Batch $batchId state is $state," +
+                  s" but the application state is ${app.state}" +
+                  " and not terminated after kill succeeds, set to KILLED."))
+                _applicationInfo = Some(app.copy(state = ApplicationState.KILLED))
+            }
             updateBatchMetadata()
           } else if (killMessage._1) {
             // we can not change state safely

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
@@ -37,7 +37,7 @@ import org.apache.kyuubi.client.util.BatchUtils
 import org.apache.kyuubi.client.util.BatchUtils._
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf._
-import org.apache.kyuubi.engine.{ApplicationInfo, ApplicationManagerInfo, KyuubiApplicationManager}
+import org.apache.kyuubi.engine.{ApplicationInfo, ApplicationManagerInfo, ApplicationState, KyuubiApplicationManager}
 import org.apache.kyuubi.engine.spark.SparkBatchProcessBuilder
 import org.apache.kyuubi.metrics.{MetricsConstants, MetricsSystem}
 import org.apache.kyuubi.operation.{BatchJobSubmission, OperationState}
@@ -900,6 +900,15 @@ abstract class BatchesResourceSuiteBase extends KyuubiFunSuite
       .header(AUTHORIZATION_HEADER, basicAuthorizationHeader("anonymous"))
       .delete()
     assert(deleteResp.getStatus === 200)
+
+    val batchResp = webTarget.path(s"api/v1/batches/$batchId")
+      .request(MediaType.APPLICATION_JSON_TYPE)
+      .header(AUTHORIZATION_HEADER, basicAuthorizationHeader("anonymous"))
+      .get()
+    assert(batchResp.getStatus === 200)
+    val canceledBatch = batchResp.readEntity(classOf[Batch])
+    assert(canceledBatch.getState === OperationState.CANCELED.toString)
+    assert(ApplicationState.isTerminated(ApplicationState.withName(canceledBatch.getAppState)))
 
     eventually(timeout(10.seconds)) {
       assert(getBatchJobSubmissionStateCounter(OperationState.INITIALIZED) === 0)


### PR DESCRIPTION
### Why are the changes needed?

Closes #7488.

Canceling a RUNNING batch leaves its reported `appState` stuck at `RUNNING` forever: the operation state correctly becomes `CANCELED` and the application is killed, but `getAppState` only reconciles a non-terminal application state for `ERROR` (to `UNKNOWN`), not `CANCELED`, so the stale `RUNNING` is persisted and reported by the REST API. This reconciles `CANCELED` + non-terminal application state to `KILLED`, mirroring the existing `ERROR` handling. Affects master and 1.10.1.

### How was this patch tested?

Added an assertion to the existing `BatchesResourceSuite` metrics test (v1 and v2): it cancels a RUNNING batch and now asserts the reported `appState` is terminated, which fails on the old behavior (where it stayed `RUNNING`). 

### Was this patch authored or co-authored using generative AI tooling?

Assisted-by: Claude:claude-opus-4-8
