### PR TITLE
[KYUUBI #XXXX] Do not block server shutdown on batch sessions

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/session/Session.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/session/Session.scala
@@ -97,4 +97,6 @@ trait Session {
   def closeExpiredOperations(): Unit
 
   def isForAliveProbe: Boolean
+
+  def closeOnServerStop: Boolean = true
 }

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/ServiceDiscovery.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/ServiceDiscovery.scala
@@ -66,11 +66,13 @@ abstract class ServiceDiscovery(
 
   // stop the server genteelly
   def stopGracefully(isLost: Boolean = false): Unit = {
-    var activeSessionCount = fe.be.sessionManager.getActiveUserSessionCount
-    while (activeSessionCount > 0) {
-      info(s"$activeSessionCount connection(s) are active, delay shutdown")
+    var blockingSessionCount =
+      fe.be.sessionManager.allSessions().count(_.closeOnServerStop)
+    while (blockingSessionCount > 0) {
+      info(s"$blockingSessionCount connection(s) are active, delay shutdown")
       Thread.sleep(TimeUnit.SECONDS.toMillis(10))
-      activeSessionCount = fe.be.sessionManager.getActiveUserSessionCount
+      blockingSessionCount =
+        fe.be.sessionManager.allSessions().count(_.closeOnServerStop)
     }
     isServerLost.set(isLost)
     gracefulShutdownLatch.countDown()

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/ServiceDiscovery.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/ServiceDiscovery.scala
@@ -67,7 +67,7 @@ abstract class ServiceDiscovery(
   // stop the server genteelly
   def stopGracefully(isLost: Boolean = false): Unit = {
     var blockingSessionCount =
-      fe.be.sessionManager.allSessions().count(_.closeOnServerStop)
+      fe.be.sessionManager.allSessions().count(s => s.closeOnServerStop && !s.isForAliveProbe)
     while (blockingSessionCount > 0) {
       info(s"$blockingSessionCount connection(s) are active, delay shutdown")
       Thread.sleep(TimeUnit.SECONDS.toMillis(10))

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiBatchSession.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiBatchSession.scala
@@ -229,4 +229,6 @@ class KyuubiBatchSession(
     EventBus.post(sessionEvent)
     traceMetricsOnClose()
   }
+
+  override def closeOnServerStop: Boolean = false
 }


### PR DESCRIPTION
## Why

`ServiceDiscovery.stopGracefully` waits for `getActiveUserSessionCount > 0` to reach zero before shutting down. This count includes batch sessions, which are just handles to jobs running on external clusters (YARN/K8s). Those jobs can run for hours or days — causing the server to hang indefinitely on shutdown.

## What

Introduces a `closeOnServerStop` flag on the `Session` trait (default `true` — fully backward-compatible with all existing session types).

`KyuubiBatchSession` overrides it to `false`. `ServiceDiscovery.stopGracefully` now waits only for sessions where `closeOnServerStop = true`, so batch sessions no longer block server shutdown.

## Changes

- `Session` trait: add `closeOnServerStop: Boolean = true`
- `KyuubiBatchSession`: override to `false`
- `ServiceDiscovery.stopGracefully`: switch from `getActiveUserSessionCount` to `allSessions().count(_.closeOnServerStop)`

## Test plan

- [ ] Server shuts down promptly when only batch sessions are active
- [ ] Server still waits for active interactive sessions before shutting down
- [ ] Batch jobs continue running on cluster after server restart