### PR TITLE
[CI] Use "ubuntu-slim" runner for lightweight workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ concurrency:
 jobs:
   sphinx:
     name: sphinx-build
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6.0.2
       - uses: actions/setup-python@v6

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   greeting:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   triage:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     steps:
     - uses: actions/labeler@v5
       with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     permissions:
       pull-requests: write
     steps:


### PR DESCRIPTION
### Why are the changes needed?
The changes are needed to optimize costs and resource consumption.
Details:
- [Standard GitHub-hosted runners for public repositories](https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories)
- [Actions runner pricing](https://docs.github.com/en/billing/reference/actions-runner-pricing)


### How was this patch tested?
Review / CI


### Was this patch authored or co-authored using generative AI tooling?
No
