### PR TITLE
[DOC] Align Python version and style

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: '3.11'
           cache: 'pip'
           cache-dependency-path: docs/requirements.txt
       - run: pip install -r docs/requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,30 +31,29 @@
 
 import os
 import sys
-import shlex
 import subprocess
 import datetime
 
-sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath("."))
 
 import sphinx_markdown_tables
 
 source_suffix = {
-    '.rst': 'restructuredtext',
-    '.txt': 'restructuredtext',
-    '.md': 'markdown',
+    ".rst": "restructuredtext",
+    ".txt": "restructuredtext",
+    ".md": "markdown",
 }
 
 # -- Project information -----------------------------------------------------
 
-project = 'Kyuubi'
+project = "Kyuubi"
 
 year = datetime.datetime.now().strftime("%Y")
 
-copyright = year + ' The Apache Software Foundation, Licensed under the Apache License, Version 2.0'
+copyright = year + " The Apache Software Foundation, Licensed under the Apache License, Version 2.0"
 
 
-author = 'Apache Kyuubi Community'
+author = "Apache Kyuubi Community"
 
 # The full version, including alpha/beta/rc tags
 release = subprocess.getoutput("grep 'kyuubi-parent' -C1 ../pom.xml | grep '<version>' | awk -F '[<>]' '{print $3}'")
@@ -63,36 +62,36 @@ release = subprocess.getoutput("grep 'kyuubi-parent' -C1 ../pom.xml | grep '<ver
 # -- General configuration ---------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be
-# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# extensions coming with Sphinx (named "sphinx.ext.*") or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.napoleon',
-    'sphinx.ext.mathjax',
-    'myst_parser',
-    'sphinx_copybutton',
-    'sphinx_markdown_tables',
-    'sphinx_togglebutton',
-    'notfound.extension',
-    'sphinxemoji.sphinxemoji',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.mathjax",
+    "myst_parser",
+    "sphinx_copybutton",
+    "sphinx_markdown_tables",
+    "sphinx_togglebutton",
+    "notfound.extension",
+    "sphinxemoji.sphinxemoji",
 ]
 
-master_doc = 'index'
+master_doc = "index"
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['requirements.txt', '_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["requirements.txt", "_build", "Thumbs.db", ".DS_Store"]
 
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_book_theme'
+html_theme = "sphinx_book_theme"
 html_theme_options = {
     "repository_url": "https://github.com/apache/kyuubi",
     "use_repository_button": True,
@@ -108,16 +107,16 @@ html_theme_options = {
     "toc_title": "",
 }
 
-html_logo = 'imgs/logo.png'
-html_favicon = 'imgs/logo_red_short.png'
-html_title = 'Apache Kyuubi'
+html_logo = "imgs/logo.png"
+html_favicon = "imgs/logo_red_short.png"
+html_title = "Apache Kyuubi"
 
-pygments_style = 'sphinx'
+pygments_style = "sphinx"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 html_css_files = ["css/custom.css"]
 
-github_doc_root = 'https://github.com/apache/kyuubi/tree/master/docs/'
+github_doc_root = "https://github.com/apache/kyuubi/tree/master/docs/"


### PR DESCRIPTION
### Why are the changes needed?
The changes align:
- Python version used for the documentation build in `.github/workflows/docs.yml` with [.readthedocs.yaml](https://github.com/apache/kyuubi/blob/26e3eaa93ea354245866526a697a16f23ed77455/.readthedocs.yaml#L22).
- Quotes used for strings in `docs/conf.py`.


### How was this patch tested?
Built and verify the documentation.
```shell
make html

open _build/html/overview/kyuubi_vs_hive.html
```


### Was this patch authored or co-authored using generative AI tooling?
No
