### PR TITLE
[KYUUBI][PROPOSAL] Add Spark Connect gRPC server support to Kyuubi

### DIFF
--- a/openspec/changes/kyuubi-spark-connect-grpc-server/.openspec.yaml
+++ b/openspec/changes/kyuubi-spark-connect-grpc-server/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-12

--- a/openspec/changes/kyuubi-spark-connect-grpc-server/design.md
+++ b/openspec/changes/kyuubi-spark-connect-grpc-server/design.md
@@ -1,0 +1,117 @@
+## Context
+
+Kyuubi is a multi-tenant gateway fronting Spark (and other) engines via Thrift/HiveServer2, REST, and MySQL protocols. Apache Spark 3.4 introduced Spark Connect — a gRPC-based client-server protocol using Protocol Buffers — that decouples client code from the Spark driver. PySpark users now connect with `spark.remote("sc://host:port/")` instead of embedding a local SparkSession.
+
+Currently Kyuubi has no gRPC listener and cannot accept Spark Connect clients. The engine side already supports `--spark-connect` mode (Spark 3.4+), which starts an embedded gRPC server inside the engine process. This design adds a **Spark Connect frontend** to Kyuubi that acts as an authenticated, multi-tenant proxy between Spark Connect clients and engine-side Spark Connect servers.
+
+**Constraints:**
+- Must not violate the `kyuubi-server` → `externals/*` dependency boundary.
+- Must preserve existing Thrift/REST/MySQL surfaces unchanged.
+- Protobuf and gRPC dependencies must be profile-gated (`-Pspark-connect`).
+- Proto API varies between Spark 3.4, 3.5, and 4.0; implementation must be version-aware.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Expose a gRPC endpoint on a configurable port (`kyuubi.frontend.spark.connect.bind.port`, default 15002) implementing `SparkConnectService`.
+- Authenticate gRPC connections using Kyuubi's existing auth plugin interface.
+- Map each Spark Connect `sessionId` onto a `SparkConnectSession` in Kyuubi's `SessionManager`, with user isolation and resource tagging.
+- Transparently proxy `ExecutePlan`, `AnalyzePlan`, `Config`, `Interrupt`, and `ReattachExecute` RPCs to the Spark engine running in `--spark-connect` mode.
+- Discover the engine's Spark Connect gRPC port via Kyuubi's existing engine service-discovery mechanism (ZooKeeper / Kubernetes label).
+- Support TLS for the client-facing gRPC channel, consistent with Thrift frontend.
+
+**Non-Goals:**
+- Implementing a Spark Connect-aware query planner or optimizer inside Kyuubi itself.
+- Supporting `AddArtifacts` (client-streaming file upload) in the initial implementation.
+- Supporting Spark versions before 3.4 for Spark Connect mode.
+- Replacing or modifying the Thrift, REST, or MySQL frontends.
+- Supporting Spark Connect in Kyuubi's embedded/local engine mode (development convenience; deferred).
+
+## Decisions
+
+### D1: Proxy architecture (not embed)
+
+**Decision:** Kyuubi relays Spark Connect protobuf streams between the client and the Spark engine process. The engine runs `--spark-connect` mode and handles all plan execution. Kyuubi adds auth, routing, session lifecycle, and multi-tenancy.
+
+**Rationale:** Embedding a SparkSession inside `kyuubi-server` would violate the hard boundary between server and engine modules and prevent the multi-engine / per-user isolation that is Kyuubi's core value. The proxy pattern is consistent with how Kyuubi handles Thrift — Kyuubi is the protocol gateway, not the compute layer.
+
+**Alternatives considered:**
+- *Embed SparkSession in server*: Simpler for single-user scenarios, but breaks multi-tenancy and the module boundary. Rejected.
+- *Sidecar proxy (separate process)*: Adds operational complexity with no benefit over in-process forwarding. Rejected.
+
+### D2: New Maven module `kyuubi-spark-connect`
+
+**Decision:** All gRPC/protobuf code lives in a new module `kyuubi-spark-connect/`, built only with `-Pspark-connect`. The module depends on `kyuubi-server` for session/operation APIs, not the reverse.
+
+**Rationale:** Keeps protobuf/gRPC off the classpath for deployments that don't need Spark Connect. Mirrors how Kyuubi already gate optional frontends (MySQL).
+
+**Alternatives considered:**
+- *Add to kyuubi-server directly*: Makes gRPC a mandatory dependency; harder to version-isolate proto stubs. Rejected.
+- *New `extensions/server/kyuubi-spark-connect`*: Possible, but the frontend lifecycle (start/stop with KyuubiServer) fits better as a first-class module than an extension. Deferred for community discussion.
+
+### D3: Proto version strategy — Spark 3.5 first, multi-version via profiles
+
+**Decision:** Target Spark 3.5 `spark-connect-common` proto initially, gated under `-Pspark-3.5` (already the default). Spark 4.0 support added in a subsequent profile. Source-level differences isolated to a versioned shim layer (`SparkConnectProtoShim`).
+
+**Rationale:** Spark 3.5 is the most-deployed LTS version. Proto between 3.4 and 3.5 changed substantially (new fields, renamed messages). Trying to compile a single proto for all versions is not feasible; the shim approach is consistent with how Kyuubi already handles Spark API differences.
+
+### D4: Session identity — Spark Connect `sessionId` → Kyuubi `SessionHandle`
+
+**Decision:** The Spark Connect `UserContext.user_agent` carries the `sessionId` UUID. Kyuubi creates a `SessionHandle` derived from this UUID (or generates one if absent) and stores it in `SessionManager`. Subsequent RPCs from the same `sessionId` reuse the same session handle and thus the same engine connection.
+
+**Rationale:** Spark Connect sessions are long-lived (unlike individual queries); mapping them to Kyuubi sessions enables existing resource limits, event logging, and audit to work without modification.
+
+### D5: Engine port discovery via service registry
+
+**Decision:** When the Spark engine starts in `--spark-connect` mode, it registers its Spark Connect gRPC port in Kyuubi's engine service registry (ZooKeeper node or Kubernetes label `kyuubi.apache.org/spark-connect-port`). `SparkConnectEngineProxy` reads this at session-open time.
+
+**Rationale:** Kyuubi already has a service-discovery layer for Thrift ports; extending it with a second port keeps discovery consistent and avoids hard-coding assumptions about engine-side ports.
+
+**Alternative:** Parse the engine's log output for the port — brittle and not compatible with Kubernetes. Rejected.
+
+### Architecture Diagram
+
+```
+Client (PySpark / Go / Rust)
+       │  gRPC (SparkConnectService proto)
+       │  metadata: Authorization, x-kyuubi-session-id
+       ▼
+┌──────────────────────────────────────────────────────┐
+│  kyuubi-spark-connect module (in kyuubi-server JVM)  │
+│                                                      │
+│  NettyGrpcServer (port 15002)                        │
+│    └─ AuthInterceptor (maps token → KyuubiUser)      │
+│         └─ SparkConnectFrontendService               │
+│              └─ SparkConnectSessionManager           │
+│                   └─ SparkConnectSession             │
+│                        └─ SparkConnectEngineProxy    │
+│                             (gRPC channel to engine) │
+└──────────────────────────────┬───────────────────────┘
+                               │  gRPC (SparkConnectService proto)
+                               ▼
+                  Spark Engine Process
+                  (--spark-connect, port auto-assigned)
+```
+
+## Risks / Trade-offs
+
+- **gRPC streaming backpressure** → Mitigation: Use `io.grpc.stub.StreamObserver` flow control; implement a bounded queue between inbound client stream and outbound engine channel. Fail-fast on buffer exhaustion rather than OOM.
+- **Proto version churn (Spark 3.5 → 4.0)** → Mitigation: `SparkConnectProtoShim` interface isolates version-specific field access; new profiles add new shim implementations.
+- **Kyuubi restart loses session mapping** → Mitigation: Document this as a known limitation for v1; Spark Connect clients already handle `DISCONNECTED_PLAN_WITH_NO_COMPLETION_SIGNAL` by reconnecting via `ReattachExecute`. Session state recovery is a follow-up.
+- **Netty version conflict** (`grpc-netty-shaded` bundles its own Netty)** → Mitigation: Use `grpc-netty-shaded` (not bare `grpc-netty`) to avoid classpath conflicts with the Thrift frontend's Netty. Validate with `mvn dependency:tree`.
+- **`AddArtifacts` deferred** → Clients using `sc.addPyFile()` / `sc.addJar()` will get `UNIMPLEMENTED` in v1. Document clearly; implement in a follow-up.
+
+## Migration Plan
+
+1. The feature is **additive and off by default** (`kyuubi.frontend.spark.connect.enabled=false`).
+2. Build is **profile-gated** (`-Pspark-connect`); no impact on existing binary distributions.
+3. Users opt in by setting `kyuubi.frontend.spark.connect.enabled=true` and starting Kyuubi with a build that includes the module.
+4. Spark engines must be configured to start in `--spark-connect` mode; existing engines without this flag will have Spark Connect sessions fail with a clear error at session-open time.
+5. **Rollback**: Disable the config key or remove the module from the classpath. No schema or protocol changes affect existing frontends.
+
+## Open Questions
+
+1. Should the initial implementation support `ReattachExecute` (needed for long-running streaming queries), or defer to a follow-up?
+2. Is there a community interest in running Spark Connect in Kyuubi's embedded local mode for CI/testing? If so, what is the minimal shim needed?
+3. How does the Spark Connect auth token model interact with Kyuubi's Ranger/Hive Metastore auth plugins — does the token carry the same identity used for SQL authorization?
+4. Should `kyuubi-spark-connect` be an extension (under `extensions/server/`) to allow community distribution as a separate artifact, or is it better as a first-class module under `kyuubi-server`'s parent?

--- a/openspec/changes/kyuubi-spark-connect-grpc-server/proposal.md
+++ b/openspec/changes/kyuubi-spark-connect-grpc-server/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Spark Connect (GA in Apache Spark 3.4) defines a language-agnostic gRPC protocol that decouples clients from the Spark driver. Today Kyuubi only exposes Thrift/JDBC/REST surfaces; PySpark users connecting via `spark.remote("sc://...")` or any non-JVM thin client cannot benefit from Kyuubi's multi-tenancy, session pooling, and access control. Supporting Spark Connect transforms Kyuubi into a unified gateway for both legacy JDBC workloads and modern DataFrame/Spark Connect clients, with no changes required on the Spark engine side.
+
+## What Changes
+
+- **New gRPC listener** in `kyuubi-server` implementing `SparkConnectService` proto (Apache Spark Connect protocol).
+- **New module** `kyuubi-spark-connect` containing the gRPC server, protobuf stubs, and session bridge.
+- **Session management extension**: Spark Connect sessions are mapped onto Kyuubi's existing `SessionManager` / `OperationManager` with a new `SparkConnectSession` type.
+- **Engine-side proxy**: Kyuubi spawns (or reuses) a Spark application running in `--spark-connect` mode and reverse-proxies protobuf streams between the client and the engine's embedded Spark Connect server.
+- **New configuration namespace** `kyuubi.frontend.spark.connect.*` for gRPC port, TLS, max-message-size, etc.
+- Regenerated `docs/configuration/settings.md` for new config entries.
+
+## Capabilities
+
+### New Capabilities
+- `spark-connect-frontend`: Kyuubi exposes a gRPC server endpoint implementing the Spark Connect wire protocol (`SparkConnectService`) for client connections.
+- `spark-connect-session`: Lifecycle management (create / reuse / close) of Spark Connect sessions within Kyuubi's `SessionManager`, with user isolation and resource tagging.
+- `spark-connect-engine-proxy`: Transparent forwarding of Spark Connect protobuf streams (Execute, Analyze, Config, Interrupt) from Kyuubi to a per-user Spark engine running in Spark Connect server mode.
+- `spark-connect-auth`: Authentication and authorization for gRPC connections (token-based, matching Kyuubi's existing auth plugin interface).
+
+### Modified Capabilities
+<!-- No existing spec-level requirements change; Thrift/JDBC/REST surfaces are unaffected. -->
+
+## Impact
+
+- **New module**: `kyuubi-spark-connect/` (or `extensions/server/kyuubi-spark-connect/`) with gRPC and protobuf dependencies.
+- **Dependencies added**: `grpc-netty-shaded`, `protobuf-java`, `spark-connect-common` (from Spark 3.4+); gated behind a Maven profile `-Pspark-connect`.
+- **`kyuubi-server`**: `FrontendService` abstraction extended; Netty gRPC channel added alongside existing Thrift Netty channel; startup wiring in `KyuubiServer`.
+- **`kyuubi-common`**: `SessionManager` and `OperationManager` accept the new `SparkConnectSession` / `SparkConnectOperation` subtypes.
+- **Kubernetes / HA**: Engine discovery must handle `SparkConnectServerUrl` alongside existing `ThriftServerUrl`; Spark Connect uses port 15002 by default.
+- **Configuration docs**: `dev/gen/gen_all_config_docs.sh` must be re-run after adding new `KyuubiConf` entries.
+- **License**: `spark-connect-common` proto files are Apache 2.0; confirm `LICENSE-binary` and `NOTICE` before shipping.

--- a/openspec/changes/kyuubi-spark-connect-grpc-server/specs/spark-connect-auth/spec.md
+++ b/openspec/changes/kyuubi-spark-connect-grpc-server/specs/spark-connect-auth/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Token-based authentication via gRPC metadata
+All incoming gRPC RPCs to the Spark Connect frontend SHALL pass through an `AuthInterceptor` before reaching `SparkConnectFrontendService`. The interceptor SHALL extract the bearer token from the `Authorization` gRPC metadata header (format: `Bearer <token>`) and validate it using Kyuubi's existing `AuthenticationProvider` chain. The resolved `KyuubiUser` SHALL be attached to the gRPC `Context` for use in session and engine routing.
+
+#### Scenario: Valid bearer token accepted
+- **WHEN** a client sends any RPC with a valid `Authorization: Bearer <token>` header
+- **THEN** the interceptor SHALL resolve the token to a `KyuubiUser` and proceed to the handler
+
+#### Scenario: Missing authorization header
+- **WHEN** a client sends any RPC without an `Authorization` metadata header
+- **THEN** the interceptor SHALL return gRPC status `UNAUTHENTICATED` with message "Missing Authorization header" before routing the RPC
+
+#### Scenario: Invalid or expired token
+- **WHEN** a client sends any RPC with a token that fails validation (expired, malformed, unknown)
+- **THEN** the interceptor SHALL return gRPC status `UNAUTHENTICATED` with a non-revealing error message; the failure SHALL be logged at WARN level with client IP and timestamp
+
+### Requirement: User identity propagation
+The authenticated `KyuubiUser` identity resolved by the `AuthInterceptor` SHALL be used for:
+- Keying the `SparkConnectSession` (user isolation).
+- Engine acquisition via `SessionManager` (user-level share level and limits).
+- Audit event emission (session open/close events carry the user identity).
+- SQL authorization checks when the engine performs authorization (user identity passed as `UserContext.user_name` in forwarded RPCs, overriding any client-supplied value).
+
+#### Scenario: Client-supplied user_name overridden
+- **WHEN** a client sends `ExecutePlan` with `UserContext.user_name` set to an arbitrary value
+- **THEN** Kyuubi SHALL replace `user_name` in the forwarded `UserContext` with the server-authenticated identity; the client-supplied value SHALL be ignored
+
+#### Scenario: User identity in audit log
+- **WHEN** a session is opened by authenticated user `alice`
+- **THEN** the session open event SHALL record `user=alice` in the event log, regardless of any value in the client's `UserContext`
+
+### Requirement: Anonymous access disabled
+When `kyuubi.authentication` is set to any value other than `NONE`, unauthenticated Spark Connect connections SHALL be rejected. When `kyuubi.authentication=NONE`, all connections SHALL be accepted and attributed to an anonymous user (consistent with Thrift frontend behavior in NONE mode).
+
+#### Scenario: Auth mode NONE allows all connections
+- **WHEN** `kyuubi.authentication=NONE` and a client sends an RPC without an `Authorization` header
+- **THEN** the RPC SHALL be accepted and attributed to the anonymous user identity
+
+#### Scenario: Auth mode LDAP rejects unauthenticated
+- **WHEN** `kyuubi.authentication=LDAP` and a client sends an RPC without an `Authorization` header
+- **THEN** the interceptor SHALL return `UNAUTHENTICATED`
+
+### Requirement: Authorization checks at operation level
+Before routing `ExecutePlan` or `AnalyzePlan` to the engine, Kyuubi SHALL invoke the configured `AuthorizationProvider` (e.g., Ranger) with the authenticated user identity. If authorization is denied, Kyuubi SHALL return gRPC status `PERMISSION_DENIED` without forwarding the request to the engine.
+
+#### Scenario: Authorized plan executed
+- **WHEN** the `AuthorizationProvider` grants access for the authenticated user and the requested operation
+- **THEN** the request SHALL be forwarded to the engine normally
+
+#### Scenario: Unauthorized plan rejected
+- **WHEN** the `AuthorizationProvider` denies access
+- **THEN** gRPC status `PERMISSION_DENIED` SHALL be returned to the client; no request SHALL be forwarded to the engine; the denial SHALL be logged at INFO level

--- a/openspec/changes/kyuubi-spark-connect-grpc-server/specs/spark-connect-engine-proxy/spec.md
+++ b/openspec/changes/kyuubi-spark-connect-grpc-server/specs/spark-connect-engine-proxy/spec.md
@@ -1,0 +1,51 @@
+## ADDED Requirements
+
+### Requirement: Engine-side Spark Connect port discovery
+When opening a `SparkConnectSession`, the `SparkConnectEngineProxy` SHALL discover the Spark Connect gRPC port of the assigned engine by reading the engine's service-discovery entry. For ZooKeeper-based discovery, the port SHALL be stored as a node attribute `sparkConnectPort`. For Kubernetes-based discovery, the port SHALL be read from the pod label `kyuubi.apache.org/spark-connect-port` or the pod annotation `kyuubi.apache.org/spark-connect-port`. If the engine's service-discovery entry does not contain a Spark Connect port, session opening SHALL fail with a descriptive error.
+
+#### Scenario: Engine port discovered via ZooKeeper
+- **WHEN** the engine registers with a `sparkConnectPort` attribute in its ZooKeeper node
+- **THEN** `SparkConnectEngineProxy` SHALL connect to the engine at that port for the session
+
+#### Scenario: Engine not in Spark Connect mode
+- **WHEN** the engine's service-discovery entry has no `sparkConnectPort`
+- **THEN** session creation SHALL fail with error "Engine does not support Spark Connect; start engine with --spark-connect flag"
+
+### Requirement: Transparent RPC forwarding
+For each client RPC (`ExecutePlan`, `AnalyzePlan`, `Config`, `Interrupt`, `ReattachExecute`), the `SparkConnectEngineProxy` SHALL:
+1. Open a gRPC channel to the engine (or reuse a cached channel for the session).
+2. Forward the request protobuf bytes verbatim to the engine.
+3. Stream or return the engine's response protobuf bytes verbatim to the client.
+4. Propagate gRPC status codes and trailers from the engine back to the client unchanged.
+
+Kyuubi SHALL NOT deserialize or re-serialize plan proto messages (pass-through at the byte level).
+
+#### Scenario: ExecutePlan streamed end-to-end
+- **WHEN** a client sends `ExecutePlan` with a valid plan
+- **THEN** each `ExecutePlanResponse` chunk from the engine SHALL be forwarded to the client in order, with no modification, and the stream SHALL close with the same status the engine returns
+
+#### Scenario: Engine returns error status
+- **WHEN** the engine returns gRPC status `INTERNAL` for a malformed plan
+- **THEN** the client SHALL receive gRPC status `INTERNAL` with the same error detail; Kyuubi SHALL log the failure at WARN level with the `sessionId`
+
+### Requirement: Engine channel lifecycle
+The gRPC channel from Kyuubi to the engine SHALL be established at session-open time and closed when the session closes. The channel SHALL be multiplexed across concurrent RPCs within the same session. Channel options SHALL respect `kyuubi.frontend.spark.connect.engine.channel.max.message.size` (default 128MB) and `kyuubi.frontend.spark.connect.engine.channel.keepalive.time`.
+
+#### Scenario: Concurrent RPCs share one channel
+- **WHEN** a session has multiple concurrent `Config` and `AnalyzePlan` RPCs in flight
+- **THEN** all RPCs SHALL use the same underlying HTTP/2 connection to the engine
+
+#### Scenario: Channel closed on session close
+- **WHEN** a `SparkConnectSession` is closed
+- **THEN** the engine-side gRPC channel SHALL be shut down gracefully (no abrupt TCP reset unless shutdown timeout exceeded)
+
+### Requirement: Engine connectivity failure handling
+If the engine's gRPC channel becomes unavailable after session establishment (network error, engine crash), ongoing streaming RPCs (`ExecutePlan`, `ReattachExecute`) SHALL be terminated with gRPC status `UNAVAILABLE`. Clients MAY reconnect via `ReattachExecute` if the operation is still tracked in Kyuubi's `OperationManager`.
+
+#### Scenario: Engine crashes mid-stream
+- **WHEN** the engine process terminates while `ExecutePlan` is streaming
+- **THEN** the client SHALL receive `UNAVAILABLE` with message "Engine connection lost"; the session SHALL be marked DEAD in `SessionManager`
+
+#### Scenario: ReattachExecute after transient failure
+- **WHEN** a client sends `ReattachExecute` for an operation still tracked in `OperationManager` and the engine has recovered
+- **THEN** the proxy SHALL re-establish the engine channel and resume streaming from the last acknowledged response index

--- a/openspec/changes/kyuubi-spark-connect-grpc-server/specs/spark-connect-frontend/spec.md
+++ b/openspec/changes/kyuubi-spark-connect-grpc-server/specs/spark-connect-frontend/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: gRPC server lifecycle
+Kyuubi server SHALL start a Netty-based gRPC server implementing `SparkConnectService` when `kyuubi.frontend.spark.connect.enabled=true`. The server SHALL bind to `kyuubi.frontend.spark.connect.bind.host` on port `kyuubi.frontend.spark.connect.bind.port` (default 15002). The gRPC server SHALL start and stop as part of `KyuubiServer` lifecycle (alongside the Thrift and REST frontends) and SHALL not affect startup of other frontends when it fails to bind.
+
+#### Scenario: Server starts with config enabled
+- **WHEN** `kyuubi.frontend.spark.connect.enabled=true` and the bind port is available
+- **THEN** the gRPC server SHALL bind successfully and log the effective listen address at INFO level
+
+#### Scenario: Server disabled by default
+- **WHEN** `kyuubi.frontend.spark.connect.enabled` is not explicitly set
+- **THEN** no gRPC port is opened and no gRPC-related threads are started
+
+#### Scenario: Bind port unavailable
+- **WHEN** `kyuubi.frontend.spark.connect.enabled=true` and the port is already in use
+- **THEN** server startup SHALL fail with a clear error message identifying the port conflict; other frontends SHALL continue unaffected
+
+### Requirement: Spark Connect RPC surface
+The gRPC server SHALL implement the following `SparkConnectService` methods: `ExecutePlan` (server-streaming), `AnalyzePlan` (unary), `Config` (unary), `Interrupt` (unary), and `ReattachExecute` (server-streaming). The `AddArtifacts` method SHALL return `UNIMPLEMENTED`. All other methods not listed SHALL return `UNIMPLEMENTED`.
+
+#### Scenario: ExecutePlan request routed
+- **WHEN** a connected client sends an `ExecutePlan` request with a valid `sessionId` and plan
+- **THEN** the server SHALL authenticate the caller, resolve or create the corresponding `SparkConnectSession`, proxy the request to the engine, and stream `ExecutePlanResponse` messages back to the client
+
+#### Scenario: AddArtifacts returns UNIMPLEMENTED
+- **WHEN** a client sends an `AddArtifacts` request
+- **THEN** the server SHALL return gRPC status `UNIMPLEMENTED` with message "AddArtifacts is not yet supported by Kyuubi Spark Connect frontend"
+
+### Requirement: TLS support
+When `kyuubi.frontend.spark.connect.ssl.enabled=true`, the gRPC server SHALL use TLS with the keystore configured by `kyuubi.frontend.spark.connect.ssl.keystore.path` and `kyuubi.frontend.spark.connect.ssl.keystore.password`. The server SHALL refuse plaintext connections when TLS is enabled.
+
+#### Scenario: TLS handshake succeeds
+- **WHEN** TLS is configured and a client presents a valid certificate chain
+- **THEN** the connection SHALL be established and RPCs proceed normally
+
+#### Scenario: Plaintext rejected when TLS enabled
+- **WHEN** TLS is enabled and a client attempts a plaintext (non-TLS) connection
+- **THEN** the connection SHALL be rejected before any RPC metadata is read
+
+### Requirement: Configuration keys
+The following `KyuubiConf` entries SHALL be added under the `kyuubi.frontend.spark.connect.*` namespace:
+
+| Key | Default | Description |
+|---|---|---|
+| `kyuubi.frontend.spark.connect.enabled` | `false` | Enable the Spark Connect gRPC frontend |
+| `kyuubi.frontend.spark.connect.bind.host` | `<system default>` | Bind hostname/IP |
+| `kyuubi.frontend.spark.connect.bind.port` | `15002` | Bind port |
+| `kyuubi.frontend.spark.connect.max.message.size` | `128MB` | Maximum inbound message size |
+| `kyuubi.frontend.spark.connect.ssl.enabled` | `false` | Enable TLS |
+| `kyuubi.frontend.spark.connect.ssl.keystore.path` | (none) | Keystore file path |
+| `kyuubi.frontend.spark.connect.ssl.keystore.password` | (none) | Keystore password |
+
+After adding entries, `dev/gen/gen_all_config_docs.sh` SHALL be re-run and the generated diff committed in the same PR.
+
+#### Scenario: Default port
+- **WHEN** `kyuubi.frontend.spark.connect.bind.port` is not set
+- **THEN** the server SHALL bind to port 15002 (Spark Connect's standard default)
+
+#### Scenario: Missing keystore path with TLS enabled
+- **WHEN** `kyuubi.frontend.spark.connect.ssl.enabled=true` and `kyuubi.frontend.spark.connect.ssl.keystore.path` is empty
+- **THEN** server startup SHALL fail with a descriptive error indicating the missing keystore configuration

--- a/openspec/changes/kyuubi-spark-connect-grpc-server/specs/spark-connect-session/spec.md
+++ b/openspec/changes/kyuubi-spark-connect-grpc-server/specs/spark-connect-session/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Session creation on first RPC
+A `SparkConnectSession` SHALL be created in Kyuubi's `SessionManager` the first time a client sends any RPC with a `sessionId` that is not already tracked. The session SHALL be keyed by the tuple `(kyuubiUser, sessionId)`. If `sessionId` is absent from the request, Kyuubi SHALL generate a UUID and return it in the first response's `session_id` field.
+
+#### Scenario: New sessionId opens a session
+- **WHEN** a client sends `ExecutePlan` with a `sessionId` not present in `SessionManager`
+- **THEN** a new `SparkConnectSession` SHALL be created, associated with the authenticated user, and the engine acquisition SHALL begin
+
+#### Scenario: Existing sessionId reuses session
+- **WHEN** a client sends a second RPC with the same `sessionId` and same authenticated user
+- **THEN** the existing `SparkConnectSession` SHALL be reused; no new engine acquisition occurs
+
+#### Scenario: sessionId collision across users
+- **WHEN** two different authenticated users send RPCs with the same `sessionId`
+- **THEN** each user SHALL receive an independent session; sessions SHALL be isolated by user identity
+
+### Requirement: Session isolation and resource limits
+Each `SparkConnectSession` SHALL be subject to the same per-user engine and session limits enforced by `SessionManager` for Thrift sessions. Specifically:
+- `kyuubi.session.engine.share.level` applies (USER, CONNECTION, GROUP, SERVER).
+- `kyuubi.session.check.interval` governs idle session cleanup.
+- Session-level configs passed via `Config` RPC SHALL be stored in the `SparkConnectSession` and forwarded to the engine at session open time.
+
+#### Scenario: Per-user engine limit honored
+- **WHEN** a user already has the maximum allowed engines and opens a new Spark Connect session under `USER` share level
+- **THEN** the new session SHALL reuse the existing engine rather than spawning a new one
+
+#### Scenario: Idle session cleanup
+- **WHEN** a `SparkConnectSession` has had no RPC activity for longer than `kyuubi.session.idle.timeout`
+- **THEN** `SessionManager` SHALL close the session and release the engine connection
+
+### Requirement: Session close
+A `SparkConnectSession` SHALL be closed when:
+1. The client sends an `Interrupt` RPC with `interrupt_type = SESSION_CLOSE`, OR
+2. The session idle timeout elapses, OR
+3. Kyuubi server shuts down.
+
+On close, any in-progress `ExecutePlan` or `ReattachExecute` streams to the client SHALL be terminated with gRPC status `CANCELLED` or `UNAVAILABLE` as appropriate.
+
+#### Scenario: Graceful close via Interrupt RPC
+- **WHEN** a client sends `Interrupt` with `interrupt_type = SESSION_CLOSE`
+- **THEN** the session SHALL be closed, the engine connection released, and the RPC SHALL return success
+
+#### Scenario: Server shutdown terminates sessions
+- **WHEN** Kyuubi server initiates graceful shutdown
+- **THEN** all active `SparkConnectSession` instances SHALL be closed within the shutdown timeout; streaming clients SHALL receive `UNAVAILABLE`
+
+### Requirement: Event logging
+Session open, close, and key lifecycle events for `SparkConnectSession` SHALL be published to Kyuubi's event logging system (same `EventBus` used by Thrift sessions) with event type `SparkConnectSessionEvent`.
+
+#### Scenario: Session open event emitted
+- **WHEN** a `SparkConnectSession` is created
+- **THEN** an event with `eventType=SESSION_CREATED`, `user`, `sessionId`, and `timestamp` SHALL be published to the event bus

--- a/openspec/changes/kyuubi-spark-connect-grpc-server/tasks.md
+++ b/openspec/changes/kyuubi-spark-connect-grpc-server/tasks.md
@@ -1,0 +1,78 @@
+## 1. Module and Build Infrastructure
+
+- [ ] 1.1 Create `kyuubi-spark-connect/` Maven module with `pom.xml`; add `grpc-netty-shaded`, `protobuf-java`, and `spark-connect-common` (Spark 3.5) as dependencies scoped to `-Pspark-connect` profile
+- [ ] 1.2 Add `kyuubi-spark-connect` to the parent `pom.xml` module list under the `-Pspark-connect` profile and to `kyuubi-assembly` packaging
+- [ ] 1.3 Run `build/dependency.sh --replace` to update `dev/dependencyList`; verify no license-incompatible transitive deps are pulled in; update `LICENSE-binary` and `NOTICE` as needed
+- [ ] 1.4 Configure `grpc-netty-shaded` shading in `kyuubi-spark-connect` to avoid Netty classpath conflicts with the Thrift frontend; validate with `mvn dependency:tree`
+- [ ] 1.5 Add Spotless/Scalafmt config for generated proto sources (mark `target/generated-sources` as excluded from style checks)
+
+## 2. Protobuf and gRPC Stubs
+
+- [ ] 2.1 Import `SparkConnectService.proto` and dependent message protos from `spark-connect-common` (Spark 3.5 artifact) into `kyuubi-spark-connect/src/main/protobuf/`
+- [ ] 2.2 Configure `protobuf-maven-plugin` to generate Java stubs from proto files into `target/generated-sources/protobuf/java`
+- [ ] 2.3 Create `SparkConnectProtoShim` interface to abstract any Spark-version-specific proto field differences; add Spark 3.5 shim implementation
+- [ ] 2.4 Verify generated stubs compile cleanly with `build/mvn clean compile -pl kyuubi-spark-connect -Pspark-connect -DskipTests`
+
+## 3. Configuration Entries
+
+- [ ] 3.1 Add `KyuubiConf` entries for `kyuubi.frontend.spark.connect.enabled`, `bind.host`, `bind.port` (default 15002), `max.message.size`, `ssl.enabled`, `ssl.keystore.path`, `ssl.keystore.password` in `kyuubi-common`
+- [ ] 3.2 Add engine-channel config entries: `kyuubi.frontend.spark.connect.engine.channel.max.message.size`, `kyuubi.frontend.spark.connect.engine.channel.keepalive.time`
+- [ ] 3.3 Mark server-only entries with `.serverOnly` on the `ConfigEntry` builder so they are stripped before engine propagation
+- [ ] 3.4 Run `dev/gen/gen_all_config_docs.sh` and commit the regenerated `docs/configuration/settings.md` diff
+
+## 4. Session and Operation Types
+
+- [ ] 4.1 Create `SparkConnectSession` class extending Kyuubi's `AbstractSession`; keyed by `(user, sessionId)`; stores session-level config map from `Config` RPCs
+- [ ] 4.2 Create `SparkConnectOperation` class extending `AbstractOperation`; holds the engine-side gRPC call reference and last-acknowledged response index for `ReattachExecute`
+- [ ] 4.3 Extend `SessionManager.openSession` to accept a `SparkConnectSession` type and apply existing per-user engine limits and idle-timeout logic
+- [ ] 4.4 Define `SparkConnectSessionEvent` and wire it into Kyuubi's `EventBus` for session open/close events
+
+## 5. Engine Proxy
+
+- [ ] 5.1 Create `SparkConnectEngineProxy` class; implement engine gRPC channel creation using `ManagedChannelBuilder` with configurable max message size and keepalive
+- [ ] 5.2 Extend ZooKeeper-based `EngineRef` to store and retrieve `sparkConnectPort`; update `AbstractEngineRef.doRegister` to write this attribute when engine starts in `--spark-connect` mode
+- [ ] 5.3 Extend Kubernetes-based engine discovery to read `kyuubi.apache.org/spark-connect-port` label/annotation from engine pod and expose it via `EngineRef`
+- [ ] 5.4 Implement `ExecutePlan` forwarding: open server-streaming call to engine, pipe `ExecutePlanResponse` chunks back to client `StreamObserver`, propagate gRPC status and trailers
+- [ ] 5.5 Implement `AnalyzePlan`, `Config`, and `Interrupt` forwarding (unary RPCs — simpler than streaming)
+- [ ] 5.6 Implement `ReattachExecute` forwarding: look up tracked `SparkConnectOperation` in `OperationManager`, re-establish engine stream from last acknowledged index
+- [ ] 5.7 Implement engine channel close on session close; handle in-flight stream termination with `UNAVAILABLE` status to client
+- [ ] 5.8 Override `user_name` in forwarded `UserContext` with the server-authenticated Kyuubi user identity before forwarding any request to the engine
+
+## 6. Authentication Interceptor
+
+- [ ] 6.1 Create `SparkConnectAuthInterceptor` implementing `io.grpc.ServerInterceptor`; extract `Authorization: Bearer <token>` from gRPC metadata
+- [ ] 6.2 Validate the token via Kyuubi's `AuthenticationProvider` chain; attach resolved `KyuubiUser` to gRPC `Context`
+- [ ] 6.3 Return `UNAUTHENTICATED` for missing or invalid tokens; log failures at WARN level with client IP and timestamp
+- [ ] 6.4 Implement `NONE` auth bypass: when `kyuubi.authentication=NONE`, skip token validation and attribute to anonymous user (consistent with Thrift frontend)
+- [ ] 6.5 Add authorization check in `SparkConnectFrontendService` before forwarding `ExecutePlan` / `AnalyzePlan` to engine; return `PERMISSION_DENIED` on denial
+
+## 7. Frontend Service and Server
+
+- [ ] 7.1 Create `SparkConnectFrontendService` implementing `SparkConnectServiceGrpc.SparkConnectServiceImplBase`; route each RPC method to `SparkConnectSession` / `SparkConnectEngineProxy`
+- [ ] 7.2 Return `UNIMPLEMENTED` for `AddArtifacts` with message "AddArtifacts is not yet supported by Kyuubi Spark Connect frontend"
+- [ ] 7.3 Create `SparkConnectFrontend` class (mirrors `ThriftFrontendService` pattern) wrapping `io.grpc.Server`; implement `initialize(conf)`, `start()`, `stop()` lifecycle methods
+- [ ] 7.4 Configure TLS in `SparkConnectFrontend` when `kyuubi.frontend.spark.connect.ssl.enabled=true`; validate keystore path at startup and fail fast if missing
+- [ ] 7.5 Wire `SparkConnectFrontend` into `KyuubiServer.initialize` / `start` / `stop` behind the `kyuubi.frontend.spark.connect.enabled` guard
+
+## 8. Engine-Side Registration (Spark Engine Module)
+
+- [ ] 8.1 In `kyuubi-spark-sql-engine`, detect when `--spark-connect` mode is active and read the embedded gRPC server's bound port at engine startup
+- [ ] 8.2 Write `sparkConnectPort` to the engine's ZooKeeper `EngineRef` node alongside the existing Thrift URL attribute
+- [ ] 8.3 Add `kyuubi.apache.org/spark-connect-port` label to the engine pod spec in the Kubernetes engine launcher when `--spark-connect` mode is active
+
+## 9. Tests
+
+- [ ] 9.1 Unit test `SparkConnectAuthInterceptor`: valid token, missing token, invalid token, NONE-mode bypass
+- [ ] 9.2 Unit test `SparkConnectEngineProxy` port-discovery logic: ZooKeeper node with `sparkConnectPort`, node without `sparkConnectPort` (expect error)
+- [ ] 9.3 Unit test `SparkConnectSession` lifecycle: create, reuse by sessionId, user isolation (same sessionId, different users = different sessions), idle-timeout close
+- [ ] 9.4 Integration test `SparkConnectFrontendSuite`: start Kyuubi with a mock engine gRPC server; send `ExecutePlan`, `AnalyzePlan`, `Config`, `Interrupt` requests and verify forwarding
+- [ ] 9.5 Integration test: `AddArtifacts` returns `UNIMPLEMENTED`
+- [ ] 9.6 Integration test: TLS handshake success and plaintext rejection when TLS is enabled
+- [ ] 9.7 Integration test: `user_name` in forwarded `UserContext` is overridden with server-authenticated user
+
+## 10. Documentation and Release Prep
+
+- [ ] 10.1 Add user-facing documentation page `docs/connector/spark/spark_connect.md` covering: feature overview, prerequisites (Spark 3.5+), configuration keys, PySpark client example (`spark.remote("sc://...")`), known limitations (no `AddArtifacts`)
+- [ ] 10.2 Update `docs/deployment/kyuubi_on_kubernetes.md` and `docs/deployment/on_yarn.md` to note Spark Connect port exposure requirements
+- [ ] 10.3 Run `dev/reformat` and confirm CI style checks pass before opening PR
+- [ ] 10.4 Fill PR template: link GitHub issue, describe motivation, list test commands, note "Assisted-by: Claude:claude-sonnet-4-6" in the generative AI field

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours


### PR DESCRIPTION
## Why are the changes needed?

Apache Spark 3.4 introduced Spark Connect — a gRPC-based client-server protocol using Protocol Buffers that decouples clients from the Spark driver. PySpark users can now connect via `spark.remote("sc://host:port/")` instead of embedding a local SparkSession. Currently Kyuubi has no gRPC listener and cannot accept Spark Connect clients, meaning PySpark thin clients and any non-JVM Spark Connect clients (Go, Rust) cannot benefit from Kyuubi's multi-tenancy, session pooling, and access control.

This PR adds planning artifacts (proposal, design, specs, tasks) for implementing Spark Connect support in Kyuubi as a multi-tenant gRPC proxy gateway.

## Architecture

```mermaid
flowchart TD
    subgraph Clients
        A1["PySpark\nspark.remote('sc://...')"]
        A2["Go / Rust\nSpark Connect client"]
    end

    subgraph KyuubiServer ["Kyuubi Server (kyuubi-spark-connect module)"]
        B["NettyGrpcServer\n:15002"]
        C["AuthInterceptor\n(Bearer token → KyuubiUser)"]
        D["SparkConnectFrontendService\n(SparkConnectServiceGrpc)"]
        E["SparkConnectSessionManager\n(session lifecycle, user isolation)"]
        F["SparkConnectEngineProxy\n(gRPC channel to engine)"]
        G["ServiceDiscovery\n(ZooKeeper / Kubernetes)"]
    end

    subgraph EngineAlice ["Spark Engine – user alice"]
        H1["SparkConnect gRPC\n(embedded, auto-port)"]
        H2["SparkSession"]
    end

    subgraph EngineBob ["Spark Engine – user bob"]
        I1["SparkConnect gRPC\n(embedded, auto-port)"]
        I2["SparkSession"]
    end

    A1 -- "gRPC (Spark Connect proto)" --> B
    A2 -- "gRPC (Spark Connect proto)" --> B
    B --> C
    C -- "KyuubiUser" --> D
    D --> E
    E -- "open / reuse session" --> F
    F -- "discover sparkConnectPort" --> G
    F -- "proxy protobuf stream\n(alice)" --> H1
    F -- "proxy protobuf stream\n(bob)" --> I1
    H1 --- H2
    I1 --- I2
```

## What Changes

This is a **planning/proposal PR** containing `openspec/` artifacts only — no production code is changed. The design proposes:

- A new profile-gated Maven module `kyuubi-spark-connect` exposing a `SparkConnectService` gRPC endpoint (default port 15002).
- **Proxy architecture**: Kyuubi authenticates clients and routes Spark Connect protobuf streams to a Spark engine running in `--spark-connect` mode. Kyuubi does NOT embed a SparkSession (preserving the server/engine module boundary).
- Session lifecycle mapped onto Kyuubi's existing `SessionManager`; per-user engine limits and idle timeouts apply unchanged.
- Engine gRPC port discovered via ZooKeeper node attribute or Kubernetes pod label.
- Bearer-token auth via existing `AuthenticationProvider` chain; user identity overrides client-supplied `UserContext.user_name`.
- Feature off by default (`kyuubi.frontend.spark.connect.enabled=false`); additive and non-breaking.

### Artifacts included
| File | Description |
|---|---|
| `openspec/changes/kyuubi-spark-connect-grpc-server/proposal.md` | Motivation, capability list, impact |
| `openspec/changes/kyuubi-spark-connect-grpc-server/design.md` | Architecture, key decisions, risks, open questions |
| `openspec/changes/kyuubi-spark-connect-grpc-server/specs/spark-connect-frontend/spec.md` | gRPC server lifecycle, RPC surface, TLS, config keys |
| `openspec/changes/kyuubi-spark-connect-grpc-server/specs/spark-connect-session/spec.md` | Session lifecycle, user isolation, event logging |
| `openspec/changes/kyuubi-spark-connect-grpc-server/specs/spark-connect-engine-proxy/spec.md` | Port discovery, transparent forwarding, failure handling |
| `openspec/changes/kyuubi-spark-connect-grpc-server/specs/spark-connect-auth/spec.md` | Auth interceptor, identity propagation, authz checks |
| `openspec/changes/kyuubi-spark-connect-grpc-server/tasks.md` | 37 implementation tasks across 10 groups |

## How was this patch tested?

This PR contains planning artifacts only; no code to test. Implementation PRs will include unit and integration tests per `tasks.md` section 9.

## Was this patch authored or co-authored using generative AI tooling?

Assisted-by: Claude:claude-sonnet-4-6