### PR TITLE
Remove broken status badges from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,12 +130,6 @@ Ready? [Getting Started](https://kyuubi.readthedocs.io/en/master/quick_start/) w
     <img src="https://img.shields.io/github/actions/workflow/status/apache/kyuubi/master.yml?style=plastic">
   </a>
   <img src="https://img.shields.io/github/languages/top/apache/kyuubi?style=plastic">
-  <a href="https://github.com/apache/kyuubi/pulse">
-    <img src="https://img.shields.io/tokei/lines/github/apache/kyuubi?style=plastic" />
-  </a>
-</p>
-<p align="center">
-  <img src="https://contributor-graph-api.apiseven.com/contributors-svg?chart=contributorOverTime&repo=apache/kyuubi" />
 </p>
 
 ## Aside


### PR DESCRIPTION
### Why are the changes needed?
The changes are needed to keep README correct and clean from broken links:
- `tokei` was [deprecated](https://github.com/badges/shields/pull/9581) and added to [retiring-badges](https://github.com/badges/shields/blob/35221ad0c76d93b14b3f4005ea5da98ebdd6598d/doc/retiring-badges.md?plain=1#L135).
- [`contributor-graph`](https://github.com/api7/contributor-graph) stopped working and has not received updates for a long time.

<img width="979" height="403" alt="image" src="https://github.com/user-attachments/assets/645566e4-443c-4560-9f3b-ca93b8ea6be0" />


### How was this patch tested?
Tested in the [fork branch](https://github.com/dnskr/kyuubi/tree/remove-broken-status-badges#project--community-status).
<img width="940" height="359" alt="image" src="https://github.com/user-attachments/assets/22d4d7a3-402b-42bc-8777-2edb680ab57d" />


### Was this patch authored or co-authored using generative AI tooling?
No
