### PR TITLE
[KYUUBI #7515] Handle Spark variant type in metadata

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/schema/SchemaHelper.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/schema/SchemaHelper.scala
@@ -32,6 +32,11 @@ object SchemaHelper {
    */
   final val TIMESTAMP_NTZ = "TimestampNTZType$"
 
+  /**
+   * Spark 4.0.0 DataType VariantType's class name.
+   */
+  final val VARIANT = "VariantType$"
+
   def toTTypeId(typ: DataType): TTypeId = typ match {
     case NullType => TTypeId.NULL_TYPE
     case BooleanType => TTypeId.BOOLEAN_TYPE
@@ -46,6 +51,7 @@ object SchemaHelper {
     case DateType => TTypeId.DATE_TYPE
     case TimestampType => TTypeId.TIMESTAMP_TYPE
     case ntz if ntz.getClass.getSimpleName.equals(TIMESTAMP_NTZ) => TTypeId.TIMESTAMP_TYPE
+    case variant if variant.getClass.getSimpleName.equals(VARIANT) => TTypeId.STRING_TYPE
     case BinaryType => TTypeId.BINARY_TYPE
     case CalendarIntervalType => TTypeId.STRING_TYPE
     case _: DayTimeIntervalType => TTypeId.INTERVAL_DAY_TIME_TYPE
@@ -112,6 +118,7 @@ object SchemaHelper {
     case DateType => java.sql.Types.DATE
     case TimestampType => java.sql.Types.TIMESTAMP
     case ntz if ntz.getClass.getSimpleName.equals(TIMESTAMP_NTZ) => java.sql.Types.TIMESTAMP
+    case variant if variant.getClass.getSimpleName.equals(VARIANT) => java.sql.Types.OTHER
     case BinaryType => java.sql.Types.BINARY
     case _: ArrayType => java.sql.Types.ARRAY
     case _: MapType => java.sql.Types.JAVA_OBJECT

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/SparkOperationSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/SparkOperationSuite.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.types._
 
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.engine.spark.WithSparkSQLEngine
-import org.apache.kyuubi.engine.spark.schema.SchemaHelper.TIMESTAMP_NTZ
+import org.apache.kyuubi.engine.spark.schema.SchemaHelper.{TIMESTAMP_NTZ, VARIANT}
 import org.apache.kyuubi.engine.spark.util.SparkCatalogUtils
 import org.apache.kyuubi.jdbc.hive.KyuubiStatement
 import org.apache.kyuubi.operation.{HiveMetadataTests, SparkQueryTests}
@@ -97,6 +97,9 @@ class SparkOperationSuite extends WithSparkSQLEngine with HiveMetadataTests with
     if (SPARK_ENGINE_RUNTIME_VERSION >= "3.4") {
       schema = schema.add("c20", "timestamp_ntz", nullable = true, "20")
     }
+    if (SPARK_ENGINE_RUNTIME_VERSION >= "4.0") {
+      schema = schema.add("c21", "variant", nullable = true, "21")
+    }
 
     val ddl =
       s"""
@@ -135,7 +138,8 @@ class SparkOperationSuite extends WithSparkSQLEngine with HiveMetadataTests with
           STRUCT,
           OTHER,
           OTHER,
-          TIMESTAMP)
+          TIMESTAMP,
+          OTHER)
 
         var pos = 0
 
@@ -150,6 +154,8 @@ class SparkOperationSuite extends WithSparkSQLEngine with HiveMetadataTests with
           val colSize = rowSet.getInt(COLUMN_SIZE)
           schema(pos).dataType match {
             case StringType | BinaryType | _: ArrayType | _: MapType => assert(colSize === 0)
+            case variant if variant.getClass.getSimpleName.equals(VARIANT) =>
+              assert(colSize === 0)
             case d: DecimalType => assert(colSize === d.precision)
             case StructType(fields) if fields.length == 1 => assert(colSize === 0)
             case o => assert(colSize === o.defaultSize)
@@ -187,6 +193,61 @@ class SparkOperationSuite extends WithSparkSQLEngine with HiveMetadataTests with
 
       val rowSet = metaData.getColumns(null, "*", "not_exist", "not_exist")
       assert(!rowSet.next())
+    }
+  }
+
+  test("get result set metadata with variant column") {
+    assume(SPARK_ENGINE_RUNTIME_VERSION >= "4.0")
+
+    withSessionHandle { (client, handle) =>
+      def executeStatement(statement: String): TOperationHandle = {
+        val req = new TExecuteStatementReq()
+        req.setSessionHandle(handle)
+        req.setStatement(statement)
+        val resp = client.ExecuteStatement(req)
+        assert(resp.getStatus.getStatusCode === TStatusCode.SUCCESS_STATUS)
+        val opHandle = resp.getOperationHandle
+        waitForOperationToComplete(client, opHandle)
+        val statusResp = client.GetOperationStatus(new TGetOperationStatusReq(opHandle))
+        assert(statusResp.getStatus.getStatusCode === TStatusCode.SUCCESS_STATUS)
+        assert(statusResp.getOperationState === TOperationState.FINISHED_STATE)
+        opHandle
+      }
+
+      def assertVariantMetadata(opHandle: TOperationHandle): Unit = {
+        val tGetResultSetMetadataResp = client.GetResultSetMetadata(
+          new TGetResultSetMetadataReq(opHandle))
+        assert(tGetResultSetMetadataResp.getStatus.getStatusCode === TStatusCode.SUCCESS_STATUS)
+        val columns = tGetResultSetMetadataResp.getSchema.getColumns
+        assert(columns.size() === 1)
+        assert(columns.get(0).getColumnName === "v")
+        assert(columns.get(0).getTypeDesc.getTypes.get(0).getPrimitiveEntry.getType ===
+          TTypeId.STRING_TYPE)
+      }
+
+      val directQuery = executeStatement("""SELECT parse_json('{"a":1}') AS v""")
+      assertVariantMetadata(directQuery)
+      val tFetchDirectResultsResp = client.FetchResults(
+        new TFetchResultsReq(directQuery, TFetchOrientation.FETCH_NEXT, 1))
+      assert(tFetchDirectResultsResp.getStatus.getStatusCode === TStatusCode.SUCCESS_STATUS)
+      val directValues = tFetchDirectResultsResp.getResults.getColumns.get(0).getStringVal.getValues
+      assert(directValues.asScala.nonEmpty)
+
+      val tableName = "spark_variant_result_metadata"
+      executeStatement(s"DROP TABLE IF EXISTS $tableName")
+      try {
+        executeStatement(s"CREATE TABLE $tableName (v VARIANT) USING parquet")
+        executeStatement(s"""INSERT INTO $tableName SELECT parse_json('{"a":1}')""")
+        val tableQuery = executeStatement(s"SELECT * FROM $tableName")
+        assertVariantMetadata(tableQuery)
+        val tFetchTableResultsResp = client.FetchResults(
+          new TFetchResultsReq(tableQuery, TFetchOrientation.FETCH_NEXT, 1))
+        assert(tFetchTableResultsResp.getStatus.getStatusCode === TStatusCode.SUCCESS_STATUS)
+        val tableValues = tFetchTableResultsResp.getResults.getColumns.get(0).getStringVal.getValues
+        assert(tableValues.asScala.nonEmpty)
+      } finally {
+        executeStatement(s"DROP TABLE IF EXISTS $tableName")
+      }
     }
   }
 

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/schema/SchemaHelperSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/schema/SchemaHelperSuite.scala
@@ -29,6 +29,12 @@ import org.apache.kyuubi.shaded.hive.service.rpc.thrift.{TCLIServiceConstants, T
 
 class SchemaHelperSuite extends KyuubiFunSuite {
 
+  private object VariantType extends DataType {
+    override def defaultSize: Int = 2048
+    override def asNullable: DataType = this
+    override def typeName: String = "variant"
+  }
+
   val innerSchema: StructType = new StructType()
     .add("a", StringType, nullable = true, "")
     .add("b", IntegerType, nullable = true, "")
@@ -70,10 +76,15 @@ class SchemaHelperSuite extends KyuubiFunSuite {
     assert(toTTypeId(outerSchema(14).dataType) === TTypeId.MAP_TYPE)
     assert(toTTypeId(outerSchema(15).dataType) === TTypeId.STRUCT_TYPE)
     assert(toTTypeId(outerSchema(16).dataType) === TTypeId.STRING_TYPE)
+    assert(toTTypeId(VariantType) === TTypeId.STRING_TYPE)
     val e1 = intercept[IllegalArgumentException](toTTypeId(CharType(1)))
     assert(e1.getMessage === "Unrecognized type name: char(1)")
     val e2 = intercept[IllegalArgumentException](toTTypeId(VarcharType(1)))
     assert(e2.getMessage === "Unrecognized type name: varchar(1)")
+  }
+
+  test("toJavaSQLType") {
+    assert(toJavaSQLType(VariantType) === java.sql.Types.OTHER)
   }
 
   test("toTTypeQualifiers") {


### PR DESCRIPTION
### Why are the changes needed?

Fixes #7515.

Spark 4 introduced `VariantType`. Kyuubi's Spark schema conversion did not handle it when building HiveServer2 result-set metadata, so `GetResultSetMetadata` could fail with `Unrecognized type name: variant` even when the query itself completed.

This patch maps Spark `VariantType` to the existing HiveServer2 `STRING_TYPE` representation for query result-set metadata, and reports `java.sql.Types.OTHER` for `DatabaseMetaData.getColumns` `DATA_TYPE`.

### How was this patch tested?

- Added `SchemaHelperSuite` coverage for `VariantType` mapping to `TTypeId.STRING_TYPE` and `java.sql.Types.OTHER`.
- Added Spark 4 regression coverage for `SELECT parse_json('{"a":1}') AS v` result-set metadata.
- Added Spark 4 regression coverage for `SELECT *` from a dummy table with a `VARIANT` column populated via `parse_json`.
- Added Spark `getColumns` coverage for reporting `VARIANT` as `java.sql.Types.OTHER`.
- `dev/reformat`
- `env JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home PATH=/opt/homebrew/opt/openjdk@17/bin:$PATH ./build/mvn test -pl externals/kyuubi-spark-sql-engine -Dtest=none -DwildcardSuites=org.apache.kyuubi.engine.spark.schema.SchemaHelperSuite -Pspark-4.1 -Pscala-2.13`
- `env JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home PATH=/opt/homebrew/opt/openjdk@17/bin:$PATH ./build/mvn test -pl externals/kyuubi-spark-sql-engine -Dtest=none -Dsuites=org.apache.kyuubi.engine.spark.operation.SparkOperationSuite -Pspark-4.1 -Pscala-2.13`

### Was this patch authored or co-authored using generative AI tooling?

Assisted-by: OpenAI Codex
