### PR TITLE
[KYUUBI #7433][SPARK] Preserve Hive delegation tokens with non-empty service

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkTBinaryFrontendService.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkTBinaryFrontendService.scala
@@ -139,6 +139,31 @@ object SparkTBinaryFrontendService extends Logging {
       oldCreds: Credentials,
       updateCreds: Credentials): Unit = {
     val metastoreUris = hiveConf(sc.hadoopConfiguration).getTrimmed("hive.metastore.uris", "")
+    mergeHiveTokens(metastoreUris, newTokens, oldCreds, updateCreds)
+  }
+
+  private[spark] def mergeHiveTokens(
+      metastoreUris: String,
+      newTokens: Map[Text, Token[_ <: TokenIdentifier]],
+      oldCreds: Credentials,
+      updateCreds: Credentials): Unit = {
+    // A Hive delegation token whose service field is non-empty is bound to a specific metastore
+    // via `hive.metastore.token.signature`, which is stored in the token service. When an engine
+    // accesses several metastores with different Kerberos principals, each metastore yields one
+    // such token. The single-metastore matching below only keeps the token whose service is empty,
+    // so these signature-bound tokens were silently dropped and never reached the engine UGI. Add
+    // them keyed by their alias so they survive.
+    val (signatureBoundTokens, defaultServiceTokens) = newTokens.partition {
+      case (_, token) => token.getService != new Text()
+    }
+    signatureBoundTokens.foreach { case (alias, token) =>
+      val oldToken = oldCreds.getToken(alias)
+      if (oldToken == null || KyuubiHadoopUtils.compareIssueDate(token, oldToken) > 0) {
+        updateCreds.addToken(alias, token)
+      } else {
+        warn(s"Ignore Hive token with earlier issue date: $token")
+      }
+    }
 
     // `HiveMetaStoreClient` selects the first token whose service is "" and kind is
     // "HIVE_DELEGATION_TOKEN" to authenticate.
@@ -148,11 +173,11 @@ object SparkTBinaryFrontendService extends Logging {
       }
 
     if (metastoreUris.nonEmpty && oldAliasAndToken.isDefined) {
-      // Each entry of `newTokens` is a <uris, token> pair for a metastore cluster.
+      // Each entry of `defaultServiceTokens` is a <uris, token> pair for a metastore cluster.
       // If entry's uris and engine's metastore uris have at least 1 same uri, we presume they
       // represent the same metastore cluster.
       val uriSet = metastoreUris.split(",").filter(_.nonEmpty).toSet
-      val newToken = newTokens
+      val newToken = defaultServiceTokens
         .find { case (uris, token) =>
           val matched = uris.toString.split(",").exists(uriSet.contains) &&
             token.getService == new Text()
@@ -169,7 +194,7 @@ object SparkTBinaryFrontendService extends Logging {
           warn(s"Ignore Hive token with earlier issue date: $token")
         }
       }
-      if (newToken.isEmpty) {
+      if (newToken.isEmpty && defaultServiceTokens.nonEmpty) {
         warn(s"No matching Hive token found for engine metastore uris $metastoreUris")
       }
     } else if (metastoreUris.isEmpty) {

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/SparkTBinaryFrontendServiceSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/SparkTBinaryFrontendServiceSuite.scala
@@ -17,7 +17,13 @@
 
 package org.apache.kyuubi.engine.spark
 
+import scala.util.Random
+
 import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.hive.thrift.{DelegationTokenIdentifier => HiveTokenIdent}
+import org.apache.hadoop.io.Text
+import org.apache.hadoop.security.Credentials
+import org.apache.hadoop.security.token.{Token, TokenIdentifier}
 
 import org.apache.kyuubi.KyuubiFunSuite
 
@@ -25,5 +31,109 @@ class SparkTBinaryFrontendServiceSuite extends KyuubiFunSuite {
   test("new hive conf") {
     val hiveConf = SparkTBinaryFrontendService.hiveConf(new Configuration())
     assert(hiveConf.getClass().getName == SparkTBinaryFrontendService.HIVE_CONF_CLASSNAME)
+  }
+
+  test("merge Hive tokens preserves signature-bound tokens for multiple metastores") {
+    val newTokens = Map(
+      new Text("hms_a") -> newHiveToken(issueDate = 1000, service = "hms_a"),
+      new Text("hms_b") -> newHiveToken(issueDate = 1000, service = "hms_b"))
+    val updateCreds = new Credentials()
+
+    SparkTBinaryFrontendService.mergeHiveTokens(
+      metastoreUris = "",
+      newTokens = newTokens,
+      oldCreds = new Credentials(),
+      updateCreds = updateCreds)
+
+    assert(updateCreds.numberOfTokens() == 2)
+    assert(updateCreds.getToken(new Text("hms_a")) != null)
+    assert(updateCreds.getToken(new Text("hms_b")) != null)
+  }
+
+  test("merge Hive tokens ignores signature-bound token with earlier issue date") {
+    val alias = new Text("hms_a")
+    val oldCreds = new Credentials()
+    oldCreds.addToken(alias, newHiveToken(issueDate = 2000, service = "hms_a"))
+    val newTokens = Map(alias -> newHiveToken(issueDate = 1000, service = "hms_a"))
+    val updateCreds = new Credentials()
+
+    SparkTBinaryFrontendService.mergeHiveTokens(
+      metastoreUris = "",
+      newTokens = newTokens,
+      oldCreds = oldCreds,
+      updateCreds = updateCreds)
+
+    assert(updateCreds.getToken(alias) == null)
+  }
+
+  test("merge Hive tokens updates signature-bound token with later issue date") {
+    val alias = new Text("hms_a")
+    val oldCreds = new Credentials()
+    oldCreds.addToken(alias, newHiveToken(issueDate = 1000, service = "hms_a"))
+    val newToken = newHiveToken(issueDate = 2000, service = "hms_a")
+    val updateCreds = new Credentials()
+
+    SparkTBinaryFrontendService.mergeHiveTokens(
+      metastoreUris = "",
+      newTokens = Map(alias -> newToken),
+      oldCreds = oldCreds,
+      updateCreds = updateCreds)
+
+    assert(updateCreds.getToken(alias) === newToken)
+  }
+
+  test("merge Hive tokens keeps single-metastore matching for default-service tokens") {
+    val metastoreUris = "thrift://hms:9083"
+    val defaultAlias = new Text("hive_default")
+    val oldCreds = new Credentials()
+    oldCreds.addToken(defaultAlias, newHiveToken(issueDate = 1000, service = ""))
+    // The map key is the metastore uris the token was issued for.
+    val newToken = newHiveToken(issueDate = 2000, service = "")
+    val updateCreds = new Credentials()
+
+    SparkTBinaryFrontendService.mergeHiveTokens(
+      metastoreUris = metastoreUris,
+      newTokens = Map(new Text(metastoreUris) -> newToken),
+      oldCreds = oldCreds,
+      updateCreds = updateCreds)
+
+    assert(updateCreds.getToken(defaultAlias) === newToken)
+  }
+
+  test("merge Hive tokens adds signature-bound tokens without touching the default path") {
+    val metastoreUris = "thrift://hms:9083"
+    val defaultAlias = new Text("hive_default")
+    val oldCreds = new Credentials()
+    oldCreds.addToken(defaultAlias, newHiveToken(issueDate = 1000, service = ""))
+    // Only signature-bound tokens arrive, so the default-service matching produces nothing.
+    val signatureAlias = new Text("hms_a")
+    val newTokens = Map(signatureAlias -> newHiveToken(issueDate = 2000, service = "hms_a"))
+    val updateCreds = new Credentials()
+
+    SparkTBinaryFrontendService.mergeHiveTokens(
+      metastoreUris = metastoreUris,
+      newTokens = newTokens,
+      oldCreds = oldCreds,
+      updateCreds = updateCreds)
+
+    assert(updateCreds.numberOfTokens() == 1)
+    assert(updateCreds.getToken(signatureAlias) != null)
+    assert(updateCreds.getToken(defaultAlias) == null)
+  }
+
+  private def newHiveToken(issueDate: Long, service: String): Token[TokenIdentifier] = {
+    val who = new Text("who")
+    val tokenId = new HiveTokenIdent(who, who, who)
+    tokenId.setIssueDate(issueDate)
+    val token = new Token[TokenIdentifier]
+    token.setID(tokenId.getBytes)
+    token.setKind(tokenId.getKind)
+    val password = new Array[Byte](128)
+    Random.nextBytes(password)
+    token.setPassword(password)
+    if (service.nonEmpty) {
+      token.setService(new Text(service))
+    }
+    token
   }
 }


### PR DESCRIPTION
### Why are the changes needed?

Closes #7433.

`SparkTBinaryFrontendService#addHiveToken` keeps only the Hive delegation token whose `service` field is empty (the one `HiveMetaStoreClient` selects by default) and silently drops every Hive token whose `service` is non-empty.

A Hive delegation token gets a non-empty `service` when it is bound to a specific metastore via `hive.metastore.token.signature` (the signature is stored in the token service). When an engine talks to multiple Hive metastores that use different Kerberos principals — e.g. two Iceberg catalogs, each backed by its own HMS — each metastore produces its own signature-bound token. Because these tokens are dropped before reaching the engine UGI, the engine fails to authenticate against the non-default metastore with `DIGEST-MD5: IO error acquiring password`.

This is the engine-side counterpart of #1091 (renewing delegation tokens for multiple Hive metastore clusters): even when the server pushes per-metastore tokens, the engine drops them.

Affected versions: 1.11.1.

This change partitions the incoming Hive tokens by their `service` field:

- Tokens with a non-empty `service` are added to the engine credentials keyed by their alias, reusing the same issue-date downgrade guard the default path already applies.
- The existing single-metastore URI matching now runs only over the default (empty-`service`) tokens, so behavior for the common single-HMS case is unchanged.
- The `No matching Hive token found ...` warning is emitted only when a default-`service` token was actually expected, to avoid noise in metastore deployments that rely solely on signature-bound tokens.

### How was this patch tested?

Added unit tests in `SparkTBinaryFrontendServiceSuite` (the token-merging logic was extracted into `mergeHiveTokens` so it can be exercised without a `SparkContext`):

- signature-bound tokens for multiple metastores are preserved, keyed by alias;
- a signature-bound token with an earlier issue date is ignored, and a later one replaces the existing token;
- the existing single-metastore matching for default-`service` tokens is unchanged;
- signature-bound tokens are added without disturbing the default-`service` path.

```
build/mvn test -pl externals/kyuubi-spark-sql-engine -am \
  -Dtest=none \
  -DwildcardSuites=org.apache.kyuubi.engine.spark.SparkTBinaryFrontendServiceSuite
```

### Was this patch authored or co-authored using generative AI tooling?

Assisted-by: Claude:claude-opus-4-8
