### PR TITLE
[KYUUBI #7435][SERVER] Honor server-level kyuubi.server.info.provider in getInfo

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -3077,7 +3077,6 @@ object KyuubiConf {
 
   val SERVER_INFO_PROVIDER: ConfigEntry[String] =
     buildConf("kyuubi.server.info.provider")
-      .serverOnly
       .doc("The server information provider name, some clients may rely on this information" +
         " to check the server compatibilities and functionalities." +
         " <li>SERVER: Return Kyuubi server information.</li>" +

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiServerInfoProviderSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiServerInfoProviderSuite.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.operation
+
+import org.apache.kyuubi.WithKyuubiServer
+import org.apache.kyuubi.config.KyuubiConf
+import org.apache.kyuubi.shaded.hive.service.rpc.thrift.{TGetInfoReq, TGetInfoType}
+
+class KyuubiServerInfoProviderSuite extends WithKyuubiServer with HiveJDBCTestHelper {
+
+  override protected def jdbcUrl: String = getJdbcUrl
+
+  // `kyuubi.server.info.provider` is set only at the server level, mimicking a
+  // kyuubi-defaults.conf entry, so the test exercises the serverOnly fallback path.
+  override protected val conf: KyuubiConf =
+    KyuubiConf().set(KyuubiConf.SERVER_INFO_PROVIDER, "SERVER")
+
+  test("KYUUBI #7435: honor server-level kyuubi.server.info.provider in getInfo") {
+    withSessionHandle { (client, handle) =>
+      val req = new TGetInfoReq()
+      req.setSessionHandle(handle)
+      req.setInfoType(TGetInfoType.CLI_DBMS_NAME)
+      // Without the fix the serverOnly value is stripped from the session conf and getInfo
+      // falls back to ENGINE, which would return the engine name ("Spark SQL") instead.
+      assert(client.GetInfo(req).getInfoValue.getStringValue === "Apache Kyuubi")
+    }
+  }
+}


### PR DESCRIPTION
### Why are the changes needed?

Closes #7435.

`kyuubi.server.info.provider` was declared `.serverOnly`, so `KyuubiConf#getUserDefaults` stripped it from the per-session conf that `KyuubiSessionManager#openSession` builds. As a result `KyuubiSessionImpl#getInfo` read it through `sessionConf.get(SERVER_INFO_PROVIDER)`, which never saw the server-level value and always returned the hard-coded default `ENGINE`. Setting `kyuubi.server.info.provider=SERVER` in `kyuubi-defaults.conf` was therefore silently ignored, and every `GetInfo` request waited for the engine to launch and forwarded to it instead of being answered by the server directly.

`SERVER_INFO_PROVIDER` is only read on the server frontend (`KyuubiSessionImpl#getInfo`); the engine never reads it. Dropping the `serverOnly` flag lets the server-level value flow into the session conf so `getInfo` honors it, while an explicit per-session value still wins as before.

Affected versions: 1.11.1.

### How was this patch tested?

Added `KyuubiServerInfoProviderSuite`, which boots a server with `kyuubi.server.info.provider=SERVER` set only at the server level (no per-session override) and asserts `GetInfo(CLI_DBMS_NAME)` returns `Apache Kyuubi`. Before the fix it returns the engine name (`Spark SQL`).

```
build/mvn test -pl kyuubi-server -am \
  -Dtest=none \
  -DwildcardSuites=org.apache.kyuubi.operation.KyuubiServerInfoProviderSuite
```

### Was this patch authored or co-authored using generative AI tooling?

Assisted-by: Claude:claude-opus-4-8
