### PR TITLE
[JDBC] Respect interrupt while waiting for engine launch

### DIFF
--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
@@ -79,6 +79,7 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
   public static final Logger LOG = LoggerFactory.getLogger(KyuubiConnection.class.getName());
   public static final String BEELINE_MODE_PROPERTY = "BEELINE_MODE";
   public static final String HS2_PROXY_USER = "hive.server2.proxy.user";
+  private static final String SQL_STATE_LAUNCH_ENGINE_CANCELED = "01000";
   public static int DEFAULT_ENGINE_LOG_THREAD_TIMEOUT = 10 * 1000;
 
   private String jdbcUriString;
@@ -207,6 +208,16 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
         } catch (Exception ex) {
           // Swallow the exception
           LOG.debug("Error while closing the connection", ex);
+        }
+        if (isInterrupted(e)) {
+          // KyuubiInterruptedException is the public JDBC signal for this path. Clear the
+          // thread flag so callers do not observe both an exception and an interrupted thread.
+          // When this exception reaches the caller, the current thread is not interrupted.
+          Thread.interrupted();
+          if (e instanceof KyuubiInterruptedException) {
+            throw (SQLException) e;
+          }
+          throw newLaunchEngineInterruptedException(e);
         }
         if (ZooKeeperHiveClientHelper.isZkDynamicDiscoveryMode(sessConfMap)) {
           errMsg = "Could not open client transport for any of the Server URI's in ZooKeeper: ";
@@ -1140,15 +1151,23 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
   }
 
   private void closeOnLaunchEngineFailure() throws SQLException {
-    if (engineLogThread != null && engineLogThread.isAlive()) {
-      engineLogThread.interrupt();
-      try {
-        engineLogThread.join(DEFAULT_ENGINE_LOG_THREAD_TIMEOUT);
-      } catch (Exception ignore) {
+    boolean interrupted = Thread.currentThread().isInterrupted();
+    try {
+      if (engineLogThread != null && engineLogThread.isAlive()) {
+        engineLogThread.interrupt();
+        try {
+          engineLogThread.join(DEFAULT_ENGINE_LOG_THREAD_TIMEOUT);
+        } catch (InterruptedException e) {
+          interrupted = true;
+        }
+      }
+      engineLogThread = null;
+      close();
+    } finally {
+      if (interrupted) {
+        Thread.currentThread().interrupt();
       }
     }
-    engineLogThread = null;
-    close();
   }
 
   /**
@@ -1469,6 +1488,7 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
     // Poll on the operation status, till the operation is complete
     while (!launchEngineOpCompleted) {
       try {
+        checkInterruptedWhileLaunchingEngine();
         TGetOperationStatusResp statusResp = client.GetOperationStatus(statusReq);
         Utils.verifySuccessWithInfo(statusResp.getStatus());
         if (statusResp.isSetOperationState()) {
@@ -1499,15 +1519,61 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
           }
         }
       } catch (Exception e) {
+        Exception exceptionToThrow = e;
+        if (isInterrupted(e)) {
+          // KyuubiInterruptedException is the public JDBC signal for this path. Clear the
+          // thread flag so callers do not observe both an exception and an interrupted thread.
+          // When this exception reaches the caller, the current thread is not interrupted.
+          Thread.interrupted();
+          if (!(e instanceof KyuubiInterruptedException)) {
+            exceptionToThrow = newLaunchEngineInterruptedException(e);
+          }
+        }
         engineLogInflight = false;
-        closeOnLaunchEngineFailure();
-        if (e instanceof SQLException) {
-          throw (SQLException) e;
+        try {
+          closeOnLaunchEngineFailure();
+        } catch (SQLException closeException) {
+          exceptionToThrow.addSuppressed(closeException);
+        }
+        if (exceptionToThrow instanceof KyuubiInterruptedException) {
+          // Cleanup can also observe an interrupt while joining the engine log thread. Keep the
+          // launch cancellation contract simple: KyuubiInterruptedException is the signal, and the
+          // thread is not interrupted when the caller receives it.
+          Thread.interrupted();
+        }
+        if (exceptionToThrow instanceof SQLException) {
+          throw (SQLException) exceptionToThrow;
         } else {
-          throw new KyuubiSQLException(e.getMessage(), "08S01", e);
+          throw new KyuubiSQLException(exceptionToThrow.getMessage(), "08S01", exceptionToThrow);
         }
       }
     }
+  }
+
+  private void checkInterruptedWhileLaunchingEngine() throws SQLException {
+    if (Thread.currentThread().isInterrupted()) {
+      // The interrupt is converted into a typed JDBC exception, so consume the flag here. The
+      // caller receives KyuubiInterruptedException while the current thread is not interrupted.
+      Thread.interrupted();
+      throw newLaunchEngineInterruptedException(
+          new InterruptedException("Interrupted while waiting for launch engine"));
+    }
+  }
+
+  private static KyuubiInterruptedException newLaunchEngineInterruptedException(Throwable cause) {
+    return new KyuubiInterruptedException(
+        "Interrupted while waiting for launch engine", SQL_STATE_LAUNCH_ENGINE_CANCELED, cause);
+  }
+
+  private static boolean isInterrupted(Throwable throwable) {
+    Throwable cause = throwable;
+    while (cause != null) {
+      if (cause instanceof InterruptedException) {
+        return true;
+      }
+      cause = cause.getCause();
+    }
+    return false;
   }
 
   private void fetchLaunchEngineResult() {

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
@@ -80,7 +80,8 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
   public static final Logger LOG = LoggerFactory.getLogger(KyuubiConnection.class.getName());
   public static final String BEELINE_MODE_PROPERTY = "BEELINE_MODE";
   public static final String HS2_PROXY_USER = "hive.server2.proxy.user";
-  private static final String SQL_STATE_LAUNCH_ENGINE_CANCELED = "01000";
+  // Use an error-class SQLState for launch engine cancellation; 01000 is a warning class.
+  private static final String SQL_STATE_LAUNCH_ENGINE_CANCELED = "57014";
   public static int DEFAULT_ENGINE_LOG_THREAD_TIMEOUT = 10 * 1000;
 
   private String jdbcUriString;
@@ -1493,8 +1494,8 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
               engineLogInflight = false;
               break;
             case CANCELED_STATE:
-              // 01000 -> warning
-              throw new KyuubiSQLException("Launch engine was cancelled", "01000");
+              throw new KyuubiSQLException(
+                  "Launch engine was cancelled", SQL_STATE_LAUNCH_ENGINE_CANCELED);
             case TIMEDOUT_STATE:
               throw new SQLTimeoutException("Launch engine timeout");
             case ERROR_STATE:

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
@@ -41,6 +41,7 @@ import javax.security.auth.Subject;
 import javax.security.sasl.Sasl;
 import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.HttpResponse;
 import org.apache.http.NoHttpResponseException;
@@ -209,7 +210,7 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
           // Swallow the exception
           LOG.debug("Error while closing the connection", ex);
         }
-        if (isInterrupted(e)) {
+        if (ExceptionUtils.indexOfType(e, InterruptedException.class) >= 0) {
           // KyuubiInterruptedException is the public JDBC signal for this path. Clear the
           // thread flag so callers do not observe both an exception and an interrupted thread.
           // When this exception reaches the caller, the current thread is not interrupted.
@@ -1513,7 +1514,7 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
       } catch (Exception e) {
         engineLogInflight = false;
         closeOnLaunchEngineFailure();
-        if (isInterrupted(e)) {
+        if (ExceptionUtils.indexOfType(e, InterruptedException.class) >= 0) {
           // KyuubiInterruptedException is the public JDBC signal for this path. Clear the
           // thread flag so callers do not observe both an exception and an interrupted thread.
           // When this exception reaches the caller, the current thread is not interrupted.
@@ -1545,17 +1546,6 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
   private static KyuubiInterruptedException newLaunchEngineInterruptedException(Throwable cause) {
     return new KyuubiInterruptedException(
         "Interrupted while waiting for launch engine", SQL_STATE_LAUNCH_ENGINE_CANCELED, cause);
-  }
-
-  private static boolean isInterrupted(Throwable throwable) {
-    Throwable cause = throwable;
-    while (cause != null) {
-      if (cause instanceof InterruptedException) {
-        return true;
-      }
-      cause = cause.getCause();
-    }
-    return false;
   }
 
   private void fetchLaunchEngineResult() {

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
@@ -1151,23 +1151,15 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
   }
 
   private void closeOnLaunchEngineFailure() throws SQLException {
-    boolean interrupted = Thread.currentThread().isInterrupted();
-    try {
-      if (engineLogThread != null && engineLogThread.isAlive()) {
-        engineLogThread.interrupt();
-        try {
-          engineLogThread.join(DEFAULT_ENGINE_LOG_THREAD_TIMEOUT);
-        } catch (InterruptedException e) {
-          interrupted = true;
-        }
-      }
-      engineLogThread = null;
-      close();
-    } finally {
-      if (interrupted) {
-        Thread.currentThread().interrupt();
+    if (engineLogThread != null && engineLogThread.isAlive()) {
+      engineLogThread.interrupt();
+      try {
+        engineLogThread.join(DEFAULT_ENGINE_LOG_THREAD_TIMEOUT);
+      } catch (Exception ignore) {
       }
     }
+    engineLogThread = null;
+    close();
   }
 
   /**
@@ -1522,10 +1514,9 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
         engineLogInflight = false;
         closeOnLaunchEngineFailure();
         if (isInterrupted(e)) {
-          // KyuubiInterruptedException is the public JDBC signal for this path. Cleanup can also
-          // observe an interrupt while joining the engine log thread, so clear the thread flag
-          // before throwing. When this exception reaches the caller, the current thread is not
-          // interrupted.
+          // KyuubiInterruptedException is the public JDBC signal for this path. Clear the
+          // thread flag so callers do not observe both an exception and an interrupted thread.
+          // When this exception reaches the caller, the current thread is not interrupted.
           Thread.interrupted();
           if (e instanceof KyuubiInterruptedException) {
             throw (KyuubiInterruptedException) e;

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
@@ -1519,32 +1519,23 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
           }
         }
       } catch (Exception e) {
-        Exception exceptionToThrow = e;
-        if (isInterrupted(e)) {
-          // KyuubiInterruptedException is the public JDBC signal for this path. Clear the
-          // thread flag so callers do not observe both an exception and an interrupted thread.
-          // When this exception reaches the caller, the current thread is not interrupted.
-          Thread.interrupted();
-          if (!(e instanceof KyuubiInterruptedException)) {
-            exceptionToThrow = newLaunchEngineInterruptedException(e);
-          }
-        }
         engineLogInflight = false;
-        try {
-          closeOnLaunchEngineFailure();
-        } catch (SQLException closeException) {
-          exceptionToThrow.addSuppressed(closeException);
-        }
-        if (exceptionToThrow instanceof KyuubiInterruptedException) {
-          // Cleanup can also observe an interrupt while joining the engine log thread. Keep the
-          // launch cancellation contract simple: KyuubiInterruptedException is the signal, and the
-          // thread is not interrupted when the caller receives it.
+        closeOnLaunchEngineFailure();
+        if (isInterrupted(e)) {
+          // KyuubiInterruptedException is the public JDBC signal for this path. Cleanup can also
+          // observe an interrupt while joining the engine log thread, so clear the thread flag
+          // before throwing. When this exception reaches the caller, the current thread is not
+          // interrupted.
           Thread.interrupted();
+          if (e instanceof KyuubiInterruptedException) {
+            throw (KyuubiInterruptedException) e;
+          }
+          throw newLaunchEngineInterruptedException(e);
         }
-        if (exceptionToThrow instanceof SQLException) {
-          throw (SQLException) exceptionToThrow;
+        if (e instanceof SQLException) {
+          throw (SQLException) e;
         } else {
-          throw new KyuubiSQLException(exceptionToThrow.getMessage(), "08S01", exceptionToThrow);
+          throw new KyuubiSQLException(e.getMessage(), "08S01", e);
         }
       }
     }

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiDataSource.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiDataSource.java
@@ -46,6 +46,8 @@ public class KyuubiDataSource implements SQLDataSource {
         info.setProperty(AUTH_PASSWD, password);
       }
       return new KyuubiConnection("", info);
+    } catch (SQLException ex) {
+      throw ex;
     } catch (Exception ex) {
       throw new KyuubiSQLException("Error in getting HiveConnection", ex);
     }

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiInterruptedException.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiInterruptedException.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.jdbc.hive;
+
+/** JDBC APIs can only throw SQLException, so this type carries thread-interrupt cancellation. */
+public class KyuubiInterruptedException extends KyuubiSQLException {
+
+  private static final long serialVersionUID = 0;
+
+  public KyuubiInterruptedException(String reason, String sqlState, Throwable cause) {
+    super(reason, sqlState, cause);
+  }
+}

--- a/kyuubi-hive-jdbc/src/test/java/org/apache/kyuubi/jdbc/hive/KyuubiConnectionTest.java
+++ b/kyuubi-hive-jdbc/src/test/java/org/apache/kyuubi/jdbc/hive/KyuubiConnectionTest.java
@@ -74,7 +74,7 @@ public class KyuubiConnectionTest {
       KyuubiInterruptedException exception =
           assertThrows(KyuubiInterruptedException.class, connection::waitLaunchEngineToComplete);
 
-      assertEquals("01000", exception.getSQLState());
+      assertEquals("57014", exception.getSQLState());
       assertTrue(ExceptionUtils.indexOfType(exception, InterruptedException.class) >= 0);
       assertFalse(Thread.currentThread().isInterrupted());
       verify(client).CloseSession(any(TCloseSessionReq.class));
@@ -96,13 +96,29 @@ public class KyuubiConnectionTest {
       KyuubiInterruptedException exception =
           assertThrows(KyuubiInterruptedException.class, connection::waitLaunchEngineToComplete);
 
-      assertEquals("01000", exception.getSQLState());
+      assertEquals("57014", exception.getSQLState());
       assertTrue(ExceptionUtils.indexOfType(exception, InterruptedException.class) >= 0);
       assertFalse(Thread.currentThread().isInterrupted());
       verify(client).CloseSession(any(TCloseSessionReq.class));
     } finally {
       Thread.interrupted();
     }
+  }
+
+  @Test
+  public void waitLaunchEngineToCompleteUsesErrorSqlStateForLaunchCancel() throws Exception {
+    Iface client = mock(Iface.class);
+    TGetOperationStatusResp canceledResp = new TGetOperationStatusResp();
+    canceledResp.setStatus(new TStatus(TStatusCode.SUCCESS_STATUS));
+    canceledResp.setOperationState(TOperationState.CANCELED_STATE);
+    when(client.GetOperationStatus(any(TGetOperationStatusReq.class))).thenReturn(canceledResp);
+    KyuubiConnection connection = newKyuubiConnection(client, null);
+
+    KyuubiSQLException exception =
+        assertThrows(KyuubiSQLException.class, connection::waitLaunchEngineToComplete);
+
+    assertEquals("57014", exception.getSQLState());
+    verify(client).CloseSession(any(TCloseSessionReq.class));
   }
 
   @Test

--- a/kyuubi-hive-jdbc/src/test/java/org/apache/kyuubi/jdbc/hive/KyuubiConnectionTest.java
+++ b/kyuubi-hive-jdbc/src/test/java/org/apache/kyuubi/jdbc/hive/KyuubiConnectionTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.when;
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.kyuubi.shaded.hive.service.rpc.thrift.TCLIService.Iface;
 import org.apache.kyuubi.shaded.hive.service.rpc.thrift.TCloseSessionReq;
 import org.apache.kyuubi.shaded.hive.service.rpc.thrift.TGetOperationStatusReq;
@@ -74,7 +75,7 @@ public class KyuubiConnectionTest {
           assertThrows(KyuubiInterruptedException.class, connection::waitLaunchEngineToComplete);
 
       assertEquals("01000", exception.getSQLState());
-      assertTrue(hasCause(exception, InterruptedException.class));
+      assertTrue(ExceptionUtils.indexOfType(exception, InterruptedException.class) >= 0);
       assertFalse(Thread.currentThread().isInterrupted());
       verify(client).CloseSession(any(TCloseSessionReq.class));
     } finally {
@@ -96,7 +97,7 @@ public class KyuubiConnectionTest {
           assertThrows(KyuubiInterruptedException.class, connection::waitLaunchEngineToComplete);
 
       assertEquals("01000", exception.getSQLState());
-      assertTrue(hasCause(exception, InterruptedException.class));
+      assertTrue(ExceptionUtils.indexOfType(exception, InterruptedException.class) >= 0);
       assertFalse(Thread.currentThread().isInterrupted());
       verify(client).CloseSession(any(TCloseSessionReq.class));
     } finally {
@@ -175,16 +176,5 @@ public class KyuubiConnectionTest {
     Field field = target.getClass().getDeclaredField(name);
     field.setAccessible(true);
     field.set(target, value);
-  }
-
-  private static boolean hasCause(Throwable throwable, Class<? extends Throwable> causeClass) {
-    Throwable cause = throwable;
-    while (cause != null) {
-      if (causeClass.isInstance(cause)) {
-        return true;
-      }
-      cause = cause.getCause();
-    }
-    return false;
   }
 }

--- a/kyuubi-hive-jdbc/src/test/java/org/apache/kyuubi/jdbc/hive/KyuubiConnectionTest.java
+++ b/kyuubi-hive-jdbc/src/test/java/org/apache/kyuubi/jdbc/hive/KyuubiConnectionTest.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kyuubi.jdbc.hive;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.kyuubi.shaded.hive.service.rpc.thrift.TCLIService.Iface;
+import org.apache.kyuubi.shaded.hive.service.rpc.thrift.TCloseSessionReq;
+import org.apache.kyuubi.shaded.hive.service.rpc.thrift.TGetOperationStatusReq;
+import org.apache.kyuubi.shaded.hive.service.rpc.thrift.TGetOperationStatusResp;
+import org.apache.kyuubi.shaded.hive.service.rpc.thrift.THandleIdentifier;
+import org.apache.kyuubi.shaded.hive.service.rpc.thrift.TOperationHandle;
+import org.apache.kyuubi.shaded.hive.service.rpc.thrift.TOperationState;
+import org.apache.kyuubi.shaded.hive.service.rpc.thrift.TOperationType;
+import org.apache.kyuubi.shaded.hive.service.rpc.thrift.TSessionHandle;
+import org.apache.kyuubi.shaded.hive.service.rpc.thrift.TStatus;
+import org.apache.kyuubi.shaded.hive.service.rpc.thrift.TStatusCode;
+import org.apache.kyuubi.shaded.thrift.TException;
+import org.junit.jupiter.api.Test;
+import org.objenesis.ObjenesisStd;
+
+public class KyuubiConnectionTest {
+
+  @Test
+  public void waitLaunchEngineToCompleteHonorsInterrupt() throws Exception {
+    Iface client = mock(Iface.class);
+    TGetOperationStatusResp finishedResp = new TGetOperationStatusResp();
+    finishedResp.setStatus(new TStatus(TStatusCode.SUCCESS_STATUS));
+    finishedResp.setOperationState(TOperationState.FINISHED_STATE);
+    when(client.GetOperationStatus(any(TGetOperationStatusReq.class))).thenReturn(finishedResp);
+
+    Thread engineLogThread =
+        new Thread(
+            () -> {
+              try {
+                Thread.sleep(Long.MAX_VALUE);
+              } catch (InterruptedException ignored) {
+              }
+            });
+    engineLogThread.setDaemon(true);
+    engineLogThread.start();
+
+    KyuubiConnection connection = newKyuubiConnection(client, engineLogThread);
+
+    try {
+      Thread.currentThread().interrupt();
+
+      KyuubiInterruptedException exception =
+          assertThrows(KyuubiInterruptedException.class, connection::waitLaunchEngineToComplete);
+
+      assertEquals("01000", exception.getSQLState());
+      assertTrue(hasCause(exception, InterruptedException.class));
+      assertFalse(Thread.currentThread().isInterrupted());
+      verify(client).CloseSession(any(TCloseSessionReq.class));
+    } finally {
+      Thread.interrupted();
+      engineLogThread.interrupt();
+      engineLogThread.join(1000);
+    }
+  }
+
+  @Test
+  public void waitLaunchEngineToCompleteMapsInterruptedCauseToCancel() throws Exception {
+    Iface client = mock(Iface.class);
+    when(client.GetOperationStatus(any(TGetOperationStatusReq.class)))
+        .thenThrow(new TException("interrupted", new InterruptedException("interrupted")));
+    KyuubiConnection connection = newKyuubiConnection(client, null);
+
+    try {
+      KyuubiInterruptedException exception =
+          assertThrows(KyuubiInterruptedException.class, connection::waitLaunchEngineToComplete);
+
+      assertEquals("01000", exception.getSQLState());
+      assertTrue(hasCause(exception, InterruptedException.class));
+      assertFalse(Thread.currentThread().isInterrupted());
+      verify(client).CloseSession(any(TCloseSessionReq.class));
+    } finally {
+      Thread.interrupted();
+    }
+  }
+
+  @Test
+  public void waitLaunchEngineToCompleteClearsCleanupInterruptForLaunchCancel() throws Exception {
+    Iface client = mock(Iface.class);
+    AtomicBoolean keepAlive = new AtomicBoolean(true);
+    Thread engineLogThread =
+        new Thread(
+            () -> {
+              while (keepAlive.get()) {
+                try {
+                  Thread.sleep(1000);
+                } catch (InterruptedException ignored) {
+                }
+              }
+            });
+    engineLogThread.setDaemon(true);
+    engineLogThread.start();
+
+    KyuubiConnection connection = newKyuubiConnection(client, engineLogThread);
+    Thread currentThread = Thread.currentThread();
+    Thread cleanupInterrupter =
+        new Thread(
+            () -> {
+              try {
+                Thread.sleep(50);
+              } catch (InterruptedException ignored) {
+              }
+              currentThread.interrupt();
+            });
+
+    int originalEngineLogThreadTimeout = KyuubiConnection.DEFAULT_ENGINE_LOG_THREAD_TIMEOUT;
+    try {
+      KyuubiConnection.DEFAULT_ENGINE_LOG_THREAD_TIMEOUT = 1000;
+      Thread.currentThread().interrupt();
+      cleanupInterrupter.start();
+
+      assertThrows(KyuubiInterruptedException.class, connection::waitLaunchEngineToComplete);
+
+      assertFalse(Thread.currentThread().isInterrupted());
+      verify(client).CloseSession(any(TCloseSessionReq.class));
+    } finally {
+      KyuubiConnection.DEFAULT_ENGINE_LOG_THREAD_TIMEOUT = originalEngineLogThreadTimeout;
+      Thread.interrupted();
+      cleanupInterrupter.join(1000);
+      keepAlive.set(false);
+      engineLogThread.interrupt();
+      engineLogThread.join(1000);
+    }
+  }
+
+  private static KyuubiConnection newKyuubiConnection(Iface client, Thread engineLogThread)
+      throws Exception {
+    KyuubiConnection connection =
+        (KyuubiConnection) new ObjenesisStd().newInstance(KyuubiConnection.class);
+    setField(connection, "client", client);
+    setField(connection, "sessHandle", new TSessionHandle());
+    setField(connection, "isClosed", false);
+    setField(connection, "engineLogThread", engineLogThread);
+    setField(connection, "launchEngineOpHandle", newOperationHandle());
+    return connection;
+  }
+
+  private static TOperationHandle newOperationHandle() {
+    THandleIdentifier identifier =
+        new THandleIdentifier(ByteBuffer.wrap(new byte[16]), ByteBuffer.wrap(new byte[16]));
+    return new TOperationHandle(identifier, TOperationType.UNKNOWN, false);
+  }
+
+  private static void setField(Object target, String name, Object value) throws Exception {
+    Field field = target.getClass().getDeclaredField(name);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+
+  private static boolean hasCause(Throwable throwable, Class<? extends Throwable> causeClass) {
+    Throwable cause = throwable;
+    while (cause != null) {
+      if (causeClass.isInstance(cause)) {
+        return true;
+      }
+      cause = cause.getCause();
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
### Why are the changes needed?

JDBC clients can block inside `KyuubiConnection` construction while waiting for engine launch. If the caller cancels that connection attempt with `Thread.interrupt()`, the wait loop previously kept polling and the caller still had no returned `Connection` object to close.

This patch makes the launch wait path honor interruption by converting it to a typed JDBC exception, `KyuubiInterruptedException`. The interrupt status is intentionally consumed before the exception reaches the caller, and comments explain that the caller receives the typed exception while the current thread is not interrupted.

The patch also keeps `SQLException` subclasses intact when `KyuubiDataSource` creates a connection, so callers can distinguish the interrupted launch path.

### How was this patch tested?

- `./build/mvn -pl kyuubi-hive-jdbc -am spotless:apply`
- `./build/mvn -pl kyuubi-hive-jdbc -am -Dtest=KyuubiConnectionTest,KyuubiStatementTest,TestJdbcDriver,TestKyuubiPreparedStatement,UtilsTest,ZooKeeperHiveClientHelperTest -DwildcardSuites=none test`
- `git diff --check`

Also attempted `dev/reformat`, but the full repo reformat is blocked in this local environment because Spotless expects `black 22.3.0` while the installed executable is `black 25.1.0`.

### Was this patch authored or co-authored using generative AI tooling?

Assisted-by: OpenAI Codex: GPT-5
