### PR TITLE
KSHC supports Spark 4.1

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -217,6 +217,11 @@ jobs:
             spark-compile: "3.5"
             spark-runtime: "4.0"
             comment: "normal"
+          - java: 21
+            scala: "2.13"
+            spark-compile: "3.5"
+            spark-runtime: "4.1"
+            comment: "normal"
     env:
       SPARK_LOCAL_IP: localhost
       TEST_MODULES: "extensions/spark/kyuubi-spark-connector-hive,\

--- a/dev/kyuubi-codecov/pom.xml
+++ b/dev/kyuubi-codecov/pom.xml
@@ -259,7 +259,11 @@
                     <artifactId>kyuubi-extension-spark-4-1_${scala.binary.version}</artifactId>
                     <version>${project.version}</version>
                 </dependency>
-                <!-- TODO: support KSHC -->
+                <dependency>
+                    <groupId>org.apache.kyuubi</groupId>
+                    <artifactId>kyuubi-spark-connector-hive_${scala.binary.version}</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
                 <!-- TODO: support authz -->
                 <dependency>
                     <groupId>org.apache.kyuubi</groupId>

--- a/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveTable.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveTable.scala
@@ -27,6 +27,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
+import org.apache.spark.sql.catalyst.util.quoteIfNeeded
 import org.apache.spark.sql.connector.catalog.{SupportsRead, SupportsWrite, Table, TableCapability}
 import org.apache.spark.sql.connector.catalog.TableCapability.{BATCH_READ, BATCH_WRITE, OVERWRITE_BY_FILTER, OVERWRITE_DYNAMIC}
 import org.apache.spark.sql.connector.expressions.Transform
@@ -77,7 +78,13 @@ case class HiveTable(
     }
   }
 
-  override def name(): String = catalogTable.identifier.unquotedString
+  override def name(): String = {
+    val ident = catalogTable.identifier
+    ident.database match {
+      case Some(db) => s"${quoteIfNeeded(db)}.${quoteIfNeeded(ident.table)}"
+      case None => quoteIfNeeded(ident.table)
+    }
+  }
 
   override def schema(): StructType = catalogTable.schema
 

--- a/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveTableCatalog.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveTableCatalog.scala
@@ -46,7 +46,6 @@ import org.apache.spark.sql.internal.StaticSQLConf.{CATALOG_IMPLEMENTATION, GLOB
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
-import org.apache.kyuubi.spark.connector.hive.HiveConnectorUtils.withSparkSQLConf
 import org.apache.kyuubi.spark.connector.hive.HiveTableCatalog.{getStorageFormatAndProvider, toCatalogDatabase, CatalogDatabaseHelper, HIVE_TABLE_RESERVED_SERDE_PROPERTIES, IdentifierHelper, NamespaceHelper}
 import org.apache.kyuubi.spark.connector.hive.KyuubiHiveConnectorConf.DROP_TABLE_AS_PURGE_TABLE
 import org.apache.kyuubi.spark.connector.hive.KyuubiHiveConnectorDelegationTokenProvider.metastoreTokenSignature
@@ -61,8 +60,6 @@ class HiveTableCatalog(sparkSession: SparkSession)
   def this() = this(SparkSession.active)
 
   private val externalCatalogManager = ExternalCatalogManager.getOrCreate(sparkSession)
-
-  private val LEGACY_NON_IDENTIFIER_OUTPUT_CATALOG_NAME = "spark.sql.legacy.v1IdentifierNoCatalog"
 
   private val sc = sparkSession.sparkContext
 
@@ -165,24 +162,22 @@ class HiveTableCatalog(sparkSession: SparkSession)
 
   override val defaultNamespace: Array[String] = Array("default")
 
-  override def listTables(namespace: Array[String]): Array[Identifier] =
-    withSparkSQLConf(LEGACY_NON_IDENTIFIER_OUTPUT_CATALOG_NAME -> "true") {
-      namespace match {
-        case Array(db) =>
-          catalog
-            .listTables(db)
-            .map(ident =>
-              Identifier.of(ident.database.map(Array(_)).getOrElse(Array()), ident.table))
-            .toArray
-        case _ =>
-          throw new NoSuchNamespaceException(namespace)
-      }
+  override def listTables(namespace: Array[String]): Array[Identifier] = {
+    namespace match {
+      case Array(db) =>
+        catalog
+          .listTables(db)
+          .map(ident =>
+            Identifier.of(ident.database.map(Array(_)).getOrElse(Array()), ident.table))
+          .toArray
+      case _ =>
+        throw new NoSuchNamespaceException(namespace)
     }
+  }
 
-  override def loadTable(ident: Identifier): Table =
-    withSparkSQLConf(LEGACY_NON_IDENTIFIER_OUTPUT_CATALOG_NAME -> "true") {
-      HiveTable(sparkSession, catalog.getTableMetadata(ident.asTableIdentifier), this)
-    }
+  override def loadTable(ident: Identifier): Table = {
+    HiveTable(sparkSession, catalog.getTableMetadata(ident.asTableIdentifier(catalogName)), this)
+  }
 
   // scalastyle:off
   private def newCatalogTable(
@@ -311,90 +306,88 @@ class HiveTableCatalog(sparkSession: SparkSession)
       ident: Identifier,
       schema: StructType,
       partitions: Array[Transform],
-      properties: util.Map[String, String]): Table =
-    withSparkSQLConf(LEGACY_NON_IDENTIFIER_OUTPUT_CATALOG_NAME -> "true") {
-      import org.apache.spark.sql.hive.kyuubi.connector.HiveBridgeHelper.TransformHelper
-      val (partitionColumns, maybeBucketSpec) = partitions.toSeq.convertTransforms
-      val location = Option(properties.get(TableCatalog.PROP_LOCATION))
-      val maybeProvider = Option(properties.get(TableCatalog.PROP_PROVIDER))
-      val allProps = properties.asScala.toMap
-      val (optionsProps, serdeProps) = toOptionsAndSerdeProps(allProps)
-      val (storage, provider) =
-        getStorageFormatAndProvider(
-          maybeProvider,
-          location,
-          allProps,
-          optionsProps,
-          serdeProps)
-      val isExternal = properties.containsKey(TableCatalog.PROP_EXTERNAL)
-      val tableType =
-        if (isExternal || location.isDefined) {
-          CatalogTableType.EXTERNAL
-        } else {
-          CatalogTableType.MANAGED
-        }
-
-      val tableDesc = newCatalogTable(
-        identifier = ident.asTableIdentifier,
-        tableType = tableType,
-        storage = storage,
-        schema = schema,
-        provider = Some(provider),
-        partitionColumnNames = partitionColumns,
-        bucketSpec = maybeBucketSpec,
-        properties = toTableProps(allProps, optionsProps ++ serdeProps),
-        tracksPartitionsInCatalog = conf.manageFilesourcePartitions,
-        comment = Option(properties.get(TableCatalog.PROP_COMMENT)))
-
-      try {
-        catalog.createTable(tableDesc, ignoreIfExists = false)
-      } catch {
-        case _: TableAlreadyExistsException =>
-          throw new TableAlreadyExistsException(ident)
+      properties: util.Map[String, String]): Table = {
+    import org.apache.spark.sql.hive.kyuubi.connector.HiveBridgeHelper.TransformHelper
+    val (partitionColumns, maybeBucketSpec) = partitions.toSeq.convertTransforms
+    val location = Option(properties.get(TableCatalog.PROP_LOCATION))
+    val maybeProvider = Option(properties.get(TableCatalog.PROP_PROVIDER))
+    val allProps = properties.asScala.toMap
+    val (optionsProps, serdeProps) = toOptionsAndSerdeProps(allProps)
+    val (storage, provider) =
+      getStorageFormatAndProvider(
+        maybeProvider,
+        location,
+        allProps,
+        optionsProps,
+        serdeProps)
+    val isExternal = properties.containsKey(TableCatalog.PROP_EXTERNAL)
+    val tableType =
+      if (isExternal || location.isDefined) {
+        CatalogTableType.EXTERNAL
+      } else {
+        CatalogTableType.MANAGED
       }
 
-      loadTable(ident)
+    val tableDesc = newCatalogTable(
+      identifier = ident.asTableIdentifier(catalogName),
+      tableType = tableType,
+      storage = storage,
+      schema = schema,
+      provider = Some(provider),
+      partitionColumnNames = partitionColumns,
+      bucketSpec = maybeBucketSpec,
+      properties = toTableProps(allProps, optionsProps ++ serdeProps),
+      tracksPartitionsInCatalog = conf.manageFilesourcePartitions,
+      comment = Option(properties.get(TableCatalog.PROP_COMMENT)))
+
+    try {
+      catalog.createTable(tableDesc, ignoreIfExists = false)
+    } catch {
+      case _: TableAlreadyExistsException =>
+        throw new TableAlreadyExistsException(ident)
     }
 
-  override def alterTable(ident: Identifier, changes: TableChange*): Table =
-    withSparkSQLConf(LEGACY_NON_IDENTIFIER_OUTPUT_CATALOG_NAME -> "true") {
-      val catalogTable =
-        try {
-          catalog.getTableMetadata(ident.asTableIdentifier)
-        } catch {
-          case _: NoSuchTableException =>
-            throw new NoSuchTableException(ident)
-        }
+    loadTable(ident)
+  }
 
-      val properties = CatalogV2Util.applyPropertiesChanges(catalogTable.properties, changes)
-      val schema = HiveConnectorUtils.applySchemaChanges(
-        catalogTable.schema,
-        changes)
-      val comment = properties.get(TableCatalog.PROP_COMMENT)
-      val owner = properties.getOrElse(TableCatalog.PROP_OWNER, catalogTable.owner)
-      val location = properties.get(TableCatalog.PROP_LOCATION).map(CatalogUtils.stringToURI)
-      val storage =
-        if (location.isDefined) {
-          catalogTable.storage.copy(locationUri = location)
-        } else {
-          catalogTable.storage
-        }
-
+  override def alterTable(ident: Identifier, changes: TableChange*): Table = {
+    val catalogTable =
       try {
-        catalog.alterTable(
-          catalogTable.copy(
-            properties = properties,
-            schema = schema,
-            owner = owner,
-            comment = comment,
-            storage = storage))
+        catalog.getTableMetadata(ident.asTableIdentifier(catalogName))
       } catch {
         case _: NoSuchTableException =>
           throw new NoSuchTableException(ident)
       }
 
-      loadTable(ident)
+    val properties = CatalogV2Util.applyPropertiesChanges(catalogTable.properties, changes)
+    val schema = HiveConnectorUtils.applySchemaChanges(
+      catalogTable.schema,
+      changes)
+    val comment = properties.get(TableCatalog.PROP_COMMENT)
+    val owner = properties.getOrElse(TableCatalog.PROP_OWNER, catalogTable.owner)
+    val location = properties.get(TableCatalog.PROP_LOCATION).map(CatalogUtils.stringToURI)
+    val storage =
+      if (location.isDefined) {
+        catalogTable.storage.copy(locationUri = location)
+      } else {
+        catalogTable.storage
+      }
+
+    try {
+      catalog.alterTable(
+        catalogTable.copy(
+          properties = properties,
+          schema = schema,
+          owner = owner,
+          comment = comment,
+          storage = storage))
+    } catch {
+      case _: NoSuchTableException =>
+        throw new NoSuchTableException(ident)
     }
+
+    loadTable(ident)
+  }
 
   override def purgeTable(ident: Identifier): Boolean = {
     dropTableInternal(ident, purge = true)
@@ -405,34 +398,34 @@ class HiveTableCatalog(sparkSession: SparkSession)
     dropTableInternal(ident, purge)
   }
 
-  private def dropTableInternal(ident: Identifier, purge: Boolean): Boolean =
-    withSparkSQLConf(LEGACY_NON_IDENTIFIER_OUTPUT_CATALOG_NAME -> "true") {
-      try {
-        if (loadTable(ident) != null) {
-          catalog.dropTable(
-            ident.asTableIdentifier,
-            ignoreIfNotExists = true,
-            purge /* whether to skip HDFS trash */ )
-          true
-        } else {
-          false
-        }
-      } catch {
-        case _: NoSuchTableException =>
-          false
+  private def dropTableInternal(ident: Identifier, purge: Boolean): Boolean = {
+    try {
+      if (loadTable(ident) != null) {
+        catalog.dropTable(
+          ident.asTableIdentifier(catalogName),
+          ignoreIfNotExists = true,
+          purge /* whether to skip HDFS trash */ )
+        true
+      } else {
+        false
       }
+    } catch {
+      case _: NoSuchTableException =>
+        false
+    }
+  }
+
+  override def renameTable(oldIdent: Identifier, newIdent: Identifier): Unit = {
+    if (tableExists(newIdent)) {
+      throw new TableAlreadyExistsException(newIdent)
     }
 
-  override def renameTable(oldIdent: Identifier, newIdent: Identifier): Unit =
-    withSparkSQLConf(LEGACY_NON_IDENTIFIER_OUTPUT_CATALOG_NAME -> "true") {
-      if (tableExists(newIdent)) {
-        throw new TableAlreadyExistsException(newIdent)
-      }
-
-      // Load table to make sure the table exists
-      loadTable(oldIdent)
-      catalog.renameTable(oldIdent.asTableIdentifier, newIdent.asTableIdentifier)
-    }
+    // Load table to make sure the table exists
+    loadTable(oldIdent)
+    catalog.renameTable(
+      oldIdent.asTableIdentifier(catalogName),
+      newIdent.asTableIdentifier(catalogName))
+  }
 
   /**
    * Splits properties into optionsProps and serdeProps based on the `options.` prefix.
@@ -477,56 +470,52 @@ class HiveTableCatalog(sparkSession: SparkSession)
         && !HIVE_TABLE_RESERVED_SERDE_PROPERTIES.contains(key)).toMap
   }
 
-  override def listNamespaces(): Array[Array[String]] =
-    withSparkSQLConf(LEGACY_NON_IDENTIFIER_OUTPUT_CATALOG_NAME -> "true") {
-      catalog.listDatabases().map(Array(_)).toArray
-    }
+  override def listNamespaces(): Array[Array[String]] = {
+    catalog.listDatabases().map(Array(_)).toArray
+  }
 
-  override def listNamespaces(namespace: Array[String]): Array[Array[String]] =
-    withSparkSQLConf(LEGACY_NON_IDENTIFIER_OUTPUT_CATALOG_NAME -> "true") {
-      namespace match {
-        case Array() =>
-          listNamespaces()
-        case Array(db) if catalog.databaseExists(db) =>
-          Array()
-        case _ =>
-          throw new NoSuchNamespaceException(namespace)
-      }
+  override def listNamespaces(namespace: Array[String]): Array[Array[String]] = {
+    namespace match {
+      case Array() =>
+        listNamespaces()
+      case Array(db) if catalog.databaseExists(db) =>
+        Array()
+      case _ =>
+        throw new NoSuchNamespaceException(namespace)
     }
+  }
 
-  override def loadNamespaceMetadata(namespace: Array[String]): util.Map[String, String] =
-    withSparkSQLConf(LEGACY_NON_IDENTIFIER_OUTPUT_CATALOG_NAME -> "true") {
-      namespace match {
-        case Array(db) =>
-          try {
-            catalog.getDatabaseMetadata(db).toMetadata
-          } catch {
-            case _: NoSuchDatabaseException =>
-              throw new NoSuchNamespaceException(namespace)
-          }
+  override def loadNamespaceMetadata(namespace: Array[String]): util.Map[String, String] = {
+    namespace match {
+      case Array(db) =>
+        try {
+          catalog.getDatabaseMetadata(db).toMetadata
+        } catch {
+          case _: NoSuchDatabaseException =>
+            throw new NoSuchNamespaceException(namespace)
+        }
 
-        case _ =>
-          throw new NoSuchNamespaceException(namespace)
-      }
+      case _ =>
+        throw new NoSuchNamespaceException(namespace)
     }
+  }
 
   override def createNamespace(
       namespace: Array[String],
-      metadata: util.Map[String, String]): Unit =
-    withSparkSQLConf(LEGACY_NON_IDENTIFIER_OUTPUT_CATALOG_NAME -> "true") {
-      namespace match {
-        case Array(db) if !catalog.databaseExists(db) =>
-          catalog.createDatabase(
-            toCatalogDatabase(db, metadata, defaultLocation = Some(getCatalogDefaultDBPath(db))),
-            ignoreIfExists = false)
+      metadata: util.Map[String, String]): Unit = {
+    namespace match {
+      case Array(db) if !catalog.databaseExists(db) =>
+        catalog.createDatabase(
+          toCatalogDatabase(db, metadata, defaultLocation = Some(getCatalogDefaultDBPath(db))),
+          ignoreIfExists = false)
 
-        case Array(_) =>
-          throw new NamespaceAlreadyExistsException(namespace)
+      case Array(_) =>
+        throw new NamespaceAlreadyExistsException(namespace)
 
-        case _ =>
-          throw new IllegalArgumentException(s"Invalid namespace name: ${namespace.quoted}")
-      }
+      case _ =>
+        throw new IllegalArgumentException(s"Invalid namespace name: ${namespace.quoted}")
     }
+  }
 
   /**
    * Returns the default database path with catalog-level warehouse configuration precedence.
@@ -547,27 +536,26 @@ class HiveTableCatalog(sparkSession: SparkSession)
     }
   }
 
-  override def alterNamespace(namespace: Array[String], changes: NamespaceChange*): Unit =
-    withSparkSQLConf(LEGACY_NON_IDENTIFIER_OUTPUT_CATALOG_NAME -> "true") {
-      namespace match {
-        case Array(db) =>
-          // validate that this catalog's reserved properties are not removed
-          changes.foreach {
-            case remove: RemoveProperty
-                if NAMESPACE_RESERVED_PROPERTIES.contains(remove.property) =>
-              throw new UnsupportedOperationException(
-                s"Cannot remove reserved property: ${remove.property}")
-            case _ =>
-          }
+  override def alterNamespace(namespace: Array[String], changes: NamespaceChange*): Unit = {
+    namespace match {
+      case Array(db) =>
+        // validate that this catalog's reserved properties are not removed
+        changes.foreach {
+          case remove: RemoveProperty
+              if NAMESPACE_RESERVED_PROPERTIES.contains(remove.property) =>
+            throw new UnsupportedOperationException(
+              s"Cannot remove reserved property: ${remove.property}")
+          case _ =>
+        }
 
-          val metadata = catalog.getDatabaseMetadata(db).toMetadata
-          catalog.alterDatabase(
-            toCatalogDatabase(db, CatalogV2Util.applyNamespaceChanges(metadata, changes)))
+        val metadata = catalog.getDatabaseMetadata(db).toMetadata
+        catalog.alterDatabase(
+          toCatalogDatabase(db, CatalogV2Util.applyNamespaceChanges(metadata, changes)))
 
-        case _ =>
-          throw new NoSuchNamespaceException(namespace)
-      }
+      case _ =>
+        throw new NoSuchNamespaceException(namespace)
     }
+  }
 
   /**
    * List the metadata of partitions that belong to the specified table, assuming it exists, that
@@ -587,21 +575,20 @@ class HiveTableCatalog(sparkSession: SparkSession)
 
   override def dropNamespace(
       namespace: Array[String],
-      cascade: Boolean): Boolean =
-    withSparkSQLConf(LEGACY_NON_IDENTIFIER_OUTPUT_CATALOG_NAME -> "true") {
-      namespace match {
-        case Array(db) if catalog.databaseExists(db) =>
-          catalog.dropDatabase(db, ignoreIfNotExists = false, cascade)
-          true
+      cascade: Boolean): Boolean = {
+    namespace match {
+      case Array(db) if catalog.databaseExists(db) =>
+        catalog.dropDatabase(db, ignoreIfNotExists = false, cascade)
+        true
 
-        case Array(_) =>
-          // exists returned false
-          false
+      case Array(_) =>
+        // exists returned false
+        false
 
-        case _ =>
-          throw new NoSuchNamespaceException(namespace)
-      }
+      case _ =>
+        throw new NoSuchNamespaceException(namespace)
     }
+  }
 }
 
 private object HiveTableCatalog extends Logging {
@@ -615,6 +602,36 @@ private object HiveTableCatalog extends Logging {
     HIVE_STORED_AS,
     HIVE_OUTPUT_FORMAT,
     HIVE_INPUT_FORMAT)
+
+  /**
+   * Attaches the KSHC catalog name to a V1 [[TableIdentifier]].
+   *
+   * Since Spark 3.4 (SPARK-46283), [[TableIdentifier]] carries a `catalog` field. Spark 4.1's
+   * `SessionCatalog.requireTableExists` reads it via `name.catalog.get`, which throws
+   * `NoSuchElementException` when it is `None`. KSHC deliberately avoids the wrong default
+   * catalog name (`spark_catalog`) by attaching its *own* catalog name here instead of relying
+   * on the `spark.sql.legacy.v1IdentifierNoCatalog` workaround, so `TableIdentifier.catalog` is
+   * never `None` on Spark 3.4+. On Spark 3.3 (no `catalog` field) the 3-arg constructor is
+   * absent and the identifier is returned unchanged.
+   */
+  private def attachCatalogName(
+      identifier: TableIdentifier,
+      catalogName: String): TableIdentifier = {
+    Try { // Spark 3.4+ (SPARK-46283): TableIdentifier(table, database, catalog)
+      DynConstructors.builder()
+        .impl(
+          classOf[TableIdentifier],
+          classOf[String],
+          classOf[Option[String]],
+          classOf[Option[String]])
+        .buildChecked()
+        .invokeChecked[TableIdentifier](
+          null,
+          identifier.table,
+          identifier.database,
+          Some(catalogName))
+    }.recover { case _: Exception => identifier }.get
+  }
 
   private def toCatalogDatabase(
       db: String,
@@ -712,12 +729,15 @@ private object HiveTableCatalog extends Logging {
 
     def asMultipartIdentifier: Seq[String] = ident.namespace :+ ident.name
 
-    def asTableIdentifier: TableIdentifier = ident.namespace match {
-      case ns if ns.isEmpty => TableIdentifier(ident.name)
-      case Array(dbName) => TableIdentifier(ident.name, Some(dbName))
-      case _ =>
-        throw KyuubiHiveConnectorException(
-          s"$quoted is not a valid TableIdentifier as it has more than 2 name parts.")
+    def asTableIdentifier(catalogName: String): TableIdentifier = {
+      val base = ident.namespace match {
+        case ns if ns.isEmpty => TableIdentifier(ident.name)
+        case Array(dbName) => TableIdentifier(ident.name, Some(dbName))
+        case _ =>
+          throw KyuubiHiveConnectorException(
+            s"$quoted is not a valid TableIdentifier as it has more than 2 name parts.")
+      }
+      attachCatalogName(base, catalogName)
     }
   }
 

--- a/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/HiveCatalogSuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/HiveCatalogSuite.scala
@@ -254,7 +254,7 @@ class HiveCatalogSuite extends KyuubiHiveTest {
       Array.empty[Transform],
       properties).asInstanceOf[HiveTable]
     assert(t1.catalogTable.location ===
-      catalog.catalog.defaultTablePath(testIdent.asTableIdentifier))
+      catalog.catalog.defaultTablePath(testIdent.asTableIdentifier(catalog.name())))
     catalog.dropTable(testIdent)
 
     // relative path


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->
This PR makes KSHC (Kyuubi Spark Hive Connector) support Spark 4.1

Main idea: get rid of `spark.sql.legacy.v1IdentifierNoCatalog` (which does not work well in Spark 4.1) and use `attachCatalogName` to adapt to SPARK-46283

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Update GHA workflow to enable KSCH tests for Spark 4.1, also update KSHC cross-version tests - build with Spark 3.5, test on Spark 4.1

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has assisted in authoring or reviewing this patch, please include
an 'Assisted-by: ' trailer that identifies the agent and model.
For example: 'Assisted-by: Claude:claude-opus-4-7' or 'Assisted-by: Claude Opus 4.7'.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Assisted-by: GLM 5.2