### PR TITLE
Bump Log4j 2.26.1

### DIFF
--- a/dev/dependencyList
+++ b/dev/dependencyList
@@ -124,11 +124,11 @@ kubernetes-model-rbac/6.14.0//kubernetes-model-rbac-6.14.0.jar
 kubernetes-model-resource/6.14.0//kubernetes-model-resource-6.14.0.jar
 kubernetes-model-scheduling/6.14.0//kubernetes-model-scheduling-6.14.0.jar
 kubernetes-model-storageclass/6.14.0//kubernetes-model-storageclass-6.14.0.jar
-log4j-1.2-api/2.26.0//log4j-1.2-api-2.26.0.jar
-log4j-api/2.26.0//log4j-api-2.26.0.jar
-log4j-core/2.26.0//log4j-core-2.26.0.jar
-log4j-layout-template-json/2.26.0//log4j-layout-template-json-2.26.0.jar
-log4j-slf4j-impl/2.26.0//log4j-slf4j-impl-2.26.0.jar
+log4j-1.2-api/2.26.1//log4j-1.2-api-2.26.1.jar
+log4j-api/2.26.1//log4j-api-2.26.1.jar
+log4j-core/2.26.1//log4j-core-2.26.1.jar
+log4j-layout-template-json/2.26.1//log4j-layout-template-json-2.26.1.jar
+log4j-slf4j-impl/2.26.1//log4j-slf4j-impl-2.26.1.jar
 logging-interceptor/3.12.12//logging-interceptor-3.12.12.jar
 metrics-annotation/4.2.30//metrics-annotation-4.2.30.jar
 metrics-core/4.2.30//metrics-core-4.2.30.jar

--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
         <kyuubi-relocated.version>0.6.0</kyuubi-relocated.version>
         <kyuubi-relocated-zookeeper.artifacts>kyuubi-relocated-zookeeper-34</kyuubi-relocated-zookeeper.artifacts>
         <ldapsdk.version>6.0.5</ldapsdk.version>
-        <log4j.version>2.26.0</log4j.version>
+        <log4j.version>2.26.1</log4j.version>
         <mysql.jdbc.version>8.4.0</mysql.jdbc.version>
         <mockito.version>4.11.0</mockito.version>
         <netty.version>4.2.7.Final</netty.version>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->
Log4j 2.26.1 Release notes (released 02 Jul 2026, patch on 2.26.0):

https://github.com/apache/logging-log4j2/releases/tag/rel/2.26.1

Notable fixes in 2.26.1: 
- `RollingFileAppender` `createOnDemand` deferral;
- non-finite number handling in MapMessage→JSON;
- MSGID/SD-ID encoding in StructuredDataMessage→XML;
- stack-trace rendering for exceptions with colliding `equals()`/`hashCode()`;
- resource leaks in `ConfigurationSource` on failed URL config load;
- `KafkaAppender` spurious error after successful retry;
- plus improved `LinkageError` logging around LMAX Disruptor.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
GHA.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has assisted in authoring or reviewing this patch, please include
an 'Assisted-by: ' trailer that identifies the agent and model.
For example: 'Assisted-by: Claude:claude-opus-4-7' or 'Assisted-by: Claude Opus 4.7'.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Assisted-by: GLM 5.2