### PR TITLE
[KYUUBI #2470][AUTHZ] Add Ranger performance tracing to rule authorization

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/pom.xml
+++ b/extensions/spark/kyuubi-spark-authz/pom.xml
@@ -307,6 +307,14 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.kyuubi</groupId>
+            <artifactId>kyuubi-common_${scala.binary.version}</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-hive_${scala.binary.version}</artifactId>
             <scope>test</scope>

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleAuthorization.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleAuthorization.scala
@@ -20,6 +20,7 @@ package org.apache.kyuubi.plugin.spark.authz.ranger
 import scala.collection.mutable
 
 import org.apache.ranger.plugin.policyengine.RangerAccessRequest
+import org.apache.ranger.plugin.util.RangerPerfTracer
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 
@@ -31,55 +32,70 @@ import org.apache.kyuubi.plugin.spark.authz.rule.Authorization
 import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
 
 case class RuleAuthorization(spark: SparkSession) extends Authorization(spark) {
+  private val PERF_SPARKAUTH_REQUEST_LOG =
+    RangerPerfTracer.getPerfLogger("sparkauth.request")
+
   override def checkPrivileges(spark: SparkSession, plan: LogicalPlan): Unit = {
-    val auditHandler = new SparkRangerAuditHandler
-    val ugi = getAuthzUgi(spark.sparkContext)
-    val (inputs, outputs, opType) = PrivilegesBuilder.build(plan, spark)
-
-    // Use a HashSet to deduplicate the same AccessResource and AccessType, the requests will be all
-    // the non-duplicate requests and in the same order as the input requests.
-    val requests = new mutable.ArrayBuffer[AccessRequest]()
-    val requestsSet = new mutable.HashSet[(AccessResource, AccessType)]()
-
-    def addAccessRequest(objects: Iterable[PrivilegeObject], isInput: Boolean): Unit = {
-      objects.foreach { obj =>
-        val resource = AccessResource(obj, opType)
-        val accessType = ranger.AccessType(obj, opType, isInput)
-        if (accessType != AccessType.NONE && !requestsSet.contains((resource, accessType))) {
-          requests += AccessRequest(resource, ugi, opType, accessType)
-          requestsSet.add(resource, accessType)
-        }
-      }
+    val perf = if (RangerPerfTracer.isPerfTraceEnabled(PERF_SPARKAUTH_REQUEST_LOG)) {
+      RangerPerfTracer.getPerfTracer(
+        PERF_SPARKAUTH_REQUEST_LOG,
+        "RuleAuthorization.checkPrivileges()")
+    } else {
+      null
     }
 
-    addAccessRequest(inputs, isInput = true)
-    addAccessRequest(outputs, isInput = false)
+    try {
+      val auditHandler = new SparkRangerAuditHandler
+      val ugi = getAuthzUgi(spark.sparkContext)
+      val (inputs, outputs, opType) = PrivilegesBuilder.build(plan, spark)
 
-    val requestArrays = requests.map { request =>
-      val resource = request.getResource.asInstanceOf[AccessResource]
-      resource.objectType match {
-        case ObjectType.COLUMN if resource.getColumns.nonEmpty =>
-          resource.getColumns.map { col =>
-            val cr =
-              AccessResource(
-                COLUMN,
-                resource.getDatabase,
-                resource.getTable,
-                col,
-                Option(resource.getOwnerUser),
-                resource.catalog)
-            AccessRequest(cr, ugi, opType, request.accessType).asInstanceOf[RangerAccessRequest]
+      // Use a HashSet to deduplicate the same AccessResource and AccessType. The requests will be
+      // all the non-duplicate requests and in the same order as the input requests.
+      val requests = new mutable.ArrayBuffer[AccessRequest]()
+      val requestsSet = new mutable.HashSet[(AccessResource, AccessType)]()
+
+      def addAccessRequest(objects: Iterable[PrivilegeObject], isInput: Boolean): Unit = {
+        objects.foreach { obj =>
+          val resource = AccessResource(obj, opType)
+          val accessType = ranger.AccessType(obj, opType, isInput)
+          if (accessType != AccessType.NONE && !requestsSet.contains((resource, accessType))) {
+            requests += AccessRequest(resource, ugi, opType, accessType)
+            requestsSet.add(resource, accessType)
           }
-        case _ => Seq(request)
+        }
       }
-    }.toSeq
 
-    if (authorizeInSingleCall) {
-      verify(requestArrays.flatten, auditHandler)
-    } else {
-      requestArrays.flatten.foreach { req =>
-        verify(Seq(req), auditHandler)
+      addAccessRequest(inputs, isInput = true)
+      addAccessRequest(outputs, isInput = false)
+
+      val requestArrays = requests.map { request =>
+        val resource = request.getResource.asInstanceOf[AccessResource]
+        resource.objectType match {
+          case ObjectType.COLUMN if resource.getColumns.nonEmpty =>
+            resource.getColumns.map { col =>
+              val cr =
+                AccessResource(
+                  COLUMN,
+                  resource.getDatabase,
+                  resource.getTable,
+                  col,
+                  Option(resource.getOwnerUser),
+                  resource.catalog)
+              AccessRequest(cr, ugi, opType, request.accessType).asInstanceOf[RangerAccessRequest]
+            }
+          case _ => Seq(request)
+        }
+      }.toSeq
+
+      if (authorizeInSingleCall) {
+        verify(requestArrays.flatten, auditHandler)
+      } else {
+        requestArrays.flatten.foreach { req =>
+          verify(Seq(req), auditHandler)
+        }
       }
+    } finally {
+      RangerPerfTracer.log(perf)
     }
   }
 }

--- a/extensions/spark/kyuubi-spark-authz/src/test/gen/scala/org/apache/kyuubi/plugin/spark/authz/gen/PolicyJsonFileGenerator.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/gen/scala/org/apache/kyuubi/plugin/spark/authz/gen/PolicyJsonFileGenerator.scala
@@ -27,8 +27,8 @@ import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import org.apache.ranger.plugin.model.RangerPolicy
-import org.apache.kyuubi.KyuubiFunSuite
 
+import org.apache.kyuubi.KyuubiFunSuite
 import org.apache.kyuubi.plugin.spark.authz.RangerTestNamespace._
 import org.apache.kyuubi.plugin.spark.authz.RangerTestUsers._
 import org.apache.kyuubi.plugin.spark.authz.gen.KRangerPolicyItemAccess.allowTypes

--- a/extensions/spark/kyuubi-spark-authz/src/test/gen/scala/org/apache/kyuubi/plugin/spark/authz/gen/PolicyJsonFileGenerator.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/gen/scala/org/apache/kyuubi/plugin/spark/authz/gen/PolicyJsonFileGenerator.scala
@@ -27,8 +27,7 @@ import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import org.apache.ranger.plugin.model.RangerPolicy
-// scalastyle:off
-import org.scalatest.funsuite.AnyFunSuite
+import org.apache.kyuubi.KyuubiFunSuite
 
 import org.apache.kyuubi.plugin.spark.authz.RangerTestNamespace._
 import org.apache.kyuubi.plugin.spark.authz.RangerTestUsers._
@@ -52,8 +51,7 @@ import org.apache.kyuubi.util.GoldenFileUtils._
  *   dev/gen/gen_ranger_policy_json.sh
  * }}}
  */
-class PolicyJsonFileGenerator extends AnyFunSuite {
-  // scalastyle:on
+class PolicyJsonFileGenerator extends KyuubiFunSuite {
   final private val mapper: ObjectMapper = JsonMapper.builder()
     .addModule(DefaultScalaModule)
     .serializationInclusion(Include.NON_NULL)

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/FunctionPrivilegesBuilderSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/FunctionPrivilegesBuilderSuite.scala
@@ -18,16 +18,12 @@
 package org.apache.kyuubi.plugin.spark.authz
 
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
-// scalastyle:off
-import org.scalatest.funsuite.AnyFunSuite
+import org.apache.kyuubi.KyuubiFunSuite
 
 import org.apache.kyuubi.plugin.spark.authz.OperationType.QUERY
 import org.apache.kyuubi.plugin.spark.authz.ranger.AccessType
 
-abstract class FunctionPrivilegesBuilderSuite extends AnyFunSuite
-  with SparkSessionProvider with BeforeAndAfterAll with BeforeAndAfterEach {
-  // scalastyle:on
+abstract class FunctionPrivilegesBuilderSuite extends KyuubiFunSuite with SparkSessionProvider {
 
   protected def withTable(t: String)(f: String => Unit): Unit = {
     try {

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/FunctionPrivilegesBuilderSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/FunctionPrivilegesBuilderSuite.scala
@@ -18,8 +18,8 @@
 package org.apache.kyuubi.plugin.spark.authz
 
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-import org.apache.kyuubi.KyuubiFunSuite
 
+import org.apache.kyuubi.KyuubiFunSuite
 import org.apache.kyuubi.plugin.spark.authz.OperationType.QUERY
 import org.apache.kyuubi.plugin.spark.authz.ranger.AccessType
 

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/IcebergCatalogPrivilegesBuilderSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/IcebergCatalogPrivilegesBuilderSuite.scala
@@ -17,8 +17,6 @@
 
 package org.apache.kyuubi.plugin.spark.authz
 
-import org.scalatest.Outcome
-
 import org.apache.kyuubi.Utils
 import org.apache.kyuubi.plugin.spark.authz.OperationType._
 import org.apache.kyuubi.plugin.spark.authz.ranger.AccessType
@@ -48,10 +46,6 @@ class IcebergCatalogPrivilegesBuilderSuite extends V2CommandsPrivilegesSuite {
       s"spark.sql.catalog.$catalogV2.warehouse",
       Utils.createTempDir("iceberg-hadoop").toString)
     super.beforeAll()
-  }
-
-  override def withFixture(test: NoArgTest): Outcome = {
-    test()
   }
 
   test("DeleteFromIcebergTable") {

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilderSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilderSuite.scala
@@ -25,8 +25,8 @@ import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.sources.{BaseRelation, InsertableRelation, SchemaRelationProvider}
 import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
-import org.apache.kyuubi.KyuubiFunSuite
 
+import org.apache.kyuubi.KyuubiFunSuite
 import org.apache.kyuubi.plugin.spark.authz.OperationType._
 import org.apache.kyuubi.plugin.spark.authz.RangerTestNamespace._
 import org.apache.kyuubi.plugin.spark.authz.RangerTestUsers._

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilderSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilderSuite.scala
@@ -25,9 +25,7 @@ import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.sources.{BaseRelation, InsertableRelation, SchemaRelationProvider}
 import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
-import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
-// scalastyle:off
-import org.scalatest.funsuite.AnyFunSuite
+import org.apache.kyuubi.KyuubiFunSuite
 
 import org.apache.kyuubi.plugin.spark.authz.OperationType._
 import org.apache.kyuubi.plugin.spark.authz.RangerTestNamespace._
@@ -36,9 +34,7 @@ import org.apache.kyuubi.plugin.spark.authz.ranger.AccessType
 import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
 import org.apache.kyuubi.util.AssertionUtils._
 
-abstract class PrivilegesBuilderSuite extends AnyFunSuite
-  with SparkSessionProvider with BeforeAndAfterAll with BeforeAndAfterEach {
-// scalastyle:on
+abstract class PrivilegesBuilderSuite extends KyuubiFunSuite with SparkSessionProvider {
 
   protected def withTable(t: String)(f: String => Unit): Unit = {
     try {

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/V2JdbcTableCatalogPrivilegesBuilderSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/V2JdbcTableCatalogPrivilegesBuilderSuite.scala
@@ -20,8 +20,6 @@ import java.sql.DriverManager
 
 import scala.util.Try
 
-import org.scalatest.Outcome
-
 import org.apache.kyuubi.plugin.spark.authz.V2JdbcTableCatalogPrivilegesBuilderSuite._
 import org.apache.kyuubi.plugin.spark.authz.serde._
 import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
@@ -53,10 +51,6 @@ class V2JdbcTableCatalogPrivilegesBuilderSuite extends V2CommandsPrivilegesSuite
     Try {
       DriverManager.getConnection(s"$dbUrl;shutdown=true")
     }
-  }
-
-  override def withFixture(test: NoArgTest): Outcome = {
-    test()
   }
 
   test("Extracting table info with ResolvedDbObjectNameTableExtractor") {

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/CheckAuthzExtractorSPISuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/CheckAuthzExtractorSPISuite.scala
@@ -20,7 +20,6 @@ package org.apache.kyuubi.plugin.spark.authz.gen
 import java.nio.file.Paths
 
 import org.apache.kyuubi.KyuubiFunSuite
-
 import org.apache.kyuubi.util.AssertionUtils._
 import org.apache.kyuubi.util.GoldenFileUtils._
 

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/CheckAuthzExtractorSPISuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/CheckAuthzExtractorSPISuite.scala
@@ -19,14 +19,12 @@ package org.apache.kyuubi.plugin.spark.authz.gen
 
 import java.nio.file.Paths
 
-// scalastyle:off
-import org.scalatest.funsuite.AnyFunSuite
+import org.apache.kyuubi.KyuubiFunSuite
 
 import org.apache.kyuubi.util.AssertionUtils._
 import org.apache.kyuubi.util.GoldenFileUtils._
 
-class CheckAuthzExtractorSPISuite extends AnyFunSuite {
-  // scalastyle:on
+class CheckAuthzExtractorSPISuite extends KyuubiFunSuite {
 
   test("check authz extractor SPI service file sorted") {
     Seq(

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/JsonSpecFileGenerator.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/JsonSpecFileGenerator.scala
@@ -20,8 +20,7 @@ package org.apache.kyuubi.plugin.spark.authz.gen
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Paths, StandardOpenOption}
 
-//scalastyle:off
-import org.scalatest.funsuite.AnyFunSuite
+import org.apache.kyuubi.KyuubiFunSuite
 
 import org.apache.kyuubi.plugin.spark.authz.serde.{mapper, CommandSpec}
 import org.apache.kyuubi.plugin.spark.authz.serde.CommandSpecs
@@ -41,8 +40,7 @@ import org.apache.kyuubi.util.GoldenFileUtils._
  *   dev/gen/gen_ranger_spec_json.sh
  * }}}
  */
-class JsonSpecFileGenerator extends AnyFunSuite {
-  // scalastyle:on
+class JsonSpecFileGenerator extends KyuubiFunSuite {
   test("check spec json files") {
     writeCommandSpecJson("database", Seq(DatabaseCommands))
     writeCommandSpecJson(

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/JsonSpecFileGenerator.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/gen/JsonSpecFileGenerator.scala
@@ -21,7 +21,6 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Paths, StandardOpenOption}
 
 import org.apache.kyuubi.KyuubiFunSuite
-
 import org.apache.kyuubi.plugin.spark.authz.serde.{mapper, CommandSpec}
 import org.apache.kyuubi.plugin.spark.authz.serde.CommandSpecs
 import org.apache.kyuubi.util.AssertionUtils._

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/AccessResourceSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/AccessResourceSuite.scala
@@ -17,13 +17,11 @@
 
 package org.apache.kyuubi.plugin.spark.authz.ranger
 
-// scalastyle:off
-import org.scalatest.funsuite.AnyFunSuite
+import org.apache.kyuubi.KyuubiFunSuite
 
 import org.apache.kyuubi.plugin.spark.authz.ObjectType._
 
-class AccessResourceSuite extends AnyFunSuite {
-// scalastyle:on
+class AccessResourceSuite extends KyuubiFunSuite {
   test("generate spark ranger resources") {
     val resource = AccessResource(DATABASE, "my_db_name", None)
     assert(resource.catalog.isEmpty)

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/AccessResourceSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/AccessResourceSuite.scala
@@ -18,7 +18,6 @@
 package org.apache.kyuubi.plugin.spark.authz.ranger
 
 import org.apache.kyuubi.KyuubiFunSuite
-
 import org.apache.kyuubi.plugin.spark.authz.ObjectType._
 
 class AccessResourceSuite extends KyuubiFunSuite {

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/AuthzSessionSigningSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/AuthzSessionSigningSuite.scala
@@ -21,8 +21,8 @@ import java.util.Base64
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSessionExtensions
-import org.apache.kyuubi.KyuubiFunSuite
 
+import org.apache.kyuubi.KyuubiFunSuite
 import org.apache.kyuubi.config.KyuubiReservedKeys.{KYUUBI_SESSION_SIGN_PUBLICKEY, KYUUBI_SESSION_USER_KEY, KYUUBI_SESSION_USER_SIGN}
 import org.apache.kyuubi.plugin.spark.authz.{AccessControlException, SparkSessionProvider}
 import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/AuthzSessionSigningSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/AuthzSessionSigningSuite.scala
@@ -21,18 +21,14 @@ import java.util.Base64
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSessionExtensions
-import org.scalatest.BeforeAndAfterAll
-// scalastyle:off
-import org.scalatest.funsuite.AnyFunSuite
+import org.apache.kyuubi.KyuubiFunSuite
 
 import org.apache.kyuubi.config.KyuubiReservedKeys.{KYUUBI_SESSION_SIGN_PUBLICKEY, KYUUBI_SESSION_USER_KEY, KYUUBI_SESSION_USER_SIGN}
 import org.apache.kyuubi.plugin.spark.authz.{AccessControlException, SparkSessionProvider}
 import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils
 import org.apache.kyuubi.util.SignUtils
 
-class AuthzSessionSigningSuite extends AnyFunSuite
-  with SparkSessionProvider with BeforeAndAfterAll {
-  // scalastyle:on
+class AuthzSessionSigningSuite extends KyuubiFunSuite with SparkSessionProvider {
   override protected val extension: SparkSessionExtensions => Unit = new RangerSparkExtension
   override protected val catalogImpl: String = "in-memory"
   override protected val extraSparkConf: SparkConf = new SparkConf()

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/DeltaCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/DeltaCatalogRangerSparkExtensionSuite.scala
@@ -18,8 +18,6 @@ package org.apache.kyuubi.plugin.spark.authz.ranger
 
 import java.nio.file.Path
 
-import org.scalatest.Outcome
-
 import org.apache.kyuubi.Utils
 import org.apache.kyuubi.plugin.spark.authz.AccessControlException
 import org.apache.kyuubi.plugin.spark.authz.RangerTestNamespace._
@@ -74,10 +72,6 @@ class DeltaCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
        |PARTITIONED BY (gender)
        |${propString(props)}
        |""".stripMargin
-
-  override def withFixture(test: NoArgTest): Outcome = {
-    test()
-  }
 
   override def beforeAll(): Unit = {
     spark.conf.set(s"spark.sql.catalog.$sparkCatalog", deltaCatalogClassName)

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/IcebergCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/IcebergCatalogRangerSparkExtensionSuite.scala
@@ -22,8 +22,6 @@ import java.text.SimpleDateFormat
 import scala.util.Try
 
 import org.apache.spark.sql.Row
-import org.scalatest.Outcome
-
 import org.apache.kyuubi.Utils
 // scalastyle:off
 import org.apache.kyuubi.plugin.spark.authz.AccessControlException
@@ -50,10 +48,6 @@ class IcebergCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite 
   val outputTable1 = "outputTable1"
   val bobNamespace = "default_bob"
   val bobSelectTable = "table_select_bob_1"
-
-  override def withFixture(test: NoArgTest): Outcome = {
-    test()
-  }
 
   override def beforeAll(): Unit = {
     super.beforeAll()

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/IcebergCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/IcebergCatalogRangerSparkExtensionSuite.scala
@@ -22,6 +22,7 @@ import java.text.SimpleDateFormat
 import scala.util.Try
 
 import org.apache.spark.sql.Row
+
 import org.apache.kyuubi.Utils
 // scalastyle:off
 import org.apache.kyuubi.plugin.spark.authz.AccessControlException

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/PaimonCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/PaimonCatalogRangerSparkExtensionSuite.scala
@@ -16,6 +16,8 @@
  */
 package org.apache.kyuubi.plugin.spark.authz.ranger
 
+import org.scalatest.Tag
+
 import org.apache.kyuubi.Utils
 import org.apache.kyuubi.plugin.spark.authz.AccessControlException
 import org.apache.kyuubi.plugin.spark.authz.RangerTestUsers._
@@ -39,18 +41,20 @@ class PaimonCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
   val namespace1 = "paimon_ns"
   val table1 = "table1"
 
-  override def beforeEach(): Unit = {
-    assume(isSupportedVersion)
-    super.beforeEach()
+  override protected def test(testName: String, testTags: Tag*)(
+      testFun: => Any)(implicit pos: org.scalactic.source.Position): Unit = {
+    if (isSupportedVersion) {
+      super.test(testName, testTags: _*)(testFun)(pos)
+    }
   }
 
   override def beforeAll(): Unit = {
+    super.beforeAll()
     if (isSupportedVersion) {
       spark.conf.set(s"spark.sql.catalog.$catalogV2", "org.apache.paimon.spark.SparkCatalog")
       spark.conf.set(
         s"spark.sql.catalog.$catalogV2.warehouse",
         Utils.createTempDir(catalogV2).toString)
-      super.beforeAll()
       doAs(admin, sql(s"CREATE DATABASE IF NOT EXISTS $catalogV2.$namespace1"))
     }
   }
@@ -58,11 +62,10 @@ class PaimonCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
   override def afterAll(): Unit = {
     if (isSupportedVersion) {
       doAs(admin, sql(s"DROP DATABASE IF EXISTS $catalogV2.$namespace1"))
-
-      super.afterAll()
       spark.sessionState.catalog.reset()
       spark.sessionState.conf.clear()
     }
+    super.afterAll()
   }
 
   test("CreateTable") {

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/PaimonCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/PaimonCatalogRangerSparkExtensionSuite.scala
@@ -40,8 +40,8 @@ class PaimonCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
   val table1 = "table1"
 
   override def beforeEach(): Unit = {
-    super.beforeEach()
     assume(isSupportedVersion)
+    super.beforeEach()
   }
 
   override def beforeAll(): Unit = {

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/PaimonCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/PaimonCatalogRangerSparkExtensionSuite.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.kyuubi.plugin.spark.authz.ranger
 
+import org.scalactic.source
 import org.scalatest.Tag
 
 import org.apache.kyuubi.Utils
@@ -42,19 +43,18 @@ class PaimonCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
   val table1 = "table1"
 
   override protected def test(testName: String, testTags: Tag*)(
-      testFun: => Any)(implicit pos: org.scalactic.source.Position): Unit = {
-    if (isSupportedVersion) {
-      super.test(testName, testTags: _*)(testFun)(pos)
-    }
+      testFun: => Any)(implicit pos: source.Position): Unit = {
+    assume(isSupportedVersion)
+    super.test(testName, testTags: _*)(testFun)(pos)
   }
 
   override def beforeAll(): Unit = {
-    super.beforeAll()
     if (isSupportedVersion) {
       spark.conf.set(s"spark.sql.catalog.$catalogV2", "org.apache.paimon.spark.SparkCatalog")
       spark.conf.set(
         s"spark.sql.catalog.$catalogV2.warehouse",
         Utils.createTempDir(catalogV2).toString)
+      super.beforeAll()
       doAs(admin, sql(s"CREATE DATABASE IF NOT EXISTS $catalogV2.$namespace1"))
     }
   }
@@ -62,10 +62,10 @@ class PaimonCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
   override def afterAll(): Unit = {
     if (isSupportedVersion) {
       doAs(admin, sql(s"DROP DATABASE IF EXISTS $catalogV2.$namespace1"))
+      super.afterAll()
       spark.sessionState.catalog.reset()
       spark.sessionState.conf.clear()
     }
-    super.afterAll()
   }
 
   test("CreateTable") {

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/PaimonCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/PaimonCatalogRangerSparkExtensionSuite.scala
@@ -16,8 +16,6 @@
  */
 package org.apache.kyuubi.plugin.spark.authz.ranger
 
-import org.scalatest.Outcome
-
 import org.apache.kyuubi.Utils
 import org.apache.kyuubi.plugin.spark.authz.AccessControlException
 import org.apache.kyuubi.plugin.spark.authz.RangerTestUsers._
@@ -41,9 +39,9 @@ class PaimonCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
   val namespace1 = "paimon_ns"
   val table1 = "table1"
 
-  override def withFixture(test: NoArgTest): Outcome = {
+  override def beforeEach(): Unit = {
+    super.beforeEach()
     assume(isSupportedVersion)
-    test()
   }
 
   override def beforeAll(): Unit = {

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
@@ -23,6 +23,7 @@ import java.nio.file.Path
 import scala.util.Try
 
 import org.apache.hadoop.security.UserGroupInformation
+import org.apache.logging.log4j.Level
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{DataFrame, Row, SparkSessionExtensions}
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
@@ -37,7 +38,7 @@ import org.scalatest.BeforeAndAfterAll
 // scalastyle:off
 import org.scalatest.funsuite.AnyFunSuite
 
-import org.apache.kyuubi.Utils
+import org.apache.kyuubi.{LogAppenderSuite, Utils}
 import org.apache.kyuubi.plugin.lineage.Lineage
 import org.apache.kyuubi.plugin.lineage.helper.SparkSQLLineageParseHelper
 import org.apache.kyuubi.plugin.spark.authz.{AccessControlException, SparkSessionProvider}
@@ -50,7 +51,7 @@ import org.apache.kyuubi.util.AssertionUtils._
 import org.apache.kyuubi.util.reflect.ReflectUtils._
 
 abstract class RangerSparkExtensionSuite extends AnyFunSuite
-  with SparkSessionProvider with BeforeAndAfterAll with MysqlContainerEnv {
+  with SparkSessionProvider with BeforeAndAfterAll with MysqlContainerEnv with LogAppenderSuite {
   // scalastyle:on
   override protected val extension: SparkSessionExtensions => Unit = new RangerSparkExtension
 
@@ -166,6 +167,31 @@ abstract class RangerSparkExtensionSuite extends AnyFunSuite
     }
 
     assert(logicalPlan.getTagValue(KYUUBI_AUTHZ_TAG).nonEmpty)
+  }
+
+  test("[KYUUBI #2470] RuleAuthorization: trace successful and failed privilege checks") {
+    def assertPrivilegeCheckTraced(f: => Unit): Unit = {
+      val appender = new LogAppender
+      appender.setThreshold(Level.DEBUG)
+      withLogAppender(
+        appender,
+        Seq("org.apache.ranger.perf.sparkauth.request"),
+        Some(Level.DEBUG)) {
+        f
+        assert(appender.loggingEvents.exists(
+          _.getMessage.getFormattedMessage.contains("RuleAuthorization.checkPrivileges()")))
+      }
+    }
+
+    val successPlan = spark.sessionState.sqlParser.parsePlan("SHOW TABLES")
+    assertPrivilegeCheckTraced {
+      doAs(admin, new RuleAuthorization(spark).apply(successPlan))
+    }
+
+    assertPrivilegeCheckTraced {
+      intercept[AccessControlException](
+        doAs(denyUser, sql("CREATE DATABASE kyuubi_2470")))
+    }
   }
 
   test("[KYUUBI #3226]: Another session should also check even if the plan is cached.") {

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
@@ -34,11 +34,8 @@ import org.apache.spark.sql.execution.columnar.InMemoryRelation
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
-import org.scalatest.BeforeAndAfterAll
-// scalastyle:off
-import org.scalatest.funsuite.AnyFunSuite
 
-import org.apache.kyuubi.{LogAppenderSuite, Utils}
+import org.apache.kyuubi.{KyuubiFunSuite, Utils}
 import org.apache.kyuubi.plugin.lineage.Lineage
 import org.apache.kyuubi.plugin.lineage.helper.SparkSQLLineageParseHelper
 import org.apache.kyuubi.plugin.spark.authz.{AccessControlException, SparkSessionProvider}
@@ -50,9 +47,8 @@ import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
 import org.apache.kyuubi.util.AssertionUtils._
 import org.apache.kyuubi.util.reflect.ReflectUtils._
 
-abstract class RangerSparkExtensionSuite extends AnyFunSuite
-  with SparkSessionProvider with BeforeAndAfterAll with MysqlContainerEnv with LogAppenderSuite {
-  // scalastyle:on
+abstract class RangerSparkExtensionSuite extends KyuubiFunSuite
+  with SparkSessionProvider with MysqlContainerEnv {
   override protected val extension: SparkSessionExtensions => Unit = new RangerSparkExtension
 
   var mysqlJdbcUrl = ""

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPluginSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPluginSuite.scala
@@ -18,8 +18,8 @@
 package org.apache.kyuubi.plugin.spark.authz.ranger
 
 import org.apache.hadoop.security.UserGroupInformation
-import org.apache.kyuubi.KyuubiFunSuite
 
+import org.apache.kyuubi.KyuubiFunSuite
 import org.apache.kyuubi.plugin.spark.authz.{ObjectType, OperationType}
 import org.apache.kyuubi.plugin.spark.authz.RangerTestNamespace._
 import org.apache.kyuubi.plugin.spark.authz.RangerTestUsers._

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPluginSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPluginSuite.scala
@@ -18,16 +18,14 @@
 package org.apache.kyuubi.plugin.spark.authz.ranger
 
 import org.apache.hadoop.security.UserGroupInformation
-// scalastyle:off
-import org.scalatest.funsuite.AnyFunSuite
+import org.apache.kyuubi.KyuubiFunSuite
 
 import org.apache.kyuubi.plugin.spark.authz.{ObjectType, OperationType}
 import org.apache.kyuubi.plugin.spark.authz.RangerTestNamespace._
 import org.apache.kyuubi.plugin.spark.authz.RangerTestUsers._
 import org.apache.kyuubi.plugin.spark.authz.ranger.SparkRangerAdminPlugin._
 
-class SparkRangerAdminPluginSuite extends AnyFunSuite {
-// scalastyle:on
+class SparkRangerAdminPluginSuite extends KyuubiFunSuite {
 
   test("get filter expression") {
     val bob = UserGroupInformation.createRemoteUser("bob")

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingForIcebergSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingForIcebergSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.kyuubi.plugin.spark.authz.ranger.datamasking
 
 import org.apache.spark.SparkConf
+
 import org.apache.kyuubi.Utils
 import org.apache.kyuubi.tags.IcebergTest
 

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingForIcebergSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingForIcebergSuite.scala
@@ -18,8 +18,6 @@
 package org.apache.kyuubi.plugin.spark.authz.ranger.datamasking
 
 import org.apache.spark.SparkConf
-import org.scalatest.Outcome
-
 import org.apache.kyuubi.Utils
 import org.apache.kyuubi.tags.IcebergTest
 
@@ -49,7 +47,4 @@ class DataMaskingForIcebergSuite extends DataMaskingTestBase {
     super.afterAll()
   }
 
-  override def withFixture(test: NoArgTest): Outcome = {
-    test()
-  }
 }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingForJDBCV2Suite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingForJDBCV2Suite.scala
@@ -21,6 +21,7 @@ import java.sql.DriverManager
 import scala.util.Try
 
 import org.apache.spark.SparkConf
+
 import org.apache.kyuubi.plugin.spark.authz.V2JdbcTableCatalogPrivilegesBuilderSuite._
 import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
 

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingForJDBCV2Suite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingForJDBCV2Suite.scala
@@ -21,8 +21,6 @@ import java.sql.DriverManager
 import scala.util.Try
 
 import org.apache.spark.SparkConf
-import org.scalatest.Outcome
-
 import org.apache.kyuubi.plugin.spark.authz.V2JdbcTableCatalogPrivilegesBuilderSuite._
 import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
 
@@ -53,7 +51,4 @@ class DataMaskingForJDBCV2Suite extends DataMaskingTestBase {
     }
   }
 
-  override def withFixture(test: NoArgTest): Outcome = {
-    test()
-  }
 }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingTestBase.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingTestBase.scala
@@ -24,8 +24,8 @@ import scala.util.Try
 import org.apache.commons.codec.digest.DigestUtils.md5Hex
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{Row, SparkSessionExtensions}
-import org.apache.kyuubi.KyuubiFunSuite
 
+import org.apache.kyuubi.KyuubiFunSuite
 import org.apache.kyuubi.plugin.spark.authz.RangerTestUsers._
 import org.apache.kyuubi.plugin.spark.authz.SparkSessionProvider
 import org.apache.kyuubi.plugin.spark.authz.ranger.RangerSparkExtension

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingTestBase.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/datamasking/DataMaskingTestBase.scala
@@ -21,12 +21,10 @@ import java.sql.Timestamp
 
 import scala.util.Try
 
-// scalastyle:off
 import org.apache.commons.codec.digest.DigestUtils.md5Hex
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{Row, SparkSessionExtensions}
-import org.scalatest.BeforeAndAfterAll
-import org.scalatest.funsuite.AnyFunSuite
+import org.apache.kyuubi.KyuubiFunSuite
 
 import org.apache.kyuubi.plugin.spark.authz.RangerTestUsers._
 import org.apache.kyuubi.plugin.spark.authz.SparkSessionProvider
@@ -36,8 +34,7 @@ import org.apache.kyuubi.plugin.spark.authz.ranger.RangerSparkExtension
  * Base trait for data masking tests, derivative classes shall name themselves following:
  *  DataMaskingFor CatalogImpl?  FileFormat? Additions? Suite
  */
-trait DataMaskingTestBase extends AnyFunSuite with SparkSessionProvider with BeforeAndAfterAll {
-// scalastyle:on
+trait DataMaskingTestBase extends KyuubiFunSuite with SparkSessionProvider {
   override protected val extension: SparkSessionExtensions => Unit = new RangerSparkExtension
 
   // SPARK-44444 (Spark 4.0) enables ANSI SQL mode by default. Under ANSI mode,

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/rowfiltering/RowFilteringForIcebergSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/rowfiltering/RowFilteringForIcebergSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.kyuubi.plugin.spark.authz.ranger.rowfiltering
 
 import org.apache.spark.SparkConf
+
 import org.apache.kyuubi.Utils
 import org.apache.kyuubi.tags.IcebergTest
 

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/rowfiltering/RowFilteringForIcebergSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/rowfiltering/RowFilteringForIcebergSuite.scala
@@ -18,8 +18,6 @@
 package org.apache.kyuubi.plugin.spark.authz.ranger.rowfiltering
 
 import org.apache.spark.SparkConf
-import org.scalatest.Outcome
-
 import org.apache.kyuubi.Utils
 import org.apache.kyuubi.tags.IcebergTest
 
@@ -49,7 +47,4 @@ class RowFilteringForIcebergSuite extends RowFilteringTestBase {
     super.afterAll()
   }
 
-  override def withFixture(test: NoArgTest): Outcome = {
-    test()
-  }
 }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/rowfiltering/RowFilteringForJDBCV2Suite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/rowfiltering/RowFilteringForJDBCV2Suite.scala
@@ -22,6 +22,7 @@ import java.sql.DriverManager
 import scala.util.Try
 
 import org.apache.spark.SparkConf
+
 import org.apache.kyuubi.plugin.spark.authz.V2JdbcTableCatalogPrivilegesBuilderSuite._
 import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
 

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/rowfiltering/RowFilteringForJDBCV2Suite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/rowfiltering/RowFilteringForJDBCV2Suite.scala
@@ -22,8 +22,6 @@ import java.sql.DriverManager
 import scala.util.Try
 
 import org.apache.spark.SparkConf
-import org.scalatest.Outcome
-
 import org.apache.kyuubi.plugin.spark.authz.V2JdbcTableCatalogPrivilegesBuilderSuite._
 import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
 
@@ -54,7 +52,4 @@ class RowFilteringForJDBCV2Suite extends RowFilteringTestBase {
     }
   }
 
-  override def withFixture(test: NoArgTest): Outcome = {
-    test()
-  }
 }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/rowfiltering/RowFilteringTestBase.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/rowfiltering/RowFilteringTestBase.scala
@@ -17,12 +17,10 @@
 
 package org.apache.kyuubi.plugin.spark.authz.ranger.rowfiltering
 
-// scalastyle:off
 import scala.util.Try
 
 import org.apache.spark.sql.{Row, SparkSessionExtensions}
-import org.scalatest.BeforeAndAfterAll
-import org.scalatest.funsuite.AnyFunSuite
+import org.apache.kyuubi.KyuubiFunSuite
 
 import org.apache.kyuubi.plugin.spark.authz.RangerTestUsers._
 import org.apache.kyuubi.plugin.spark.authz.SparkSessionProvider
@@ -32,8 +30,7 @@ import org.apache.kyuubi.plugin.spark.authz.ranger.RangerSparkExtension
  * Base trait for row filtering tests, derivative classes shall name themselves following:
  *  RowFilteringFor CatalogImpl?  FileFormat? Additions? Suite
  */
-trait RowFilteringTestBase extends AnyFunSuite with SparkSessionProvider with BeforeAndAfterAll {
-// scalastyle:on
+trait RowFilteringTestBase extends KyuubiFunSuite with SparkSessionProvider {
   override protected val extension: SparkSessionExtensions => Unit = new RangerSparkExtension
 
   private def setup(): Unit = {

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/rowfiltering/RowFilteringTestBase.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/rowfiltering/RowFilteringTestBase.scala
@@ -20,8 +20,8 @@ package org.apache.kyuubi.plugin.spark.authz.ranger.rowfiltering
 import scala.util.Try
 
 import org.apache.spark.sql.{Row, SparkSessionExtensions}
-import org.apache.kyuubi.KyuubiFunSuite
 
+import org.apache.kyuubi.KyuubiFunSuite
 import org.apache.kyuubi.plugin.spark.authz.RangerTestUsers._
 import org.apache.kyuubi.plugin.spark.authz.SparkSessionProvider
 import org.apache.kyuubi.plugin.spark.authz.ranger.RangerSparkExtension

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/rule/AuthzConfigurationCheckerSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/rule/AuthzConfigurationCheckerSuite.scala
@@ -47,8 +47,8 @@ class AuthzConfigurationCheckerSuite extends KyuubiFunSuite with SparkSessionPro
     intercept[AccessControlException](extension.apply(p6))
     val p7 = sql("set spark.sql.efg=hijk").queryExecution.analyzed
     extension.apply(p7)
-    val p8 = sql(
-      s"set spark.sql.optimizer.excludedRules=${classOf[RuleAuthorization].getName}").queryExecution.analyzed
+    val p8 = sql(s"set spark.sql.optimizer.excludedRules=${classOf[RuleAuthorization].getName}")
+      .queryExecution.analyzed
     intercept[AccessControlException](extension.apply(p8))
     val p9 = sql(
       "set spark.kyuubi.authz.skipCataloglessV2Relation.enabled=true").queryExecution.analyzed

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/rule/AuthzConfigurationCheckerSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/rule/AuthzConfigurationCheckerSuite.scala
@@ -18,7 +18,6 @@
 package org.apache.kyuubi.plugin.spark.authz.rule
 
 import org.apache.kyuubi.KyuubiFunSuite
-
 import org.apache.kyuubi.plugin.spark.authz.{AccessControlException, SparkSessionProvider}
 import org.apache.kyuubi.plugin.spark.authz.ranger.RuleAuthorization
 import org.apache.kyuubi.plugin.spark.authz.rule.config.AuthzConfigurationChecker

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/rule/AuthzConfigurationCheckerSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/rule/AuthzConfigurationCheckerSuite.scala
@@ -17,16 +17,13 @@
 
 package org.apache.kyuubi.plugin.spark.authz.rule
 
-import org.scalatest.BeforeAndAfterAll
-// scalastyle:off
-import org.scalatest.funsuite.AnyFunSuite
+import org.apache.kyuubi.KyuubiFunSuite
 
 import org.apache.kyuubi.plugin.spark.authz.{AccessControlException, SparkSessionProvider}
 import org.apache.kyuubi.plugin.spark.authz.ranger.RuleAuthorization
 import org.apache.kyuubi.plugin.spark.authz.rule.config.AuthzConfigurationChecker
 
-class AuthzConfigurationCheckerSuite extends AnyFunSuite with SparkSessionProvider
-  with BeforeAndAfterAll {
+class AuthzConfigurationCheckerSuite extends KyuubiFunSuite with SparkSessionProvider {
 
   override protected val catalogImpl: String = "in-memory"
   override def afterAll(): Unit = {

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/serde/DataSourceV2RelationTableExtractorSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/serde/DataSourceV2RelationTableExtractorSuite.scala
@@ -23,12 +23,10 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.connector.catalog.{Identifier, Table => V2Table, TableCapability}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
-import org.scalatest.BeforeAndAfterAll
-// scalastyle:off
-import org.scalatest.funsuite.AnyFunSuite
 
-class DataSourceV2RelationTableExtractorSuite extends AnyFunSuite with BeforeAndAfterAll {
-// scalastyle:on
+import org.apache.kyuubi.KyuubiFunSuite
+
+class DataSourceV2RelationTableExtractorSuite extends KyuubiFunSuite {
 
   private val skipConfKey = "spark.kyuubi.authz.skipCataloglessV2Relation.enabled"
 

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/spark/sql/RuleAuthorizationBenchmark.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/spark/sql/RuleAuthorizationBenchmark.scala
@@ -26,8 +26,8 @@ import scala.concurrent.duration.Duration
 import scala.reflect.io.Path.jfile2path
 
 import org.apache.spark.benchmark.Benchmark
-import org.apache.kyuubi.KyuubiFunSuite
 
+import org.apache.kyuubi.KyuubiFunSuite
 import org.apache.kyuubi.plugin.spark.authz.SparkSessionProvider
 import org.apache.kyuubi.plugin.spark.authz.benchmark.KyuubiBenchmarkBase
 import org.apache.kyuubi.plugin.spark.authz.ranger.RuleAuthorization

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/spark/sql/RuleAuthorizationBenchmark.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/spark/sql/RuleAuthorizationBenchmark.scala
@@ -26,9 +26,7 @@ import scala.concurrent.duration.Duration
 import scala.reflect.io.Path.jfile2path
 
 import org.apache.spark.benchmark.Benchmark
-import org.scalatest.BeforeAndAfterAll
-// scalastyle:off
-import org.scalatest.funsuite.AnyFunSuite
+import org.apache.kyuubi.KyuubiFunSuite
 
 import org.apache.kyuubi.plugin.spark.authz.SparkSessionProvider
 import org.apache.kyuubi.plugin.spark.authz.benchmark.KyuubiBenchmarkBase
@@ -44,10 +42,8 @@ import org.apache.kyuubi.util.ThreadUtils
  *   -Dtest=none -DwildcardSuites=org.apache.spark.sql.RuleAuthorizationBenchmark
  * }}}
  */
-class RuleAuthorizationBenchmark extends AnyFunSuite
-  with SparkSessionProvider with BeforeAndAfterAll
+class RuleAuthorizationBenchmark extends KyuubiFunSuite with SparkSessionProvider
   with KyuubiBenchmarkBase {
-  // scalastyle:on
 
   override protected val catalogImpl: String = "hive"
   private val runBenchmark = sys.env.contains("RUN_BENCHMARK")

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/KyuubiFunSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/KyuubiFunSuite.scala
@@ -32,41 +32,7 @@ import org.slf4j.bridge.SLF4JBridgeHandler
 import org.apache.kyuubi.config.internal.Tests.IS_TESTING
 import org.apache.kyuubi.service.authentication.InternalSecurityAccessor
 
-trait KyuubiFunSuite extends AnyFunSuite
-  with BeforeAndAfterAll
-  with BeforeAndAfterEach
-  with Eventually
-  with ThreadAudit
-  with Logging {
-
-  // Redirect jul to sl4j
-  SLF4JBridgeHandler.removeHandlersForRootLogger()
-  SLF4JBridgeHandler.install()
-
-  // scalastyle:on
-  override def beforeAll(): Unit = {
-    System.setProperty(IS_TESTING.key, "true")
-    doThreadPreAudit()
-    InternalSecurityAccessor.reset()
-    super.beforeAll()
-  }
-
-  override def afterAll(): Unit = {
-    super.afterAll()
-    doThreadPostAudit()
-  }
-
-  final override def withFixture(test: NoArgTest): Outcome = {
-    val testName = test.text
-    val suiteName = this.getClass.getName
-    val shortSuiteName = suiteName.replaceAll("org\\.apache\\.kyuubi", "o\\.a\\.k")
-    try {
-      info(s"\n\n===== TEST OUTPUT FOR $shortSuiteName: '$testName' =====\n")
-      test()
-    } finally {
-      info(s"\n\n===== FINISHED $shortSuiteName: '$testName' =====\n")
-    }
-  }
+trait LogAppenderSuite {
 
   /**
    * Adds a log appender and optionally sets a log level to the root logger or the logger with
@@ -134,6 +100,44 @@ trait KyuubiFunSuite extends AnyFunSuite
 
     def loggingEvents: ArrayBuffer[LogEvent] = _loggingEvents.synchronized {
       _loggingEvents.filterNot(_ == null)
+    }
+  }
+}
+
+trait KyuubiFunSuite extends AnyFunSuite
+  with BeforeAndAfterAll
+  with BeforeAndAfterEach
+  with Eventually
+  with ThreadAudit
+  with Logging
+  with LogAppenderSuite {
+
+  // Redirect jul to sl4j
+  SLF4JBridgeHandler.removeHandlersForRootLogger()
+  SLF4JBridgeHandler.install()
+
+  // scalastyle:on
+  override def beforeAll(): Unit = {
+    System.setProperty(IS_TESTING.key, "true")
+    doThreadPreAudit()
+    InternalSecurityAccessor.reset()
+    super.beforeAll()
+  }
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    doThreadPostAudit()
+  }
+
+  final override def withFixture(test: NoArgTest): Outcome = {
+    val testName = test.text
+    val suiteName = this.getClass.getName
+    val shortSuiteName = suiteName.replaceAll("org\\.apache\\.kyuubi", "o\\.a\\.k")
+    try {
+      info(s"\n\n===== TEST OUTPUT FOR $shortSuiteName: '$testName' =====\n")
+      test()
+    } finally {
+      info(s"\n\n===== FINISHED $shortSuiteName: '$testName' =====\n")
     }
   }
 

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/KyuubiFunSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/KyuubiFunSuite.scala
@@ -32,7 +32,41 @@ import org.slf4j.bridge.SLF4JBridgeHandler
 import org.apache.kyuubi.config.internal.Tests.IS_TESTING
 import org.apache.kyuubi.service.authentication.InternalSecurityAccessor
 
-trait LogAppenderSuite {
+trait KyuubiFunSuite extends AnyFunSuite
+  with BeforeAndAfterAll
+  with BeforeAndAfterEach
+  with Eventually
+  with ThreadAudit
+  with Logging {
+
+  // Redirect jul to sl4j
+  SLF4JBridgeHandler.removeHandlersForRootLogger()
+  SLF4JBridgeHandler.install()
+
+  // scalastyle:on
+  override def beforeAll(): Unit = {
+    System.setProperty(IS_TESTING.key, "true")
+    doThreadPreAudit()
+    InternalSecurityAccessor.reset()
+    super.beforeAll()
+  }
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    doThreadPostAudit()
+  }
+
+  final override def withFixture(test: NoArgTest): Outcome = {
+    val testName = test.text
+    val suiteName = this.getClass.getName
+    val shortSuiteName = suiteName.replaceAll("org\\.apache\\.kyuubi", "o\\.a\\.k")
+    try {
+      info(s"\n\n===== TEST OUTPUT FOR $shortSuiteName: '$testName' =====\n")
+      test()
+    } finally {
+      info(s"\n\n===== FINISHED $shortSuiteName: '$testName' =====\n")
+    }
+  }
 
   /**
    * Adds a log appender and optionally sets a log level to the root logger or the logger with
@@ -100,44 +134,6 @@ trait LogAppenderSuite {
 
     def loggingEvents: ArrayBuffer[LogEvent] = _loggingEvents.synchronized {
       _loggingEvents.filterNot(_ == null)
-    }
-  }
-}
-
-trait KyuubiFunSuite extends AnyFunSuite
-  with BeforeAndAfterAll
-  with BeforeAndAfterEach
-  with Eventually
-  with ThreadAudit
-  with Logging
-  with LogAppenderSuite {
-
-  // Redirect jul to sl4j
-  SLF4JBridgeHandler.removeHandlersForRootLogger()
-  SLF4JBridgeHandler.install()
-
-  // scalastyle:on
-  override def beforeAll(): Unit = {
-    System.setProperty(IS_TESTING.key, "true")
-    doThreadPreAudit()
-    InternalSecurityAccessor.reset()
-    super.beforeAll()
-  }
-
-  override def afterAll(): Unit = {
-    super.afterAll()
-    doThreadPostAudit()
-  }
-
-  final override def withFixture(test: NoArgTest): Outcome = {
-    val testName = test.text
-    val suiteName = this.getClass.getName
-    val shortSuiteName = suiteName.replaceAll("org\\.apache\\.kyuubi", "o\\.a\\.k")
-    try {
-      info(s"\n\n===== TEST OUTPUT FOR $shortSuiteName: '$testName' =====\n")
-      test()
-    } finally {
-      info(s"\n\n===== FINISHED $shortSuiteName: '$testName' =====\n")
     }
   }
 


### PR DESCRIPTION
### Why are the changes needed?

Closes #2470.

`RuleAuthorization.checkPrivileges` currently has no Ranger performance trace around privilege-request construction and evaluation. This adds the established `sparkauth.request` tracer around the complete authorization path and logs it from `finally`, so both successful checks and exceptions finish the timing record without changing authorization results.

### How was this patch tested?

- `JAVA_HOME=$(/usr/libexec/java_home -v 17) ./dev/reformat`
- `JAVA_HOME=$(/usr/libexec/java_home -v 17) ./build/mvn -pl extensions/spark/kyuubi-spark-authz -am -DwildcardSuites=org.apache.kyuubi.plugin.spark.authz.ranger.InMemoryCatalogRangerSparkExtensionSuite -DskipITs test`
  - 16 tests passed, including a new assertion that captures the performance trace on both successful and denied authorization paths.
- `git diff --check`

### Was this patch authored or co-authored using generative AI tooling?

Assisted-by: OpenAI Codex with GPT-5
