### PR TITLE
[KYUUBI #7230][AUTHZ] Support skipping privilege check for DataSourceV2Relation without catalog and identifier

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/rule/config/AuthzConfigurationChecker.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/rule/config/AuthzConfigurationChecker.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.command.SetCommand
 
 import org.apache.kyuubi.plugin.spark.authz.AccessControlException
+import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils.SKIP_CATALOGLESS_V2_RELATION_ENABLED_KEY
 
 /**
  * For banning end-users from set restricted spark configurations
@@ -31,7 +32,11 @@ case class AuthzConfigurationChecker(spark: SparkSession) extends (LogicalPlan =
   final val RESTRICT_LIST_KEY = "spark.kyuubi.conf.restricted.list"
 
   private val restrictedConfList: Set[String] =
-    Set(RESTRICT_LIST_KEY, "spark.sql.runSQLOnFiles", "spark.sql.extensions") ++
+    Set(
+      RESTRICT_LIST_KEY,
+      "spark.sql.runSQLOnFiles",
+      "spark.sql.extensions",
+      SKIP_CATALOGLESS_V2_RELATION_ENABLED_KEY) ++
       spark.conf.getOption(RESTRICT_LIST_KEY).map(_.split(',').toSet).getOrElse(Set.empty)
 
   override def apply(plan: LogicalPlan): Unit = plan match {

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/serde/tableExtractors.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/serde/tableExtractors.scala
@@ -207,6 +207,16 @@ class DataSourceV2RelationTableExtractor extends TableExtractor {
   override def apply(spark: SparkSession, v1: AnyRef): Option[Table] = {
     val plan = v1.asInstanceOf[LogicalPlan]
     plan.find(_.getClass.getSimpleName == "DataSourceV2Relation").get match {
+      // A relation from a TableProvider without SupportsCatalogOptions, e.g.
+      // spark.read.format("mongodb"), carries neither catalog nor identifier,
+      // and its table.name() is connector-defined — usually not a resolvable
+      // identifier, so the extracted resource can never match a Ranger policy.
+      // Skipping is opt-in because credentials for the external system may be
+      // ambient to the shared Spark principal rather than supplied per query.
+      case v2Relation: DataSourceV2Relation
+          if v2Relation.identifier.isEmpty && v2Relation.catalog.isEmpty &&
+            isSkipCataloglessV2RelationEnabled(spark) =>
+        None
       case v2Relation: DataSourceV2Relation
           if v2Relation.identifier.isEmpty ||
             !isPathIdentifier(v2Relation.identifier.get.name(), spark) =>

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/util/AuthZUtils.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/util/AuthZUtils.scala
@@ -27,6 +27,7 @@ import org.apache.commons.lang3.StringUtils
 import org.apache.hadoop.security.UserGroupInformation
 import org.apache.ranger.plugin.service.RangerBasePlugin
 import org.apache.spark.{SPARK_VERSION, SparkContext}
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, View}
 
 import org.apache.kyuubi.plugin.spark.authz.AccessControlException
@@ -67,6 +68,13 @@ private[authz] object AuthZUtils {
         false
     }
   }
+
+  final val SKIP_CATALOGLESS_V2_RELATION_ENABLED_KEY =
+    "spark.kyuubi.authz.skipCataloglessV2Relation.enabled"
+
+  def isSkipCataloglessV2RelationEnabled(spark: SparkSession): Boolean =
+    spark.conf.getOption(SKIP_CATALOGLESS_V2_RELATION_ENABLED_KEY)
+      .exists(_.equalsIgnoreCase("true"))
 
   lazy val isRanger21orGreater: Boolean = {
     try {

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/rule/AuthzConfigurationCheckerSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/rule/AuthzConfigurationCheckerSuite.scala
@@ -54,5 +54,8 @@ class AuthzConfigurationCheckerSuite extends AnyFunSuite with SparkSessionProvid
     val p8 = sql(
       s"set spark.sql.optimizer.excludedRules=${classOf[RuleAuthorization].getName}").queryExecution.analyzed
     intercept[AccessControlException](extension.apply(p8))
+    val p9 = sql(
+      "set spark.kyuubi.authz.skipCataloglessV2Relation.enabled=true").queryExecution.analyzed
+    intercept[AccessControlException](extension.apply(p9))
   }
 }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/serde/DataSourceV2RelationTableExtractorSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/serde/DataSourceV2RelationTableExtractorSuite.scala
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.plugin.spark.authz.serde
+
+import java.util
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.connector.catalog.{Identifier, Table => V2Table, TableCapability}
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+import org.apache.spark.sql.types.{StringType, StructField, StructType}
+import org.scalatest.BeforeAndAfterAll
+// scalastyle:off
+import org.scalatest.funsuite.AnyFunSuite
+
+class DataSourceV2RelationTableExtractorSuite extends AnyFunSuite with BeforeAndAfterAll {
+// scalastyle:on
+
+  private val skipConfKey = "spark.kyuubi.authz.skipCataloglessV2Relation.enabled"
+
+  private lazy val spark: SparkSession = SparkSession.builder()
+    .master("local[1]")
+    .appName(getClass.getSimpleName)
+    .getOrCreate()
+
+  override def afterAll(): Unit = {
+    spark.stop()
+    super.afterAll()
+  }
+
+  private val extractor = new DataSourceV2RelationTableExtractor
+
+  /**
+   * A v2 table from a TableProvider without SupportsCatalogOptions, such as the
+   * MongoTable created by `spark.read.format("mongodb")`. Spark's non-catalog
+   * fallback leaves both catalog and identifier empty on the relation, and name()
+   * is a synthetic descriptor rather than a resolvable identifier.
+   */
+  private class CatalogLessTable extends V2Table {
+    override def name(): String = "MongoTable()"
+    override def schema(): StructType = StructType(Seq(StructField("_id", StringType)))
+    override def capabilities(): util.Set[TableCapability] =
+      util.EnumSet.of(TableCapability.BATCH_READ)
+  }
+
+  private def cataloglessRelation: DataSourceV2Relation =
+    DataSourceV2Relation.create(new CatalogLessTable, None, None)
+
+  test("extract table name verbatim for catalog-less relation by default") {
+    val maybeTable = extractor.apply(spark, cataloglessRelation)
+    assert(maybeTable.nonEmpty)
+    assert(maybeTable.get.table === "MongoTable()")
+    assert(maybeTable.get.database.isEmpty)
+  }
+
+  test("skip relation without catalog and identifier when skip conf is enabled") {
+    spark.conf.set(skipConfKey, "true")
+    try {
+      assert(extractor.apply(spark, cataloglessRelation).isEmpty)
+    } finally {
+      spark.conf.unset(skipConfKey)
+    }
+  }
+
+  test("still extract the table when an identifier is present") {
+    spark.conf.set(skipConfKey, "true")
+    try {
+      val identifier = Identifier.of(Array("some_db"), "some_table")
+      val relation = DataSourceV2Relation.create(new CatalogLessTable, None, Some(identifier))
+      val maybeTable = extractor.apply(spark, relation)
+      assert(maybeTable.nonEmpty)
+      assert(maybeTable.get.database === Some("some_db"))
+    } finally {
+      spark.conf.unset(skipConfKey)
+    }
+  }
+}


### PR DESCRIPTION
### Why are the changes needed?

DSv2 `TableProvider`s that do not implement `SupportsCatalogOptions` (the MongoDB connector, the ClickHouse native connector, etc.), when used directly via `format(...).load()` / `.save()`, produce a `DataSourceV2Relation` with neither `catalog` nor `identifier` — Spark's non-catalog fallback in `DataSourceV2Utils.loadV2Source` / `DataFrameWriter` passes `(None, None)`, and the read-side fallback carries Spark's own TODO note that "Non-catalog paths for DSV2 are currently not well defined".

For such relations `DataSourceV2RelationTableExtractor` falls back to `table.name()`, which is connector-defined and usually synthetic (e.g. `MongoTable()`). The resulting Ranger resource has no `database` element, and a resource missing a parent level of the `database → table → column` hierarchy matches no policy at all — not even `database=* / table=*` (`RangerDefaultPolicyResourceMatcher.isHierarchyValidForResources`, Ranger 2.6.0). So the current behavior is an unconditional deny that operators cannot lift with any policy, reported in #7230. Meanwhile the v1 path is already skipped: a `LogicalRelation` without `catalogTable` produces no privilege object.

This PR adds an operator-level opt-out, default `false` so default behavior is unchanged:

- `spark.kyuubi.authz.skip.catalogless.v2.relation.enabled` (default `false`): when enabled, the extractor returns `None` for a `DataSourceV2Relation` whose catalog and identifier are both empty, restoring parity with the v1 path.
- The key is added to `AuthzConfigurationChecker`'s built-in restricted list (like `spark.sql.runSQLOnFiles`), so end users cannot flip it with `SET`. Operators should also consider listing it in `kyuubi.session.conf.restrict.list`.

Note: whether skipping is safe is deployment-specific — fine when credentials for the external system are supplied per query by the end user, risky when the shared Spark principal holds ambient credentials. Hence opt-in rather than unconditional. Skipped relations produce no Ranger audit events.

### How was this patch tested?

- New `DataSourceV2RelationTableExtractorSuite`:
  - default behavior preserved: the synthetic `table.name()` is still extracted verbatim when the conf is off;
  - the relation is skipped when the conf is enabled;
  - relations carrying an identifier are unaffected even with the conf enabled (the database fallback from #6544 still applies).
- Extended `AuthzConfigurationCheckerSuite`: `SET` on the new key throws `AccessControlException`.

### Was this patch authored or co-authored using generative AI tooling?

Assisted-by: Claude Opus 4.8
