### PR TITLE
[INFRA] Bump GHA workflows to latest action versions

### DIFF
--- a/.github/actions/setup-maven/action.yaml
+++ b/.github/actions/setup-maven/action.yaml
@@ -21,7 +21,7 @@ runs:
   using: composite
   steps:
     - name: Restore cached Maven
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: build/apache-maven-*
         key: setup-maven-${{ hashFiles('pom.xml') }}

--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -39,7 +39,7 @@ jobs:
   asf-allowlist-check:
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - uses: apache/infrastructure-actions/allowlist-check@main

--- a/.github/workflows/dep.yml
+++ b/.github/workflows/dep.yml
@@ -38,9 +38,9 @@ jobs:
     name: Dependency check
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7
       - name: setup java
-        uses: actions/setup-java@v5.4.0
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 8

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,8 +34,8 @@ jobs:
     name: sphinx-build
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@v7.0.0
-      - uses: actions/setup-python@v6.3.0
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -34,9 +34,9 @@ jobs:
     name: License
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7
       - name: Setup JDK 8
-        uses: actions/setup-java@v5.4.0
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 8

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -101,13 +101,13 @@ jobs:
     env:
       SPARK_LOCAL_IP: localhost
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7
       - name: Free up disk space
         run: ./.github/scripts/free_disk_space.sh
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
       - name: Setup JDK ${{ matrix.java }}
-        uses: actions/setup-java@v5.4.0
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
@@ -115,7 +115,7 @@ jobs:
       - name: Setup Maven
         uses: ./.github/actions/setup-maven
       - name: Setup Python
-        uses: actions/setup-python@v6.3.0
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
       - name: Resolve engine archive download URLs
@@ -180,13 +180,13 @@ jobs:
         spark:
           - '3.5'
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7
       - name: Free up disk space
         run: ./.github/scripts/free_disk_space.sh
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
       - name: Setup JDK ${{ matrix.java }}
-        uses: actions/setup-java@v5.4.0
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
@@ -264,13 +264,13 @@ jobs:
         extensions/spark/kyuubi-spark-connector-tpcds,\
         extensions/spark/kyuubi-spark-connector-tpch"
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7
       - name: Free up disk space
         run: ./.github/scripts/free_disk_space.sh
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
       - name: Setup JDK ${{ matrix.java }}
-        uses: actions/setup-java@v5.4.0
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
@@ -323,13 +323,13 @@ jobs:
             flink-archive: '-Dflink.archive.mirror=https://www.apache.org/dyn/closer.lua/flink/flink-1.19.3 -Dflink.archive.name=flink-1.19.3-bin-scala_2.12.tgz'
             comment: 'verify-on-flink-1.19-binary'
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7
       - name: Free up disk space
         run: ./.github/scripts/free_disk_space.sh
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
       - name: Setup JDK ${{ matrix.java }}
-        uses: actions/setup-java@v5.4.0
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
@@ -391,13 +391,13 @@ jobs:
             hive-archive: '-Dhive.archive.mirror=https://github.com/pan3793/cdh-hive/releases/download/cdh6.3.2-release -Dhive.archive.name=apache-hive-2.1.1-cdh6.3.2-bin.tar.gz -Dhive.archive.query='
             comment: 'verify-on-hive-2.1-cdh6-binary'
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7
       - name: Free up disk space
         run: ./.github/scripts/free_disk_space.sh
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
       - name: Setup JDK ${{ matrix.java }}
-        uses: actions/setup-java@v5.4.0
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
@@ -444,13 +444,13 @@ jobs:
         java: [ 8 ]
         comment: [ "normal" ]
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7
       - name: Free up disk space
         run: ./.github/scripts/free_disk_space.sh
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
       - name: Setup JDK ${{ matrix.java }}
-        uses: actions/setup-java@v5.4.0
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
@@ -494,7 +494,7 @@ jobs:
     name: Kyuubi Server On Kubernetes Integration Test
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7
       - name: Free up disk space
         run: ./.github/scripts/free_disk_space.sh
       # https://github.com/docker/build-push-action
@@ -570,11 +570,11 @@ jobs:
     name: Spark Engine On Kubernetes Integration Test
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7
       - name: Free up disk space
         run: ./.github/scripts/free_disk_space.sh
       - name: Setup JDK 11
-        uses: actions/setup-java@v5.4.0
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 11
@@ -636,11 +636,11 @@ jobs:
         zookeeper: ["3.4", "3.5", "3.6", "3.7" ]
         comment: [ "normal" ]
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
       - name: Setup JDK ${{ matrix.java }}
-        uses: actions/setup-java@v5.4.0
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,11 +34,11 @@ jobs:
     env:
       SPARK_LOCAL_IP: localhost
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
       - name: Setup JDK 17
-        uses: actions/setup-java@v5.4.0
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17

--- a/.github/workflows/publish-snapshot-docker.yml
+++ b/.github/workflows/publish-snapshot-docker.yml
@@ -27,7 +27,7 @@ jobs:
     if: ${{ startsWith(github.repository, 'apache/') }}
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7
       - name: Free up disk space
         run: ./.github/scripts/free_disk_space.sh
       - name: Set up QEMU

--- a/.github/workflows/publish-snapshot-nexus.yml
+++ b/.github/workflows/publish-snapshot-nexus.yml
@@ -42,13 +42,13 @@ jobs:
           - branch: branch-1.9
             profiles: -Pflink-provided,spark-provided,hive-provided,spark-3.5
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7
         with:
           ref: ${{ matrix.branch }}
       - name: Free up disk space
         run: ./.github/scripts/free_disk_space.sh
       - name: Setup JDK 8
-        uses: actions/setup-java@v5.4.0
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 8

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -48,9 +48,9 @@ jobs:
     env:
       PYTHONHASHSEED: random
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6.3.0
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Start Testing Containers

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -27,7 +27,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/stale@v10.3.0
+      - uses: actions/stale@v10
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-pr-message: >

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -38,11 +38,11 @@ jobs:
           - '-Pflink-provided,hive-provided,spark-provided,spark-3.5,spark-3.4,spark-3.3,tpcds,kubernetes-it'
 
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Setup JDK 17
-        uses: actions/setup-java@v5.4.0
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
@@ -50,7 +50,7 @@ jobs:
       - name: Setup Maven
         uses: ./.github/actions/setup-maven
       - name: Setup Python 3
-        uses: actions/setup-python@v6.3.0
+        uses: actions/setup-python@v6
         with:
           python-version: '3.9'
           cache: 'pip'

--- a/.github/workflows/web-ui.yml
+++ b/.github/workflows/web-ui.yml
@@ -19,9 +19,9 @@ jobs:
     name: Kyuubi Web UI check
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7
       - name: Setup JDK 8
-        uses: actions/setup-java@v5.4.0
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 8
@@ -40,7 +40,7 @@ jobs:
           cache: npm
           cache-dependency-path: ./kyuubi-server/web-ui/package.json
       - name: Cache NPM dependencies
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@v6
         with:
           path: ./kyuubi-server/web-ui/node_modules
           key: webui-dependencies-${{ hashFiles('kyuubi-server/web-ui/pnpm-lock.yaml') }}


### PR DESCRIPTION
### Why are the changes needed?

To keep our CI on the latest GitHub Actions versions, per the [apache/infrastructure-actions allowlist](https://github.com/apache/infrastructure-actions/blob/main/actions.yml).

- For the GitHub-maintained actions (`actions/*`, `github/*`) and allowlisted `*` actions, the allowlist permits any version, so this PR tracks the latest **major** version tags (`@vN`) rather than specific patches.
- For hash-pinned allowlisted third-party actions, the convention is to pin to the allowlisted commit hash with a `# vX.Y.Z` comment. The Docker actions used here were already at the latest allowlisted hashes, so they are unchanged.

Changes (patch tag -> latest major):

- `actions/checkout`      `v7.0.0`  -> `v7`
- `actions/setup-java`    `v5.4.0`  -> `v5`
- `actions/setup-python`  `v6.3.0`  -> `v6`
- `actions/cache`         `v6.1.0`  -> `v6`  (and `v4` -> `v6` in `.github/actions/setup-maven/action.yaml`)
- `actions/stale`         `v10.3.0` -> `v10`

### How was this patch tested?

YAML-only change; no unit tests apply. Verified by:

- Cross-checked each action's target against the ASF allowlist and the latest release tag on GitHub.
- Ran `./dev/reformat` (no source changes; Spotless does not manage YAML).
- The `ASF Allowlist Check` workflow in this repo enforces the allowlist on this PR.

### Was this patch authored or co-authored using generative AI tooling?

Assisted-by: codemaker with glm-5.2
