### PR TITLE
[INFRA] Bump GHA workflows to latest action versions (branch-1.11 backport)

### DIFF
--- a/.github/actions/setup-maven/action.yaml
+++ b/.github/actions/setup-maven/action.yaml
@@ -21,7 +21,7 @@ runs:
   using: composite
   steps:
     - name: Restore cached Maven
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: build/apache-maven-*
         key: setup-maven-${{ hashFiles('pom.xml') }}

--- a/.github/workflows/dep.yml
+++ b/.github/workflows/dep.yml
@@ -38,9 +38,9 @@ jobs:
     name: Dependency check
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: setup java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 8
@@ -50,6 +50,6 @@ jobs:
       - name: Check dependency list
         run: build/dependency.sh
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@v5
         with:
           fail-on-severity: moderate

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,8 +31,8 @@ jobs:
     name: sphinx-build
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -41,7 +41,7 @@ jobs:
       - name: make html
         run: make -d --directory docs html
       - name: upload html
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           path: |
             docs/_build/html/

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -27,7 +27,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-    - uses: actions/first-interaction@v1
+    - uses: actions/first-interaction@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         issue-message: |

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -28,7 +28,7 @@ jobs:
   triage:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/labeler@v5
+    - uses: actions/labeler@v6
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         sync-labels: true

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -34,9 +34,9 @@ jobs:
     name: License
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Setup JDK 8
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 8
@@ -47,7 +47,7 @@ jobs:
             -Pspark-3.3 -Pspark-3.4 -Pspark-3.5 -Pspark-4.0 -Pspark-4.1
       - name: Upload rat report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: rat-report
           path: "**/target/rat*.txt"

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -100,13 +100,13 @@ jobs:
     env:
       SPARK_LOCAL_IP: localhost
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Free up disk space
         run: ./.github/scripts/free_disk_space.sh
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
       - name: Setup JDK ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
@@ -114,7 +114,7 @@ jobs:
       - name: Setup Maven
         uses: ./.github/actions/setup-maven
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
       - name: Resolve engine archive download URLs
@@ -152,12 +152,12 @@ jobs:
           matrix.java == 8 &&
           matrix.spark == '3.5' &&
           matrix.spark-archive == ''
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v7
         with:
           verbose: true
       - name: Upload test logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: unit-tests-log-java-${{ matrix.java }}-spark-${{ matrix.spark }}-${{ matrix.comment }}
           path: |
@@ -178,13 +178,13 @@ jobs:
         spark:
           - '3.5'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Free up disk space
         run: ./.github/scripts/free_disk_space.sh
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
       - name: Setup JDK ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
@@ -217,7 +217,7 @@ jobs:
           -Pscala-${{ matrix.scala }} -Pjava-${{ matrix.java }} -Pspark-${{ matrix.spark }}
       - name: Upload test logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: unit-tests-log-scala-${{ matrix.scala }}-java-${{ matrix.java }}-spark-${{ matrix.spark }}
           path: |
@@ -257,13 +257,13 @@ jobs:
         extensions/spark/kyuubi-spark-connector-tpcds,\
         extensions/spark/kyuubi-spark-connector-tpch"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Free up disk space
         run: ./.github/scripts/free_disk_space.sh
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
       - name: Setup JDK ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
@@ -280,7 +280,7 @@ jobs:
           -Pscala-${{ matrix.scala }} -Pspark-${{ matrix.spark-runtime }} -Pcross-version-test
       - name: Upload test logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: "unit-tests-log-java-${{ matrix.java }}-scala-${{ matrix.scala }}\
             -spark-compile-${{ matrix.spark-compile }}-spark-runtime-${{ matrix.spark-runtime }}\
@@ -316,13 +316,13 @@ jobs:
             flink-archive: '-Dflink.archive.mirror=https://www.apache.org/dyn/closer.lua/flink/flink-1.19.3 -Dflink.archive.name=flink-1.19.3-bin-scala_2.12.tgz'
             comment: 'verify-on-flink-1.19-binary'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Free up disk space
         run: ./.github/scripts/free_disk_space.sh
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
       - name: Setup JDK ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
@@ -358,7 +358,7 @@ jobs:
           ./build/mvn -pl ${IT_MODULE} -Pflink-${IT_FLINK} ${{ matrix.flink-archive }} test
       - name: Upload test logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: unit-tests-log-java-${{ matrix.java }}-flink-${{ matrix.flink }}-${{ matrix.comment }}
           path: |
@@ -384,13 +384,13 @@ jobs:
             hive-archive: '-Dhive.archive.mirror=https://github.com/pan3793/cdh-hive/releases/download/cdh6.3.2-release -Dhive.archive.name=apache-hive-2.1.1-cdh6.3.2-bin.tar.gz -Dhive.archive.query='
             comment: 'verify-on-hive-2.1-cdh6-binary'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Free up disk space
         run: ./.github/scripts/free_disk_space.sh
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
       - name: Setup JDK ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
@@ -420,7 +420,7 @@ jobs:
           ./build/mvn ${{ matrix.hive-archive }} -pl ${TEST_MODULES} test
       - name: Upload test logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: unit-tests-log-java-${{ matrix.java }}-hive-${{ matrix.comment }}
           path: |
@@ -436,13 +436,13 @@ jobs:
         java: [ 8 ]
         comment: [ "normal" ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Free up disk space
         run: ./.github/scripts/free_disk_space.sh
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
       - name: Setup JDK ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
@@ -474,7 +474,7 @@ jobs:
           -Dtest=none -DwildcardSuites=org.apache.kyuubi.operation.tpcds,org.apache.kyuubi.spark.connector.tpcds.TPCDSQuerySuite,org.apache.kyuubi.spark.connector.tpch.TPCHQuerySuite
       - name: Upload test logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: unit-tests-log-java-${{ matrix.java }}-hive-${{ matrix.comment }}
           path: |
@@ -486,19 +486,19 @@ jobs:
     name: Kyuubi Server On Kubernetes Integration Test
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Free up disk space
         run: ./.github/scripts/free_disk_space.sh
       # https://github.com/docker/build-push-action
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:
           cache-binary: false
       - name: Pull Spark image
         run: |
           docker pull apache/spark:3.5.8
       - name: Build Kyuubi Docker Image
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           # passthrough CI into build container
           build-args: |
@@ -551,7 +551,7 @@ jobs:
           kubectl get pods | grep driver | awk -F " " '{print$1}' | xargs -I {} kubectl logs {}
       - name: Upload test logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: unit-tests-log-kyuubi-on-k8s-it
           path: |
@@ -562,11 +562,11 @@ jobs:
     name: Spark Engine On Kubernetes Integration Test
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Free up disk space
         run: ./.github/scripts/free_disk_space.sh
       - name: Setup JDK 11
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 11
@@ -609,7 +609,7 @@ jobs:
           kubectl get pods | grep driver | awk -F " " '{print$1}' | xargs -I {} kubectl logs {}
       - name: Upload test logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: unit-tests-log-spark-on-k8s-it
           path: |
@@ -628,11 +628,11 @@ jobs:
         zookeeper: ["3.4", "3.5", "3.6", "3.7" ]
         comment: [ "normal" ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
       - name: Setup JDK ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
@@ -647,7 +647,7 @@ jobs:
           ./build/mvn -pl ${TEST_MODULES} test
       - name: Upload test logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: unit-tests-log-java-${{ matrix.java }}-zookeeper-${{ matrix.comment }}
           path: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,11 +33,11 @@ jobs:
     env:
       SPARK_LOCAL_IP: localhost
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
       - name: Setup JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
@@ -48,7 +48,7 @@ jobs:
         run: ./build/mvn clean install ${{ matrix.profiles }} -Dmaven.javadoc.skip=true -V
       - name: Upload test logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: unit-tests-log
           path: |

--- a/.github/workflows/publish-snapshot-docker.yml
+++ b/.github/workflows/publish-snapshot-docker.yml
@@ -27,20 +27,20 @@ jobs:
     if: ${{ startsWith(github.repository, 'apache/') }}
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Free up disk space
         run: ./.github/scripts/free_disk_space.sh
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Login to Docker Hub
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and Push Kyuubi Docker Image
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294	# v7.0.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           # build cache on Github Actions, See: https://docs.docker.com/build/cache/backends/gha/#using-dockerbuild-push-action
           cache-from: type=gha

--- a/.github/workflows/publish-snapshot-nexus.yml
+++ b/.github/workflows/publish-snapshot-nexus.yml
@@ -41,13 +41,13 @@ jobs:
           - branch: branch-1.9
             profiles: -Pflink-provided,spark-provided,hive-provided,spark-3.5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ matrix.branch }}
       - name: Free up disk space
         run: ./.github/scripts/free_disk_space.sh
       - name: Setup JDK 8
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 8

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -45,9 +45,9 @@ jobs:
     env:
       PYTHONHASHSEED: random
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Start Testing Containers

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -27,7 +27,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-pr-message: >

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -37,11 +37,11 @@ jobs:
           - '-Pflink-provided,hive-provided,spark-provided,spark-3.5,spark-3.4,spark-3.3,tpcds,kubernetes-it'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Setup JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Maven
         uses: ./.github/actions/setup-maven
       - name: Setup Python 3
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.9'
           cache: 'pip'
@@ -96,7 +96,7 @@ jobs:
           echo "NODEJS_VERSION=${NODEJS_VERSION}" >> "$GITHUB_ENV"
           echo "PNPM_VERSION=${PNPM_VERSION}" >> "$GITHUB_ENV"
       - name: setup npm
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{env.NODEJS_VERSION}}
       - name: Web UI Style with node
@@ -130,7 +130,7 @@ jobs:
           VALIDATE_XML: true
       - name: Upload Super Linter logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: super-linter-log
           path: super-linter.log

--- a/.github/workflows/web-ui.yml
+++ b/.github/workflows/web-ui.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Setup JDK 8
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 8
@@ -35,13 +35,13 @@ jobs:
           echo "NODEJS_VERSION=${NODEJS_VERSION}" >> "$GITHUB_ENV"
           echo "PNPM_VERSION=${PNPM_VERSION}" >> "$GITHUB_ENV"
       - name: Setup Nodejs and NPM
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{env.NODEJS_VERSION}}
           cache: npm
           cache-dependency-path: ./kyuubi-server/web-ui/package.json
       - name: Cache NPM dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ./kyuubi-server/web-ui/node_modules
           key: webui-dependencies-${{ hashFiles('kyuubi-server/web-ui/pnpm-lock.yaml') }}


### PR DESCRIPTION
Backport of the master bump in #7564 to `branch-1.11`.

### Why are the changes needed?

Keep CI on `branch-1.11` on the latest GitHub Actions versions, per the [apache/infrastructure-actions allowlist](https://github.com/apache/infrastructure-actions/blob/main/actions.yml).

The missing dependabot bump chain on master (`#7464`–`#7548`) plus the major-tag normalization in `#7564` are reimplemented here as a **single cumulative change** rather than cherry-picked, because the intermediate bumps touch overlapping version lines and won't apply cleanly onto `branch-1.11`'s older baseline. Only action **version references** are updated; `branch-1.11`'s workflow structure is preserved.

Changes (`branch-1.11` baseline -> latest):

- `actions/checkout`                 `v4` -> `v7`
- `actions/setup-java`               `v4` -> `v5`
- `actions/setup-python`             `v5` -> `v6`
- `actions/setup-node`               `v4` -> `v6`
- `actions/stale`                    `v9` -> `v10`
- `actions/upload-artifact`          `v4` -> `v7`
- `actions/dependency-review-action` `v4` -> `v5`
- `actions/first-interaction`        `v1` -> `v3`
- `actions/labeler`                  `v5` -> `v6`  (`.github/labeler.yml` is already v6-schema, so no config migration needed)
- `codecov/codecov-action`           `v3` -> `v7`
- `actions/cache`                    `v4` -> `v6`  (in `.github/actions/setup-maven`; `@v6` elsewhere unchanged)
- `docker/build-push-action`   -> `53b7df96...` (# v7.3.0)
- `docker/setup-buildx-action` -> `bb05f3f5...` (# v4.2.0)
- `docker/setup-qemu-action`   -> `96fe6ef7...` (# v4.2.0)
- `docker/login-action`        -> `af1e73f9...` (# v4.4.0)

`github/super-linter/slim@v7` was already latest; unchanged.

### How was this patch tested?

YAML-only change; no unit tests apply. Verified by:

- The resulting `uses:` set on `branch-1.11` now matches `master` exactly.
- `./dev/reformat` was run; it only failed on the Spotless `black` step (a local pyenv-shim issue, exit 127) and modified no files — Spotless does not manage YAML, and the working tree contains only the `.github` version bumps.
- All references here are at the latest allowlisted versions / major tags, consistent with what the `ASF Allowlist Check` workflow enforces on `master`.

### Was this patch authored or co-authored using generative AI tooling?

Assisted-by: codemaker with glm-5.2
