### PR TITLE
[SERVER] Improve Engine UI proxy 403 response

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/EngineUIProxyServlet.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/EngineUIProxyServlet.scala
@@ -20,7 +20,7 @@ package org.apache.kyuubi.server.api
 import java.net.{URI, URL}
 import java.util.Locale
 import java.util.regex.Pattern
-import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
 import scala.util.Try
 
@@ -43,8 +43,7 @@ private[api] class EngineUIProxyServlet(
   override def rewriteTarget(request: HttpServletRequest): String = {
     val requestURL = request.getRequestURL
     val requestURI = request.getRequestURI
-    // If proxying is enabled and the request URI host is not allowed, return null so Jetty
-    // responds with 403 Forbidden.
+    // A null target is handled by onProxyRewriteFailed with an actionable 403 response.
     val targetURL = allowedTarget(requestURI).map { targetAddress =>
       val targetURI = targetAddress.path match {
         // for some reason, the proxy can not handle redirect well, as a workaround,
@@ -66,6 +65,19 @@ private[api] class EngineUIProxyServlet(
     targetURL
   }
 
+  override def onProxyRewriteFailed(
+      request: HttpServletRequest,
+      response: HttpServletResponse): Unit = {
+    val (title, message) = deniedRequestMessage(request.getRequestURI)
+    response.setStatus(HttpServletResponse.SC_FORBIDDEN)
+    response.setCharacterEncoding("UTF-8")
+    response.setContentType("text/html")
+    response.getWriter.write(EngineUIProxyServlet.errorPage(
+      title,
+      message,
+      extractTargetAddress(request.getRequestURI)))
+  }
+
   override def addXForwardedHeaders(
       clientRequest: HttpServletRequest,
       proxyRequest: Request): Unit = {
@@ -85,6 +97,35 @@ private[api] class EngineUIProxyServlet(
 
   private def allowedTarget(requestURI: String): Option[TargetAddress] =
     extractTargetAddress(requestURI).filter(target => isAllowedHost(target.host))
+
+  private[api] def deniedRequestMessage(requestURI: String): (String, String) = {
+    if (!proxyEnabled) {
+      val allowedHost = extractTargetAddress(requestURI)
+        .map(target => s"add <code>${EngineUIProxyServlet.escapeHtml(target.host)}</code> to")
+        .getOrElse("add the target host to")
+      (
+        "Engine UI proxy is disabled",
+        s"Ask an administrator to set <code>${
+            KyuubiConf.FRONTEND_REST_ENGINE_UI_PROXY_ENABLED.key
+          }</code> to <code>true</code>, then $allowedHost <code>${
+            KyuubiConf.FRONTEND_REST_ENGINE_UI_PROXY_HOSTS.key
+          }</code>.")
+    } else {
+      extractTargetAddress(requestURI) match {
+        case Some(target) =>
+          val escapedHost = EngineUIProxyServlet.escapeHtml(target.host)
+          (
+            "Engine UI host is not allowed",
+            s"Ask an administrator to add <code>$escapedHost</code> " +
+              s"to <code>${KyuubiConf.FRONTEND_REST_ENGINE_UI_PROXY_HOSTS.key}</code>.")
+        case None =>
+          (
+            "Invalid Engine UI address",
+            "The URL must include an engine host and port, for example " +
+              "<code>/engine-ui/spark.example.com:4040/</code>.")
+      }
+    }
+  }
 
   private[api] def extractTargetAddress(requestURI: String): Option[TargetAddress] = {
     val target = requestURI.stripPrefix("/engine-ui/")
@@ -108,6 +149,78 @@ private[api] class EngineUIProxyServlet(
 private[api] case class TargetAddress(host: String, port: Int, path: String)
 
 private[api] object EngineUIProxyServlet {
+
+  private def errorPage(
+      title: String,
+      message: String,
+      targetAddress: Option[TargetAddress]): String = {
+    val target = targetAddress.map { address =>
+      s"""<div class="target">
+         |      <span>Target engine</span>
+         |      <code>${escapeHtml(address.host)}:${address.port}</code>
+         |    </div>""".stripMargin
+    }.getOrElse("")
+
+    s"""<!DOCTYPE html>
+       |<html lang="en">
+       |<head>
+       |  <meta charset="UTF-8">
+       |  <meta name="viewport" content="width=device-width, initial-scale=1">
+       |  <title>403 - $title</title>
+       |  <style>
+       |    * { box-sizing: border-box; }
+       |    body { margin: 0; min-height: 100vh; display: grid; place-items: center;
+       |      font-family: "Myriad Pro", "Helvetica Neue", Arial, Helvetica, sans-serif;
+       |      background: #eef0f3; color: #242e42; }
+       |    main { width: min(680px, calc(100% - 40px)); background: #fff;
+       |      border: 1px solid #dcdfe6; border-top: 4px solid #242e42;
+       |      box-shadow: 0 8px 24px rgba(0, 21, 41, .08); }
+       |    header { height: 56px; display: flex; align-items: center; padding: 0 28px;
+       |      border-bottom: 1px solid #ebeef5; color: #999; font-size: 14px;
+       |      font-weight: 600; letter-spacing: .06em; }
+       |    header::before { content: ""; width: 10px; height: 10px; margin-right: 10px;
+       |      background: #e7211a; transform: rotate(45deg); }
+       |    article { padding: 36px 40px 40px; }
+       |    .status { color: #db2828; font-size: 13px; font-weight: 700; letter-spacing: .08em; }
+       |    h1 { margin: 10px 0 12px; font-size: 30px; line-height: 1.25; font-weight: 600; }
+       |    p { margin: 0; color: #606266; font-size: 16px; line-height: 1.7; }
+       |    code { padding: 2px 6px; background: #f2f6fc; color: #242e42;
+       |      font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+       |      font-size: 14px; overflow-wrap: anywhere; }
+       |    .target { margin: 28px 0 20px; padding: 14px 16px; display: flex;
+       |      align-items: center; gap: 16px; background: #f5f7fa; border-left: 3px solid #1890ff; }
+       |    .target span { min-width: 96px; color: #909399; font-size: 13px; font-weight: 600;
+       |      letter-spacing: .02em; text-transform: uppercase; }
+       |    .target code { padding: 0; background: transparent; color: #001529; font-weight: 600; }
+       |    @media (max-width: 540px) {
+       |      article { padding: 28px 24px 32px; }
+       |      header { padding: 0 24px; }
+       |      h1 { font-size: 25px; }
+       |      .target { align-items: flex-start; flex-direction: column; gap: 6px; }
+       |    }
+       |  </style>
+       |</head>
+       |<body>
+       |  <main>
+       |    <header>APACHE KYUUBI</header>
+       |    <article>
+       |      <div class="status">403 / ACCESS DENIED</div>
+       |      <h1>$title</h1>
+       |      $target
+       |      <p>$message</p>
+       |    </article>
+       |  </main>
+       |</body>
+       |</html>""".stripMargin
+  }
+
+  private def escapeHtml(value: String): String =
+    value
+      .replace("&", "&amp;")
+      .replace("<", "&lt;")
+      .replace(">", "&gt;")
+      .replace("\"", "&quot;")
+      .replace("'", "&#39;")
 
   def apply(fe: KyuubiRestFrontendService): EngineUIProxyServlet = {
     new EngineUIProxyServlet(

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/EngineUIProxyServletSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/EngineUIProxyServletSuite.scala
@@ -17,9 +17,10 @@
 
 package org.apache.kyuubi.server.api
 
-import javax.servlet.http.HttpServletRequest
+import java.io.{PrintWriter, StringWriter}
+import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
-import org.mockito.Mockito.when
+import org.mockito.Mockito.{verify, when}
 import org.scalatestplus.mockito.MockitoSugar.mock
 
 import org.apache.kyuubi.KyuubiFunSuite
@@ -67,6 +68,21 @@ class EngineUIProxyServletSuite extends KyuubiFunSuite {
     val servlet = new EngineUIProxyServlet(true, Set.empty)
 
     assert(servlet.rewriteTarget(request("/engine-ui/engine-host:4040")) === null)
+  }
+
+  test("denied response explains the required engine UI proxy configuration") {
+    val servlet = new EngineUIProxyServlet(false, Set.empty)
+    val response = mock[HttpServletResponse]
+    val body = new StringWriter
+    when(response.getWriter).thenReturn(new PrintWriter(body))
+
+    servlet.onProxyRewriteFailed(request("/engine-ui/engine-host:4040/"), response)
+
+    verify(response).setStatus(HttpServletResponse.SC_FORBIDDEN)
+    assert(body.toString.contains("Target engine"))
+    assert(body.toString.contains("engine-host:4040"))
+    assert(body.toString.contains("kyuubi.frontend.rest.engine.ui.proxy.enabled"))
+    assert(body.toString.contains("kyuubi.frontend.rest.engine.ui.proxy.hosts"))
   }
 
   test("rewrite target denies request smuggling through user info") {


### PR DESCRIPTION
### Why are the changes needed?

The Engine UI proxy currently falls back to Jetty's generic 403 page when proxying is disabled, the target host is not allowlisted, or the URL is invalid. The page does not tell users which Kyuubi settings need to be changed.

This patch keeps the existing 403 status and host validation, but returns an actionable Kyuubi-styled page that shows the target engine and the relevant proxy and host allowlist settings.

### How was this patch tested?

- `dev/reformat`
- `build/mvn -pl kyuubi-server -am -Pspark-provided,hive-provided,flink-provided scalastyle:check`
- `build/mvn test -pl kyuubi-server -am -rf :kyuubi-server_2.12 -Pspark-provided,hive-provided,flink-provided -Dtest=none -DwildcardSuites=org.apache.kyuubi.server.api.EngineUIProxyServletSuite`
- Compared the previous and updated 403 responses through real Jetty servlets in a browser.

### Visual comparison

Before:

![Jetty default 403 response](https://raw.githubusercontent.com/wangzhigang1999/kyuubi/zhigang/pr-7567-assets/pr-assets/7567/before.png)

After:

![Actionable Kyuubi Engine UI 403 response](https://raw.githubusercontent.com/wangzhigang1999/kyuubi/zhigang/pr-7567-assets/pr-assets/7567/after.png)

### Was this patch authored or co-authored using generative AI tooling?

Assisted-by: Codex with GPT-5
