### PR TITLE
[KYUUBI #7568][AUTHZ] Eliminate TypeOfPlaceHolder across the whole plan

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/rule/RuleEliminateTypeOf.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/rule/RuleEliminateTypeOf.scala
@@ -25,7 +25,11 @@ import org.apache.kyuubi.plugin.spark.authz.rule.expression.TypeOfPlaceHolder
 
 object RuleEliminateTypeOf extends Rule[LogicalPlan] {
   override def apply(plan: LogicalPlan): LogicalPlan = {
-    plan.transformExpressionsUp {
+    // Must cover the whole plan, mirroring RuleApplyTypeOfMarker. transformExpressionsUp only
+    // visits the root node's expressions, leaving any placeholder below it (under Sort, Union,
+    // Aggregate, a subquery, ...) to reach execution, where it fails: TypeOfPlaceHolder
+    // implements no eval, only doGenCode.
+    plan.transformAllExpressions {
       case toph: TypeOfPlaceHolder => TypeOf(toph.expr)
     }
   }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
@@ -1413,14 +1413,16 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
           s"SELECT typeof(id) AS t FROM $db1.$table1 ORDER BY t",
           Seq(Row("int")))
 
-        // root is Union
-        checkAnswer(
+        // root is Union. UNION ALL has no order guarantee, and an ORDER BY would put a Sort
+        // above the Union, so sort the collected rows instead to keep Union as the root node.
+        doAs(
           admin,
-          s"""
-             |SELECT typeof(id) FROM $db1.$table1
-             |UNION ALL
-             |SELECT typeof(day) FROM $db1.$table1""".stripMargin,
-          Seq(Row("int"), Row("string")))
+          assert(sql(
+            s"""
+               |SELECT typeof(id) FROM $db1.$table1
+               |UNION ALL
+               |SELECT typeof(day) FROM $db1.$table1""".stripMargin)
+            .collect().sortBy(_.getString(0)) === Seq(Row("int"), Row("string"))))
 
         // root is Aggregate
         checkAnswer(

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
@@ -1387,6 +1387,56 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
     }
   }
 
+  test("[KYUUBI #7568][AUTHZ] Typeof expression is eliminated below the root plan node") {
+    // RuleEliminateTypeOf must walk the whole plan, mirroring RuleApplyTypeOfMarker which
+    // marks with transformAllExpressions. When only the root node is visited, a TypeOfPlaceHolder
+    // living under Sort/Union/Aggregate survives into execution and fails with
+    // CLASS_NOT_OVERRIDE_EXPECTED_METHOD, since the placeholder implements no eval.
+    val db1 = defaultDb
+    val table1 = "table1"
+    withSingleCallEnabled {
+      withCleanTmpResources(Seq((s"$db1.$table1", "table"))) {
+        doAs(
+          admin,
+          sql(
+            s"""
+               |CREATE TABLE IF NOT EXISTS $db1.$table1(
+               |id int,
+               |scope int,
+               |day string)
+               |""".stripMargin))
+        doAs(admin, sql(s"INSERT INTO $db1.$table1 SELECT 1, 2, 'TONY'"))
+
+        // root is Sort
+        checkAnswer(
+          admin,
+          s"SELECT typeof(id) AS t FROM $db1.$table1 ORDER BY t",
+          Seq(Row("int")))
+
+        // root is Union
+        checkAnswer(
+          admin,
+          s"""
+             |SELECT typeof(id) FROM $db1.$table1
+             |UNION ALL
+             |SELECT typeof(day) FROM $db1.$table1""".stripMargin,
+          Seq(Row("int"), Row("string")))
+
+        // root is Aggregate
+        checkAnswer(
+          admin,
+          s"SELECT typeof(id), count(*) FROM $db1.$table1 GROUP BY typeof(id)",
+          Seq(Row("int", 1)))
+
+        // typeof inside a subquery
+        checkAnswer(
+          admin,
+          s"SELECT t FROM (SELECT typeof(scope) AS t FROM $db1.$table1) x WHERE t = 'int'",
+          Seq(Row("int")))
+      }
+    }
+  }
+
   test("[KYUUBI #5692][Bug] Authz not skip explain command") {
     val db1 = defaultDb
     val table1 = "table1"


### PR DESCRIPTION
### Why are the changes needed?

Fixes #7568.

`RuleApplyTypeOfMarker` marks every `TypeOf` in the whole plan (`transformAllExpressions`), but since #5997 `RuleEliminateTypeOf` reverts them with `transformExpressionsUp`, which only visits the root node's expressions. A `TypeOfPlaceHolder` below the root — under `Sort`, `Union`, `Aggregate`, or a subquery — survives into execution and fails with `CLASS_NOT_OVERRIDE_EXPECTED_METHOD`, since it implements `doGenCode` but no `eval`.

This change uses `transformAllExpressions` on the eliminating side as well, so both rules cover the same scope in a single pass.

Affects 1.9.0 onwards, including master.

### How was this patch tested?

Added a test to `RangerSparkExtensionSuite` covering the root shapes the existing `Project`-root-only test misses: `Sort`, `Union`, `Aggregate`, and a subquery. It fails on master and passes with this change. Full `extensions/spark/kyuubi-spark-authz` suite: 657 passed, 0 failed.

### Was this patch authored or co-authored using generative AI tooling?

Assisted-by: Claude:claude-opus-4-8
