### PR TITLE
[INFRA] Redirect build/mvn fallback message to stderr to avoid corrupting captures

### DIFF
--- a/build/mvn
+++ b/build/mvn
@@ -54,8 +54,8 @@ install_app() {
     wget ${wget_opts} -O "${local_tarball}" "${remote_tarball}"
   # if both were unsuccessful, exit
   [ ! -f "${local_tarball}" ] && \
-    echo -n "ERROR: Cannot download $2 with cURL or wget; " && \
-    echo "please install manually and try again." && \
+    echo -n "ERROR: Cannot download $2 with cURL or wget; " 1>&2 && \
+    echo "please install manually and try again." 1>&2 && \
     exit 2
   cd "${_DIR}" && tar -xzf "$2"
   rm -rf "$local_tarball"
@@ -85,7 +85,7 @@ install_mvn() {
     if [ $(command -v curl) ]; then
       if ! curl -L --output /dev/null --silent --head --fail "${APACHE_MIRROR}/${FILE_PATH}/${MVN_TARBALL}${MIRROR_URL_QUERY}" ; then
         # Fall back to archive.apache.org for older Maven
-        echo "Falling back to archive.apache.org to download Maven"
+        echo "Falling back to archive.apache.org to download Maven" 1>&2
         APACHE_MIRROR="https://archive.apache.org/dist"
         MIRROR_URL_QUERY=""
       fi


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->
For example, the Spark version was wrongly captured as `Falling back to archive.apache.org to download Maven`

https://github.com/apache/kyuubi/actions/runs/29387027103/job/87262361668?pr=7570

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Merge then monitor CI.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has assisted in authoring or reviewing this patch, please include
an 'Assisted-by: ' trailer that identifies the agent and model.
For example: 'Assisted-by: Claude:claude-opus-4-7' or 'Assisted-by: Claude Opus 4.7'.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.