### PR TITLE
[KYUUBI #7574] Fix typo in kyuubi-extension-spark-jdbc-dialect pom.xml

### DIFF
--- a/extensions/spark/kyuubi-extension-spark-jdbc-dialect/pom.xml
+++ b/extensions/spark/kyuubi-extension-spark-jdbc-dialect/pom.xml
@@ -58,8 +58,8 @@
                 <directory>${project.basedir}/src/test/resources</directory>
             </testResource>
         </testResources>
-        <outputDirectory>target/scala-${scala.binary.verison}/classes</outputDirectory>
-        <testOutputDirectory>target/scala-${scala.binary.verison}/test-classes</testOutputDirectory>
+        <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
+        <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
     </build>
 
 </project>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->
Fixed https://github.com/apache/kyuubi/issues/7574. There is a typo in extensions/spark/kyuubi-extension-spark-jdbc-dialect/pom.xml:
```
<outputDirectory>target/scala-${scala.binary.verison}/classes</outputDirectory>
<testOutputDirectory>target/scala-${scala.binary.verison}/test-classes</testOutputDirectory>
```
The property name `scala.binary.verison` is misspelled (should be `scala.binary.version`). Because Maven cannot resolve the misspelled property, the placeholder is not substituted, and the build outputs are written to a directory literally named target/scala-${scala.binary.verison}/ instead of the expected target/scala-2.12/ or target/scala-2.13/.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Pass GHA.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has assisted in authoring or reviewing this patch, please include
an 'Assisted-by: ' trailer that identifies the agent and model.
For example: 'Assisted-by: Claude:claude-opus-4-7' or 'Assisted-by: Claude Opus 4.7'.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No