### PR TITLE
[K8S][HELM] Update default Kyuubi version to 1.12.0

### DIFF
--- a/charts/kyuubi/Chart.yaml
+++ b/charts/kyuubi/Chart.yaml
@@ -20,7 +20,7 @@ name: kyuubi
 description: A Helm chart for Kyuubi server
 type: application
 version: 0.1.0
-appVersion: 1.10.0
+appVersion: 1.12.0
 home: https://kyuubi.apache.org
 icon: https://raw.githubusercontent.com/apache/kyuubi/master/docs/imgs/logo.png
 sources:


### PR DESCRIPTION
### Why are the changes needed?
Default Kyuubi version used in the Helm chart should be aligned with the latest release version.


### How was this patch tested?
Render the chart templates to ensure `1.12.0` version is used.
```shell
helm template kyuubi charts/kyuubi
```
Output (reduced)
```yaml
# Source: kyuubi/templates/kyuubi-statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: kyuubi
  labels:
    ...
    app.kubernetes.io/version: "1.12.0"
spec:
  template:
    ...
    spec:
      serviceAccountName: kyuubi
      containers:
        - name: kyuubi-server
          image: "apache/kyuubi:1.12.0"
          imagePullPolicy: IfNotPresent
          ...
```


### Was this patch authored or co-authored using generative AI tooling?
No
