### PR TITLE
[INFRA] Reduce snapshot Docker image publish schedule to every 5 days

### DIFF
--- a/.github/workflows/publish-snapshot-docker.yml
+++ b/.github/workflows/publish-snapshot-docker.yml
@@ -19,7 +19,7 @@ name: Publish Snapshot Docker Image
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 */5 * *'
 
 jobs:
   push_to_registry:


### PR DESCRIPTION
### Why are the changes needed?

The `Publish Snapshot Docker Image` workflow runs daily and writes a large
multi-arch build cache via `type=gha`. Because a repo shares a limited GitHub
Actions cache quota with LRU eviction, this daily snapshot cache occupies a big
chunk of the quota and pushes out other workflows' caches, causing them to be
evicted and re-downloaded more often.

Reducing the cadence to every 5 days (`0 0 */5 * *`) keeps the master-snapshot
image fresh enough while relieving cache-quota pressure on other workflows.

### How was this patch tested?

CI scheduling change only; no functional code change.

### Was this patch authored or co-authored using generative AI tooling?

Assisted-by: Claude:claude-opus-4-8