### PR TITLE
[SPARK] Use the larger advisory partition size when both configs are set

### DIFF
--- a/extensions/spark/kyuubi-extension-spark-3-5/src/main/scala/org/apache/kyuubi/sql/KyuubiSQLConf.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-5/src/main/scala/org/apache/kyuubi/sql/KyuubiSQLConf.scala
@@ -259,7 +259,8 @@ object KyuubiSQLConf {
     buildConf("spark.sql.adaptive.rebalancePartitionsAdvisoryPartitionSizeInBytes")
       .doc("The advisory partition size for RebalancePartitions operator. When set, it will be " +
         "passed to `optAdvisoryPartitionSize` of the RebalancePartitions node. " +
-        "It takes precedence over `spark.sql.finalStage.adaptive.advisoryPartitionSizeInBytes`.")
+        "When both this and `spark.sql.finalStage.adaptive.advisoryPartitionSizeInBytes` are " +
+        "set, the larger value is used.")
       .version("1.12.0")
       .bytesConf(ByteUnit.BYTE)
       .createOptional
@@ -319,14 +320,18 @@ object KyuubiSQLConf {
       .createWithDefault(true)
 
   def getAdvisoryPartitionSize(conf: SQLConf): Option[Long] = {
-    conf.getConf(REBALANCE_PARTITIONS_ADVISORY_PARTITION_SIZE).orElse {
-      if (conf.contains(FINAL_STAGE_ADVISORY_PARTITION_SIZE_KEY)) {
-        Some(JavaUtils.byteStringAs(
-          conf.getConfString(FINAL_STAGE_ADVISORY_PARTITION_SIZE_KEY),
-          ByteUnit.BYTE))
-      } else {
-        None
-      }
+    val rebalanceTargetSize = conf.getConf(REBALANCE_PARTITIONS_ADVISORY_PARTITION_SIZE)
+    val finalStageTargetSize = if (conf.contains(FINAL_STAGE_ADVISORY_PARTITION_SIZE_KEY)) {
+      Some(JavaUtils.byteStringAs(
+        conf.getConfString(FINAL_STAGE_ADVISORY_PARTITION_SIZE_KEY),
+        ByteUnit.BYTE))
+    } else {
+      None
+    }
+    if (rebalanceTargetSize.isDefined && finalStageTargetSize.isDefined) {
+      Some(rebalanceTargetSize.get.max(finalStageTargetSize.get))
+    } else {
+      rebalanceTargetSize.orElse(finalStageTargetSize)
     }
   }
 }

--- a/extensions/spark/kyuubi-extension-spark-3-5/src/test/scala/org/apache/spark/sql/RebalanceBeforeWritingSuite.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-5/src/test/scala/org/apache/spark/sql/RebalanceBeforeWritingSuite.scala
@@ -464,7 +464,7 @@ class RebalanceBeforeWritingSuite extends KyuubiSparkSQLExtensionTest {
     }
   }
 
-  test("advisory partition size - kyuubi config takes precedence over finalStage") {
+  test("advisory partition size - larger value wins when both configs are set") {
     withSQLConf(
       KyuubiSQLConf.INSERT_REPARTITION_BEFORE_WRITE.key -> "true",
       KyuubiSQLConf.INSERT_REPARTITION_BEFORE_WRITE_IF_NO_SHUFFLE.key -> "true",
@@ -477,8 +477,8 @@ class RebalanceBeforeWritingSuite extends KyuubiSparkSQLExtensionTest {
           val rebalances = write.collect { case r: RebalancePartitions => r }
           assert(rebalances.size === 1)
           assert(rebalances.head.optAdvisoryPartitionSize.isDefined)
-          // kyuubi config takes precedence over finalStage
-          assert(rebalances.head.optAdvisoryPartitionSize.get === 209715200L) // 200MB
+          // both set: the larger of the two values wins
+          assert(rebalances.head.optAdvisoryPartitionSize.get === 314572800L) // 300MB
         }
       }
     }
@@ -516,11 +516,25 @@ class RebalanceBeforeWritingSuite extends KyuubiSparkSQLExtensionTest {
       assert(KyuubiSQLConf.getAdvisoryPartitionSize(conf).get === 1073741824L) // 1GB
     }
 
-    // Both set: kyuubi config takes precedence
+    // Both set: the larger value wins (kyuubi larger)
     withSQLConf(
       KyuubiSQLConf.REBALANCE_PARTITIONS_ADVISORY_PARTITION_SIZE.key -> "1gb",
       KyuubiSQLConf.FINAL_STAGE_ADVISORY_PARTITION_SIZE_KEY -> "500MB") {
       assert(KyuubiSQLConf.getAdvisoryPartitionSize(conf).get === 1073741824L) // 1GB
+    }
+
+    // Both set: the larger value wins (finalStage larger)
+    withSQLConf(
+      KyuubiSQLConf.REBALANCE_PARTITIONS_ADVISORY_PARTITION_SIZE.key -> "200MB",
+      KyuubiSQLConf.FINAL_STAGE_ADVISORY_PARTITION_SIZE_KEY -> "500MB") {
+      assert(KyuubiSQLConf.getAdvisoryPartitionSize(conf).get === 524288000L) // 500MB
+    }
+
+    // Both set to the same value
+    withSQLConf(
+      KyuubiSQLConf.REBALANCE_PARTITIONS_ADVISORY_PARTITION_SIZE.key -> "256MB",
+      KyuubiSQLConf.FINAL_STAGE_ADVISORY_PARTITION_SIZE_KEY -> "256MB") {
+      assert(KyuubiSQLConf.getAdvisoryPartitionSize(conf).get === 268435456L) // 256MB
     }
   }
 }

--- a/extensions/spark/kyuubi-extension-spark-4-0/src/main/scala/org/apache/kyuubi/sql/KyuubiSQLConf.scala
+++ b/extensions/spark/kyuubi-extension-spark-4-0/src/main/scala/org/apache/kyuubi/sql/KyuubiSQLConf.scala
@@ -259,7 +259,8 @@ object KyuubiSQLConf {
     buildConf("spark.sql.adaptive.rebalancePartitionsAdvisoryPartitionSizeInBytes")
       .doc("The advisory partition size for RebalancePartitions operator. When set, it will be " +
         "passed to `optAdvisoryPartitionSize` of the RebalancePartitions node. " +
-        "It takes precedence over `spark.sql.finalStage.adaptive.advisoryPartitionSizeInBytes`.")
+        "When both this and `spark.sql.finalStage.adaptive.advisoryPartitionSizeInBytes` are " +
+        "set, the larger value is used.")
       .version("1.12.0")
       .bytesConf(ByteUnit.BYTE)
       .createOptional
@@ -319,14 +320,18 @@ object KyuubiSQLConf {
       .createWithDefault(true)
 
   def getAdvisoryPartitionSize(conf: SQLConf): Option[Long] = {
-    conf.getConf(REBALANCE_PARTITIONS_ADVISORY_PARTITION_SIZE).orElse {
-      if (conf.contains(FINAL_STAGE_ADVISORY_PARTITION_SIZE_KEY)) {
-        Some(JavaUtils.byteStringAs(
-          conf.getConfString(FINAL_STAGE_ADVISORY_PARTITION_SIZE_KEY),
-          ByteUnit.BYTE))
-      } else {
-        None
-      }
+    val rebalanceTargetSize = conf.getConf(REBALANCE_PARTITIONS_ADVISORY_PARTITION_SIZE)
+    val finalStageTargetSize = if (conf.contains(FINAL_STAGE_ADVISORY_PARTITION_SIZE_KEY)) {
+      Some(JavaUtils.byteStringAs(
+        conf.getConfString(FINAL_STAGE_ADVISORY_PARTITION_SIZE_KEY),
+        ByteUnit.BYTE))
+    } else {
+      None
+    }
+    if (rebalanceTargetSize.isDefined && finalStageTargetSize.isDefined) {
+      Some(rebalanceTargetSize.get.max(finalStageTargetSize.get))
+    } else {
+      rebalanceTargetSize.orElse(finalStageTargetSize)
     }
   }
 }

--- a/extensions/spark/kyuubi-extension-spark-4-0/src/test/scala/org/apache/spark/sql/RebalanceBeforeWritingSuite.scala
+++ b/extensions/spark/kyuubi-extension-spark-4-0/src/test/scala/org/apache/spark/sql/RebalanceBeforeWritingSuite.scala
@@ -425,7 +425,7 @@ class RebalanceBeforeWritingSuite extends KyuubiSparkSQLExtensionTest {
     }
   }
 
-  test("advisory partition size - kyuubi config takes precedence over finalStage") {
+  test("advisory partition size - larger value wins when both configs are set") {
     withSQLConf(
       KyuubiSQLConf.INSERT_REPARTITION_BEFORE_WRITE.key -> "true",
       KyuubiSQLConf.INSERT_REPARTITION_BEFORE_WRITE_IF_NO_SHUFFLE.key -> "true",
@@ -438,8 +438,8 @@ class RebalanceBeforeWritingSuite extends KyuubiSparkSQLExtensionTest {
           val rebalances = write.collect { case r: RebalancePartitions => r }
           assert(rebalances.size === 1)
           assert(rebalances.head.optAdvisoryPartitionSize.isDefined)
-          // kyuubi config takes precedence over finalStage
-          assert(rebalances.head.optAdvisoryPartitionSize.get === 209715200L) // 200MB
+          // both set: the larger of the two values wins
+          assert(rebalances.head.optAdvisoryPartitionSize.get === 314572800L) // 300MB
         }
       }
     }
@@ -477,11 +477,25 @@ class RebalanceBeforeWritingSuite extends KyuubiSparkSQLExtensionTest {
       assert(KyuubiSQLConf.getAdvisoryPartitionSize(conf).get === 1073741824L) // 1GB
     }
 
-    // Both set: kyuubi config takes precedence
+    // Both set: the larger value wins (kyuubi larger)
     withSQLConf(
       KyuubiSQLConf.REBALANCE_PARTITIONS_ADVISORY_PARTITION_SIZE.key -> "1gb",
       KyuubiSQLConf.FINAL_STAGE_ADVISORY_PARTITION_SIZE_KEY -> "500MB") {
       assert(KyuubiSQLConf.getAdvisoryPartitionSize(conf).get === 1073741824L) // 1GB
+    }
+
+    // Both set: the larger value wins (finalStage larger)
+    withSQLConf(
+      KyuubiSQLConf.REBALANCE_PARTITIONS_ADVISORY_PARTITION_SIZE.key -> "200MB",
+      KyuubiSQLConf.FINAL_STAGE_ADVISORY_PARTITION_SIZE_KEY -> "500MB") {
+      assert(KyuubiSQLConf.getAdvisoryPartitionSize(conf).get === 524288000L) // 500MB
+    }
+
+    // Both set to the same value
+    withSQLConf(
+      KyuubiSQLConf.REBALANCE_PARTITIONS_ADVISORY_PARTITION_SIZE.key -> "256MB",
+      KyuubiSQLConf.FINAL_STAGE_ADVISORY_PARTITION_SIZE_KEY -> "256MB") {
+      assert(KyuubiSQLConf.getAdvisoryPartitionSize(conf).get === 268435456L) // 256MB
     }
   }
 }

--- a/extensions/spark/kyuubi-extension-spark-4-1/src/main/scala/org/apache/kyuubi/sql/KyuubiSQLConf.scala
+++ b/extensions/spark/kyuubi-extension-spark-4-1/src/main/scala/org/apache/kyuubi/sql/KyuubiSQLConf.scala
@@ -259,7 +259,8 @@ object KyuubiSQLConf {
     buildConf("spark.sql.adaptive.rebalancePartitionsAdvisoryPartitionSizeInBytes")
       .doc("The advisory partition size for RebalancePartitions operator. When set, it will be " +
         "passed to `optAdvisoryPartitionSize` of the RebalancePartitions node. " +
-        "It takes precedence over `spark.sql.finalStage.adaptive.advisoryPartitionSizeInBytes`.")
+        "When both this and `spark.sql.finalStage.adaptive.advisoryPartitionSizeInBytes` are " +
+        "set, the larger value is used.")
       .version("1.12.0")
       .bytesConf(ByteUnit.BYTE)
       .createOptional
@@ -319,14 +320,18 @@ object KyuubiSQLConf {
       .createWithDefault(true)
 
   def getAdvisoryPartitionSize(conf: SQLConf): Option[Long] = {
-    conf.getConf(REBALANCE_PARTITIONS_ADVISORY_PARTITION_SIZE).orElse {
-      if (conf.contains(FINAL_STAGE_ADVISORY_PARTITION_SIZE_KEY)) {
-        Some(JavaUtils.byteStringAs(
-          conf.getConfString(FINAL_STAGE_ADVISORY_PARTITION_SIZE_KEY),
-          ByteUnit.BYTE))
-      } else {
-        None
-      }
+    val rebalanceTargetSize = conf.getConf(REBALANCE_PARTITIONS_ADVISORY_PARTITION_SIZE)
+    val finalStageTargetSize = if (conf.contains(FINAL_STAGE_ADVISORY_PARTITION_SIZE_KEY)) {
+      Some(JavaUtils.byteStringAs(
+        conf.getConfString(FINAL_STAGE_ADVISORY_PARTITION_SIZE_KEY),
+        ByteUnit.BYTE))
+    } else {
+      None
+    }
+    if (rebalanceTargetSize.isDefined && finalStageTargetSize.isDefined) {
+      Some(rebalanceTargetSize.get.max(finalStageTargetSize.get))
+    } else {
+      rebalanceTargetSize.orElse(finalStageTargetSize)
     }
   }
 }

--- a/extensions/spark/kyuubi-extension-spark-4-1/src/test/scala/org/apache/spark/sql/RebalanceBeforeWritingSuite.scala
+++ b/extensions/spark/kyuubi-extension-spark-4-1/src/test/scala/org/apache/spark/sql/RebalanceBeforeWritingSuite.scala
@@ -425,7 +425,7 @@ class RebalanceBeforeWritingSuite extends KyuubiSparkSQLExtensionTest {
     }
   }
 
-  test("advisory partition size - kyuubi config takes precedence over finalStage") {
+  test("advisory partition size - larger value wins when both configs are set") {
     withSQLConf(
       KyuubiSQLConf.INSERT_REPARTITION_BEFORE_WRITE.key -> "true",
       KyuubiSQLConf.INSERT_REPARTITION_BEFORE_WRITE_IF_NO_SHUFFLE.key -> "true",
@@ -438,8 +438,8 @@ class RebalanceBeforeWritingSuite extends KyuubiSparkSQLExtensionTest {
           val rebalances = write.collect { case r: RebalancePartitions => r }
           assert(rebalances.size === 1)
           assert(rebalances.head.optAdvisoryPartitionSize.isDefined)
-          // kyuubi config takes precedence over finalStage
-          assert(rebalances.head.optAdvisoryPartitionSize.get === 209715200L) // 200MB
+          // both set: the larger of the two values wins
+          assert(rebalances.head.optAdvisoryPartitionSize.get === 314572800L) // 300MB
         }
       }
     }
@@ -477,11 +477,25 @@ class RebalanceBeforeWritingSuite extends KyuubiSparkSQLExtensionTest {
       assert(KyuubiSQLConf.getAdvisoryPartitionSize(conf).get === 1073741824L) // 1GB
     }
 
-    // Both set: kyuubi config takes precedence
+    // Both set: the larger value wins (kyuubi larger)
     withSQLConf(
       KyuubiSQLConf.REBALANCE_PARTITIONS_ADVISORY_PARTITION_SIZE.key -> "1gb",
       KyuubiSQLConf.FINAL_STAGE_ADVISORY_PARTITION_SIZE_KEY -> "500MB") {
       assert(KyuubiSQLConf.getAdvisoryPartitionSize(conf).get === 1073741824L) // 1GB
+    }
+
+    // Both set: the larger value wins (finalStage larger)
+    withSQLConf(
+      KyuubiSQLConf.REBALANCE_PARTITIONS_ADVISORY_PARTITION_SIZE.key -> "200MB",
+      KyuubiSQLConf.FINAL_STAGE_ADVISORY_PARTITION_SIZE_KEY -> "500MB") {
+      assert(KyuubiSQLConf.getAdvisoryPartitionSize(conf).get === 524288000L) // 500MB
+    }
+
+    // Both set to the same value
+    withSQLConf(
+      KyuubiSQLConf.REBALANCE_PARTITIONS_ADVISORY_PARTITION_SIZE.key -> "256MB",
+      KyuubiSQLConf.FINAL_STAGE_ADVISORY_PARTITION_SIZE_KEY -> "256MB") {
+      assert(KyuubiSQLConf.getAdvisoryPartitionSize(conf).get === 268435456L) // 256MB
     }
   }
 }

--- a/extensions/spark/kyuubi-extension-spark-4-2/src/main/scala/org/apache/kyuubi/sql/KyuubiSQLConf.scala
+++ b/extensions/spark/kyuubi-extension-spark-4-2/src/main/scala/org/apache/kyuubi/sql/KyuubiSQLConf.scala
@@ -259,7 +259,8 @@ object KyuubiSQLConf {
     buildConf("spark.sql.adaptive.rebalancePartitionsAdvisoryPartitionSizeInBytes")
       .doc("The advisory partition size for RebalancePartitions operator. When set, it will be " +
         "passed to `optAdvisoryPartitionSize` of the RebalancePartitions node. " +
-        "It takes precedence over `spark.sql.finalStage.adaptive.advisoryPartitionSizeInBytes`.")
+        "When both this and `spark.sql.finalStage.adaptive.advisoryPartitionSizeInBytes` are " +
+        "set, the larger value is used.")
       .version("1.12.0")
       .bytesConf(ByteUnit.BYTE)
       .createOptional
@@ -319,14 +320,18 @@ object KyuubiSQLConf {
       .createWithDefault(true)
 
   def getAdvisoryPartitionSize(conf: SQLConf): Option[Long] = {
-    conf.getConf(REBALANCE_PARTITIONS_ADVISORY_PARTITION_SIZE).orElse {
-      if (conf.contains(FINAL_STAGE_ADVISORY_PARTITION_SIZE_KEY)) {
-        Some(JavaUtils.byteStringAs(
-          conf.getConfString(FINAL_STAGE_ADVISORY_PARTITION_SIZE_KEY),
-          ByteUnit.BYTE))
-      } else {
-        None
-      }
+    val rebalanceTargetSize = conf.getConf(REBALANCE_PARTITIONS_ADVISORY_PARTITION_SIZE)
+    val finalStageTargetSize = if (conf.contains(FINAL_STAGE_ADVISORY_PARTITION_SIZE_KEY)) {
+      Some(JavaUtils.byteStringAs(
+        conf.getConfString(FINAL_STAGE_ADVISORY_PARTITION_SIZE_KEY),
+        ByteUnit.BYTE))
+    } else {
+      None
+    }
+    if (rebalanceTargetSize.isDefined && finalStageTargetSize.isDefined) {
+      Some(rebalanceTargetSize.get.max(finalStageTargetSize.get))
+    } else {
+      rebalanceTargetSize.orElse(finalStageTargetSize)
     }
   }
 }

--- a/extensions/spark/kyuubi-extension-spark-4-2/src/test/scala/org/apache/spark/sql/RebalanceBeforeWritingSuite.scala
+++ b/extensions/spark/kyuubi-extension-spark-4-2/src/test/scala/org/apache/spark/sql/RebalanceBeforeWritingSuite.scala
@@ -425,7 +425,7 @@ class RebalanceBeforeWritingSuite extends KyuubiSparkSQLExtensionTest {
     }
   }
 
-  test("advisory partition size - kyuubi config takes precedence over finalStage") {
+  test("advisory partition size - larger value wins when both configs are set") {
     withSQLConf(
       KyuubiSQLConf.INSERT_REPARTITION_BEFORE_WRITE.key -> "true",
       KyuubiSQLConf.INSERT_REPARTITION_BEFORE_WRITE_IF_NO_SHUFFLE.key -> "true",
@@ -438,8 +438,8 @@ class RebalanceBeforeWritingSuite extends KyuubiSparkSQLExtensionTest {
           val rebalances = write.collect { case r: RebalancePartitions => r }
           assert(rebalances.size === 1)
           assert(rebalances.head.optAdvisoryPartitionSize.isDefined)
-          // kyuubi config takes precedence over finalStage
-          assert(rebalances.head.optAdvisoryPartitionSize.get === 209715200L) // 200MB
+          // both set: the larger of the two values wins
+          assert(rebalances.head.optAdvisoryPartitionSize.get === 314572800L) // 300MB
         }
       }
     }
@@ -477,11 +477,25 @@ class RebalanceBeforeWritingSuite extends KyuubiSparkSQLExtensionTest {
       assert(KyuubiSQLConf.getAdvisoryPartitionSize(conf).get === 1073741824L) // 1GB
     }
 
-    // Both set: kyuubi config takes precedence
+    // Both set: the larger value wins (kyuubi larger)
     withSQLConf(
       KyuubiSQLConf.REBALANCE_PARTITIONS_ADVISORY_PARTITION_SIZE.key -> "1gb",
       KyuubiSQLConf.FINAL_STAGE_ADVISORY_PARTITION_SIZE_KEY -> "500MB") {
       assert(KyuubiSQLConf.getAdvisoryPartitionSize(conf).get === 1073741824L) // 1GB
+    }
+
+    // Both set: the larger value wins (finalStage larger)
+    withSQLConf(
+      KyuubiSQLConf.REBALANCE_PARTITIONS_ADVISORY_PARTITION_SIZE.key -> "200MB",
+      KyuubiSQLConf.FINAL_STAGE_ADVISORY_PARTITION_SIZE_KEY -> "500MB") {
+      assert(KyuubiSQLConf.getAdvisoryPartitionSize(conf).get === 524288000L) // 500MB
+    }
+
+    // Both set to the same value
+    withSQLConf(
+      KyuubiSQLConf.REBALANCE_PARTITIONS_ADVISORY_PARTITION_SIZE.key -> "256MB",
+      KyuubiSQLConf.FINAL_STAGE_ADVISORY_PARTITION_SIZE_KEY -> "256MB") {
+      assert(KyuubiSQLConf.getAdvisoryPartitionSize(conf).get === 268435456L) // 256MB
     }
   }
 }


### PR DESCRIPTION
### Why are the changes needed?

When both `spark.sql.adaptive.rebalancePartitionsAdvisoryPartitionSizeInBytes`
and `spark.sql.finalStage.adaptive.advisoryPartitionSizeInBytes` are set,
`KyuubiSQLConf.getAdvisoryPartitionSize` previously let the rebalance config
unconditionally take precedence. This could pick a smaller advisory partition
size than the finalStage config even when the finalStage value is larger.

This changes the resolution so the larger of the two values is used when both
are set, which better reflects the intent of both knobs. The doc for the
rebalance config is updated accordingly. The change is applied to the
spark-3.5, 4.0 and 4.1 extension modules.

### How was this patch tested?

Updated `RebalanceBeforeWritingSuite` in all three modules to cover:
- both set, rebalance larger -> rebalance wins
- both set, finalStage larger -> finalStage wins
- both set to the same value

Ran the suite locally:

```
build/mvn test -pl extensions/spark/kyuubi-extension-spark-3-5 -am -Pspark-3.5 \
  -Dtest=none -DwildcardSuites=org.apache.spark.sql.RebalanceBeforeWritingSuite   # 14 passed
build/mvn test -pl extensions/spark/kyuubi-extension-spark-4-0 -am -Pspark-4.0 -Pscala-2.13 \
  -Dtest=none -DwildcardSuites=org.apache.spark.sql.RebalanceBeforeWritingSuite   # 12 passed
build/mvn test -pl extensions/spark/kyuubi-extension-spark-4-1 -am -Pspark-4.1 -Pscala-2.13 \
  -Dtest=none -DwildcardSuites=org.apache.spark.sql.RebalanceBeforeWritingSuite   # 12 passed
```

### Was this patch authored or co-authored using generative AI tooling?

Yes.

Assisted-by: Claude Opus 4.8