### PR TITLE
[KYUUBI #7589][AUTHZ] Rejecting RESET on the restricted configs parameters

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/rule/config/AuthzConfigurationChecker.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/rule/config/AuthzConfigurationChecker.scala
@@ -19,7 +19,7 @@ package org.apache.kyuubi.plugin.spark.authz.rule.config
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-import org.apache.spark.sql.execution.command.SetCommand
+import org.apache.spark.sql.execution.command.{ResetCommand, SetCommand}
 
 import org.apache.kyuubi.plugin.spark.authz.AccessControlException
 import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils.SKIP_CATALOGLESS_V2_RELATION_ENABLED_KEY
@@ -46,6 +46,10 @@ case class AuthzConfigurationChecker(spark: SparkSession) extends (LogicalPlan =
       throw new AccessControlException("Excluding Authz security rules is not allowed")
     case SetCommand(Some((k, Some(_)))) if restrictedConfList.contains(k) =>
       throw new AccessControlException(s"Modifying config $k is not allowed")
+    case ResetCommand(Some(k)) if restrictedConfList.contains(k) =>
+      throw new AccessControlException(s"Resetting config $k is not allowed")
+    case ResetCommand(None) =>
+      throw new AccessControlException("Resetting all configs is not allowed")
     case _ =>
   }
 }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/rule/AuthzConfigurationCheckerSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/rule/AuthzConfigurationCheckerSuite.scala
@@ -54,4 +54,30 @@ class AuthzConfigurationCheckerSuite extends KyuubiFunSuite with SparkSessionPro
       "set spark.kyuubi.authz.skipCataloglessV2Relation.enabled=true").queryExecution.analyzed
     intercept[AccessControlException](extension.apply(p9))
   }
+
+  test("apply spark configuration restriction rules for RESET") {
+    sql("set spark.kyuubi.conf.restricted.list=spark.sql.abc,spark.sql.xyz")
+    val extension = AuthzConfigurationChecker(spark)
+
+    // RESET of hardcoded restricted keys must be blocked
+    val pReset1 = sql("reset spark.sql.runSQLOnFiles").queryExecution.analyzed
+    intercept[AccessControlException](extension.apply(pReset1))
+    val pReset2 = sql(s"reset ${extension.RESTRICT_LIST_KEY}").queryExecution.analyzed
+    intercept[AccessControlException](extension.apply(pReset2))
+    val pReset3 = sql(
+      "reset spark.kyuubi.authz.skipCataloglessV2Relation.enabled").queryExecution.analyzed
+    intercept[AccessControlException](extension.apply(pReset3))
+
+    // RESET of admin-configured restricted keys must be blocked
+    val pReset4 = sql("reset spark.sql.abc").queryExecution.analyzed
+    intercept[AccessControlException](extension.apply(pReset4))
+
+    // RESET of a non-restricted key must be allowed
+    val pReset5 = sql("reset spark.sql.efg").queryExecution.analyzed
+    extension.apply(pReset5)
+
+    // Bare RESET (no key) must be blocked - it would wipe all session configs at once
+    val pResetAll = sql("reset").queryExecution.analyzed
+    intercept[AccessControlException](extension.apply(pResetAll))
+  }
 }


### PR DESCRIPTION
### Why are the changes needed?

The `AuthzConfigurationChecker` only validates setting configuration parameters to explicit values (`SET <key>=<value>`). It currently fails to check actions that restore default values or remove configurations entirely, such as `RESET <key>` or `RESET` (which reset all the config parameters).

For more details, see the: https://spark.apache.org/docs/latest/sql-ref-syntax-aux-conf-mgmt-reset.html

### How was this patch tested?

A unit test was extended.

### Was this patch authored or co-authored using generative AI tooling?

Yes.

Assisted-by: Claude:claude-sonnet