### PR TITLE
[KYUUBI #7590][SPARK] Exit engine when SparkContext stops

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
@@ -230,6 +230,8 @@ object SparkSQLEngine extends Logging {
 
   private val sparkSessionCreated = new AtomicBoolean(false)
 
+  private val ENGINE_TERMINATION_CHECK_INTERVAL_SECONDS = 1L
+
   final private val POD_NAME_MAX_LENGTH = 253
   final private val POD_UID_MAX_LENGTH = 36
   final private val POD_LOGS_DIRECTORY_SEPARATOR_LENGTH = 2
@@ -414,7 +416,11 @@ object SparkSQLEngine extends Logging {
         try {
           startEngine(spark)
           // blocking main thread
-          countDownLatch.await()
+          waitForEngineTermination(
+            countDownLatch,
+            () => spark.sparkContext.isStopped,
+            ENGINE_TERMINATION_CHECK_INTERVAL_SECONDS,
+            TimeUnit.SECONDS)
         } catch {
           case e: KyuubiException =>
             currentEngine match {
@@ -445,6 +451,21 @@ object SparkSQLEngine extends Logging {
         if (spark != null) {
           spark.stop()
         }
+      }
+    }
+  }
+
+  @VisibleForTesting
+  private[kyuubi] def waitForEngineTermination(
+      latch: CountDownLatch,
+      isSparkContextStopped: () => Boolean,
+      checkInterval: Long,
+      timeUnit: TimeUnit): Unit = {
+    while (!latch.await(checkInterval, timeUnit)) {
+      // Engine shutdown may stall before stopServer releases the latch.
+      if (isSparkContextStopped() && !latch.await(0, TimeUnit.NANOSECONDS)) {
+        throw new KyuubiException(
+          "SparkContext stopped while engine is running, exiting main thread")
       }
     }
   }

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/SparkSQLEngineSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/SparkSQLEngineSuite.scala
@@ -17,12 +17,41 @@
 
 package org.apache.kyuubi.engine.spark
 
-import org.apache.kyuubi.KyuubiFunSuite
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+
+import org.apache.kyuubi.{KyuubiException, KyuubiFunSuite}
 
 class SparkSQLEngineSuite extends KyuubiFunSuite {
 
   private val namespace = "n" * 63
   private val podUid = "u" * 36
+
+  test("[KYUUBI #7590] stop waiting when SparkContext is stopped") {
+    val latch = new CountDownLatch(1)
+
+    val error = intercept[KyuubiException] {
+      SparkSQLEngine.waitForEngineTermination(
+        latch,
+        () => true,
+        1,
+        TimeUnit.MILLISECONDS)
+    }
+
+    assert(error.getMessage.contains("SparkContext stopped"))
+  }
+
+  test("[KYUUBI #7590] complete normally when shutdown wins the race") {
+    val latch = new CountDownLatch(1)
+
+    SparkSQLEngine.waitForEngineTermination(
+      latch,
+      () => {
+        latch.countDown()
+        true
+      },
+      1,
+      TimeUnit.MILLISECONDS)
+  }
 
   test("[KYUUBI #3385] generate executor pod name prefix with user or UUID") {
     val userName1 = "/kyuubi_user+-*"


### PR DESCRIPTION
### Why are the changes needed?

Closes #7590.

After `SparkContext` stops, engine shutdown can stall before `stopServer` releases the
main-thread latch. In that state, `SparkSQLEngine` waits indefinitely and leaves a
zombie engine process.

This patch checks the `SparkContext` state while waiting for normal engine shutdown.
It also rechecks the latch before reporting failure so that a concurrent normal
shutdown wins the race.

### How was this patch tested?

Added tests for both the stopped-`SparkContext` path and the concurrent normal-shutdown
path.

```shell
mvn test -pl :kyuubi-spark-sql-engine_2.12 -am \
  -Dtest=none \
  -DwildcardSuites=org.apache.kyuubi.engine.spark.SparkSQLEngineSuite
```

Result: 3 tests passed.

Also ran the repository Spotless formatter.

### Was this patch authored or co-authored using generative AI tooling?

Assisted-by: OpenAI Codex with GPT-5
