### PR TITLE
[KYUUBI #7597][INFRA] Fix labeler.yml YAML parsing error under actions/labeler v7

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -20,178 +20,155 @@
 
 "kind:build":
   - changed-files:
-    - any-glob-to-any-file: [
-      '.dockerignore',
-      '.rat-excludes',
-      '.scalafmt',
-      '**/*pom.xml',
-      'bin/docker-image-tool.sh',
-      'build/**/*',
-      'docker/**/*',
-      'docs/requirements',
-      'kyuubi-assembly/**/*',
-      'scalastyle-config.xml'
-    ]
-    - all-globs-to-any-file: [
-      'dev/**/*',
-      '!dev/kyuubi-codecov/**/*',
-      '!dev/kyuubi-tpcds/**/*'
-    ]
+    - any-glob-to-any-file:
+      - '.dockerignore'
+      - '.rat-excludes'
+      - '.scalafmt'
+      - '**/*pom.xml'
+      - 'bin/docker-image-tool.sh'
+      - 'build/**/*'
+      - 'docker/**/*'
+      - 'docs/requirements'
+      - 'kyuubi-assembly/**/*'
+      - 'scalastyle-config.xml'
+    - all-globs-to-any-file:
+      - 'dev/**/*'
+      - '!dev/kyuubi-codecov/**/*'
+      - '!dev/kyuubi-tpcds/**/*'
 
 "kind:deploy":
   - changed-files:
-    - all-globs-to-any-file: [
-      'bin/**/*',
-      '!bin/beeline',
-      '!bin/docker-image-tool.sh'
-    ]
-    
+    - all-globs-to-any-file:
+      - 'bin/**/*'
+      - '!bin/beeline'
+      - '!bin/docker-image-tool.sh'
+
 "kind:documentation":
   - changed-files:
-    - any-glob-to-any-file: [
-      '*.md',
-      'conf/**/*',
-      'docs/**/*',
-      'readthedocs.yml'
-    ]
+    - any-glob-to-any-file:
+      - '*.md'
+      - 'conf/**/*'
+      - 'docs/**/*'
+      - 'readthedocs.yml'
 
 "kind:infra":
   - changed-files:
-    - any-glob-to-any-file: [
-      '.asf.yaml',
-      '.gitattributes',
-      '.github/**/*',
-      '.gitignore',
-      'LICENSE',
-      'LICENSE-binary',
-      'NOTICE',
-      'NOTICE-binary',
-      'codecov.yml',
-      'dev/kyuubi-codecov/**/*',
-      'licenses-binary'
-    ]
+    - any-glob-to-any-file:
+      - '.asf.yaml'
+      - '.gitattributes'
+      - '.github/**/*'
+      - '.gitignore'
+      - 'LICENSE'
+      - 'LICENSE-binary'
+      - 'NOTICE'
+      - 'NOTICE-binary'
+      - 'codecov.yml'
+      - 'dev/kyuubi-codecov/**/*'
+      - 'licenses-binary'
 
 "module:common":
   - changed-files:
-    - any-glob-to-any-file: [
-      'kyuubi-common/**/*'
-    ]
+    - any-glob-to-any-file:
+      - 'kyuubi-common/**/*'
 
 "module:ctl":
   - changed-files:
-    - any-glob-to-any-file: [
-      'bin/beeline',
-      'kyuubi-ctl/**/*',
-      'kyuubi-hive-beeline/**/*',
-      'kyuubi-hive-jdbc/**/*',
-      'kyuubi-hive-jdbc-shaded/**/*'
-    ]
+    - any-glob-to-any-file:
+      - 'bin/beeline'
+      - 'kyuubi-ctl/**/*'
+      - 'kyuubi-hive-beeline/**/*'
+      - 'kyuubi-hive-jdbc/**/*'
+      - 'kyuubi-hive-jdbc-shaded/**/*'
 
 "module:events":
   - changed-files:
-    - any-glob-to-any-file: [
-      'kyuubi-events/**/*'
-    ]
+    - any-glob-to-any-file:
+      - 'kyuubi-events/**/*'
 
 "module:flink":
   - changed-files:
-    - any-glob-to-any-file: [
-      'externals/kyuubi-flink-sql-engine/**/*',
-      'integration-tests/kyuubi-flink-it/**/*'
-    ]
+    - any-glob-to-any-file:
+      - 'externals/kyuubi-flink-sql-engine/**/*'
+      - 'integration-tests/kyuubi-flink-it/**/*'
 
 "module:ha":
   - changed-files:
-    - any-glob-to-any-file: [
-      'kyuubi-ha/**/*',
-      'kyuubi-zookeeper/**/*'
-    ]
+    - any-glob-to-any-file:
+      - 'kyuubi-ha/**/*'
+      - 'kyuubi-zookeeper/**/*'
 
 "module:hive":
   - changed-files:
-    - any-glob-to-any-file: [
-      'bin/beeline',
-      'externals/kyuubi-hive-sql-engine/**/*',
-      'kyuubi-hive-beeline/**/*',
-      'kyuubi-hive-jdbc/**/*',
-      'kyuubi-hive-jdbc-shaded/**/*'
-    ]
+    - any-glob-to-any-file:
+      - 'bin/beeline'
+      - 'externals/kyuubi-hive-sql-engine/**/*'
+      - 'kyuubi-hive-beeline/**/*'
+      - 'kyuubi-hive-jdbc/**/*'
+      - 'kyuubi-hive-jdbc-shaded/**/*'
 
 "module:jdbc":
   - changed-files:
-    - any-glob-to-any-file: [
-      'externals/kyuubi-jdbc-engine/**/*'
-    ]
+    - any-glob-to-any-file:
+      - 'externals/kyuubi-jdbc-engine/**/*'
 
 "module:kubernetes":
   - changed-files:
-    - any-glob-to-any-file: [
-      '.dockerignore',
-      'bin/docker-image-tool.sh',
-      'docker/**/*',
-      'integration-tests/kyuubi-kubernetes-it/**/*'
-    ]
+    - any-glob-to-any-file:
+      - '.dockerignore'
+      - 'bin/docker-image-tool.sh'
+      - 'docker/**/*'
+      - 'integration-tests/kyuubi-kubernetes-it/**/*'
 
 "module:metrics":
   - changed-files:
-    - any-glob-to-any-file: [
-      'kyuubi-metrics/**/*'
-    ]
+    - any-glob-to-any-file:
+      - 'kyuubi-metrics/**/*'
 
 "module:trino":
   - changed-files:
-    - any-glob-to-any-file: [
-      'externals/kyuubi-trino-engine/**/*'
-    ]
+    - any-glob-to-any-file:
+      - 'externals/kyuubi-trino-engine/**/*'
 
 "module:tpcds":
   - changed-files:
-    - any-glob-to-any-file: [
-      'dev/kyuubi-tpcds/**/*'
-    ]
+    - any-glob-to-any-file:
+      - 'dev/kyuubi-tpcds/**/*'
 
 "module:server":
   - changed-files:
-    - any-glob-to-any-file: [
-      'bin/kyuubi',
-      'kyuubi-server/src/**/*',
-      'kyuubi-server/pom.xml',
-      'extension/server/kyuubi-server-plugin/**/*'
-    ]
+    - any-glob-to-any-file:
+      - 'bin/kyuubi'
+      - 'kyuubi-server/src/**/*'
+      - 'kyuubi-server/pom.xml'
+      - 'extension/server/kyuubi-server-plugin/**/*'
 
 "module:spark":
   - changed-files:
-      - any-glob-to-any-file: [
-        'externals/kyuubi-spark-sql-engine/**/*',
-        'extensions/spark/**/*'
-      ]
+    - any-glob-to-any-file:
+      - 'externals/kyuubi-spark-sql-engine/**/*'
+      - 'extensions/spark/**/*'
 
 "module:extensions":
   - changed-files:
-    - any-glob-to-any-file: [
-      'extensions/**/*'
-    ]
+    - any-glob-to-any-file:
+      - 'extensions/**/*'
 
 "module:rest-client":
   - changed-files:
-    - any-glob-to-any-file: [
-      'kyuubi-rest-client/**/*'
-    ]
+    - any-glob-to-any-file:
+      - 'kyuubi-rest-client/**/*'
 
 "module:integration-tests":
   - changed-files:
-    - any-glob-to-any-file: [
-      'integration-tests/**/*'
-    ]
+    - any-glob-to-any-file:
+      - 'integration-tests/**/*'
 
 "module:authz":
   - changed-files:
-    - any-glob-to-any-file: [
-      'extensions/spark/kyuubi-spark-authz/**/*'
-    ]
+    - any-glob-to-any-file:
+      - 'extensions/spark/kyuubi-spark-authz/**/*'
 
 "module:ui":
   - changed-files:
-    - any-glob-to-any-file: [
-      'kyuubi-server/web-ui/**/*'
-    ]
+    - any-glob-to-any-file:
+      - 'kyuubi-server/web-ui/**/*'


### PR DESCRIPTION
Closes #7597

### Why are the changes needed?

`actions/labeler@v7` fails to parse `.github/labeler.yml` and aborts the workflow before applying any labels:

```
Run actions/labeler@v7
The configuration file (path: .github/labeler.yml) was not found locally, fetching via the api
Error: YAMLException: deficient indentation (24:7)

 21 | "kind:build":
 22 |   - changed-files:
 23 |     - any-glob-to-any-file: [
 24 |       '.dockerignore',
------------^
 25 |       '.rat-excludes',
 26 |       '.scalafmt',
```

Every `any-glob-to-any-file: [ ... ]` / `all-globs-to-any-file: [ ... ]` block fails with the same error, so the job bails out and no `kind:*` / `module:*` labels are applied to PRs. Triage has been silently broken since the v7 bump in #7583.

**Root cause.** The file uses YAML flow-style sequences (`[ ... ]`) split across multiple lines, with continuation lines indented at 6 spaces while the opening `[` sits at column 27. YAML 1.2 (and `js-yaml@4`, which `actions/labeler@v7` depends on) requires flow-sequence continuation lines to be indented at least one column past the line containing the opening bracket — hence `deficient indentation`.

The format was introduced in #5874 (commit `7e96dc7bc9`, 2023-12-19) when the action was bumped from v4 to v5. v5/v6 bundled an older `js-yaml` that did not strictly enforce the indentation rule, which is why the bug stayed latent for ~2 years.

### What does this PR do?

Rewrite every `any-glob-to-any-file: [ ... ]` and `all-globs-to-any-file: [ ... ]` block in `.github/labeler.yml` as a standard YAML block-style sequence. Same 22 labels, same glob sets — no semantic change. The file now parses cleanly under strict YAML 1.2 and is forward-compatible with future `actions/labeler` releases.

Also dropped:
- the trailing whitespace on line 48 of the old file (under the `kind:deploy` block)
- the inconsistent 6-space indent under `module:spark`, which was the only block at odds with the rest of the file

### How was this patch tested?

1. Parsed the rewritten file with `python3 -c "import yaml; yaml.safe_load(open('.github/labeler.yml'))"` — succeeds.
2. Cross-checked label keys and glob counts against the pre-change file: 22 labels preserved, identical glob counts per label.
3. Spotless does not process YAML files (see `pom.xml` — only `java`, `scala`, `pom`, `python`, `markdown` are in scope), so no format step is required for this change.

End-to-end verification will happen on the next PR opened against `apache/master` that runs the `Pull Request Labeler` workflow.

### Was this patch authored or co-authored using generative AI tooling?

Assisted-by: OpenCode with MiniMax-M3