### PR TITLE
[Web] Bump Node.js to v24 LTS and pnpm to v11

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -49,6 +49,7 @@ build/scala-*/**
 **/web-ui/dist/**
 **/web-ui/coverage/**
 **/pnpm-lock.yaml
+**/pnpm-workspace.yaml
 **/node_modules/**
 **/gen/*
 **/*.tokens

--- a/kyuubi-server/web-ui/README.md
+++ b/kyuubi-server/web-ui/README.md
@@ -2,7 +2,7 @@
 
 ### Start Using
 
-Node.js 18 or higher is required.
+Node.js 24 or higher is required.
 You can learn how to install the corresponding version from its official website.
 
 - [node](https://nodejs.org/en/)
@@ -45,7 +45,7 @@ npm run prettier
 
 ### Recommend
 
-If you want to save disk space and boost installation speed, we recommend using `pnpm 8.x.x` to instead of npm.
+If you want to save disk space and boost installation speed, we recommend using `pnpm 11.x.x` to instead of npm.
 You can learn how to install the corresponding version from its official website.
 
 - [pnpm](https://pnpm.io/)

--- a/kyuubi-server/web-ui/package.json
+++ b/kyuubi-server/web-ui/package.json
@@ -15,7 +15,7 @@
     "coverage": "vitest run --coverage"
   },
   "engines": {
-    "node": "^20.19.0 || >=22.12.0"
+    "node": ">=24.0.0"
   },
   "dependencies": {
     "@element-plus/icons-vue": "^2.3.2",
@@ -54,13 +54,5 @@
     "vite": "^8.1.2",
     "vitest": "^4.1.9",
     "vue-tsc": "^3.3.6"
-  },
-  "pnpm": {
-    "overrides": {
-      "lodash": "^4.18.1",
-      "lodash-es": "^4.18.1",
-      "brace-expansion@1": "^1.1.15",
-      "picomatch@2": "^2.3.2"
-    }
   }
 }

--- a/kyuubi-server/web-ui/pnpm-workspace.yaml
+++ b/kyuubi-server/web-ui/pnpm-workspace.yaml
@@ -1,0 +1,9 @@
+overrides:
+  lodash: ^4.18.1
+  lodash-es: ^4.18.1
+  brace-expansion@1: ^1.1.15
+  picomatch@2: ^2.3.2
+
+allowBuilds:
+  '@parcel/watcher': true
+  vue-demi: true

--- a/pom.xml
+++ b/pom.xml
@@ -233,8 +233,8 @@
 
         <!-- webui -->
         <webui.skip>true</webui.skip>
-        <node.version>v22.23.1</node.version>
-        <pnpm.version>v9.11.0</pnpm.version>
+        <node.version>v24.11.1</node.version>
+        <pnpm.version>v11.18.0</pnpm.version>
 
         <hive.jdbc.artifact>kyuubi-hive-jdbc</hive.jdbc.artifact>
 


### PR DESCRIPTION
### Why are the changes needed?

Stay on a supported LTS line and pick up the latest pnpm stable. Node v22 has moved to Maintenance LTS (security fixes only, EOL 2027-04-30); v24 is the current Active LTS and is supported until 2028-04-30. pnpm v12 is still beta, so the latest v11 stable is the right target.

| Tool    | Before   | After            | Released   |
| ------- | -------- | ---------------- | ---------- |
| Node.js | v22.23.1 | **v24.11.1** (Active LTS) | 2025-11-11 |
| pnpm    | v9.11.0  | **v11.18.0**     | 2026-07-29 |

Migration notes:

- pnpm v11 no longer reads the `pnpm` field in `package.json`; moved the security overrides to a new `kyuubi-server/web-ui/pnpm-workspace.yaml`.
- pnpm v11's `strictDepBuilds` defaults to true; explicitly allow `@parcel/watcher` and `vue-demi` via `allowBuilds` since Vite's toolchain depends on their install/postinstall scripts.
- `engines.node` simplified to `>=24.0.0`.

### How was this patch tested?

- Local `pnpm install` against the updated toolchain succeeded with no resolution drift (lockfile content byte-identical to v9.11.0).
- `pnpm run build` and `pnpm run lint` pass locally.
- GitHub `web-ui` and `style` workflows both read `node.version` / `pnpm.version` from `pom.xml` and will exercise the new versions end-to-end.

### Was this patch authored or co-authored using generative AI tooling?

Yes. Assisted-by: OpenCode with MiniMax-M3