### PR TITLE
[KYUUBI #6718][AUTHZ] Support {OWNER} variable for Hudi update/delete/merge

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/serde/tableExtractors.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/serde/tableExtractors.scala
@@ -72,6 +72,19 @@ object TableExtractor {
       case _: Exception => None
     }
   }
+
+  /**
+   * Get owner from a `org.apache.spark.sql.execution.datasources.LogicalRelation`
+   * that wraps a Spark `CatalogTable`.
+   */
+  def getLogicalRelationOwner(v: AnyRef): Option[String] = {
+    try {
+      val maybeCatalogTable = invokeAs[Option[CatalogTable]](v, "catalogTable")
+      maybeCatalogTable.flatMap(ct => Option(ct.owner).filter(_.nonEmpty))
+    } catch {
+      case _: Exception => None
+    }
+  }
 }
 
 /**
@@ -321,11 +334,13 @@ class HudiDataSourceV2RelationTableExtractor extends TableExtractor {
   override def apply(spark: SparkSession, v1: AnyRef): Option[Table] = {
     invokeAs[LogicalPlan](v1, "table") match {
       // Match multipartIdentifier with tableAlias
-      case SubqueryAlias(_, SubqueryAlias(identifier, _)) =>
+      case SubqueryAlias(_, SubqueryAlias(identifier, relation)) =>
         lookupExtractor[StringTableExtractor].apply(spark, identifier.toString())
+          .map(_.copy(owner = TableExtractor.getLogicalRelationOwner(relation)))
       // Match multipartIdentifier without tableAlias
-      case SubqueryAlias(identifier, _) =>
+      case SubqueryAlias(identifier, relation) =>
         lookupExtractor[StringTableExtractor].apply(spark, identifier.toString())
+          .map(_.copy(owner = TableExtractor.getLogicalRelationOwner(relation)))
       case _ => None
     }
   }
@@ -350,9 +365,11 @@ class HudiMergeIntoTargetTableExtractor extends TableExtractor {
       // Match multipartIdentifier with tableAlias
       case SubqueryAlias(_, SubqueryAlias(identifier, relation)) =>
         lookupExtractor[StringTableExtractor].apply(spark, identifier.toString())
+          .map(_.copy(owner = TableExtractor.getLogicalRelationOwner(relation)))
       // Match multipartIdentifier without tableAlias
-      case SubqueryAlias(identifier, _) =>
+      case SubqueryAlias(identifier, relation) =>
         lookupExtractor[StringTableExtractor].apply(spark, identifier.toString())
+          .map(_.copy(owner = TableExtractor.getLogicalRelationOwner(relation)))
       case _ => None
     }
   }

--- a/extensions/spark/kyuubi-spark-authz/src/test/gen/scala/org/apache/kyuubi/plugin/spark/authz/gen/PolicyJsonFileGenerator.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/gen/scala/org/apache/kyuubi/plugin/spark/authz/gen/PolicyJsonFileGenerator.scala
@@ -175,7 +175,13 @@ class PolicyJsonFileGenerator extends KyuubiFunSuite {
     name = "all - database, udf",
     description = "Policy for all - database, udf",
     resources = Map(
-      databaseRes(defaultDb, sparkCatalog, icebergNamespace, namespace1, paimonNamespace),
+      databaseRes(
+        defaultDb,
+        sparkCatalog,
+        icebergNamespace,
+        namespace1,
+        paimonNamespace,
+        hudiNamespace),
       allTableRes,
       allColumnRes),
     policyItems = List(

--- a/extensions/spark/kyuubi-spark-authz/src/test/resources/sparkSql_hive_jenkins.json
+++ b/extensions/spark/kyuubi-spark-authz/src/test/resources/sparkSql_hive_jenkins.json
@@ -198,7 +198,7 @@
         "isRecursive" : false
       },
       "database" : {
-        "values" : [ "default", "spark_catalog", "iceberg_ns", "ns1", "paimon_ns" ],
+        "values" : [ "default", "spark_catalog", "iceberg_ns", "ns1", "paimon_ns", "hudi_ns" ],
         "isExcludes" : false,
         "isRecursive" : false
       },

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/HudiCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/HudiCatalogRangerSparkExtensionSuite.scala
@@ -17,6 +17,7 @@
 package org.apache.kyuubi.plugin.spark.authz.ranger
 
 import org.apache.spark.SparkConf
+import org.apache.spark.sql.catalyst.TableIdentifier
 
 import org.apache.kyuubi.Utils
 import org.apache.kyuubi.plugin.spark.authz.AccessControlException
@@ -490,6 +491,90 @@ class HudiCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
           s"[$namespace1/$table2/city,$namespace1/$table2/id,$namespace1/$table2/name], " +
           s"[update] privilege on [$namespace1/$table1]")
         doAs(admin, sql(mergeIntoSQL))
+      }
+    }
+  }
+
+  test("Support {OWNER} variable for Hudi update/delete/merge") {
+    withSingleCallEnabled {
+      withCleanTmpResources(Seq(
+        (s"$namespace1.$table1", "table"),
+        (s"$namespace1.$table2", "table"),
+        (namespace1, "database"))) {
+        doAs(admin, sql(s"CREATE DATABASE IF NOT EXISTS $namespace1"))
+
+        // createOnlyUser creates and owns table1
+        doAs(
+          createOnlyUser,
+          sql(
+            s"""
+               |CREATE TABLE IF NOT EXISTS $namespace1.$table1(id int, name string, city string)
+               |USING HUDI
+               |OPTIONS (
+               | type = 'cow',
+               | primaryKey = 'id',
+               | 'hoodie.datasource.hive_sync.enable' = 'false'
+               |)
+               |PARTITIONED BY(city)
+               |""".stripMargin))
+
+        // createOnlyUser creates and owns table2 as merge source
+        doAs(
+          createOnlyUser,
+          sql(
+            s"""
+               |CREATE TABLE IF NOT EXISTS $namespace1.$table2(id int, name string, city string)
+               |USING HUDI
+               |OPTIONS (
+               | type = 'cow',
+               | primaryKey = 'id',
+               | 'hoodie.datasource.hive_sync.enable' = 'false'
+               |)
+               |PARTITIONED BY(city)
+               |""".stripMargin))
+
+        // The in-memory catalog does not automatically populate `CatalogTable.owner`
+        // (unlike Hive Metastore). Manually set it to simulate the production case
+        // where the creator becomes the owner, which is required by Ranger {OWNER}.
+        Seq(table1, table2).foreach { t =>
+          val ident = TableIdentifier(t, Some(namespace1))
+          val ct = spark.sessionState.catalog.getTableMetadata(ident)
+          spark.sessionState.catalog.alterTable(ct.copy(owner = createOnlyUser))
+        }
+
+        val deleteSql = s"DELETE FROM $namespace1.$table1 WHERE id = 10"
+        // owner should be allowed
+        doAs(createOnlyUser, sql(deleteSql))
+        // non-owner should still be denied
+        interceptEndsWith[AccessControlException] {
+          doAs(someone, sql(deleteSql))
+        }(s"does not have [update] privilege on [$namespace1/$table1]")
+
+        val updateSql = s"UPDATE $namespace1.$table1 SET name = 'test' WHERE id > 10"
+        // owner should be allowed
+        doAs(createOnlyUser, sql(updateSql))
+        // non-owner should still be denied
+        interceptEndsWith[AccessControlException] {
+          doAs(someone, sql(updateSql))
+        }(s"does not have [update] privilege on [$namespace1/$table1]")
+
+        val mergeIntoSql =
+          s"""
+             |MERGE INTO $namespace1.$table1 target
+             |USING $namespace1.$table2 source
+             |ON target.id = source.id
+             |WHEN MATCHED
+             |AND target.name == 'test'
+             | THEN UPDATE SET id = source.id, name = source.name, city = source.city
+             |""".stripMargin
+        // owner (of both target and source) should be allowed
+        doAs(createOnlyUser, sql(mergeIntoSql))
+        // non-owner should still be denied
+        interceptEndsWith[AccessControlException] {
+          doAs(someone, sql(mergeIntoSql))
+        }(s"does not have [select] privilege on " +
+          s"[$namespace1/$table2/city,$namespace1/$table2/id,$namespace1/$table2/name], " +
+          s"[update] privilege on [$namespace1/$table1]")
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->
Fix https://github.com/apache/kyuubi/issues/6718.

Hudi `UPDATE` / `DELETE` / `MERGE INTO` commands are handled by `HudiDataSourceV2RelationTableExtractor` and `HudiMergeIntoTargetTableExtractor` in `table_command_spec.json`. Previously, both extractors delegated the `SubqueryAlias(identifier, _)` case to `StringTableExtractor`, which only parses `database.table` from a string and always leaves `Table.owner` as `None`.

As a result, `AccessResource#setOwnerUser` is never called for these commands, so Ranger cannot resolve the `{OWNER}` variable, and a policy like `{OWNER}` -> `ALL on database/table/column` never matches — even when the user running the statement is exactly the table's creator/owner.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Added UT.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has assisted in authoring or reviewing this patch, please include
an 'Assisted-by: ' trailer that identifies the agent and model.
For example: 'Assisted-by: Claude:claude-opus-4-7' or 'Assisted-by: Claude Opus 4.7'.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Assisted-by: Claude:claude-opus-4-7