### PR TITLE
Performance and allocations improvement in TRowSet generation

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/schema/RowSet.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/schema/RowSet.scala
@@ -37,11 +37,7 @@ object RowSet {
       .buildChecked(HiveResult)
       .invokeChecked[BinaryFormatter]()
 
-  def toHiveString(
-      valueAndType: (Any, DataType),
-      nested: JBoolean = false,
-      timeFormatters: TimeFormatters,
-      binaryFormatter: BinaryFormatter): String =
+  private val toHiveStringMethod =
     DynMethods.builder("toHiveString")
       .impl( // for Spark 3.5 and before
         HiveResult.getClass,
@@ -55,5 +51,11 @@ object RowSet {
         classOf[TimeFormatters],
         classOf[BinaryFormatter])
       .buildChecked(HiveResult)
-      .invokeChecked[String](valueAndType, nested, timeFormatters, binaryFormatter)
+
+  def toHiveString(
+      valueAndType: (Any, DataType),
+      nested: JBoolean = false,
+      timeFormatters: TimeFormatters,
+      binaryFormatter: BinaryFormatter): String =
+    toHiveStringMethod.invokeChecked[String](valueAndType, nested, timeFormatters, binaryFormatter)
 }

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/engine/result/TColumnGenerator.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/engine/result/TColumnGenerator.scala
@@ -20,8 +20,6 @@ import java.lang.{Boolean => JBoolean, Byte => JByte, Double => JDouble, Float =
 import java.nio.ByteBuffer
 import java.util.{ArrayList => JArrayList, BitSet => JBitSet, List => JList}
 
-import scala.collection.JavaConverters._
-
 import org.apache.kyuubi.shaded.hive.service.rpc.thrift._
 
 trait TColumnGenerator[RowT] extends TRowSetColumnGetter[RowT] {
@@ -32,19 +30,19 @@ trait TColumnGenerator[RowT] extends TRowSetColumnGetter[RowT] {
       convertFunc: (RowT, Int) => T = null): (JList[T], ByteBuffer) = {
     val rowSize = rows.length
     val ret = new JArrayList[T](rowSize)
-    val nulls = new JBitSet()
+    val nulls = new JBitSet(rowSize)
+    val valueOf: (RowT, Int) => T =
+      if (convertFunc == null) (row, ord) => getColumnAs[T](row, ord) else convertFunc
+    val iter = rows.iterator
     var idx = 0
-    val isConvertFuncNull = convertFunc == null
-    rows.foreach { row =>
-      val value = if (isColumnNullAt(row, ordinal)) {
-        nulls.set(idx, true)
-        defaultVal
-      } else if (isConvertFuncNull) {
-        getColumnAs[T](row, ordinal)
+    while (iter.hasNext) {
+      val row = iter.next()
+      if (isColumnNullAt(row, ordinal)) {
+        nulls.set(idx)
+        ret.add(defaultVal)
       } else {
-        convertFunc(row, ordinal)
+        ret.add(valueOf(row, ordinal))
       }
-      ret.add(value)
       idx += 1
     }
     (ret, ByteBuffer.wrap(nulls.toByteArray))
@@ -85,9 +83,12 @@ trait TColumnGenerator[RowT] extends TRowSetColumnGetter[RowT] {
   }
 
   def asFloatTColumn(rows: Seq[RowT], ordinal: Int): TColumn = {
-    val (values, nulls) = getColumnToList[JFloat](rows, ordinal, 0.toFloat)
-    val doubleValues = values.asScala.map(f => JDouble.valueOf(f.toString)).asJava
-    TColumn.doubleVal(new TDoubleColumn(doubleValues, nulls))
+    val (values, nulls) = getColumnToList[JDouble](
+      rows,
+      ordinal,
+      0.toDouble,
+      (row, ord) => JDouble.valueOf(getColumnAs[JFloat](row, ord).toString))
+    TColumn.doubleVal(new TDoubleColumn(values, nulls))
   }
 
   def asDoubleTColumn(rows: Seq[RowT], ordinal: Int): TColumn = {
@@ -105,8 +106,11 @@ trait TColumnGenerator[RowT] extends TRowSetColumnGetter[RowT] {
   }
 
   def asByteArrayTColumn(rows: Seq[RowT], ordinal: Int): TColumn = {
-    val (values, nulls) = getColumnToList[Array[Byte]](rows, ordinal, defaultVal = Array[Byte]())
-    val byteBufferValues = values.asScala.map(ByteBuffer.wrap).asJava
-    TColumn.binaryVal(new TBinaryColumn(byteBufferValues, nulls))
+    val (values, nulls) = getColumnToList[ByteBuffer](
+      rows,
+      ordinal,
+      defaultVal = ByteBuffer.wrap(Array[Byte]()),
+      (row, ord) => ByteBuffer.wrap(getColumnAs[Array[Byte]](row, ord)))
+    TColumn.binaryVal(new TBinaryColumn(values, nulls))
   }
 }

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/engine/result/TRowSetGenerator.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/engine/result/TRowSetGenerator.scala
@@ -18,8 +18,6 @@
 package org.apache.kyuubi.engine.result
 import java.util.{ArrayList => JArrayList}
 
-import scala.collection.JavaConverters._
-
 import org.apache.kyuubi.shaded.hive.service.rpc.thrift._
 
 trait TRowSetGenerator[SchemaT, RowT, ColumnT]
@@ -42,23 +40,24 @@ trait TRowSetGenerator[SchemaT, RowT, ColumnT]
   }
 
   def toRowBasedSet(rows: Seq[RowT], schema: SchemaT): TRowSet = {
-    val tRows = rows.map { row =>
-      var i = 0
-      val columnSize = getColumnSizeFromSchemaType(schema)
+    val columnSize = getColumnSizeFromSchemaType(schema)
+    val tRows = new JArrayList[TRow](rows.size)
+    val rowIter = rows.iterator
+    while (rowIter.hasNext) {
+      val row = rowIter.next()
       val tColumnValues = new JArrayList[TColumnValue](columnSize)
+      var i = 0
       while (i < columnSize) {
-        val columnValue = toTColumnValue(row, i, schema)
-        tColumnValues.add(columnValue)
+        tColumnValues.add(toTColumnValue(row, i, schema))
         i += 1
       }
-      new TRow(tColumnValues)
-    }.asJava
+      tRows.add(new TRow(tColumnValues))
+    }
     new TRowSet(0, tRows)
   }
 
   def toColumnBasedSet(rows: Seq[RowT], schema: SchemaT): TRowSet = {
-    val rowSize = rows.length
-    val tRowSet = new TRowSet(0, new JArrayList[TRow](rowSize))
+    val tRowSet = new TRowSet(0, new JArrayList[TRow](0))
     var i = 0
     val columnSize = getColumnSizeFromSchemaType(schema)
     val tColumns = new JArrayList[TColumn](columnSize)


### PR DESCRIPTION
### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->
`TRowSet` generation is on the hot path of every result fetch. This patch removes pure-overhead allocations, with no wire-protocol/API change and byte-identical output:

- `getColumnToList`: `foreach` closure -> `while` loop (row index and null bitmap stay in registers instead of captured heap `IntRef`s), hoist the `convertFunc == null` check out of the loop, pre-size the null `BitSet` to `rowSize` (was default 64-bit, paying growth copies).
- `asFloatTColumn` / `asByteArrayTColumn`: two passes -> one. The old code built an intermediate boxed list (`JList[JFloat]` / `JList[Array[Byte]]`) and re-mapped it via JavaConverters; now `convertFunc` produces `JList[JDouble]` / `JList[ByteBuffer]` directly. The float->string->double conversion (float display semantics) is unchanged.
- `toColumnBasedSet`: the `rows` list is always empty in columnar layout — create it with zero capacity instead of `rowSize`.
- Spark engine `RowSet.toHiveString`: the `DynMethods` chain (two reflective method-table scans) was rebuilt on every cell of a complex-typed column (Date/Timestamp/Decimal/Array/Map/Struct). Build the bound method once in a `private val`; only `invokeChecked` runs per cell.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
No new tests: behavior-preserving refactor; existing engine `RowSetSuite`s (Spark/Flink/Trino) cover these paths in CI.

Verified with a side-by-side harness: old vs new implementations over 100k-row columns, asserting value lists and null bitmaps are equal (string/integer/float/binary, with/without `convertFunc`, 0%/10% nulls). Numbers below: JDK 17, 50 interleaved samples, median; allocation via `ThreadMXBean.getCurrentThreadAllocatedBytes`.

| Scenario | Time (old -> new) | Allocation (old -> new) |
|---|---|---|
| String column, 10% nulls, no convertFunc | 0.41 -> 0.41 ms (~1.0x) | 435 -> 415 KB/op (-20 KB, BitSet pre-sizing) |
| Integer column (boxed), 10% nulls, no convertFunc | 0.38 -> 0.38 ms (~1.0x) | 435 -> 415 KB/op (-20 KB) |
| Float column (`asFloatTColumn`), 10% nulls | 8.39 -> 7.51 ms (**1.12x**) | 14.6 -> 12.6 MB/op (**1.16x**, intermediate `JFloat` list eliminated) |
| Binary column (`asByteArrayTColumn`), 10% nulls | 1.41 -> 0.90 ms (**1.57x**) | 6.9 -> 5.3 MB/op (**1.30x**) |
| `toColumnBasedSet` rows list (per result set) | — | 391 KB saved per 100k rows, 3.9 MB per 1M rows (retained, not garbage) |
| Spark `RowSet.toHiveString`, DateType cell | 1.05 -> 0.51 µs (**2.0x**) | 920 -> 608 B/cell (**1.5x**) |
| Spark `RowSet.toHiveString`, TimestampType cell | 0.57 -> 0.36 µs (**1.6x**) | 949 -> 635 B/cell (**1.5x**) |
| Spark `RowSet.toHiveString`, Decimal cell | 0.18 -> 0.11 µs (**1.7x**) | 478 -> 184 B/cell (**2.6x**) |
| Spark `RowSet.toHiveString`, ArrayType cell | 0.63 -> 0.36 µs (**1.8x**) | 1232 -> 944 B/cell (**1.3x**) |

The `toHiveString` numbers were measured against the real Spark 3.5.8 `HiveResult` (not a stub); outputs of old and new implementations are asserted equal per case.

Also: `build/mvn -Pfast clean install -pl kyuubi-common -am -DskipTests`, `spotless:check`, `dev/reformat`.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has assisted in authoring or reviewing this patch, please include
an 'Assisted-by: ' trailer that identifies the agent and model.
For example: 'Assisted-by: Claude:claude-opus-4-7' or 'Assisted-by: Claude Opus 4.7'.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Assisted-by: Kimi Code CLI (Moonshot AI)
