### PR TITLE
[KYUUBI #7608][AUTHZ] Include commons-collections into authz

### DIFF
--- a/extensions/spark/kyuubi-spark-authz-shaded/pom.xml
+++ b/extensions/spark/kyuubi-spark-authz-shaded/pom.xml
@@ -56,6 +56,7 @@
                             <include>com.fasterxml.jackson.jaxrs:*</include>
                             <include>com.sun.jersey:*</include>
                             <include>javax.ws.rs:jsr311-api</include>
+                            <include>commons-collections:commons-collections</include>
                         </includes>
                     </artifactSet>
                     <filters>

--- a/extensions/spark/kyuubi-spark-authz-shaded/pom.xml
+++ b/extensions/spark/kyuubi-spark-authz-shaded/pom.xml
@@ -106,6 +106,10 @@
                             <pattern>com.kstruct.gethostname4j</pattern>
                             <shadedPattern>${kyuubi.shade.packageName}.com.kstruct.gethostname4j</shadedPattern>
                         </relocation>
+                        <relocation>
+                            <pattern>org.apache.commons.collections</pattern>
+                            <shadedPattern>${kyuubi.shade.packageName}.org.apache.commons.collections</shadedPattern>
+                        </relocation>
                     </relocations>
                     <transformers>
                         <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"></transformer>

--- a/extensions/spark/kyuubi-spark-authz/pom.xml
+++ b/extensions/spark/kyuubi-spark-authz/pom.xml
@@ -283,7 +283,6 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->
Fix https://github.com/apache/kyuubi/issues/7608. kyuubi-spark-authz fails during plugin initialization on Spark 4.1+
```
java.lang.NoClassDefFoundError: org/apache/commons/collections/CollectionUtils
  at org.apache.ranger.authorization.hadoop.config.RangerPluginConfig.setSuperUsersGroups(RangerPluginConfig.java:239)
  at org.apache.ranger.plugin.service.RangerBasePlugin.setSuperUsersAndGroups(RangerBasePlugin.java:263)
  at org.apache.ranger.plugin.service.RangerBasePlugin.<init>(RangerBasePlugin.java:112)
  at org.apache.kyuubi.plugin.spark.authz.ranger.SparkRangerAdminPlugin$.<init>(SparkRangerAdminPlugin.scala:30)
  at org.apache.kyuubi.plugin.spark.authz.ranger.RangerSparkExtension.<init>(RangerSparkExtension.scala:44)
```
Ranger's `RangerPluginConfig` uses `org.apache.commons.collections.CollectionUtils` (commons-collections 3.x) but declares that dependency with provided scope. Spark 3.x ships commons-collections-3.2.2.jar in $SPARK_HOME/jars/, but Spark 4.1+ only ships commons-collections4, and Hadoop 3.4.2+ removed the 3.x transitive dependency via [HADOOP-15760](https://issues.apache.org/jira/browse/HADOOP-15760).

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
```
$ build/mvn dependency:tree -pl :kyuubi-spark-authz_2.13 -am -Pspark-4.1 -Pscala-2.13 -Dincludes=commons-collections:commons-collections

[INFO] org.apache.kyuubi:kyuubi-spark-authz_2.13:jar:1.13.0-SNAPSHOT
[INFO] \- commons-collections:commons-collections:jar:3.2.2:compile


$ build/mvn clean package -DskipTests -pl :kyuubi-spark-authz-shaded_2.13 -am -Pspark-4.1 -Pscala-2.13
$ jar tf extensions/spark/kyuubi-spark-authz-shaded/target/kyuubi-spark-authz-shaded_2.13-1.13.0-SNAPSHOT.jar | grep org/apache/commons/collections/CollectionUtils

org/apache/kyuubi/shade/org/apache/commons/collections/CollectionUtils.class
```

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has assisted in authoring or reviewing this patch, please include
an 'Assisted-by: ' trailer that identifies the agent and model.
For example: 'Assisted-by: Claude:claude-opus-4-7' or 'Assisted-by: Claude Opus 4.7'.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Assisted-by: Claude:claude-opus-4-7