### PR TITLE
[KYUUBI #7613][BUILD] Use spark 3.5 to build the extra scala 2.12 engine for spark 4.x

### DIFF
--- a/build/dist
+++ b/build/dist
@@ -186,6 +186,13 @@ SPARK_VERSION=$("$MVN" help:evaluate -Dexpression=spark.version $@ 2>/dev/null\
     | grep -v "WARNING"\
     | tail -n 1)
 
+BUILD_EXTRA_SPARK_ENGINE=false
+case "$SPARK_VERSION" in
+  3.3.*|3.4.*|3.5.*)
+    BUILD_EXTRA_SPARK_ENGINE=true
+    ;;
+esac
+
 # shellcheck disable=SC2068
 HADOOP_VERSION=$("$MVN" help:evaluate -Dexpression=hadoop.version $@ 2>/dev/null\
     | grep -v "INFO"\
@@ -249,29 +256,31 @@ echo -e "\nBuilding with..."
 echo -e "\$ ${BUILD_COMMAND[@]}\n"
 "${BUILD_COMMAND[@]}"
 
-FILTERED_ARGS=()
-# shellcheck disable=SC2045
-for arg in "$@"; do
+if [[ "$BUILD_EXTRA_SPARK_ENGINE" == "true" ]]; then
+  FILTERED_ARGS=()
+  # shellcheck disable=SC2045
+  for arg in "$@"; do
     if [[ $arg == *scala-2.12* ]]; then
-        FILTERED_ARGS+=("${arg//scala-2.12/scala-2.13}")
+      FILTERED_ARGS+=("${arg//scala-2.12/scala-2.13}")
     elif [[ $arg == *scala-2.13* ]]; then
-        FILTERED_ARGS+=("${arg//scala-2.13/scala-2.12}")
+      FILTERED_ARGS+=("${arg//scala-2.13/scala-2.12}")
     else
-        FILTERED_ARGS+=("$arg")
+      FILTERED_ARGS+=("$arg")
     fi
-done
+  done
 
-# shellcheck disable=SC2050
-if [ "$SCALA_VERSION" = "2.12" ]; then
-  EXTRA_SPARK_ENGINE_BUILD_COMMAND=("$MVN" install $MVN_DIST_OPT ${FILTERED_ARGS[@]} -Pscala-2.13 -pl :kyuubi-spark-sql-engine_2.13 -am)
-else
-  EXTRA_SPARK_ENGINE_BUILD_COMMAND=("$MVN" install $MVN_DIST_OPT ${FILTERED_ARGS[@]} -pl :kyuubi-spark-sql-engine_2.12 -am)
+  # shellcheck disable=SC2050
+  if [ "$SCALA_VERSION" = "2.12" ]; then
+    EXTRA_SPARK_ENGINE_BUILD_COMMAND=("$MVN" install $MVN_DIST_OPT ${FILTERED_ARGS[@]} -Pscala-2.13 -pl :kyuubi-spark-sql-engine_2.13 -am)
+  else
+    EXTRA_SPARK_ENGINE_BUILD_COMMAND=("$MVN" install $MVN_DIST_OPT ${FILTERED_ARGS[@]} -pl :kyuubi-spark-sql-engine_2.12 -am)
+  fi
+
+  # shellcheck disable=SC2145
+  echo -e "\$ ${EXTRA_SPARK_ENGINE_BUILD_COMMAND[@]}\n"
+
+  "${EXTRA_SPARK_ENGINE_BUILD_COMMAND[@]}"
 fi
-
-# shellcheck disable=SC2145
-echo -e "\$ ${EXTRA_SPARK_ENGINE_BUILD_COMMAND[@]}\n"
-
-"${EXTRA_SPARK_ENGINE_BUILD_COMMAND[@]}"
 
 # Make directories
 rm -rf "$DISTDIR"
@@ -320,7 +329,11 @@ cp "$KYUUBI_HOME/externals/kyuubi-flink-sql-engine/target/kyuubi-flink-sql-engin
 
 # Copy spark engines
 # shellcheck disable=SC2045
-for scala_version in 2.12 2.13; do
+SPARK_ENGINE_SCALA_VERSIONS=("$SCALA_VERSION")
+if [[ "$BUILD_EXTRA_SPARK_ENGINE" == "true" ]]; then
+  SPARK_ENGINE_SCALA_VERSIONS=('2.12' '2.13')
+fi
+for scala_version in "${SPARK_ENGINE_SCALA_VERSIONS[@]}"; do
   cp "$KYUUBI_HOME/externals/kyuubi-spark-sql-engine/target/kyuubi-spark-sql-engine_${scala_version}-${VERSION}.jar" "$DISTDIR/externals/engines/spark/"
 done
 

--- a/build/dist
+++ b/build/dist
@@ -186,13 +186,6 @@ SPARK_VERSION=$("$MVN" help:evaluate -Dexpression=spark.version $@ 2>/dev/null\
     | grep -v "WARNING"\
     | tail -n 1)
 
-BUILD_EXTRA_SPARK_ENGINE=false
-case "$SPARK_VERSION" in
-  3.3.*|3.4.*|3.5.*)
-    BUILD_EXTRA_SPARK_ENGINE=true
-    ;;
-esac
-
 # shellcheck disable=SC2068
 HADOOP_VERSION=$("$MVN" help:evaluate -Dexpression=hadoop.version $@ 2>/dev/null\
     | grep -v "INFO"\
@@ -256,31 +249,38 @@ echo -e "\nBuilding with..."
 echo -e "\$ ${BUILD_COMMAND[@]}\n"
 "${BUILD_COMMAND[@]}"
 
-if [[ "$BUILD_EXTRA_SPARK_ENGINE" == "true" ]]; then
-  FILTERED_ARGS=()
-  # shellcheck disable=SC2045
-  for arg in "$@"; do
-    if [[ $arg == *scala-2.12* ]]; then
-      FILTERED_ARGS+=("${arg//scala-2.12/scala-2.13}")
-    elif [[ $arg == *scala-2.13* ]]; then
-      FILTERED_ARGS+=("${arg//scala-2.13/scala-2.12}")
-    else
-      FILTERED_ARGS+=("$arg")
-    fi
-  done
-
-  # shellcheck disable=SC2050
-  if [ "$SCALA_VERSION" = "2.12" ]; then
-    EXTRA_SPARK_ENGINE_BUILD_COMMAND=("$MVN" install $MVN_DIST_OPT ${FILTERED_ARGS[@]} -Pscala-2.13 -pl :kyuubi-spark-sql-engine_2.13 -am)
-  else
-    EXTRA_SPARK_ENGINE_BUILD_COMMAND=("$MVN" install $MVN_DIST_OPT ${FILTERED_ARGS[@]} -pl :kyuubi-spark-sql-engine_2.12 -am)
+FILTERED_ARGS=()
+EXTRA_SCALA_212_SPARK_PROFILE='spark-3.5'
+# shellcheck disable=SC2045
+for arg in "$@"; do
+  FILTERED_ARG="$arg"
+  if [[ $arg == *scala-2.12* ]]; then
+    FILTERED_ARG="${FILTERED_ARG//scala-2.12/scala-2.13}"
+  elif [[ $arg == *scala-2.13* ]]; then
+    FILTERED_ARG="${FILTERED_ARG//scala-2.13/scala-2.12}"
   fi
 
-  # shellcheck disable=SC2145
-  echo -e "\$ ${EXTRA_SPARK_ENGINE_BUILD_COMMAND[@]}\n"
+  # Keep the Scala 2.12 engine compatible with Spark 3.5 when building against Spark 4.
+  if [[ "$SCALA_VERSION" == "2.13" && "$SPARK_VERSION" == 4.* ]]; then
+    while [[ $FILTERED_ARG =~ spark-4\.[0-9]+ ]]; do
+      FILTERED_ARG="${FILTERED_ARG/${BASH_REMATCH[0]}/$EXTRA_SCALA_212_SPARK_PROFILE}"
+    done
+    FILTERED_ARG="${FILTERED_ARG//spark-master/$EXTRA_SCALA_212_SPARK_PROFILE}"
+  fi
+  FILTERED_ARGS+=("$FILTERED_ARG")
+done
 
-  "${EXTRA_SPARK_ENGINE_BUILD_COMMAND[@]}"
+# shellcheck disable=SC2050
+if [ "$SCALA_VERSION" = "2.12" ]; then
+  EXTRA_SPARK_ENGINE_BUILD_COMMAND=("$MVN" install $MVN_DIST_OPT ${FILTERED_ARGS[@]} -Pscala-2.13 -pl :kyuubi-spark-sql-engine_2.13 -am)
+else
+  EXTRA_SPARK_ENGINE_BUILD_COMMAND=("$MVN" install $MVN_DIST_OPT ${FILTERED_ARGS[@]} -pl :kyuubi-spark-sql-engine_2.12 -am)
 fi
+
+# shellcheck disable=SC2145
+echo -e "\$ ${EXTRA_SPARK_ENGINE_BUILD_COMMAND[@]}\n"
+
+"${EXTRA_SPARK_ENGINE_BUILD_COMMAND[@]}"
 
 # Make directories
 rm -rf "$DISTDIR"
@@ -329,11 +329,7 @@ cp "$KYUUBI_HOME/externals/kyuubi-flink-sql-engine/target/kyuubi-flink-sql-engin
 
 # Copy spark engines
 # shellcheck disable=SC2045
-SPARK_ENGINE_SCALA_VERSIONS=("$SCALA_VERSION")
-if [[ "$BUILD_EXTRA_SPARK_ENGINE" == "true" ]]; then
-  SPARK_ENGINE_SCALA_VERSIONS=('2.12' '2.13')
-fi
-for scala_version in "${SPARK_ENGINE_SCALA_VERSIONS[@]}"; do
+for scala_version in 2.12 2.13; do
   cp "$KYUUBI_HOME/externals/kyuubi-spark-sql-engine/target/kyuubi-spark-sql-engine_${scala_version}-${VERSION}.jar" "$DISTDIR/externals/engines/spark/"
 done
 


### PR DESCRIPTION

### Why are the changes needed?

`build/dist` packages Spark SQL engine artifacts for both Scala 2.12 and Scala 2.13.

When Spark 4.x and Scala 2.13 profiles are specified, the extra engine build switches the Scala profile to 2.12 but retains the Spark 4.x profile. Since Spark 4.x artifacts are unavailable for Scala 2.12, Maven dependency resolution fails.

The distribution should continue shipping both engine variants so that it can support Spark 4.x while retaining compatibility with Spark 3.5 LTS. This patch replaces the Spark 4.x or `spark-master` profile with `spark-3.5` when building the extra Scala 2.12 engine.

Closes #7613.

### How was this patch tested?

build successful using the command `./build/dist --tgz --spark-provided --flink-provided --hive-provided -Pspark-4.2,scala-2.13`.

```
+ FILTERED_ARGS=()
+ EXTRA_SCALA_212_SPARK_PROFILE=spark-3.5
+ for arg in '"$@"'
+ FILTERED_ARG=-Pspark-4.2,scala-2.13
+ [[ -Pspark-4.2,scala-2.13 == *scala-2.12* ]]
+ [[ -Pspark-4.2,scala-2.13 == *scala-2.13* ]]
+ FILTERED_ARG=-Pspark-4.2,scala-2.12
+ [[ 2.13 == \2\.\1\3 ]]
+ [[ 4.2.0 == 4.* ]]
+ [[ -Pspark-4.2,scala-2.12 =~ spark-4\.[0-9]+ ]]
+ FILTERED_ARG=-Pspark-3.5,scala-2.12
+ [[ -Pspark-3.5,scala-2.12 =~ spark-4\.[0-9]+ ]]
+ FILTERED_ARG=-Pspark-3.5,scala-2.12
+ FILTERED_ARGS+=("$FILTERED_ARG")
+ '[' 2.13 = 2.12 ']'
+ EXTRA_SPARK_ENGINE_BUILD_COMMAND=("$MVN" install $MVN_DIST_OPT ${FILTERED_ARGS[@]} -pl :kyuubi-spark-sql-engine_2.12 -am)
+ echo -e '$ /Users/wforget/work/git/kyuubi/build/mvn' install -DskipTests -Dmaven.source.skip -Pspark-provided -Pflink-provided -Phive-provided -Pspark-3.5,scala-2.12 -pl :kyuubi-spark-sql-engine_2.12 '-am\n'
$ /Users/wforget/work/git/kyuubi/build/mvn install -DskipTests -Dmaven.source.skip -Pspark-provided -Pflink-provided -Phive-provided -Pspark-3.5,scala-2.12 -pl :kyuubi-spark-sql-engine_2.12 -am

+ /Users/wforget/work/git/kyuubi/build/mvn install -DskipTests -Dmaven.source.skip -Pspark-provided -Pflink-provided -Phive-provided -Pspark-3.5,scala-2.12 -pl :kyuubi-spark-sql-engine_2.12 -am
Using `mvn` from path: /Users/wforget/work/git/kyuubi/build/apache-maven-3.9.14/bin/mvn
```

<img width="873" height="116" alt="image" src="https://github.com/user-attachments/assets/6c6f9059-475f-45f2-af1f-bb450a2c460d" />

### Was this patch authored or co-authored using generative AI tooling?

Assisted-by: Codex:GPT-5.6