### PR TITLE
[KYUUBI #7615] Move engine application manager info configuration to the start method

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ProcBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ProcBuilder.scala
@@ -169,11 +169,6 @@ trait ProcBuilder {
   @volatile private[kyuubi] var process: Process = _
   @volatile private[kyuubi] var processLaunched: Boolean = false
 
-  // Set engine application manger info conf
-  conf.set(
-    KyuubiReservedKeys.KYUUBI_ENGINE_APP_MGR_INFO_KEY,
-    ApplicationManagerInfo.serialize(appMgrInfo()))
-
   private[kyuubi] lazy val engineLog: File = ProcBuilder.synchronized {
     val engineLogTimeout = conf.get(KyuubiConf.ENGINE_LOG_TIMEOUT)
     val currentTime = System.currentTimeMillis()
@@ -213,6 +208,12 @@ trait ProcBuilder {
   def validateConf(): Unit = {}
 
   final def start: Process = synchronized {
+
+    // Set engine application manger info conf
+    conf.set(
+      KyuubiReservedKeys.KYUUBI_ENGINE_APP_MGR_INFO_KEY,
+      ApplicationManagerInfo.serialize(appMgrInfo()))
+
     process = processBuilder.start()
     processLaunched = true
     val reader = Files.newBufferedReader(engineLog.toPath, StandardCharsets.UTF_8)

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilderSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilderSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.kyuubi.engine.spark
 
 import java.io.File
+import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path, Paths, StandardOpenOption}
 import java.time.{Duration, LocalDate}
 import java.time.format.DateTimeFormatter
@@ -420,6 +421,21 @@ class SparkProcessBuilderSuite extends KerberizedTestHelper with MockitoSugar {
       "spark-core_2.13.2-3.5.0.jar").foreach { f =>
       assertThrows[KyuubiException](builder.extractSparkCoreScalaVersion(Seq(f)))
     }
+  }
+
+  test("load spark master from spark-defaults.conf after initialization") {
+    val sparkHome = Utils.createTempDir("spark-home-with-defaults")
+    val sparkConfDir = Files.createDirectory(sparkHome.resolve("conf"))
+    Files.write(
+      sparkConfDir.resolve("spark-defaults.conf"),
+      s"$MASTER_KEY yarn".getBytes(StandardCharsets.UTF_8))
+
+    val builderConf = KyuubiConf(false)
+      .set("kyuubi.engineEnv.SPARK_HOME", sparkHome.toString)
+      .set("kyuubi.engineEnv.SPARK_SCALA_VERSION", SCALA_COMPILE_VERSION)
+    val builder = new SparkProcessBuilder("kentyao", true, builderConf)
+
+    assert(builder.clusterManager() === Some("yarn"))
   }
 
   test("Fix NullPointerException when SPARK_HOME is invalid") {


### PR DESCRIPTION
### Why are the changes needed?

Closes #7615.

`ProcBuilder` initializes the engine application manager information during trait construction. For `SparkProcessBuilder`, this invokes `appMgrInfo()`, which eventually evaluates `defaultsConf` before the subclass field `sparkHome` has been initialized.

At that point, `sparkHome` is still `null`, so the path to `spark-defaults.conf` is resolved incorrectly and `defaultsConf` is cached as an empty map. Consequently, `spark.master` cannot be loaded from `spark-defaults.conf`, causing Kyuubi to select the wrong cluster manager.

This patch moves the engine application manager information initialization to `ProcBuilder#start`, where the process builder has been fully initialized.

### How was this patch tested?

Added a unit test and manually verified that the Spark engine starts successfully when `spark.master` is configured in `spark-defaults.conf`.

### Was this patch authored or co-authored using generative AI tooling?

No
