### PR TITLE
[K8s] Rename checkPodAppCanceled to cleanupOrphanPodIfBatchTerminated and improve orphan pod log messages

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
@@ -585,16 +585,13 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
           val batch = metadataManager.flatMap(_.getBatchSessionMetadata(kyuubiUniqueKey))
           val batchState = batch.map(_.state).map(OperationState.withName)
           if (batchState.exists(_ == OperationState.CANCELED)) {
-            warn(s"[$kubernetesInfo] Found orphan pod ${pod.getMetadata.getName} for" +
-              s" canceled batch[$kyuubiUniqueKey], deleting it")
+            warn(s"[$kubernetesInfo] Batch[$kyuubiUniqueKey] is canceled, " +
+              s"try to delete the pod ${pod.getMetadata.getName}")
             deletePod(kubernetesInfo, pod.getMetadata.getName, kyuubiUniqueKey)
           } else if (batchState.exists(_ == OperationState.ERROR) &&
             batch.flatMap(_.appState).exists(_ == ApplicationState.NOT_FOUND)) {
-            // Batch failed because the submit timeout elapsed before the pod was observed;
-            // the pod arrived late and is now orphaned with no owning session.
-            warn(s"[$kubernetesInfo] Found orphan pod ${pod.getMetadata.getName} for" +
-              s" batch[$kyuubiUniqueKey] that failed due to submit timeout" +
-              s" (recorded app state: NOT_FOUND), deleting it")
+            warn(s"[$kubernetesInfo] Batch[$kyuubiUniqueKey] is in error state and" +
+              s" application not found, try to delete the pod ${pod.getMetadata.getName}")
             deletePod(kubernetesInfo, pod.getMetadata.getName, kyuubiUniqueKey)
           }
         }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
@@ -393,7 +393,7 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
           pod,
           appStateSource,
           appStateContainer)
-        checkPodAppCanceled(kubernetesInfo, pod)
+        cleanupOrphanPodIfBatchTerminated(kubernetesInfo, pod)
       }
     }
 
@@ -414,7 +414,7 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
           appStateSource,
           appStateContainer)
         if (firstUpdate) {
-          checkPodAppCanceled(kubernetesInfo, newPod)
+          cleanupOrphanPodIfBatchTerminated(kubernetesInfo, newPod)
         }
       }
     }
@@ -577,16 +577,24 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
     }
   }
 
-  private def checkPodAppCanceled(kubernetesInfo: KubernetesInfo, pod: Pod): Unit = {
+  private def cleanupOrphanPodIfBatchTerminated(kubernetesInfo: KubernetesInfo, pod: Pod): Unit = {
     if (kyuubiConf.isRESTEnabled) {
       cleanupCanceledAppPodExecutor.submit(new Runnable {
         override def run(): Unit = Utils.tryLogNonFatalError {
           val kyuubiUniqueKey = pod.getMetadata.getLabels.get(LABEL_KYUUBI_UNIQUE_KEY)
           val batch = metadataManager.flatMap(_.getBatchSessionMetadata(kyuubiUniqueKey))
-          if (batch.map(_.state).map(OperationState.withName)
-              .exists(_ == OperationState.CANCELED)) {
-            warn(s"[$kubernetesInfo] Batch[$kyuubiUniqueKey] is canceled, " +
-              s"try to delete the pod ${pod.getMetadata.getName}")
+          val batchState = batch.map(_.state).map(OperationState.withName)
+          if (batchState.exists(_ == OperationState.CANCELED)) {
+            warn(s"[$kubernetesInfo] Found orphan pod ${pod.getMetadata.getName} for" +
+              s" canceled batch[$kyuubiUniqueKey], deleting it")
+            deletePod(kubernetesInfo, pod.getMetadata.getName, kyuubiUniqueKey)
+          } else if (batchState.exists(_ == OperationState.ERROR) &&
+            batch.flatMap(_.appState).exists(_ == ApplicationState.NOT_FOUND)) {
+            // Batch failed because the submit timeout elapsed before the pod was observed;
+            // the pod arrived late and is now orphaned with no owning session.
+            warn(s"[$kubernetesInfo] Found orphan pod ${pod.getMetadata.getName} for" +
+              s" batch[$kyuubiUniqueKey] that failed due to submit timeout" +
+              s" (recorded app state: NOT_FOUND), deleting it")
             deletePod(kubernetesInfo, pod.getMetadata.getName, kyuubiUniqueKey)
           }
         }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
@@ -81,7 +81,7 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
 
   private var expireCleanUpTriggerCacheExecutor: ScheduledExecutorService = _
 
-  private var cleanupCanceledAppPodExecutor: ThreadPoolExecutor = _
+  private var cleanupOrphanPodExecutor: ThreadPoolExecutor = _
 
   private var kubernetesClientInitializeCleanupTerminatedPodExecutor: ThreadPoolExecutor = _
 
@@ -208,8 +208,8 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
       cleanupDriverPodCheckInterval,
       cleanupDriverPodCheckInterval,
       TimeUnit.MILLISECONDS)
-    cleanupCanceledAppPodExecutor = ThreadUtils.newDaemonCachedThreadPool(
-      "cleanup-canceled-app-pod-thread")
+    cleanupOrphanPodExecutor = ThreadUtils.newDaemonCachedThreadPool(
+      "cleanup-orphan-pod-thread")
     kubernetesClientInitializeCleanupTerminatedPodExecutor =
       ThreadUtils.newDaemonCachedThreadPool(
         "kubernetes-client-initialize-cleanup-terminated-pod-thread")
@@ -369,9 +369,9 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
       expireCleanUpTriggerCacheExecutor = null
     }
 
-    if (cleanupCanceledAppPodExecutor != null) {
-      ThreadUtils.shutdown(cleanupCanceledAppPodExecutor)
-      cleanupCanceledAppPodExecutor = null
+    if (cleanupOrphanPodExecutor != null) {
+      ThreadUtils.shutdown(cleanupOrphanPodExecutor)
+      cleanupOrphanPodExecutor = null
     }
 
     if (kubernetesClientInitializeCleanupTerminatedPodExecutor != null) {
@@ -579,7 +579,7 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
 
   private def cleanupOrphanPod(kubernetesInfo: KubernetesInfo, pod: Pod): Unit = {
     if (kyuubiConf.isRESTEnabled) {
-      cleanupCanceledAppPodExecutor.submit(new Runnable {
+      cleanupOrphanPodExecutor.submit(new Runnable {
         override def run(): Unit = Utils.tryLogNonFatalError {
           val kyuubiUniqueKey = pod.getMetadata.getLabels.get(LABEL_KYUUBI_UNIQUE_KEY)
           val batch = metadataManager.flatMap(_.getBatchSessionMetadata(kyuubiUniqueKey))

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
@@ -590,8 +590,8 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
             deletePod(kubernetesInfo, pod.getMetadata.getName, kyuubiUniqueKey)
           } else if (batchState.exists(_ == OperationState.ERROR) &&
             batch.flatMap(_.appState).exists(_ == ApplicationState.NOT_FOUND)) {
-            warn(s"[$kubernetesInfo] Batch[$kyuubiUniqueKey] is in error state and" +
-              s" application not found, try to delete the pod ${pod.getMetadata.getName}")
+            warn(s"[$kubernetesInfo] Batch[$kyuubiUniqueKey] failed due to submit timeout" +
+              s" (app state: NOT_FOUND), try to delete the orphan pod ${pod.getMetadata.getName}")
             deletePod(kubernetesInfo, pod.getMetadata.getName, kyuubiUniqueKey)
           }
         }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
@@ -393,7 +393,7 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
           pod,
           appStateSource,
           appStateContainer)
-        cleanupOrphanPodIfBatchTerminated(kubernetesInfo, pod)
+        cleanupOrphanPod(kubernetesInfo, pod)
       }
     }
 
@@ -414,7 +414,7 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
           appStateSource,
           appStateContainer)
         if (firstUpdate) {
-          cleanupOrphanPodIfBatchTerminated(kubernetesInfo, newPod)
+          cleanupOrphanPod(kubernetesInfo, newPod)
         }
       }
     }
@@ -577,7 +577,7 @@ class KubernetesApplicationOperation extends ApplicationOperation with Logging {
     }
   }
 
-  private def cleanupOrphanPodIfBatchTerminated(kubernetesInfo: KubernetesInfo, pod: Pod): Unit = {
+  private def cleanupOrphanPod(kubernetesInfo: KubernetesInfo, pod: Pod): Unit = {
     if (kyuubiConf.isRESTEnabled) {
       cleanupCanceledAppPodExecutor.submit(new Runnable {
         override def run(): Unit = Utils.tryLogNonFatalError {


### PR DESCRIPTION
## Why are the changes needed?

  `checkPodAppCanceled` was misleading: the method handles two distinct orphan-pod scenarios:

  1. **CANCELED batch** — user explicitly canceled the batch, but the pod appeared after Kyuubi gave up tracking it.                                                  
  2. **Submit-timeout batch** — `kyuubi.engine.kubernetes.submit.timeout` elapsed, Kyuubi recorded app state as `NOT_FOUND` and marked the batch FAILED, but the pod started up afterwards.
  In both cases the pod is orphaned (no owning session), and the old name only hinted at case 1.
  
  Log messages were also vague ("try to delete the pod", "is in error state and application not found") — they didn't identify the pod as an orphan or state the delete action directly.
  
  ## How was this patch tested?
  
  The ERROR+NOT_FOUND branch (submit-timeout orphan pod cleanup) is a behavior change:
  pods that previously went uncleared when a batch failed due to submit timeout will now
  be deleted when the informer observes them. The rename and log changes are non-behavioral.

  Manual verification: confirmed the orphan-pod cleanup path is triggered correctly
  under the CANCELED and submit-timeout ERROR scenarios.
  
  ## Was this patch authored or co-authored using generative AI tooling?
  
  Assisted-by: Claude:claude-sonnet-4-6
  