### PR TITLE
[KYUUBI #7625] Avoid resolving the engine result save path during shutdown

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
@@ -26,6 +26,7 @@ import scala.concurrent.duration.Duration
 import scala.util.control.NonFatal
 
 import com.google.common.annotations.VisibleForTesting
+import org.apache.hadoop.fs.Path
 import org.apache.spark.{ui, SparkConf}
 import org.apache.spark.kyuubi.{SparkContextHelper, SparkSQLEngineEventListener, SparkSQLEngineListener}
 import org.apache.spark.kyuubi.SparkUtilsHelper.getLocalDir
@@ -58,8 +59,7 @@ case class SparkSQLEngine(spark: SparkSession) extends Serverable("SparkSQLEngin
 
   @volatile private var lifetimeTerminatingChecker: Option[ScheduledExecutorService] = None
   @volatile private var stopEngineExec: Option[ThreadPoolExecutor] = None
-  private lazy val engineSavePath =
-    backendService.sessionManager.asInstanceOf[SparkSQLSessionManager].getEngineResultSavePath()
+  @volatile private var engineSavePath: Option[Path] = None
 
   override def initialize(conf: KyuubiConf): Unit = {
     val listener = new SparkSQLEngineListener(this)
@@ -91,9 +91,13 @@ case class SparkSQLEngine(spark: SparkSession) extends Serverable("SparkSQLEngin
     }
 
     if (backendService.sessionManager.getConf.get(OPERATION_RESULT_SAVE_TO_FILE)) {
-      val fs = engineSavePath.getFileSystem(spark.sparkContext.hadoopConfiguration)
-      fs.mkdirs(engineSavePath)
-      fs.deleteOnExit(engineSavePath)
+      engineSavePath = Some(backendService.sessionManager
+        .asInstanceOf[SparkSQLSessionManager].getEngineResultSavePath())
+      engineSavePath.foreach { path =>
+        val fs = path.getFileSystem(spark.sparkContext.hadoopConfiguration)
+        fs.mkdirs(path)
+        fs.deleteOnExit(path)
+      }
     }
   }
 
@@ -111,12 +115,16 @@ case class SparkSQLEngine(spark: SparkSession) extends Serverable("SparkSQLEngin
         Duration(60, TimeUnit.SECONDS))
     })
     try {
-      val fs = engineSavePath.getFileSystem(spark.sparkContext.hadoopConfiguration)
-      if (fs.exists(engineSavePath)) {
-        fs.delete(engineSavePath, true)
+      engineSavePath.foreach { path =>
+        val fs = path.getFileSystem(spark.sparkContext.hadoopConfiguration)
+        if (fs.exists(path)) {
+          fs.delete(path, true)
+        }
       }
     } catch {
-      case e: Throwable => error(s"Error cleaning engine result save path: $engineSavePath", e)
+      case e: Throwable =>
+        error(s"Error cleaning engine result save path:" +
+          s" ${engineSavePath.map(_.toString).getOrElse("<Empty>")}", e)
     }
   }
 

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
@@ -123,8 +123,8 @@ case class SparkSQLEngine(spark: SparkSession) extends Serverable("SparkSQLEngin
       }
     } catch {
       case e: Throwable =>
-        error(s"Error cleaning engine result save path:" +
-          s" ${engineSavePath.map(_.toString).getOrElse("<Empty>")}", e)
+        error("Error cleaning engine result save path: " +
+          engineSavePath.map(_.toString).getOrElse("<Empty>"), e)
     }
   }
 

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
@@ -26,6 +26,7 @@ import scala.concurrent.duration.Duration
 import scala.util.control.NonFatal
 
 import com.google.common.annotations.VisibleForTesting
+import org.apache.hadoop.fs.Path
 import org.apache.spark.{ui, SparkConf}
 import org.apache.spark.kyuubi.{SparkContextHelper, SparkSQLEngineEventListener, SparkSQLEngineListener}
 import org.apache.spark.kyuubi.SparkUtilsHelper.getLocalDir
@@ -58,8 +59,7 @@ case class SparkSQLEngine(spark: SparkSession) extends Serverable("SparkSQLEngin
 
   @volatile private var lifetimeTerminatingChecker: Option[ScheduledExecutorService] = None
   @volatile private var stopEngineExec: Option[ThreadPoolExecutor] = None
-  private val engineSavePath =
-    backendService.sessionManager.asInstanceOf[SparkSQLSessionManager].getEngineResultSavePath()
+  @volatile private var engineSavePath: Path = _
 
   override def initialize(conf: KyuubiConf): Unit = {
     val listener = new SparkSQLEngineListener(this)
@@ -92,6 +92,8 @@ case class SparkSQLEngine(spark: SparkSession) extends Serverable("SparkSQLEngin
 
     // Due to the fact that session-level enabling of `kyuubi.operation.result.saveToFile.enabled`
     // is allowed, we always create and clean up this directory
+    engineSavePath =
+      backendService.sessionManager.asInstanceOf[SparkSQLSessionManager].getEngineResultSavePath()
     val fs = engineSavePath.getFileSystem(spark.sparkContext.hadoopConfiguration)
     fs.mkdirs(engineSavePath)
     fs.deleteOnExit(engineSavePath)
@@ -110,13 +112,15 @@ case class SparkSQLEngine(spark: SparkSession) extends Serverable("SparkSQLEngin
         exec,
         Duration(60, TimeUnit.SECONDS))
     })
-    try {
-      val fs = engineSavePath.getFileSystem(spark.sparkContext.hadoopConfiguration)
-      if (fs.exists(engineSavePath)) {
-        fs.delete(engineSavePath, true)
+    if (engineSavePath != null) {
+      try {
+        val fs = engineSavePath.getFileSystem(spark.sparkContext.hadoopConfiguration)
+        if (fs.exists(engineSavePath)) {
+          fs.delete(engineSavePath, true)
+        }
+      } catch {
+        case e: Throwable => error(s"Error cleaning engine result save path: $engineSavePath", e)
       }
-    } catch {
-      case e: Throwable => error(s"Error cleaning engine result save path: $engineSavePath", e)
     }
   }
 

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
@@ -26,7 +26,6 @@ import scala.concurrent.duration.Duration
 import scala.util.control.NonFatal
 
 import com.google.common.annotations.VisibleForTesting
-import org.apache.hadoop.fs.Path
 import org.apache.spark.{ui, SparkConf}
 import org.apache.spark.kyuubi.{SparkContextHelper, SparkSQLEngineEventListener, SparkSQLEngineListener}
 import org.apache.spark.kyuubi.SparkUtilsHelper.getLocalDir
@@ -59,7 +58,8 @@ case class SparkSQLEngine(spark: SparkSession) extends Serverable("SparkSQLEngin
 
   @volatile private var lifetimeTerminatingChecker: Option[ScheduledExecutorService] = None
   @volatile private var stopEngineExec: Option[ThreadPoolExecutor] = None
-  @volatile private var engineSavePath: Option[Path] = None
+  private val engineSavePath =
+    backendService.sessionManager.asInstanceOf[SparkSQLSessionManager].getEngineResultSavePath()
 
   override def initialize(conf: KyuubiConf): Unit = {
     val listener = new SparkSQLEngineListener(this)
@@ -90,15 +90,11 @@ case class SparkSQLEngine(spark: SparkSession) extends Serverable("SparkSQLEngin
       startFastFailChecker(maxInitTimeout)
     }
 
-    if (backendService.sessionManager.getConf.get(OPERATION_RESULT_SAVE_TO_FILE)) {
-      engineSavePath = Some(backendService.sessionManager
-        .asInstanceOf[SparkSQLSessionManager].getEngineResultSavePath())
-      engineSavePath.foreach { path =>
-        val fs = path.getFileSystem(spark.sparkContext.hadoopConfiguration)
-        fs.mkdirs(path)
-        fs.deleteOnExit(path)
-      }
-    }
+    // Due to the fact that session-level enabling of `kyuubi.operation.result.saveToFile.enabled`
+    // is allowed, we always create and clean up this directory
+    val fs = engineSavePath.getFileSystem(spark.sparkContext.hadoopConfiguration)
+    fs.mkdirs(engineSavePath)
+    fs.deleteOnExit(engineSavePath)
   }
 
   override def stop(): Unit = if (shutdown.compareAndSet(false, true)) {
@@ -115,16 +111,12 @@ case class SparkSQLEngine(spark: SparkSession) extends Serverable("SparkSQLEngin
         Duration(60, TimeUnit.SECONDS))
     })
     try {
-      engineSavePath.foreach { path =>
-        val fs = path.getFileSystem(spark.sparkContext.hadoopConfiguration)
-        if (fs.exists(path)) {
-          fs.delete(path, true)
-        }
+      val fs = engineSavePath.getFileSystem(spark.sparkContext.hadoopConfiguration)
+      if (fs.exists(engineSavePath)) {
+        fs.delete(engineSavePath, true)
       }
     } catch {
-      case e: Throwable =>
-        error("Error cleaning engine result save path: " +
-          engineSavePath.map(_.toString).getOrElse("<Empty>"), e)
+      case e: Throwable => error(s"Error cleaning engine result save path: $engineSavePath", e)
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?

Avoid exceptions when Spark SQL engine shutdown

closes #7625

### How was this patch tested?

minor refactor

### Was this patch authored or co-authored using generative AI tooling?

No