### PR TITLE
[KSHC] Fix connector compatibility with Spark 4.2

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -270,6 +270,11 @@ jobs:
             spark-compile: "3.5"
             spark-runtime: "4.1"
             comment: "normal"
+          - java: 21
+            scala: "2.13"
+            spark-compile: "3.5"
+            spark-runtime: "4.2"
+            comment: "normal"
     env:
       SPARK_LOCAL_IP: localhost
       TEST_MODULES: "extensions/spark/kyuubi-spark-connector-hive,\

--- a/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveConnectorUtils.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveConnectorUtils.scala
@@ -27,7 +27,7 @@ import org.apache.hadoop.hive.ql.plan.{FileSinkDesc, TableDesc}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
-import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTablePartition}
+import org.apache.spark.sql.catalyst.catalog.{BucketSpec, CatalogStatistics, CatalogStorageFormat, CatalogTable, CatalogTablePartition, CatalogTableType}
 import org.apache.spark.sql.connector.catalog.TableChange
 import org.apache.spark.sql.connector.catalog.TableChange._
 import org.apache.spark.sql.execution.command.CommandUtils
@@ -67,6 +67,196 @@ object HiveConnectorUtils extends Logging {
         .build[HiveFileFormat]()
         .newInstance(shimFileSinkDesc)
     }.get
+
+  // `serdeName` widened the case-class `apply` from 6 to 7 args. `DynMethods.invoke`
+  // truncates trailing args to the matched arity, so the trailing `serdeName` is
+  // silently dropped on the 6-arg impl.
+  private lazy val storageFormatApply: DynMethods.StaticMethod =
+    DynMethods.builder("apply")
+      .impl( // SPARK-55645 (4.2.0): 7-arg apply with serdeName
+        classOf[CatalogStorageFormat],
+        classOf[Option[URI]],
+        classOf[Option[String]],
+        classOf[Option[String]],
+        classOf[Option[String]],
+        classOf[Boolean],
+        classOf[Map[String, String]],
+        classOf[Option[String]])
+      .impl( // Spark < 4.2.0: 6-arg apply without serdeName
+        classOf[CatalogStorageFormat],
+        classOf[Option[URI]],
+        classOf[Option[String]],
+        classOf[Option[String]],
+        classOf[Option[String]],
+        classOf[Boolean],
+        classOf[Map[String, String]])
+      .build()
+      .asStatic()
+
+  // SPARK-55645 (4.2.0): serdeName getter
+  private def storageFormatSerdeName(base: CatalogStorageFormat): Option[String] =
+    Try {
+      DynMethods.builder("serdeName")
+        .impl(classOf[CatalogStorageFormat])
+        .build()
+        .invoke[Option[String]](base)
+    }.getOrElse(None)
+
+  def newStorageFormat(
+      locationUri: Option[URI] = None,
+      inputFormat: Option[String] = None,
+      outputFormat: Option[String] = None,
+      serde: Option[String] = None,
+      compressed: Boolean = false,
+      properties: Map[String, String] = Map.empty): CatalogStorageFormat =
+    storageFormatApply.invoke[CatalogStorageFormat](
+      locationUri,
+      inputFormat,
+      outputFormat,
+      serde,
+      compressed.asInstanceOf[JBoolean],
+      properties,
+      None
+    ) // serdeName defaults to None; ignored on Spark < 4.2
+
+  def copyStorageFormat(
+      base: CatalogStorageFormat)(
+      locationUri: Option[URI] = base.locationUri,
+      inputFormat: Option[String] = base.inputFormat,
+      outputFormat: Option[String] = base.outputFormat,
+      serde: Option[String] = base.serde,
+      compressed: Boolean = base.compressed,
+      properties: Map[String, String] = base.properties): CatalogStorageFormat =
+    storageFormatApply.invoke[CatalogStorageFormat](
+      locationUri,
+      inputFormat,
+      outputFormat,
+      serde,
+      compressed.asInstanceOf[JBoolean],
+      properties,
+      storageFormatSerdeName(base))
+
+  // `collation` was inserted in the middle of `CatalogTable`'s parameter list, so
+  // `DynMethods`' trailing-arg truncation cannot be relied on. Resolve the `apply`
+  // arity and argument list from the presence of the two getters.
+
+  // SPARK-50675 (4.0.0): collation getter presence
+  private lazy val catalogTableHasCollation: Boolean =
+    Try(DynMethods.builder("collation").impl(classOf[CatalogTable]).build()).isSuccess
+
+  // SPARK-52729 (4.2.0): multipartIdentifier getter presence
+  private lazy val catalogTableHasMultipartIdentifier: Boolean =
+    Try(DynMethods.builder("multipartIdentifier").impl(classOf[CatalogTable]).build()).isSuccess
+
+  // SPARK-50675 (4.0.0): collation getter
+  private def catalogTableCollation(base: CatalogTable): Option[String] =
+    Try {
+      DynMethods.builder("collation")
+        .impl(classOf[CatalogTable])
+        .build()
+        .invoke[Option[String]](base)
+    }.getOrElse(None)
+
+  // SPARK-52729 (4.2.0): multipartIdentifier getter
+  private def catalogTableMultipartIdentifier(base: CatalogTable): Option[Seq[String]] =
+    Try {
+      DynMethods.builder("multipartIdentifier")
+        .impl(classOf[CatalogTable])
+        .build()
+        .invoke[Option[Seq[String]]](base)
+    }.getOrElse(None)
+
+  private lazy val catalogTableApply: DynMethods.StaticMethod = {
+    val baseParams: Seq[Class[_]] = Seq[Class[_]](
+      classOf[TableIdentifier],
+      classOf[CatalogTableType],
+      classOf[CatalogStorageFormat],
+      classOf[StructType],
+      classOf[Option[String]],
+      classOf[Seq[String]],
+      classOf[Option[BucketSpec]],
+      classOf[String],
+      classOf[Long],
+      classOf[Long],
+      classOf[String],
+      classOf[Map[String, String]],
+      classOf[Option[CatalogStatistics]],
+      classOf[Option[String]],
+      classOf[Option[String]])
+    // SPARK-50675 (4.0.0): collation inserted between comment and unsupportedFeatures
+    val collationParam: Seq[Class[_]] =
+      if (catalogTableHasCollation) Seq[Class[_]](classOf[Option[String]]) else Nil
+    val trailingParams: Seq[Class[_]] = Seq[Class[_]](
+      classOf[Seq[String]],
+      classOf[Boolean],
+      classOf[Boolean],
+      classOf[Map[String, String]],
+      classOf[Option[String]])
+    // SPARK-52729 (4.2.0): multipartIdentifier appended after viewOriginalText
+    val multipartParam: Seq[Class[_]] =
+      if (catalogTableHasMultipartIdentifier) Seq[Class[_]](classOf[Option[Seq[String]]]) else Nil
+    DynMethods.builder("apply")
+      .impl(
+        classOf[CatalogTable],
+        (baseParams ++ collationParam ++ trailingParams ++ multipartParam): _*)
+      .build()
+      .asStatic()
+  }
+
+  // scalastyle:off parameter.number
+  def copyCatalogTable(
+      base: CatalogTable)(
+      identifier: TableIdentifier = base.identifier,
+      tableType: CatalogTableType = base.tableType,
+      storage: CatalogStorageFormat = base.storage,
+      schema: StructType = base.schema,
+      provider: Option[String] = base.provider,
+      partitionColumnNames: Seq[String] = base.partitionColumnNames,
+      bucketSpec: Option[BucketSpec] = base.bucketSpec,
+      owner: String = base.owner,
+      createTime: Long = base.createTime,
+      lastAccessTime: Long = base.lastAccessTime,
+      createVersion: String = base.createVersion,
+      properties: Map[String, String] = base.properties,
+      stats: Option[CatalogStatistics] = base.stats,
+      viewText: Option[String] = base.viewText,
+      comment: Option[String] = base.comment,
+      unsupportedFeatures: Seq[String] = base.unsupportedFeatures,
+      tracksPartitionsInCatalog: Boolean = base.tracksPartitionsInCatalog,
+      schemaPreservesCase: Boolean = base.schemaPreservesCase,
+      ignoredProperties: Map[String, String] = base.ignoredProperties,
+      viewOriginalText: Option[String] = base.viewOriginalText): CatalogTable = {
+    val baseArgs: Seq[AnyRef] = Seq[AnyRef](
+      identifier,
+      tableType,
+      storage,
+      schema,
+      provider,
+      partitionColumnNames,
+      bucketSpec,
+      owner,
+      createTime.asInstanceOf[JLong],
+      lastAccessTime.asInstanceOf[JLong],
+      createVersion,
+      properties,
+      stats,
+      viewText,
+      comment)
+    val collationArg: Seq[AnyRef] =
+      if (catalogTableHasCollation) Seq[AnyRef](catalogTableCollation(base)) else Nil
+    val trailingArgs: Seq[AnyRef] = Seq[AnyRef](
+      unsupportedFeatures,
+      tracksPartitionsInCatalog.asInstanceOf[JBoolean],
+      schemaPreservesCase.asInstanceOf[JBoolean],
+      ignoredProperties,
+      viewOriginalText)
+    val multipartArg: Seq[AnyRef] =
+      if (catalogTableHasMultipartIdentifier) Seq[AnyRef](catalogTableMultipartIdentifier(base))
+      else Nil
+    catalogTableApply.invoke[CatalogTable](
+      (baseArgs ++ collationArg ++ trailingArgs ++ multipartArg): _*)
+  }
+  // scalastyle:on parameter.number
 
   def partitionedFilePath(file: PartitionedFile): String =
     Try { // SPARK-41970: 3.4.0

--- a/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveTableCatalog.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveTableCatalog.scala
@@ -423,14 +423,14 @@ class HiveTableCatalog(sparkSession: SparkSession)
     val location = properties.get(TableCatalog.PROP_LOCATION).map(CatalogUtils.stringToURI)
     val storage =
       if (location.isDefined) {
-        catalogTable.storage.copy(locationUri = location)
+        HiveConnectorUtils.copyStorageFormat(catalogTable.storage)(locationUri = location)
       } else {
         catalogTable.storage
       }
 
     try {
       catalog.alterTable(
-        catalogTable.copy(
+        HiveConnectorUtils.copyCatalogTable(catalogTable)(
           properties = properties,
           schema = schema,
           owner = owner,
@@ -709,14 +709,15 @@ private object HiveTableCatalog extends Logging {
       allProps: Map[String, String],
       optionsProps: Map[String, String],
       serdeProps: Map[String, String]): (CatalogStorageFormat, String) = {
-    val nonHiveStorageFormat = CatalogStorageFormat.empty.copy(
+    val nonHiveStorageFormat = HiveConnectorUtils.newStorageFormat(
       locationUri = location.map(CatalogUtils.stringToURI),
       properties = optionsProps)
 
     val conf = SQLConf.get
-    val defaultHiveStorage = HiveSerDe.getDefaultStorage(conf).copy(
-      locationUri = location.map(CatalogUtils.stringToURI),
-      properties = optionsProps)
+    val defaultHiveStorage =
+      HiveConnectorUtils.copyStorageFormat(HiveSerDe.getDefaultStorage(conf))(
+        locationUri = location.map(CatalogUtils.stringToURI),
+        properties = optionsProps)
 
     if (provider.isDefined) {
       (nonHiveStorageFormat, provider.get)
@@ -729,7 +730,7 @@ private object HiveTableCatalog extends Logging {
         // If `STORED AS fileFormat` is used, infer inputFormat, outputFormat and serde from it.
         HiveSerDe.sourceToSerDe(maybeStoredAs.get) match {
           case Some(hiveSerde) =>
-            defaultHiveStorage.copy(
+            HiveConnectorUtils.copyStorageFormat(defaultHiveStorage)(
               inputFormat = hiveSerde.inputFormat.orElse(defaultHiveStorage.inputFormat),
               outputFormat = hiveSerde.outputFormat.orElse(defaultHiveStorage.outputFormat),
               // User specified serde takes precedence over the one inferred from file format.
@@ -738,7 +739,7 @@ private object HiveTableCatalog extends Logging {
           case _ => throw KyuubiHiveConnectorException(s"Unsupported serde ${maybeSerde.get}.")
         }
       } else {
-        defaultHiveStorage.copy(
+        HiveConnectorUtils.copyStorageFormat(defaultHiveStorage)(
           inputFormat =
             maybeInputFormat.orElse(defaultHiveStorage.inputFormat),
           outputFormat =

--- a/extensions/spark/kyuubi-spark-connector-tpcds/src/main/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSTable.scala
+++ b/extensions/spark/kyuubi-spark-connector-tpcds/src/main/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSTable.scala
@@ -32,6 +32,8 @@ import org.apache.spark.sql.connector.read.ScanBuilder
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
+import org.apache.kyuubi.util.reflect.DynConstructors
+
 class TPCDSTable(tbl: String, scale: Double, tpcdsConf: TPCDSConf)
   extends SparkTable with SupportsRead {
 
@@ -79,9 +81,9 @@ class TPCDSTable(tbl: String, scale: Double, tpcdsConf: TPCDSConf)
       case (DATE, None, None) => DateType
       case (DECIMAL, Some(precision), Some(scale)) => DecimalType(precision, scale)
       case (VARCHAR, Some(precision), None) =>
-        if (tpcdsConf.useAnsiStringType) VarcharType(precision) else StringType
+        if (tpcdsConf.useAnsiStringType) TPCDSTable.varcharType(precision) else StringType
       case (CHAR, Some(precision), None) =>
-        if (tpcdsConf.useAnsiStringType) CharType(precision) else StringType
+        if (tpcdsConf.useAnsiStringType) TPCDSTable.charType(precision) else StringType
       case (t, po, so) =>
         throw new IllegalArgumentException(s"Unsupported TPC-DS type: ($t, $po, $so)")
     }
@@ -93,4 +95,30 @@ class TPCDSTable(tbl: String, scale: Double, tpcdsConf: TPCDSConf)
       case _ => if (optional.isPresent) Option(optional.get) else None
     }
   }
+}
+
+object TPCDSTable {
+  // Only the default UTF-8 binary collation is needed, so always pass an empty
+  // `Option[Int]`; `DynConstructors` drops the trailing arg on the single-arg ctor.
+  private lazy val charTypeCtor: DynConstructors.Ctor[CharType] =
+    DynConstructors.builder()
+      // SPARK-54870 (4.2.0): (Int, Option[Int]) ctor with collation
+      .impl(classOf[CharType], classOf[Int], classOf[Option[Int]])
+      // Spark < 4.2.0: (Int) ctor
+      .impl(classOf[CharType], classOf[Int])
+      .build[CharType]()
+
+  private lazy val varcharTypeCtor: DynConstructors.Ctor[VarcharType] =
+    DynConstructors.builder()
+      // SPARK-54870 (4.2.0): (Int, Option[Int]) ctor with collation
+      .impl(classOf[VarcharType], classOf[Int], classOf[Option[Int]])
+      // Spark < 4.2.0: (Int) ctor
+      .impl(classOf[VarcharType], classOf[Int])
+      .build[VarcharType]()
+
+  def charType(length: Int): CharType =
+    charTypeCtor.newInstance(Integer.valueOf(length), Option.empty[Int])
+
+  def varcharType(length: Int): VarcharType =
+    varcharTypeCtor.newInstance(Integer.valueOf(length), Option.empty[Int])
 }


### PR DESCRIPTION
### _Why are the changes needed?_

The `spark-4.2` Maven profile is already supported, but the connectors compiled against Spark 3.5 fail with `NoSuchMethodError` at runtime against Spark 4.2, because Spark 4.2 changed several case classes:

- SPARK-55645 added `serdeName` to `CatalogStorageFormat`
- SPARK-50675 added `collation` to `CatalogTable`
- SPARK-52729 added `multipartIdentifier` to `CatalogTable`
- SPARK-54870 added `collation` to `CharType`/`VarcharType`

Dispatch the affected constructors/copies through the `Dyn*` reflection helpers so the connector jar stays binary-compatible across Spark 3.5, 4.0, 4.1 and 4.2, and add Spark 4.2 to the connector cross-version test matrix to guard it.

### _How was this patch tested?_

Cross-version test matrix, compiled against Spark 3.5 and run against Spark 3.3/3.4 (Scala 2.12) and 3.5/4.0/4.1/4.2 (Scala 2.13) - all pass.

### _Was this patch authored or co-authored using generative AI tooling?_

Assisted-by: DeepSeek V4 Pro
