### PR TITLE
[KYUUBI #7623][AUTHZ] Check the effective value of spark.sql.optimizer.excludedRules

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/rule/config/AuthzConfigurationChecker.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/rule/config/AuthzConfigurationChecker.scala
@@ -30,6 +30,9 @@ import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils.SKIP_CATALOGLESS_V2_
 case class AuthzConfigurationChecker(spark: SparkSession) extends (LogicalPlan => Unit) {
 
   final val RESTRICT_LIST_KEY = "spark.kyuubi.conf.restricted.list"
+  final val EXCLUDED_RULES_KEY = "spark.sql.optimizer.excludedRules"
+
+  final private val AUTHZ_RANGER_RULE_PACKAGE = "org.apache.kyuubi.plugin.spark.authz.ranger"
 
   private val restrictedConfList: Set[String] =
     Set(
@@ -39,17 +42,27 @@ case class AuthzConfigurationChecker(spark: SparkSession) extends (LogicalPlan =
       SKIP_CATALOGLESS_V2_RELATION_ENABLED_KEY) ++
       spark.conf.getOption(RESTRICT_LIST_KEY).map(_.split(',').toSet).getOrElse(Set.empty)
 
-  override def apply(plan: LogicalPlan): Unit = plan match {
-    case SetCommand(Some((
-          "spark.sql.optimizer.excludedRules",
-          Some(v)))) if v.contains("org.apache.kyuubi.plugin.spark.authz.ranger") =>
+  override def apply(plan: LogicalPlan): Unit = {
+    // SET is not the only way the exclusion can be set: spark.conf.set and the Spark
+    // Connect Config RPC write the value with no logical plan at all, so the SetCommand
+    // case below never sees them. Check the value that is actually in effect on every
+    // plan instead - check rules are not affected by spark.sql.optimizer.excludedRules,
+    // which only filters optimizer batches, so this check cannot be turned off the same way.
+    if (spark.conf.getOption(EXCLUDED_RULES_KEY).exists(_.contains(AUTHZ_RANGER_RULE_PACKAGE))) {
       throw new AccessControlException("Excluding Authz security rules is not allowed")
-    case SetCommand(Some((k, Some(_)))) if restrictedConfList.contains(k) =>
-      throw new AccessControlException(s"Modifying config $k is not allowed")
-    case ResetCommand(Some(k)) if restrictedConfList.contains(k) =>
-      throw new AccessControlException(s"Resetting config $k is not allowed")
-    case ResetCommand(None) =>
-      throw new AccessControlException("Resetting all configs is not allowed")
-    case _ =>
+    }
+    plan match {
+      case SetCommand(Some((
+            EXCLUDED_RULES_KEY,
+            Some(v)))) if v.contains(AUTHZ_RANGER_RULE_PACKAGE) =>
+        throw new AccessControlException("Excluding Authz security rules is not allowed")
+      case SetCommand(Some((k, Some(_)))) if restrictedConfList.contains(k) =>
+        throw new AccessControlException(s"Modifying config $k is not allowed")
+      case ResetCommand(Some(k)) if restrictedConfList.contains(k) =>
+        throw new AccessControlException(s"Resetting config $k is not allowed")
+      case ResetCommand(None) =>
+        throw new AccessControlException("Resetting all configs is not allowed")
+      case _ =>
+    }
   }
 }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/rule/AuthzConfigurationCheckerSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/rule/AuthzConfigurationCheckerSuite.scala
@@ -50,9 +50,38 @@ class AuthzConfigurationCheckerSuite extends KyuubiFunSuite with SparkSessionPro
     val p8 = sql(s"set spark.sql.optimizer.excludedRules=${classOf[RuleAuthorization].getName}")
       .queryExecution.analyzed
     intercept[AccessControlException](extension.apply(p8))
+    // sql() has already applied the SET before the rule is invoked here, and the value it
+    // leaves behind is what the effective-value check rejects on every plan of this session
+    spark.conf.unset(extension.EXCLUDED_RULES_KEY)
     val p9 = sql(
       "set spark.kyuubi.authz.skipCataloglessV2Relation.enabled=true").queryExecution.analyzed
     intercept[AccessControlException](extension.apply(p9))
+  }
+
+  test("check the effective value of spark.sql.optimizer.excludedRules") {
+    val extension = AuthzConfigurationChecker(spark)
+    val plan = sql("select 1").queryExecution.analyzed
+    extension.apply(plan)
+
+    // spark.conf.set writes the config without producing a plan, the same way the
+    // Spark Connect Config RPC does, so the SetCommand case never sees it
+    spark.conf.set(extension.EXCLUDED_RULES_KEY, classOf[RuleAuthorization].getName)
+    try {
+      intercept[AccessControlException](extension.apply(plan))
+    } finally {
+      spark.conf.unset(extension.EXCLUDED_RULES_KEY)
+    }
+    extension.apply(plan)
+
+    // excluding rules that do not belong to authz stays allowed
+    spark.conf.set(
+      extension.EXCLUDED_RULES_KEY,
+      "org.apache.spark.sql.catalyst.optimizer.ConstantFolding")
+    try {
+      extension.apply(plan)
+    } finally {
+      spark.conf.unset(extension.EXCLUDED_RULES_KEY)
+    }
   }
 
   test("apply spark configuration restriction rules for RESET") {


### PR DESCRIPTION
### Why are the changes needed?

Closes #7623.

`AuthzConfigurationChecker` guards the exclusion by matching a `SetCommand` in the logical plan (`AuthzConfigurationChecker.scala:42-45`), so the protection covers the `SET` syntax only - which is also how the docs describe it (`docs/security/authorization/spark/overview.rst:106`, "A set statement with key equal to ..."). Every channel that writes the config without producing a plan keeps working: `spark.conf.set`, the Spark Connect Config RPC (`SparkConnectConfigHandler.handleSet` calls `conf.set` directly), or the key passed in a JDBC connection string. Once `RuleAuthorization` is named there, `Optimizer.batches` drops it - extension rules are not in `SparkOptimizer.nonExcludableRules` - and the rest of the session runs unauthorized.

Reproduced on Spark 4.0.3 with `kyuubi-spark-authz` and a Ranger plugin that denies by default: `create` denied, `SET spark.sql.optimizer.excludedRules=...RuleAuthorization` rejected by the checker, the same key accepted over the Connect Config RPC, the next `create` allowed.

The documented mitigation, `kyuubi.session.conf.restrict.list` (`docs/security/authorization/spark/overview.rst:85-93`), does reject such a JDBC connection - I checked that too - but it is enforced in the server's `SessionManager`, so it does not reach a client that talks to the engine directly.

This patch reads the value in effect on every plan instead of matching the statement. Check rules are not filtered by `excludedRules`, which only applies to optimizer batches, so this check cannot be removed the same way.

Two points a reviewer may want to decide differently:

- The value check matches `org.apache.kyuubi.plugin.spark.authz.ranger`, the prefix the existing `SET` case uses. The plugin also injects optimizer rules from `org.apache.kyuubi.plugin.spark.authz.rule` (`RuleEliminateMarker` and its neighbours), which neither the old nor the new check covers. I left the prefix as is rather than widen the scope here.
- The check is fail closed for the whole session: with the exclusion already in the session conf, every plan is rejected, not just the `SET`. That is the intent, but it is a visible behaviour change for a session that set the key before this patch.

### How was this patch tested?

New test in `AuthzConfigurationCheckerSuite`: the config is written through `spark.conf.set` - the same write path the Connect Config RPC takes - and the next plan is rejected, while excluding a non-authz rule (`ConstantFolding`) stays allowed.

```
build/mvn test -pl extensions/spark/kyuubi-spark-authz -Dtest=none \
    -DwildcardSuites=org.apache.kyuubi.plugin.spark.authz.rule.AuthzConfigurationCheckerSuite
```

All three tests in the suite pass; with the new check removed from `apply`, exactly the new test fails.

The existing test needed one line: `sql("set spark.sql.optimizer.excludedRules=...")` applies the value to the shared session before the rule is invoked by hand, so the test now unsets it - otherwise the effective-value check rejects every later plan in that session.

### Was this patch authored or co-authored using generative AI tooling?

Assisted-by: Claude:claude-opus-5
