### PR TITLE
[KYUUBI #7640] Fix exception double-unwrap in DynMethods.UnboundMethod.invoke

### DIFF
--- a/kyuubi-util/src/main/java/org/apache/kyuubi/util/reflect/DynMethods.java
+++ b/kyuubi-util/src/main/java/org/apache/kyuubi/util/reflect/DynMethods.java
@@ -34,8 +34,9 @@ public class DynMethods {
   /**
    * Convenience wrapper class around {@link Method}.
    *
-   * <p>Allows callers to invoke the wrapped method with all Exceptions wrapped by RuntimeException,
-   * or with a single Exception catch block.
+   * <p>Allows callers to invoke the wrapped method with any checked Exception wrapped by
+   * RuntimeException (RuntimeExceptions are rethrown as-is), or with a single Exception catch
+   * block.
    */
   public static class UnboundMethod {
 
@@ -73,11 +74,10 @@ public class DynMethods {
     public <R> R invoke(Object target, Object... args) {
       try {
         return this.invokeChecked(target, args);
+      } catch (RuntimeException e) {
+        throw e;
       } catch (Exception e) {
-        if (e.getCause() instanceof RuntimeException) {
-          throw (RuntimeException) e.getCause();
-        }
-        throw new RuntimeException(e.getCause());
+        throw new RuntimeException(e);
       }
     }
 

--- a/kyuubi-util/src/test/java/org/apache/kyuubi/util/reflect/DynMethodsTest.java
+++ b/kyuubi-util/src/test/java/org/apache/kyuubi/util/reflect/DynMethodsTest.java
@@ -29,7 +29,6 @@ public class DynMethodsTest {
 
   public static class ReflectionTarget {
 
-    /** Kept as a field so a test can assert the very same instance came back out of invoke. */
     final IllegalStateException causelessFailure = new IllegalStateException();
 
     public Object throwCheckedWithoutCause() throws IOException {
@@ -86,10 +85,6 @@ public class DynMethodsTest {
     RuntimeException thrown =
         assertThrows(RuntimeException.class, () -> method.invoke(new ReflectionTarget()));
 
-    // Before the fix, invoke unwrapped a second time and threw the IllegalArgumentException
-    // bare, dropping the target's IOException: a plausible-looking wrong type in place of the
-    // real failure. The IOException must now arrive as the wrapper's cause, with its own cause
-    // still attached.
     assertEquals(RuntimeException.class, thrown.getClass());
     assertTrue(thrown.getCause() instanceof IOException);
     assertEquals("checked failure", thrown.getCause().getMessage());

--- a/kyuubi-util/src/test/java/org/apache/kyuubi/util/reflect/DynMethodsTest.java
+++ b/kyuubi-util/src/test/java/org/apache/kyuubi/util/reflect/DynMethodsTest.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.util.reflect;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+public class DynMethodsTest {
+
+  public static class ReflectionTarget {
+
+    /** Kept as a field so a test can assert the very same instance came back out of invoke. */
+    final IllegalStateException causelessFailure = new IllegalStateException();
+
+    public Object throwCheckedWithoutCause() throws IOException {
+      throw new IOException("checked failure");
+    }
+
+    public Object throwCheckedWithRuntimeCause() throws IOException {
+      throw new IOException("checked failure", new IllegalArgumentException("root"));
+    }
+
+    public Object throwUncheckedWithCause() {
+      throw new IllegalStateException("unchecked failure", new IllegalArgumentException("cause"));
+    }
+
+    public Object throwCauselessUnchecked() {
+      throw causelessFailure;
+    }
+
+    public static Object throwStaticUnchecked() {
+      throw new IllegalStateException(
+          "static failure", new IllegalArgumentException("static cause"));
+    }
+
+    public String echo(String input) {
+      return input;
+    }
+
+    public static String staticEcho(String input) {
+      return input;
+    }
+
+    public String concat(String... parts) {
+      return String.join("", parts);
+    }
+  }
+
+  @Test
+  public void testInvokePreservesCheckedExceptionThrownByTarget() {
+    DynMethods.UnboundMethod method =
+        DynMethods.builder("throwCheckedWithoutCause").impl(ReflectionTarget.class).build();
+
+    RuntimeException thrown =
+        assertThrows(RuntimeException.class, () -> method.invoke(new ReflectionTarget()));
+
+    assertTrue(thrown.getCause() instanceof IOException);
+    assertEquals("checked failure", thrown.getCause().getMessage());
+  }
+
+  @Test
+  public void testInvokeKeepsCheckedExceptionCarryingRuntimeCause() {
+    DynMethods.UnboundMethod method =
+        DynMethods.builder("throwCheckedWithRuntimeCause").impl(ReflectionTarget.class).build();
+
+    RuntimeException thrown =
+        assertThrows(RuntimeException.class, () -> method.invoke(new ReflectionTarget()));
+
+    // Before the fix, invoke unwrapped a second time and threw the IllegalArgumentException
+    // bare, dropping the target's IOException: a plausible-looking wrong type in place of the
+    // real failure. The IOException must now arrive as the wrapper's cause, with its own cause
+    // still attached.
+    assertEquals(RuntimeException.class, thrown.getClass());
+    assertTrue(thrown.getCause() instanceof IOException);
+    assertEquals("checked failure", thrown.getCause().getMessage());
+    assertTrue(thrown.getCause().getCause() instanceof IllegalArgumentException);
+  }
+
+  @Test
+  public void testInvokeRethrowsRuntimeExceptionFromTargetAsIs() {
+    DynMethods.UnboundMethod method =
+        DynMethods.builder("throwUncheckedWithCause").impl(ReflectionTarget.class).build();
+
+    IllegalStateException thrown =
+        assertThrows(IllegalStateException.class, () -> method.invoke(new ReflectionTarget()));
+
+    assertEquals("unchecked failure", thrown.getMessage());
+    assertTrue(thrown.getCause() instanceof IllegalArgumentException);
+    assertEquals("cause", thrown.getCause().getMessage());
+  }
+
+  @Test
+  public void testInvokeRethrowsCauselessRuntimeExceptionFromTargetAsIs() {
+    ReflectionTarget target = new ReflectionTarget();
+    DynMethods.UnboundMethod method =
+        DynMethods.builder("throwCauselessUnchecked").impl(ReflectionTarget.class).build();
+
+    IllegalStateException thrown =
+        assertThrows(IllegalStateException.class, () -> method.invoke(target));
+
+    assertSame(target.causelessFailure, thrown);
+  }
+
+  @Test
+  public void testBoundMethodInvokeRethrowsRuntimeExceptionFromTargetAsIs() {
+    ReflectionTarget target = new ReflectionTarget();
+    DynMethods.BoundMethod bound =
+        DynMethods.builder("throwCauselessUnchecked").impl(ReflectionTarget.class).build(target);
+
+    IllegalStateException thrown = assertThrows(IllegalStateException.class, () -> bound.invoke());
+
+    assertSame(target.causelessFailure, thrown);
+  }
+
+  @Test
+  public void testStaticMethodInvokeRethrowsRuntimeExceptionFromTargetAsIs() {
+    DynMethods.StaticMethod staticMethod =
+        DynMethods.builder("throwStaticUnchecked").impl(ReflectionTarget.class).buildStatic();
+
+    IllegalStateException thrown =
+        assertThrows(IllegalStateException.class, () -> staticMethod.invoke());
+
+    assertEquals("static failure", thrown.getMessage());
+    assertTrue(thrown.getCause() instanceof IllegalArgumentException);
+    assertEquals("static cause", thrown.getCause().getMessage());
+  }
+
+  @Test
+  public void testWrapperInvokeReturnsTargetResult() {
+    ReflectionTarget target = new ReflectionTarget();
+    DynMethods.BoundMethod bound =
+        DynMethods.builder("echo").impl(ReflectionTarget.class, String.class).build(target);
+    assertEquals("bound", bound.invoke("bound"));
+
+    DynMethods.StaticMethod staticMethod =
+        DynMethods.builder("staticEcho").impl(ReflectionTarget.class, String.class).buildStatic();
+    assertEquals("static", staticMethod.invoke("static"));
+  }
+
+  @Test
+  public void testInvokeReturnsTargetResult() {
+    DynMethods.UnboundMethod fixedArity =
+        DynMethods.builder("echo").impl(ReflectionTarget.class, String.class).build();
+    assertEquals("arg", fixedArity.invoke(new ReflectionTarget(), "arg"));
+
+    DynMethods.UnboundMethod varargs =
+        DynMethods.builder("concat").impl(ReflectionTarget.class, String[].class).build();
+    // Method.invoke does not spread-pack loose varargs arguments, so callers pass the
+    // packed array as the single argument.
+    assertEquals("ab", varargs.invoke(new ReflectionTarget(), (Object) new String[] {"a", "b"}));
+  }
+
+  @Test
+  public void testInvokeCheckedThrowsTargetExceptionWithoutWrapping() {
+    DynMethods.UnboundMethod method =
+        DynMethods.builder("throwCheckedWithoutCause").impl(ReflectionTarget.class).build();
+
+    IOException thrown =
+        assertThrows(IOException.class, () -> method.invokeChecked(new ReflectionTarget()));
+
+    assertEquals("checked failure", thrown.getMessage());
+  }
+}


### PR DESCRIPTION
### Why are the changes needed?

Fix #7640.

`UnboundMethod.invoke` unwrapped exceptions twice: `invokeChecked` already throws the real exception produced by the invoked method, but `invoke` re-threw `e.getCause()` as if `e` were still the `InvocationTargetException`. Consequences:

- an exception without a cause degraded to `new RuntimeException(null)` — the type, message and stack trace of the real failure were all lost;
- a `RuntimeException` carrying a cause was silently replaced by that cause, so `catch (IllegalStateException)` at a call site missed an `IllegalStateException` thrown by the target.

The fix re-throws `RuntimeException` as-is and wraps checked exceptions with the real exception as cause, matching the sibling `DynConstructors.Ctor.newInstance` and restoring the semantics both upstreams always had (parquet-common, unchanged since PARQUET-777; Iceberg) and that were lost during vendoring in db0047d51 ([KYUUBI #3230]).

All in-repo `.invoke`/`.invokeChecked` call sites were audited: none depends on the old behavior. Callers going through `ReflectUtils.invokeAs` keep their top-level message but now carry the real cause; direct users of the wrappers (`EmbeddedExecutorFactory`, `KyuubiSparkUtil`, `EngineTab`, `RowSet`) now see the real exception type and message.

### How was this patch tested?

Added `DynMethodsTest`, the first unit tests for `org.apache.kyuubi.util.reflect`: 9 cases covering both failure modes of the old code, a causeless-`RuntimeException` identity pin (`assertSame`), a checked-exception-carrying-runtime-cause pin, the `BoundMethod`/`StaticMethod` wrappers, fixed-arity and varargs happy paths, and the `invokeChecked` contract.

### Was this patch authored or co-authored using generative AI tooling?

Assisted-by: GLM-5.3
Assisted-by: Claude Opus
