### PR TITLE
[KYUUBI #7645][SERVER] Fix operation state metrics transition

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/KyuubiOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/KyuubiOperation.scala
@@ -213,15 +213,18 @@ abstract class KyuubiOperation(session: Session) extends AbstractOperation(sessi
 
   if (eventEnabled) EventBus.post(getOperationEvent)
 
-  override def setState(newState: OperationState): Unit = {
+  override def setState(newState: OperationState): Unit = withLockRequired {
+    val oldState = state
+    super.setState(newState)
     MetricsSystem.tracing { ms =>
-      if (!OperationState.isTerminal(state)) {
-        ms.markMeter(MetricRegistry.name(OPERATION_STATE, opType, state.toString.toLowerCase), -1)
+      if (!OperationState.isTerminal(oldState)) {
+        ms.markMeter(
+          MetricRegistry.name(OPERATION_STATE, opType, oldState.toString.toLowerCase),
+          -1)
       }
       ms.markMeter(MetricRegistry.name(OPERATION_STATE, opType, newState.toString.toLowerCase))
       ms.markMeter(MetricRegistry.name(OPERATION_STATE, newState.toString.toLowerCase))
     }
-    super.setState(newState)
     if (eventEnabled) EventBus.post(getOperationEvent)
   }
 

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationSuite.scala
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.operation
+
+import com.codahale.metrics.MetricRegistry
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar.mock
+
+import org.apache.kyuubi.{KyuubiFunSuite, KyuubiSQLException}
+import org.apache.kyuubi.config.KyuubiConf
+import org.apache.kyuubi.metrics.{MetricsConf, MetricsConstants, MetricsSystem}
+import org.apache.kyuubi.operation.OperationState.OperationState
+import org.apache.kyuubi.session.{Session, SessionHandle, SessionManager}
+import org.apache.kyuubi.shaded.hive.service.rpc.thrift.TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V10
+
+class KyuubiOperationSuite extends KyuubiFunSuite {
+
+  private var metricsSystem: MetricsSystem = _
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    metricsSystem = new MetricsSystem()
+    metricsSystem.initialize(KyuubiConf()
+      .set(MetricsConf.METRICS_REPORTERS, Set.empty[String]))
+    metricsSystem.start()
+  }
+
+  override def afterEach(): Unit = {
+    try {
+      if (metricsSystem != null) {
+        metricsSystem.stop()
+        metricsSystem = null
+      }
+    } finally {
+      super.afterEach()
+    }
+  }
+
+  test("do not update operation state metrics on stale terminal state transition") {
+    val operation = new TestKyuubiOperation(mockSession())
+
+    operation.transitState(OperationState.RUNNING)
+    operation.transitState(OperationState.FINISHED)
+
+    val canceledMetric = stateMetric(OperationState.CANCELED)
+    val runningMetric = stateMetric(OperationState.RUNNING)
+    val canceledCount = MetricsSystem.meterValue(canceledMetric).getOrElse(0L)
+    val runningCount = MetricsSystem.meterValue(runningMetric).getOrElse(0L)
+
+    intercept[KyuubiSQLException] {
+      operation.transitState(OperationState.CANCELED)
+    }
+
+    assert(MetricsSystem.meterValue(canceledMetric).getOrElse(0L) === canceledCount)
+    assert(MetricsSystem.meterValue(runningMetric).getOrElse(0L) === runningCount)
+    assert(operation.getStatus.state === OperationState.FINISHED)
+  }
+
+  private def mockSession(): Session = {
+    val conf = KyuubiConf()
+    val sessionManager = mock[SessionManager]
+    when(sessionManager.getConf).thenReturn(conf)
+
+    val session = mock[Session]
+    when(session.protocol).thenReturn(HIVE_CLI_SERVICE_PROTOCOL_V10)
+    when(session.handle).thenReturn(SessionHandle())
+    when(session.user).thenReturn("kyuubi")
+    when(session.sessionManager).thenReturn(sessionManager)
+    session
+  }
+
+  private def stateMetric(state: OperationState): String = {
+    MetricRegistry.name(
+      MetricsConstants.OPERATION_STATE,
+      classOf[TestKyuubiOperation].getSimpleName,
+      state.toString.toLowerCase)
+  }
+}
+
+private class TestKyuubiOperation(session: Session) extends KyuubiOperation(session) {
+
+  def transitState(newState: OperationState): Unit = setState(newState)
+
+  override protected def runInternal(): Unit = {}
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->
`KyuubiOperation#setState` updated operation state metrics before delegating to `AbstractOperation#setState`, where the state transition is validated and the actual operation state is changed. It also did not protect the whole transition-and-metrics-update sequence with the operation lock.

This can cause inaccurate operation state metrics in two cases:

1. A stale or invalid state transition may update metrics before being rejected.

    For example, an operation may have already moved from `RUNNING` to `FINISHED`, while a delayed cancel/close path still tries to update it to another terminal state such as `CANCELED`. In the old implementation, the target state metric was updated before `OperationState#validateTransition` rejected the transition, so the operation remained in the original state but the metrics had already been changed.

2. Concurrent state transitions for the same operation may update metrics based on the same stale old state.

    For example, one thread may observe the remote query as finished and call `KyuubiOperation#setState(FINISHED)`, while another thread concurrently handles cancel/close/timeout/error and calls `KyuubiOperation#setState(CANCELED)` or another terminal state. Since the old implementation read `state` and updated metrics outside a common operation lock, both paths could observe the old state as `RUNNING` and both update the `RUNNING` metric, making `kyuubi.operation.state.ExecuteStatement.running` inaccurate.

This patch makes `KyuubiOperation#setState` execute under the operation lock, captures the old state once, delegates to `AbstractOperation#setState` first, and updates operation state metrics only after the state transition succeeds.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Added a unit test in `KyuubiOperationSuite` to verify that a stale terminal transition does not update operation state metrics.
```
build/mvn test -pl kyuubi-server -am \
  -Pspark-provided -Pflink-provided -Phive-provided \
  -Dtest=none \
  -DwildcardSuites=org.apache.kyuubi.operation.KyuubiOperationSuite
```

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has assisted in authoring or reviewing this patch, please include
an 'Assisted-by: ' trailer that identifies the agent and model.
For example: 'Assisted-by: Claude:claude-opus-4-7' or 'Assisted-by: Claude Opus 4.7'.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Assisted-by: TraeCode with GPT-5
