### PR TITLE
[KYUUBI #7647] Stop truncating varargs constructor arguments in DynConstructors

### DIFF
--- a/kyuubi-util/src/main/java/org/apache/kyuubi/util/reflect/DynConstructors.java
+++ b/kyuubi-util/src/main/java/org/apache/kyuubi/util/reflect/DynConstructors.java
@@ -27,12 +27,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-/**
- * Adapted from iceberg-common, which is itself derived from parquet-common.
- *
- * <p>Diverges from both upstreams: extra arguments are truncated only for non-varargs constructors;
- * varargs constructors' arguments are passed through to {@link Constructor#newInstance} unchanged.
- */
+/** Adapted from iceberg-common, which is itself derived from parquet-common. */
 public class DynConstructors {
 
   private DynConstructors() {}
@@ -51,6 +46,17 @@ public class DynConstructors {
       return constructed;
     }
 
+    /**
+     * Creates an instance, truncating extra arguments only for a non-varargs constructor.
+     *
+     * <p>{@link Constructor#newInstance} never packs loose varargs arguments into the trailing
+     * array, so truncating such a call could only drop arguments or fail with a misleading message.
+     * {@link DynMethods.UnboundMethod} skips the same truncation for varargs methods, by keeping
+     * {@code argLength} at -1.
+     *
+     * <p>Both upstream copies of this class differ here: iceberg-common truncates unconditionally,
+     * parquet-common does not truncate at all.
+     */
     public C newInstanceChecked(Object... args) throws Exception {
       try {
         if (!ctor.isVarArgs() && args.length > ctor.getParameterCount()) {

--- a/kyuubi-util/src/main/java/org/apache/kyuubi/util/reflect/DynConstructors.java
+++ b/kyuubi-util/src/main/java/org/apache/kyuubi/util/reflect/DynConstructors.java
@@ -27,7 +27,12 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-/** Copied from parquet-common */
+/**
+ * Adapted from iceberg-common, which is itself derived from parquet-common.
+ *
+ * <p>Diverges from both upstreams: extra arguments are truncated only for non-varargs constructors;
+ * varargs constructors' arguments are passed through to {@link Constructor#newInstance} unchanged.
+ */
 public class DynConstructors {
 
   private DynConstructors() {}
@@ -48,7 +53,7 @@ public class DynConstructors {
 
     public C newInstanceChecked(Object... args) throws Exception {
       try {
-        if (args.length > ctor.getParameterCount()) {
+        if (!ctor.isVarArgs() && args.length > ctor.getParameterCount()) {
           return ctor.newInstance(Arrays.copyOfRange(args, 0, ctor.getParameterCount()));
         } else {
           return ctor.newInstance(args);

--- a/kyuubi-util/src/test/java/org/apache/kyuubi/util/reflect/DynConstructorsTest.java
+++ b/kyuubi-util/src/test/java/org/apache/kyuubi/util/reflect/DynConstructorsTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.util.reflect;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class DynConstructorsTest {
+
+  public static class VarargsHolder {
+    final String first;
+    final Object[] rest;
+
+    public VarargsHolder(String first, Object... rest) {
+      this.first = first;
+      this.rest = rest;
+    }
+  }
+
+  public static class FixedArity {
+    final String value;
+
+    public FixedArity(String value) {
+      this.value = value;
+    }
+  }
+
+  @Test
+  public void testNewInstanceRejectsLooseVarargsArguments() {
+    DynConstructors.Ctor<VarargsHolder> ctor =
+        DynConstructors.builder().impl(VarargsHolder.class, String.class, Object[].class).build();
+
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> ctor.newInstance("one", new Object[] {"2a", "2b"}, "three"));
+
+    assertEquals("wrong number of arguments", thrown.getMessage());
+
+    IllegalArgumentException allLoose =
+        assertThrows(IllegalArgumentException.class, () -> ctor.newInstance("one", "2a", "2b"));
+
+    assertEquals("wrong number of arguments", allLoose.getMessage());
+
+    assertThrows(IllegalArgumentException.class, () -> ctor.newInstance("one"));
+  }
+
+  @Test
+  public void testInvokeRejectsNonNullTarget() {
+    DynConstructors.Ctor<VarargsHolder> ctor =
+        DynConstructors.builder().impl(VarargsHolder.class, String.class, Object[].class).build();
+    Object[] rest = new Object[] {"2a", "2b"};
+
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class, () -> ctor.invoke(new Object(), "one", (Object) rest));
+
+    assertEquals("Invalid call to constructor: target must be null", thrown.getMessage());
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> ctor.invokeChecked(new Object(), "one", (Object) rest));
+  }
+
+  @Test
+  public void testPackedVarargsArrayReachesConstructorThroughEveryEntryPoint() {
+    DynConstructors.Ctor<VarargsHolder> ctor =
+        DynConstructors.builder().impl(VarargsHolder.class, String.class, Object[].class).build();
+    // Constructor.newInstance does not pack loose varargs arguments; callers pass the
+    // packed array itself as the last argument.
+    Object[] rest = new Object[] {"2a", "2b"};
+
+    VarargsHolder viaNewInstance = ctor.newInstance("one", (Object) rest);
+    assertEquals("one", viaNewInstance.first);
+    assertArrayEquals(rest, viaNewInstance.rest);
+
+    VarargsHolder viaNewInstanceChecked =
+        assertDoesNotThrow(() -> ctor.newInstanceChecked("one", (Object) rest));
+    assertArrayEquals(rest, viaNewInstanceChecked.rest);
+
+    VarargsHolder viaInvoke = ctor.invoke(null, "one", (Object) rest);
+    assertArrayEquals(rest, viaInvoke.rest);
+
+    VarargsHolder viaInvokeChecked =
+        assertDoesNotThrow(() -> ctor.invokeChecked(null, "one", (Object) rest));
+    assertArrayEquals(rest, viaInvokeChecked.rest);
+  }
+
+  @Test
+  public void testNewInstanceTruncatesExtraArgsForFixedArityConstructor() {
+    DynConstructors.Ctor<FixedArity> ctor =
+        DynConstructors.builder().impl(FixedArity.class, String.class).build();
+
+    FixedArity fixedArity = ctor.newInstance("value", "ignored");
+
+    assertEquals("value", fixedArity.value);
+  }
+}

--- a/kyuubi-util/src/test/java/org/apache/kyuubi/util/reflect/DynConstructorsTest.java
+++ b/kyuubi-util/src/test/java/org/apache/kyuubi/util/reflect/DynConstructorsTest.java
@@ -21,10 +21,17 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
 public class DynConstructorsTest {
+
+  // Prefix of the IllegalArgumentException that Constructor.newInstance throws when the argument
+  // count does not fit the constructor. Matched as a prefix because the JDK 18+ accessor appends
+  // ": 3 expected: 2"; the legacy accessor stops at the prefix, and this build requests it with
+  // -Djdk.reflect.useDirectMethodHandle=false.
+  private static final String WRONG_NUMBER_OF_ARGUMENTS = "wrong number of arguments";
 
   public static class VarargsHolder {
     final String first;
@@ -49,17 +56,23 @@ public class DynConstructorsTest {
     DynConstructors.Ctor<VarargsHolder> ctor =
         DynConstructors.builder().impl(VarargsHolder.class, String.class, Object[].class).build();
 
+    // Truncating this call would construct successfully and drop "three", so this case pins the
+    // pass-through without depending on the JDK message.
     IllegalArgumentException thrown =
         assertThrows(
             IllegalArgumentException.class,
             () -> ctor.newInstance("one", new Object[] {"2a", "2b"}, "three"));
 
-    assertEquals("wrong number of arguments", thrown.getMessage());
+    assertTrue(
+        thrown.getMessage().startsWith(WRONG_NUMBER_OF_ARGUMENTS),
+        () -> "unexpected message: " + thrown.getMessage());
 
     IllegalArgumentException allLoose =
         assertThrows(IllegalArgumentException.class, () -> ctor.newInstance("one", "2a", "2b"));
 
-    assertEquals("wrong number of arguments", allLoose.getMessage());
+    assertTrue(
+        allLoose.getMessage().startsWith(WRONG_NUMBER_OF_ARGUMENTS),
+        () -> "unexpected message: " + allLoose.getMessage());
 
     assertThrows(IllegalArgumentException.class, () -> ctor.newInstance("one"));
   }


### PR DESCRIPTION
### Why are the changes needed?

Fix #7647.

`Ctor.newInstanceChecked` truncated arguments to the resolved constructor's parameter count unconditionally. `Constructor.newInstance` — like `Method.invoke` — never packs loose varargs arguments (the only valid reflection form is the packed array as the last argument), so for a **varargs** constructor the truncation could never produce a correct call:

- when the truncated prefix happened to type-match, trailing arguments were **silently dropped** and a wrong instance was constructed — e.g. for `Holder(String, Object...)`, `ctor.newInstance("one", new Object[]{"2a","2b"}, "three")` constructed `Holder("one", ["2a","2b"])` with `"three"` vanishing;
- otherwise the caller got a misleading `argument type mismatch` (an artifact of the truncated call) instead of the honest `wrong number of arguments`.

The fix skips the truncation when `ctor.isVarArgs()`: varargs constructors' arguments pass through unchanged, so callers get either a working packed-array invocation or the same fail-loudly contract parquet-mr specifies upstream.

This aligns `DynConstructors` with the sibling class in the same package rather than introducing a local special case: `DynMethods.UnboundMethod` keeps `argLength` at -1 for a varargs method and so skips the identical `Arrays.copyOfRange` truncation, both in this copy and upstream, and `KyuubiSparkUtil`'s `UriBuilder.build(Object...)` lookups depend on that.

Upstream lineage: this class is adapted from iceberg-common (itself derived from parquet-common), and the truncation logic matches Iceberg's copy — parquet-mr's `newInstanceChecked` has never truncated (its `TestDynConstructors#testFirstImplReturned` pins extra-arguments-must-throw), while Iceberg's copy carries the identical unconditional truncation, unfixed and untested for extra/varargs arguments. This is therefore a Kyuubi-local fix, recorded on `newInstanceChecked`; it may be worth reporting upstream against Iceberg separately.

Scope: the fixed-arity truncation is long-standing and load-bearing — 7 in-repo sites rely on it for cross-version constructor compatibility (`TPCDSTable` across Spark versions, `HiveSessionManager` on Hive 2.3, and optional-conf provider patterns such as `EngineSecuritySecretProvider`, which binds a no-arg constructor and passes `conf` on every call) — so it is deliberately preserved. All in-repo `DynConstructors` call sites were audited: none passes loose arguments to a varargs constructor (structurally impossible to bind one without an explicit array-typed `impl` chain, of which the repo has none for constructors), so no caller's behavior changes except the intended silent-drop → loud-failure correction.

### How was this patch tested?

Added `DynConstructorsTest`, the first unit tests for `DynConstructors`:

- rejection of loose varargs arguments in both forms (packed-plus-extras and all-loose, asserting the honest `wrong number of arguments` message by prefix, since the JDK 18+ reflection accessor appends `: 3 expected: 2`) plus the under-arity call (reflection synthesizes no empty varargs array either);
- the non-null-target guards of `invoke`/`invokeChecked`;
- the packed-array happy path through all four entry points (`newInstance`, `newInstanceChecked`, `invoke`, `invokeChecked`);
- the preserved fixed-arity truncation boundary.

### Was this patch authored or co-authored using generative AI tooling?

Assisted-by: Claude Code Opus 5


