### PR TITLE
[KYUUBI #7649] Fix compaction summarizer tokens not accumulated

### DIFF
--- a/externals/kyuubi-data-agent-engine/src/main/java/org/apache/kyuubi/engine/dataagent/runtime/event/Compaction.java
+++ b/externals/kyuubi-data-agent-engine/src/main/java/org/apache/kyuubi/engine/dataagent/runtime/event/Compaction.java
@@ -29,13 +29,23 @@ public final class Compaction extends AgentEvent {
   private final int keptCount;
   private final long triggerTokens;
   private final long observedTokens;
+  private final long summarizerPromptTokens;
+  private final long summarizerCompletionTokens;
 
-  public Compaction(int summarizedCount, int keptCount, long triggerTokens, long observedTokens) {
+  public Compaction(
+      int summarizedCount,
+      int keptCount,
+      long triggerTokens,
+      long observedTokens,
+      long summarizerPromptTokens,
+      long summarizerCompletionTokens) {
     super(EventType.COMPACTION);
     this.summarizedCount = summarizedCount;
     this.keptCount = keptCount;
     this.triggerTokens = triggerTokens;
     this.observedTokens = observedTokens;
+    this.summarizerPromptTokens = summarizerPromptTokens;
+    this.summarizerCompletionTokens = summarizerCompletionTokens;
   }
 
   public int summarizedCount() {
@@ -54,6 +64,14 @@ public final class Compaction extends AgentEvent {
     return observedTokens;
   }
 
+  public long summarizerPromptTokens() {
+    return summarizerPromptTokens;
+  }
+
+  public long summarizerCompletionTokens() {
+    return summarizerCompletionTokens;
+  }
+
   @Override
   public String toString() {
     return "Compaction{summarized="
@@ -64,6 +82,10 @@ public final class Compaction extends AgentEvent {
         + triggerTokens
         + ", observedTokens="
         + observedTokens
+        + ", summarizerPromptTokens="
+        + summarizerPromptTokens
+        + ", summarizerCompletionTokens="
+        + summarizerCompletionTokens
         + "}";
   }
 }

--- a/externals/kyuubi-data-agent-engine/src/main/java/org/apache/kyuubi/engine/dataagent/runtime/middleware/CompactionMiddleware.java
+++ b/externals/kyuubi-data-agent-engine/src/main/java/org/apache/kyuubi/engine/dataagent/runtime/middleware/CompactionMiddleware.java
@@ -18,12 +18,8 @@
 package org.apache.kyuubi.engine.dataagent.runtime.middleware;
 
 import com.openai.client.OpenAIClient;
-import com.openai.models.chat.completions.ChatCompletion;
-import com.openai.models.chat.completions.ChatCompletionCreateParams;
-import com.openai.models.chat.completions.ChatCompletionMessageParam;
-import com.openai.models.chat.completions.ChatCompletionMessageToolCall;
-import com.openai.models.chat.completions.ChatCompletionSystemMessageParam;
-import com.openai.models.chat.completions.ChatCompletionUserMessageParam;
+import com.openai.models.chat.completions.*;
+import com.openai.models.completions.CompletionUsage;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -168,30 +164,39 @@ public class CompactionMiddleware implements AgentMiddleware {
       return Decision.proceed();
     }
 
-    String summary = summarize(mem.getSystemPrompt(), split.old);
+    SummarizeResult summarized = summarize(ctx, mem.getSystemPrompt(), split.old);
 
     // 4) Build the compacted history and persist into ConversationMemory.
     List<ChatCompletionMessageParam> compacted = new ArrayList<>(1 + split.kept.size());
-    compacted.add(wrapSummaryAsUserMessage(summary));
+    compacted.add(wrapSummaryAsUserMessage(summarized.summary));
     compacted.addAll(split.kept);
     mem.replaceHistory(compacted);
 
     LOG.info(
-        "Compacted {} old msgs into 1 summary; kept {} tail msgs (lastTotal={}, newTail~={})",
+        "Compacted {} old msgs into 1 summary; kept {} tail msgs "
+            + "(lastTotal={}, newTail~={}, summarizerPromptTokens={}, summarizerCompletionTokens={})",
         split.old.size(),
         split.kept.size(),
         lastTotal,
-        newTailEstimate);
+        newTailEstimate,
+        summarized.promptTokens,
+        summarized.completionTokens);
 
     ctx.emit(
         new Compaction(
-            split.old.size(), split.kept.size(), triggerPromptTokens, lastTotal + newTailEstimate));
+            split.old.size(),
+            split.kept.size(),
+            triggerPromptTokens,
+            lastTotal + newTailEstimate,
+            summarized.promptTokens,
+            summarized.completionTokens));
 
     return Decision.replace(mem.buildLlmMessages());
   }
 
   /** Call the LLM to produce a summary of {@code oldMessages}. Failures propagate. */
-  private String summarize(String agentSystemPrompt, List<ChatCompletionMessageParam> oldMessages) {
+  private SummarizeResult summarize(
+      AgentRunContext ctx, String agentSystemPrompt, List<ChatCompletionMessageParam> oldMessages) {
     String systemPrompt = COMPACTION_SYSTEM_PROMPT;
     if (agentSystemPrompt != null && !agentSystemPrompt.isEmpty()) {
       systemPrompt =
@@ -215,7 +220,15 @@ public class CompactionMiddleware implements AgentMiddleware {
             .build();
 
     ChatCompletion response = client.chat().completions().create(params);
-    return response.choices().get(0).message().content().get();
+    String summary = response.choices().get(0).message().content().get();
+
+    CompletionUsage usage = response.usage().orElse(null);
+    long promptTokens = usage != null ? usage.promptTokens() : 0L;
+    long completionTokens = usage != null ? usage.completionTokens() : 0L;
+    if (usage != null) {
+      ctx.addTokenUsage(promptTokens, completionTokens, usage.totalTokens());
+    }
+    return new SummarizeResult(summary, promptTokens, completionTokens);
   }
 
   // ----- helpers -----
@@ -405,5 +418,17 @@ public class CompactionMiddleware implements AgentMiddleware {
     String body = "<conversation_summary>\n" + summary + "\n</conversation_summary>";
     return ChatCompletionMessageParam.ofUser(
         ChatCompletionUserMessageParam.builder().content(body).build());
+  }
+
+  private static final class SummarizeResult {
+    final String summary;
+    final long promptTokens;
+    final long completionTokens;
+
+    SummarizeResult(String summary, long promptTokens, long completionTokens) {
+      this.summary = summary;
+      this.promptTokens = promptTokens;
+      this.completionTokens = completionTokens;
+    }
   }
 }

--- a/externals/kyuubi-data-agent-engine/src/main/scala/org/apache/kyuubi/engine/dataagent/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-data-agent-engine/src/main/scala/org/apache/kyuubi/engine/dataagent/operation/ExecuteStatement.scala
@@ -161,6 +161,8 @@ class ExecuteStatement(
               n.put("kept", c.keptCount())
               n.put("triggerTokens", c.triggerTokens())
               n.put("observedTokens", c.observedTokens())
+              n.put("summarizerPromptTokens", c.summarizerPromptTokens())
+              n.put("summarizerCompletionTokens", c.summarizerCompletionTokens())
             }))
           case EventType.AGENT_FINISH =>
             val finish = event.asInstanceOf[AgentFinish]

--- a/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/runtime/middleware/CompactionMiddlewareLiveTest.java
+++ b/externals/kyuubi-data-agent-engine/src/test/java/org/apache/kyuubi/engine/dataagent/runtime/middleware/CompactionMiddlewareLiveTest.java
@@ -78,6 +78,9 @@ public class CompactionMiddlewareLiveTest {
     // Simulate the previous LLM call having reported a large prompt_tokens so the next
     // beforeLlmCall trips the threshold.
     ctx.addTokenUsage(60_000, 0, 60_000);
+    long cumulativeBeforeCompaction = memory.getCumulativeTotalTokens();
+    long accumulatedPromptBeforeCompaction = ctx.getAccumulatedPromptTokens();
+    long accumulatedCompletionBeforeCompaction = ctx.getAccumulatedCompletionTokens();
 
     CompactionMiddleware mw = new CompactionMiddleware(client, MODEL_NAME, /* trigger */ 50_000L);
 
@@ -99,5 +102,14 @@ public class CompactionMiddlewareLiveTest {
     assertTrue(
         first.contains("## User Intent") || first.contains("User Intent"),
         "summary should contain '## User Intent' section");
+    assertTrue(
+        memory.getCumulativeTotalTokens() > cumulativeBeforeCompaction,
+        "summarizer's own usage must be added to session cumulative total");
+    assertTrue(
+        ctx.getAccumulatedPromptTokens() > accumulatedPromptBeforeCompaction,
+        "summarizer's prompt tokens must be added to accumulated prompt tokens");
+    assertTrue(
+        ctx.getAccumulatedCompletionTokens() > accumulatedCompletionBeforeCompaction,
+        "summarizer's completion tokens must be added to accumulated completion tokens");
   }
 }

--- a/externals/kyuubi-data-agent-engine/src/test/scala/org/apache/kyuubi/engine/dataagent/operation/DataAgentCompactionE2ESuite.scala
+++ b/externals/kyuubi-data-agent-engine/src/test/scala/org/apache/kyuubi/engine/dataagent/operation/DataAgentCompactionE2ESuite.scala
@@ -182,6 +182,12 @@ class DataAgentCompactionE2ESuite extends HiveJDBCTestHelper with WithDataAgentE
       assert(
         c.has("triggerTokens") && c.get("triggerTokens").asLong() == 500L,
         s"compaction event should echo configured trigger: $c")
+      assert(
+        c.has("summarizerPromptTokens") && c.get("summarizerPromptTokens").asLong() > 0L,
+        s"compaction event must expose summarizerPromptTokens > 0: $c")
+      assert(
+        c.has("summarizerCompletionTokens") && c.get("summarizerCompletionTokens").asLong() >= 0L,
+        s"compaction event must expose summarizerCompletionTokens >= 0: $c")
 
       // Turn 5 was told to SELECT fresh; Frank (35000) is unambiguously the top earner.
       // If we don't get "Frank", either the agent failed to re-query after compaction


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new feature, clarify the use cases.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->
Fix https://github.com/apache/kyuubi/issues/7649. `CompactionMiddleware` fires an extra summarizer LLM call when compaction triggers, but the tokens from that call (`prompt_tokens` / `completion_tokens` / `total_tokens`) are never added to the session's accumulated token totals. As a result, token accounting diverges from the LLM provider's actual billing.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
```
export DATA_AGENT_OPENAI_API_KEY='xxx'
export DATA_AGENT_OPENAI_ENDPOINT='xxx'
export DATA_AGENT_MODEL='xxx'

./build/mvn -pl externals/kyuubi-data-agent-engine test \
  -Dtest=CompactionMiddlewareLiveTest \
  -DwildcardSuites=org.apache.kyuubi.engine.dataagent.operation.DataAgentCompactionE2ESuite \
  -DfailIfNoTests=false
```


### Was this patch assisted by generative AI tooling?
<!--
If generative AI tooling has assisted in authoring or reviewing this patch, please include
an 'Assisted-by: ' trailer that identifies the agent and/or model.
For example: 'Assisted-by: Claude Opus 4.7' or 'Assisted-by: Claude:claude-opus-4-7'.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Assisted-by: Claude Opus 4.7