### PR TITLE
[KYUUBI #7659][INFRA] Restore code coverage 

### DIFF
--- a/externals/kyuubi-data-agent-engine/pom.xml
+++ b/externals/kyuubi-data-agent-engine/pom.xml
@@ -187,7 +187,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <skipTests>${skipTests}</skipTests>
-                    <argLine>${extraJavaTestArgs}</argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -289,6 +289,10 @@
         <distMgmtSnapshotsName>Apache Development Snapshot Repository</distMgmtSnapshotsName>
         <distMgmtSnapshotsUrl>https://repository.apache.org/content/repositories/snapshots</distMgmtSnapshotsUrl>
 
+        <!-- Both test plugins default their argLine to ${argLine}; jacoco:prepare-agent
+             prepends the agent to it under -Pcodecov. Overriding argLine in plugin config
+             instead breaks that, since plugin config is interpolated before the agent runs. -->
+        <argLine>${extraJavaTestArgs}</argLine>
         <extraJavaTestArgs>-XX:+IgnoreUnrecognizedVMOptions
             --add-opens=java.base/java.lang=ALL-UNNAMED
             --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
@@ -1503,7 +1507,6 @@
                     <configuration>
                         <skipTests>true</skipTests>
                         <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
-                        <argLine>${extraJavaTestArgs}</argLine>
                         <environmentVariables>
                             <KYUUBI_WORK_DIR_ROOT>${project.build.directory}/work</KYUUBI_WORK_DIR_ROOT>
                         </environmentVariables>
@@ -1530,7 +1533,6 @@
                         <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
                         <junitxml>.</junitxml>
                         <filereports>TestSuite.txt</filereports>
-                        <argLine>${extraJavaTestArgs}</argLine>
                         <environmentVariables>
                             <KYUUBI_WORK_DIR_ROOT>${project.build.directory}/work</KYUUBI_WORK_DIR_ROOT>
                         </environmentVariables>


### PR DESCRIPTION
...by not overriding the test argLine!

Code coverage has reported nothing since 1.8.0. Both maven-surefire-plugin and scalatest-maven-plugin default their `argLine` to the `${argLine}` property, which is resolved when the mojo runs -- late enough to see the value `jacoco:prepare-agent` publishes there. KYUUBI #4849 gave both plugins an explicit `<argLine>${extraJavaTestArgs}</argLine>` to open JDK modules, and plugin configuration is interpolated during model building, long before the agent mojo runs. The agent option is therefore dropped and the forked test JVM runs uninstrumented:

    [INFO] --- jacoco:0.8.11:prepare-agent (pre-test) @ kyuubi-util-scala_2.12 ---
    [INFO] argLine set to -javaagent:.../org.jacoco.agent-0.8.11-runtime.jar=...
    [INFO] --- jacoco:0.8.11:report (report) @ kyuubi-util-scala_2.12 ---
    [INFO] Skipping JaCoCo execution due to missing execution data file.

The build stays green and every module reports zero. KYUUBI #756 ("Recover CODECOV") fixed the same thing in 2021 by deleting an `argLine` element.

Move the JDK options into the `argLine` property itself and drop both overrides, so the plugin defaults apply again. `prepare-agent` prepends the agent to the property's existing value rather than replacing it, so `--add-opens` survives:

    argLine set to -javaagent:...=destfile=... -XX:+IgnoreUnrecognizedVMOptions ...

Surefire's `@{argLine}` late replacement is not enough on its own here, since scalatest-maven-plugin has no equivalent and that is where most of Kyuubi's tests run.

Verified locally:

  - `test -Pcodecov -pl kyuubi-util-scala` (scalatest) analyzes 8 classes and writes target/jacoco.exec, where before it skipped for missing data.
  - `test -Pcodecov -pl kyuubi-rest-client` (surefire) analyzes 63 classes.
  - `test -pl kyuubi-util-scala` without the profile is green, argLine unchanged.

### Was this patch assisted by generative AI tooling?
Yes, Claude Opus 5