### PR TITLE
[KYUUBI #7668][SPARK] Use UUIDv7 for executor podNamePrefix to avoid same-millisecond collision

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
@@ -18,7 +18,7 @@
 package org.apache.kyuubi.engine.spark
 
 import java.time.Instant
-import java.util.{Locale, UUID}
+import java.util.Locale
 import java.util.concurrent.{CountDownLatch, ScheduledExecutorService, ThreadPoolExecutor, TimeUnit}
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -45,7 +45,7 @@ import org.apache.kyuubi.ha.HighAvailabilityConf._
 import org.apache.kyuubi.ha.client.RetryPolicies
 import org.apache.kyuubi.service.Serverable
 import org.apache.kyuubi.session.SessionHandle
-import org.apache.kyuubi.util.{JavaUtils, SignalRegister, ThreadUtils}
+import org.apache.kyuubi.util.{JavaUtils, SignalRegister, ThreadUtils, UuidUtils}
 import org.apache.kyuubi.util.ThreadUtils.scheduleTolerableRunnableWithFixedDelay
 
 case class SparkSQLEngine(spark: SparkSession) extends Serverable("SparkSQLEngine") {
@@ -475,11 +475,16 @@ object SparkSQLEngine extends Logging {
         .replaceAll("[^a-z0-9\\-]", "-")
         .replaceAll("-+", "-")
         .replaceAll("^-", "")
-    val podNamePrefixWithUser = s"kyuubi-$resolvedUserName-${Instant.now().toEpochMilli}"
+    // Use UUIDv7 (RFC 9562) instead of an epoch-millis suffix to avoid podNamePrefix
+    // collisions when multiple engines for the same user start within the same millisecond
+    // in the same namespace. UUIDv7 keeps the leading 48-bit timestamp so pod names remain
+    // roughly time-ordered when listed by name.
+    val uuidV7 = UuidUtils.generateUUIDv7()
+    val podNamePrefixWithUser = s"kyuubi-$resolvedUserName-$uuidV7"
     if (podNamePrefixWithUser.length <= executorPodNamePrefixMaxLength(namespace)) {
       podNamePrefixWithUser
     } else {
-      s"kyuubi-${UUID.randomUUID()}"
+      s"kyuubi-$uuidV7"
     }
   }
 

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/SparkSQLEngineSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/SparkSQLEngineSuite.scala
@@ -17,6 +17,10 @@
 
 package org.apache.kyuubi.engine.spark
 
+import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch, Executors, TimeUnit}
+
+import scala.collection.JavaConverters._
+
 import org.apache.kyuubi.KyuubiFunSuite
 
 class SparkSQLEngineSuite extends KyuubiFunSuite {
@@ -43,6 +47,39 @@ class SparkSQLEngineSuite extends KyuubiFunSuite {
     val executorPodName3 = s"$executorPodNamePrefix3-exec-${Int.MaxValue}"
     assert(!executorPodNamePrefix3.contains(userName3))
     assert(podLogsDirectoryNameLength(namespace, executorPodName3) <= 253)
+  }
+
+  test("generate executor pod name prefix should be unique for concurrent calls " +
+    "with the same user") {
+    // The previous epoch-millis suffix caused podNamePrefix collisions when two
+    // engines for the same user started within the same millisecond. Fan out
+    // concurrent calls and assert every generated prefix is still unique.
+    val userName = "same_user"
+    val count = 1000
+    val pool = Executors.newFixedThreadPool(10)
+    val latch = new CountDownLatch(count)
+    val prefixes = new ConcurrentLinkedQueue[String]()
+    try {
+      for (_ <- 0 until count) {
+        pool.execute(() => {
+          try {
+            prefixes.add(SparkSQLEngine.generateExecutorPodNamePrefixForK8s(userName))
+          } finally {
+            latch.countDown()
+          }
+        })
+      }
+      assert(latch.await(10, TimeUnit.SECONDS), "concurrent prefix generation timed out")
+    } finally {
+      pool.shutdown()
+    }
+
+    val all = prefixes.asScala.toSeq
+    assert(all.size == count)
+    assert(all.forall(_.startsWith("kyuubi-same-user-")))
+    // Under the old epoch-millis implementation, calls colliding on the same
+    // millisecond would produce duplicate prefixes and this would fail.
+    assert(all.distinct.size == all.size)
   }
 
   private def podLogsDirectoryNameLength(namespace: String, podName: String): Int = {


### PR DESCRIPTION
### Why are the changes needed?

On Kubernetes, `SparkSQLEngine.generateExecutorPodNamePrefixForK8s` built the executor podNamePrefix as `kyuubi-<user>-<epoch-millis>`. When two engines for the same user (same `resolvedUserName`) are launched within the same millisecond in the same namespace — e.g. a burst of short-lived engines from the same user, or two Kyuubi servers racing to launch engines for a `USER` share level — the two engines get an identical `spark.kubernetes.executor.podNamePrefix`. Their executor pod names (`<prefix>-exec-<id>`) then collide inside the namespace, and one of the two apps fails to create executors until the other releases the names.

This PR replaces the epoch-millis suffix with a UUIDv7 from the existing `UuidUtils.generateUUIDv7` helper. UUIDv7 keeps the 48-bit epoch millis in its leading bits so pod names remain roughly time-ordered when listed by name, while the trailing 74 bits of secure randomness make same-millisecond collisions essentially impossible. The oversized-user-name fallback path is switched to the same UUIDv7 for consistency.

### How was this patch tested?

- Added a concurrent unit test `generate executor pod name prefix should be unique for concurrent calls with the same user` in `SparkSQLEngineSuite` that fans out 1000 prefix generations across 10 threads for the same user and asserts every generated prefix is unique. Under the pre-fix epoch-millis implementation this test necessarily fails, since many calls land on the same millisecond and produce identical prefixes.
- The existing `[KYUUBI #3385] generate executor pod name prefix with user or UUID` test still passes (sanitization, length cap, and pod-log-directory length invariants unchanged).


### Was this patch assisted by generative AI tooling?
Assisted-by: Claude Opus 4.7
