### PR TITLE
[KYUUBI #7674] Fix flaky PyHive SQLAlchemy insert tests

### DIFF
--- a/python/pyhive/tests/test_sqlalchemy_hive.py
+++ b/python/pyhive/tests/test_sqlalchemy_hive.py
@@ -210,7 +210,7 @@ class TestSqlAlchemyHive(unittest.TestCase, SqlAlchemyTestCase):
     @with_engine_connection
     def test_insert_select(self, engine, connection):
         one_row = Table('one_row', MetaData(), autoload_with=engine)
-        table = Table('insert_test', MetaData(schema='pyhive_test_database'),
+        table = Table('insert_select_test', MetaData(schema='pyhive_test_database'),
                       Column('a', sqlalchemy.types.Integer))
         table.drop(checkfirst=True, bind=connection)
         table.create(bind=connection)
@@ -224,7 +224,7 @@ class TestSqlAlchemyHive(unittest.TestCase, SqlAlchemyTestCase):
 
     @with_engine_connection
     def test_insert_values(self, engine, connection):
-        table = Table('insert_test', MetaData(schema='pyhive_test_database'),
+        table = Table('insert_values_test', MetaData(schema='pyhive_test_database'),
                       Column('a', sqlalchemy.types.Integer),)
         table.drop(checkfirst=True, bind=connection)
         table.create(bind=connection)


### PR DESCRIPTION
### Why are the changes needed?

The Python test suite runs with multiple pytest-xdist workers. `test_insert_select` and `test_insert_values` used the same `pyhive_test_database.insert_test` table, and both tests dropped and recreated it.

When the tests ran concurrently, one test could drop the table while the other was inserting or querying data, causing intermittent `table not found` failures.

This patch assigns a dedicated table name to each test to prevent the collision.

Closes #7674.

### How was this patch tested?

Existing test cases.

### Was this patch assisted by generative AI tooling?

Assisted-by: OpenAI Codex (GPT-5)