### PR TITLE
[INFRA] Fix greetings workflow for PRs from forks

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -21,7 +21,7 @@ on:
   issues:
     types:
       - opened
-  pull_request:
+  pull_request_target:
     types:
       - opened
 


### PR DESCRIPTION
### Why are the changes needed?

`pull_request` action doesn't have write access to the PR. Error: https://github.com/apache/kyuubi/actions/runs/33192410137/job/98924378784

Use `pull_request_target` action instead to comment to the PR.

Reference implementations:
- https://github.com/apache/cloudberry/blob/4d209d23b45b146f9970f652a74a11b562091d6c/.github/workflows/greetings.yml#L29
- https://github.com/apache/eventmesh/blob/6ec99215ca3847404ec7bf15d94f78152f2b3c60/.github/workflows/greetings.yml#L22

### How was this patch tested?

Not tested. The fix is available only after it's merged into main.

### Was this patch assisted by generative AI tooling?

Assisted-by: OpenCode (DeepSeek V4 Flash)