### PR TITLE
[DOC] Escape ampersand in LDAP group mapping example

### DIFF
--- a/docs/deployment/engine_share_level.md
+++ b/docs/deployment/engine_share_level.md
@@ -140,7 +140,7 @@ Here is an example to configure `HadoopGroupProvider` to use LDAP-based group ma
 
 <property>
   <name>hadoop.security.group.mapping.ldap.search.filter.user</name>
-  <value>(&(objectClass=posixAccount)(cn={0}))</value>
+  <value>(&amp;(objectClass=posixAccount)(cn={0}))</value>
 </property>
 
 <property>


### PR DESCRIPTION
### Why are the changes needed?
The change is needed to fix the following warning during the documentation build process:
```
./docs/deployment/engine_share_level.md:156: WARNING: Lexing literal_block 
'<property>\n  <name>hadoop.security.group.mapping</name>\n  <value>org.apache.hadoop.security.LdapGroupsMapping</value>\n</property>\n\n<property>\n  <name>hadoop.security.group.mapping.ldap.url</name>\n  <value>ldap://localhost:389</value>\n</property>\n\n<property>\n  <name>hadoop.security.group.mapping.ldap.base</name>\n  <value>dc=example,dc=com</value>\n</property>\n\n<property>\n  <name>hadoop.security.group.mapping.ldap.bind.user</name>\n  <value>cn=Manager,dc=example,dc=com</value>\n</property>\n\n<property>\n  <name>hadoop.security.group.mapping.ldap.bind.password</name>\n  <value>example</value>\n</property>\n\n<property>\n  <name>hadoop.security.group.mapping.ldap.search.filter.user</name>\n  <value>(&(objectClass=posixAccount)(cn={0}))</value>\n</property>\n\n<property>\n  <name>hadoop.security.group.mapping.ldap.search.filter.group</name>\n  <value>(objectClass=posixGroup)</value>\n</property>\n\n<property>\n  <name>hadoop.security.group.mapping.ldap.search.attr.member</name>\n  <value>memberuid</value>\n</property>\n\n<property>\n  <name>hadoop.security.group.mapping.ldap.search.attr.group.name</name>\n  <value>cn</value>\n</property>\n'
 as "xml" resulted in an error at token: '&'. Retrying in relaxed mode. [misc.highlighting_failure]
```

The default `core-default.xml` uses `&amp;` instead of `&` character, see [here](https://github.com/apache/hadoop/blob/c48027aee9adedbcfa574647b5e06d851ca6f55b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml#L531-L532).

### How was this patch tested?
Testing by building the documentation and checking there is no warning:
```shell
make clean html
```

The `Share Level of Kyuubi Engines` page after applying the fix:
<img width="1272" height="883" alt="image" src="https://github.com/user-attachments/assets/0e269086-7dab-4a3b-abe4-e27c669e89fb" />


### Was this patch assisted by generative AI tooling?
No
