### PR TITLE
[KYUUBI-7590] Fix Spark SQL engine main thread waiting forever after SparkContext stops

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
@@ -409,8 +409,17 @@ object SparkSQLEngine extends Logging {
         sparkSessionCreated.set(true)
         try {
           startEngine(spark)
-          // blocking main thread
-          countDownLatch.await()
+          // blocking main thread, but also observe SparkContext state.
+          // If the SparkContext is stopped unexpectedly (e.g., OutOfMemoryError),
+          // the terminating checker may call stop() but the shutdown could stall
+          // before reaching stopServer(), leaving the main thread waiting forever.
+          // See: https://github.com/apache/kyuubi/issues/7590
+          while (!countDownLatch.await(1, TimeUnit.SECONDS)) {
+            if (spark.sparkContext.isStopped) {
+              warn("SparkContext has been stopped, breaking main thread wait")
+              currentEngine.foreach(e => Utils.tryLogNonFatalError(e.stop()))
+            }
+          }
         } catch {
           case e: KyuubiException =>
             currentEngine match {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change the main thread blocking wait from `countDownLatch.await()` to a polling loop that also observes the SparkContext state. When the SparkContext is stopped unexpectedly (e.g., OutOfMemoryError), the main thread breaks the wait instead of hanging forever.

### Why are the changes needed?

When an uncaught error such as an OutOfMemoryError stops the SparkContext, the engine shutdown can start on another thread but stall before reaching `stopServer()`. Since the `countDownLatch` is only released by `stopServer()`, the main thread waits forever even though the SparkContext has already stopped. In YARN cluster mode this can leave the application master process alive after the driver RPC endpoint has gone away.

### How was this patch tested?

Manually verified the code change. The fix uses the same `isStopped` check already used by the terminating checker in `SparkSQLSessionManager`.

### Does this PR introduce any user-facing change?

No.

Closes #7590