### PR TITLE
[KYUUBI-7668][K8S] Add random suffix to executor podNamePrefix to prevent collision

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
@@ -475,7 +475,8 @@ object SparkSQLEngine extends Logging {
         .replaceAll("[^a-z0-9\\-]", "-")
         .replaceAll("-+", "-")
         .replaceAll("^-", "")
-    val podNamePrefixWithUser = s"kyuubi-$resolvedUserName-${Instant.now().toEpochMilli}"
+    val podNamePrefixWithUser =
+      s"kyuubi-$resolvedUserName-${Instant.now().toEpochMilli}-${UUID.randomUUID().toString.take(4)}"
     if (podNamePrefixWithUser.length <= executorPodNamePrefixMaxLength(namespace)) {
       podNamePrefixWithUser
     } else {


### PR DESCRIPTION
## What changes were proposed in this pull request?

When two engines for the same user are launched within the same millisecond on Kubernetes, `generateExecutorPodNamePrefixForK8s` produces identical `spark.kubernetes.executor.podNamePrefix` values, causing executor pod name collisions.

This PR adds a 4-character random UUID suffix to the prefix to ensure uniqueness.

## How was this patch tested?

Existing unit tests in `SparkSQLEngineSuite` continue to pass.

Closes #7668