### PR TITLE
[KYUUBI-7659][INFRA] Restore code coverage by not overriding the test argLine

### DIFF
--- a/externals/kyuubi-data-agent-engine/pom.xml
+++ b/externals/kyuubi-data-agent-engine/pom.xml
@@ -187,7 +187,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <skipTests>${skipTests}</skipTests>
-                    <argLine>${extraJavaTestArgs}</argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -289,6 +289,10 @@
         <distMgmtSnapshotsName>Apache Development Snapshot Repository</distMgmtSnapshotsName>
         <distMgmtSnapshotsUrl>https://repository.apache.org/content/repositories/snapshots</distMgmtSnapshotsUrl>
 
+        <!-- Both test plugins default their argLine to ${argLine}; jacoco:prepare-agent
+             prepends the agent to it under -Pcodecov. Overriding argLine in plugin config
+             instead breaks that, since plugin config is interpolated before the agent runs. -->
+        <argLine>${extraJavaTestArgs}</argLine>
         <extraJavaTestArgs>-XX:+IgnoreUnrecognizedVMOptions
             --add-opens=java.base/java.lang=ALL-UNNAMED
             --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
@@ -1503,7 +1507,6 @@
                     <configuration>
                         <skipTests>true</skipTests>
                         <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
-                        <argLine>${extraJavaTestArgs}</argLine>
                         <environmentVariables>
                             <KYUUBI_WORK_DIR_ROOT>${project.build.directory}/work</KYUUBI_WORK_DIR_ROOT>
                         </environmentVariables>
@@ -1530,7 +1533,6 @@
                         <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
                         <junitxml>.</junitxml>
                         <filereports>TestSuite.txt</filereports>
-                        <argLine>${extraJavaTestArgs}</argLine>
                         <environmentVariables>
                             <KYUUBI_WORK_DIR_ROOT>${project.build.directory}/work</KYUUBI_WORK_DIR_ROOT>
                         </environmentVariables>


### PR DESCRIPTION
## What changes were proposed in this pull request?

`-Pcodecov` hasn't produced any coverage since 1.8.0 because both `maven-surefire-plugin` and `scalatest-maven-plugin` override their `argLine` with `${extraJavaTestArgs}`, which drops the JaCoCo agent that `jacoco:prepare-agent` publishes to the `${argLine}` property.

This PR moves the JDK `--add-opens` options into the `argLine` property itself (referencing `extraJavaTestArgs`) and removes the `argLine` overrides from both plugin configs. This allows `jacoco:prepare-agent` to prepend its agent to the property's existing value.

## How was this patch tested?

Manual verification:
```
build/mvn test -Pcodecov -pl kyuubi-util-scala
```
Should produce `target/jacoco.exec` and a coverage report.

Closes #7659