### PR TITLE
[KYUUBI #7701] Log the resolved host in the findLocalInetAddress loopback warning

### DIFF
--- a/kyuubi-util/src/main/java/org/apache/kyuubi/util/JavaUtils.java
+++ b/kyuubi-util/src/main/java/org/apache/kyuubi/util/JavaUtils.java
@@ -67,13 +67,15 @@ public class JavaUtils {
                   .findFirst()
                   .orElse(addresses.get(0));
 
+          // Rebuild from the raw bytes to drop the IPv6 zone suffix that getHostAddress would
+          // otherwise append.
           InetAddress strippedAddress = InetAddress.getByAddress(addr.getAddress());
 
           // We've found an address that looks reasonable!
           LOG.warn(
               "{} was resolved to a loopback address: {}, using {}",
-              addr.getHostName(),
-              addr.getHostAddress(),
+              address.getHostName(),
+              address.getHostAddress(),
               strippedAddress.getHostAddress());
           return strippedAddress;
         }


### PR DESCRIPTION
### Why are the changes needed?

Closes #7701.

`findLocalInetAddress` warns when the host name resolves to loopback and it substitutes an address taken from a network interface. The warning filled its host name and loopback slots from the substitute rather than from the address that actually resolved to loopback, so on a host with no PTR record for the substitute all three slots printed the same string: `10.0.0.5 was resolved to a loopback address: 10.0.0.5, using 10.0.0.5`. The fallback warning a few lines down already reads from the original address, so the two warnings in one method had been describing different things.

Naming the wrong subject is also what sent the thread to the resolver. An address from `NetworkInterface.getInetAddresses()` carries no cached host name, so `addr.getHostName()` blocks on a lookup, and the argument is evaluated at the call site, so the lookup happens whether or not WARN is enabled. The same call measured 0.9 ms, 1.8 ms, 6.5 ms, 324 ms, 1027 ms and 3147 ms on one host at different times, every one returning the numeric form for want of a PTR record. `InetAddress.getLocalHost()` already carries its name, so the corrected slots cost nothing. This removes that one lookup and no other: callers that ask the returned address for `getCanonicalHostName()`, such as `KyuubiRestFrontendService` and `EmbeddedZookeeper`, do their own regardless of what this method returns.

The Scala code that #6499 replaced used the original address in both slots, so the Java rewrite moved the receiver. The line is unchanged on `branch-1.12`, `branch-1.11` and `branch-1.10`, so a backport is possible if maintainers want one.

### How was this patch tested?

No unit test. `findLocalInetAddress` takes no arguments and reads `InetAddress.getLocalHost()` and `NetworkInterface.getNetworkInterfaces()` as statics, so a test cannot steer it into the loopback branch on an ordinary host. The returned address is identical before and after; only the log text differs, so an assertion over the return value would pass with this patch reverted. Asserting on the text would mean adding a logging backend or a static mocking library to `kyuubi-util`, whose test scope today is `junit-jupiter` alone. The missing coverage of these branches is tracked separately in #7692.

```
build/mvn test -pl kyuubi-util -am -DwildcardSuites=none -Dtest=JavaUtilsTest
build/mvn spotless:check -pl kyuubi-util
```

The argument rendering was checked out of tree on a host that takes the branch, where `InetAddress.getLocalHost()` returns `<name>/127.0.0.1` and an interface carries a routable address. The old arguments render as `<lan-address> was resolved to a loopback address: <lan-address>, using <lan-address>`; the new ones as `<name> was resolved to a loopback address: 127.0.0.1, using <lan-address>`.

### Was this patch assisted by generative AI tooling?

Assisted-by: Claude Opus 5
