### PR TITLE
[KYUUBI-7556] Fix engine deregistration watcher not rearmed after ZK reconnect

### DIFF
--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/zookeeper/ZookeeperDiscoveryClient.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/zookeeper/ZookeeperDiscoveryClient.scala
@@ -106,7 +106,14 @@ class ZookeeperDiscoveryClient(conf: KyuubiConf) extends DiscoveryClient {
         override def stateChanged(client: CuratorFramework, newState: ConnectionState): Unit = {
           info(s"Zookeeper client connection state changed to: $newState")
           newState match {
-            case CONNECTED | RECONNECTED => isConnected.set(true)
+            case CONNECTED => isConnected.set(true)
+            case RECONNECTED =>
+              isConnected.set(true)
+              // Re-arm the de-registration watcher after ZK session reconnects,
+              // as watches are cleared when the session expires.
+              if (serviceNode != null && watcher != null) {
+                watchNode()
+              }
             case LOST =>
               isConnected.set(false)
               val delay = getGracefulStopThreadDelay(conf)


### PR DESCRIPTION
### _What changes were proposed in this pull request?_

Fix the issue where Kyuubi engine's deregistration watcher is not re-registered after ZooKeeper session expires and reconnects.

When a ZooKeeper session expires, all watches are cleared because they are tied to the session. The `PersistentNode` handles recreating the ephemeral node when the connection is re-established, but the explicit `DeRegisterWatcher` set via `watchNode()` was never re-armed. This means if the engine later crashes, its ZK node won't be properly cleaned up because the watcher is gone.

### _Why are the changes needed?_

Without this fix, after a ZK session expiry and reconnect, the engine's deregistration watcher is lost. If the engine subsequently crashes, the ZK ephemeral node won't be cleaned up, causing stale entries in the ZooKeeper namespace.

### _How was this patch tested?_

- Manual code review of the connection state handling logic
- Existing ZK discovery client tests in `ZookeeperDiscoveryClientSuite`

### _Was this patch authored or co-authored using generative AI tooling?_

No

Closes #7556