### PR TITLE
[KYUUBI-6689] Extract kyuubiClientPrincipal/kyuubiClientKeytab from JDBC connection properties

### DIFF
--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/Utils.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/Utils.java
@@ -373,6 +373,38 @@ public class Utils {
       connParams.getSessionVars().put(AUTH_TYPE, info.getProperty(AUTH_TYPE));
     }
 
+    // Extract kyuubiClientPrincipal/kyuubiClientKeytab from JDBC connection properties
+    // if not supplied in the connection URL
+    if (!connParams.getSessionVars().containsKey(AUTH_KYUUBI_CLIENT_PRINCIPAL)) {
+      if (info.containsKey(AUTH_KYUUBI_CLIENT_PRINCIPAL)) {
+        connParams
+            .getSessionVars()
+            .put(AUTH_KYUUBI_CLIENT_PRINCIPAL, info.getProperty(AUTH_KYUUBI_CLIENT_PRINCIPAL));
+      }
+    }
+    if (!connParams.getSessionVars().containsKey(AUTH_KYUUBI_CLIENT_KEYTAB)) {
+      if (info.containsKey(AUTH_KYUUBI_CLIENT_KEYTAB)) {
+        connParams
+            .getSessionVars()
+            .put(AUTH_KYUUBI_CLIENT_KEYTAB, info.getProperty(AUTH_KYUUBI_CLIENT_KEYTAB));
+      }
+    }
+    if (!connParams.getSessionVars().containsKey(AUTH_KYUUBI_CLIENT_TICKET_CACHE)) {
+      if (info.containsKey(AUTH_KYUUBI_CLIENT_TICKET_CACHE)) {
+        connParams
+            .getSessionVars()
+            .put(AUTH_KYUUBI_CLIENT_TICKET_CACHE,
+                info.getProperty(AUTH_KYUUBI_CLIENT_TICKET_CACHE));
+      }
+    }
+    if (!connParams.getSessionVars().containsKey(AUTH_KYUUBI_SERVER_PRINCIPAL)) {
+      if (info.containsKey(AUTH_KYUUBI_SERVER_PRINCIPAL)) {
+        connParams
+            .getSessionVars()
+            .put(AUTH_KYUUBI_SERVER_PRINCIPAL, info.getProperty(AUTH_KYUUBI_SERVER_PRINCIPAL));
+      }
+    }
+
     String authorityStr = connParams.getSuppliedURLAuthority();
     // If we're using ZooKeeper, the final host, port will be read from ZooKeeper
     // (in a different method call). Therefore, we put back the original authority string


### PR DESCRIPTION
Closes #6689.

## Proposed changes

Allow users to pass `kyuubiClientPrincipal` and `kyuubiClientKeytab` through JDBC connection properties (via `DriverManager.getConnection(url, properties)` or URL parameters), instead of only being able to set them globally in `kyuubi-defaults.conf`.

Previously, `Utils.extractURLComponents()` only extracted `user`, `password`, and `auth` from the JDBC connection properties object. The `kyuubiClientPrincipal` and `kyuubiClientKeytab` could only be set through the JDBC URL session parameters.

This change adds extraction of `kyuubiClientPrincipal`, `kyuubiClientKeytab`, `kyuubiClientTicketCache`, and `kyuubiServerPrincipal` from the JDBC connection properties, similar to how `user`/`password`/`auth` are already handled.

### Usage example

```java
Properties properties = new Properties();
properties.put("kyuubiClientPrincipal", "user@REALM");
properties.put("kyuubiClientKeytab", "/path/to/user.keytab");
Connection connection = DriverManager.getConnection("jdbc:kyuubi://host:10009/default;principal=kyuubi/_HOST@REALM", properties);
```