### PR TITLE
[SPARK] Update PATH_CONFIGS and validate main-resource path

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KyuubiApplicationManager.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KyuubiApplicationManager.scala
@@ -186,6 +186,11 @@ object KyuubiApplicationManager {
           }
         }
       }
+      // the main resource is not a spark.* conf but spark-submit uploads it from the server
+      // host as the primary resource of the engine application
+      appConf.get(KyuubiConf.ENGINE_SPARK_MAIN_RESOURCE.key).filter(_.nonEmpty).foreach { path =>
+        checkApplicationAccessPath(path, kyuubiConf)
+      }
     }
   }
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
@@ -440,7 +440,7 @@ object SparkProcessBuilder {
    * - org.apache.spark.deploy.yarn.Client::prepareLocalResources
    * - KerberosConfDriverFeatureStep::configurePod
    * - KubernetesUtils.uploadAndTransformFileUris
-   * - org.apache.spark.deploy.k8s.SparkKubernetesClientFactory::createKubernetesClient
+   * - org.apache.spark.deploy.k8s.DriverKubernetesCredentialsFeatureStep::configurePod
    */
   final val PATH_CONFIGS = Seq(
     SPARK_FILES,
@@ -459,7 +459,6 @@ object SparkProcessBuilder {
     "spark.kubernetes.file.upload.path",
     "spark.kubernetes.driver.podTemplateFile",
     "spark.kubernetes.executor.podTemplateFile",
-    "spark.kubernetes.authenticate.driver.oauthTokenFile",
     "spark.kubernetes.authenticate.driver.clientCertFile",
     "spark.kubernetes.authenticate.driver.clientKeyFile",
     "spark.kubernetes.authenticate.driver.caCertFile")

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
@@ -440,6 +440,7 @@ object SparkProcessBuilder {
    * - org.apache.spark.deploy.yarn.Client::prepareLocalResources
    * - KerberosConfDriverFeatureStep::configurePod
    * - KubernetesUtils.uploadAndTransformFileUris
+   * - org.apache.spark.deploy.k8s.SparkKubernetesClientFactory::createKubernetesClient
    */
   final val PATH_CONFIGS = Seq(
     SPARK_FILES,
@@ -457,7 +458,11 @@ object SparkProcessBuilder {
     "spark.kubernetes.kerberos.krb5.path",
     "spark.kubernetes.file.upload.path",
     "spark.kubernetes.driver.podTemplateFile",
-    "spark.kubernetes.executor.podTemplateFile")
+    "spark.kubernetes.executor.podTemplateFile",
+    "spark.kubernetes.authenticate.driver.oauthTokenFile",
+    "spark.kubernetes.authenticate.driver.clientCertFile",
+    "spark.kubernetes.authenticate.driver.clientKeyFile",
+    "spark.kubernetes.authenticate.driver.caCertFile")
 
   final private[spark] val CLASS = "--class"
   final private[spark] val PROXY_USER = "--proxy-user"

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
@@ -446,6 +446,7 @@ object SparkProcessBuilder {
     "spark.jars",
     "spark.archives",
     "spark.yarn.jars",
+    "spark.yarn.archive",
     "spark.yarn.dist.files",
     "spark.yarn.dist.pyFiles",
     "spark.submit.pyFiles",
@@ -454,7 +455,9 @@ object SparkProcessBuilder {
     "spark.kerberos.keytab",
     "spark.yarn.keytab",
     "spark.kubernetes.kerberos.krb5.path",
-    "spark.kubernetes.file.upload.path")
+    "spark.kubernetes.file.upload.path",
+    "spark.kubernetes.driver.podTemplateFile",
+    "spark.kubernetes.executor.podTemplateFile")
 
   final private[spark] val CLASS = "--class"
   final private[spark] val PROXY_USER = "--proxy-user"

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/KyuubiApplicationManagerSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/KyuubiApplicationManagerSuite.scala
@@ -147,6 +147,33 @@ class KyuubiApplicationManagerSuite extends KyuubiFunSuite {
     }
   }
 
+  test("application access path checks the spark engine main resource") {
+    val localDirLimitConf = KyuubiConf()
+      .set(KyuubiConf.SESSION_LOCAL_DIR_ALLOW_LIST, Set("/apache/kyuubi"))
+    val mainResourceKey = KyuubiConf.ENGINE_SPARK_MAIN_RESOURCE.key
+
+    KyuubiApplicationManager.checkApplicationAccessPaths(
+      "SPARK_SQL",
+      Map(mainResourceKey -> "/apache/kyuubi/engine.jar"),
+      localDirLimitConf)
+    KyuubiApplicationManager.checkApplicationAccessPaths(
+      "SPARK_SQL",
+      Map(mainResourceKey -> "hdfs://nameservice/kyuubi/engine.jar"),
+      localDirLimitConf)
+    KyuubiApplicationManager.checkApplicationAccessPaths(
+      "SPARK_SQL",
+      Map(mainResourceKey -> "/apache/kyuubi/engine.jar"),
+      KyuubiConf())
+
+    val e = intercept[KyuubiException] {
+      KyuubiApplicationManager.checkApplicationAccessPaths(
+        "SPARK_SQL",
+        Map(mainResourceKey -> "/etc/security/keytabs/kyuubi.keytab"),
+        localDirLimitConf)
+    }
+    assert(e.getMessage.contains("is not in the local dir allow list"))
+  }
+
   test("Test kyuubi application Manager tag spark on kubernetes application") {
     val conf: KyuubiConf = KyuubiConf()
     val tag = "kyuubi-test-tag"


### PR DESCRIPTION
### Why are the changes needed?

Add more configs into Spark `PATH_CONFIGS`. Also, add path validation for `KyuubiConf.ENGINE_SPARK_MAIN_RESOURCE`.

This can fail sessions that previously worked because of the validation.

### How was this patch tested?

Added regression tests for `KyuubiConf.ENGINE_SPARK_MAIN_RESOURCE`.

### Was this patch assisted by generative AI tooling?

Assisted-by: OpenCode (GLM-5.3)