### PR TITLE
Fix Scala 2.13 compilation of the TPC-DS generator

### DIFF
--- a/dev/kyuubi-tpcds/src/main/scala/org/apache/kyuubi/tpcds/DataGenerator.scala
+++ b/dev/kyuubi-tpcds/src/main/scala/org/apache/kyuubi/tpcds/DataGenerator.scala
@@ -17,6 +17,10 @@
 
 package org.apache.kyuubi.tpcds
 
+import scala.concurrent.{Await, Future}
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.Duration
+
 import org.apache.spark.sql.SparkSession
 import org.slf4j.LoggerFactory
 
@@ -40,6 +44,12 @@ object DataGenerator {
       parallel: Option[Int] = None)
 
   private val logger = LoggerFactory.getLogger(this.getClass.getSimpleName.stripSuffix("$"))
+
+  // Replicates Scala 2.12's `par.foreach` using stdlib concurrency, as Scala 2.13 requires
+  // the external scala-parallel-collections module for `.par`.
+  private def parForeach[T](items: Seq[T])(f: T => Unit): Unit = {
+    Await.result(Future.traverse(items)(item => Future(f(item))), Duration.Inf)
+  }
 
   def initTable(spark: SparkSession): Seq[TableGenerator] = {
     import spark.implicits._
@@ -606,7 +616,7 @@ object DataGenerator {
     spark.sql(s"DESC DATABASE ${config.db}").show()
 
     val tpcdsTables = initTable(spark)
-    tpcdsTables.par.foreach { table =>
+    parForeach(tpcdsTables) { table =>
       table.setScaleFactor(config.scaleFactor)
       table.setFormat(config.format)
       config.parallel.foreach(table.setParallelism)

--- a/dev/kyuubi-tpcds/src/main/scala/org/apache/kyuubi/tpcds/TableGenerator.scala
+++ b/dev/kyuubi-tpcds/src/main/scala/org/apache/kyuubi/tpcds/TableGenerator.scala
@@ -59,7 +59,7 @@ case class TableGenerator(
       Results.constructResults(table, session).iterator.asScala
         .map { _.get(0).asScala } // 1st row is specific table row
         .map { row => row.map { v => if (v == Options.DEFAULT_NULL_STRING) null else v } }
-        .map { row => Row.fromSeq(row) }
+        .map { row => Row.fromSeq(row.toSeq) }
     }
 
     val columns = fields.map { f => col(f.name).cast(f.dataType).as(f.name) }

--- a/dev/kyuubi-tpcds/src/main/scala/org/apache/kyuubi/tpcds/benchmark/Benchmark.scala
+++ b/dev/kyuubi-tpcds/src/main/scala/org/apache/kyuubi/tpcds/benchmark/Benchmark.scala
@@ -264,7 +264,7 @@ object Benchmark {
 
     /** Returns full iterations from an actively running experiment. */
     def getCurrentRuns(): DataFrame = {
-      val tbl = sparkSession.createDataFrame(currentRuns)
+      val tbl = sparkSession.createDataFrame(currentRuns.toSeq)
       tbl.createOrReplaceTempView("currentRuns")
       tbl
     }

--- a/dev/kyuubi-tpcds/src/main/scala/org/apache/kyuubi/tpcds/benchmark/Benchmarkable.scala
+++ b/dev/kyuubi-tpcds/src/main/scala/org/apache/kyuubi/tpcds/benchmark/Benchmarkable.scala
@@ -84,7 +84,8 @@ trait Benchmarkable {
               parameters = Map.empty,
               failure = Some(Failure(
                 e.getClass.getSimpleName,
-                e.getMessage + ":\n" + e.getStackTraceString)))
+                // replicate Scala 2.12's getStackTraceString: mkString(EOL, EOL, EOL)
+                e.getMessage + ":\n" + e.getStackTrace.mkString("\n", "\n", "\n"))))
         }
       }
     }

--- a/dev/kyuubi-tpcds/src/main/scala/org/apache/kyuubi/tpcds/benchmark/Query.scala
+++ b/dev/kyuubi-tpcds/src/main/scala/org/apache/kyuubi/tpcds/benchmark/Query.scala
@@ -87,7 +87,7 @@ class Query(
               messages += s"Breakdown: ${node.simpleString(maxFields)}"
               val newNode = buildDataFrame.queryExecution.executedPlan.p(index)
               val executionTime = measureTimeMs {
-                newNode.execute().foreach((row: Any) => Unit)
+                newNode.execute().foreach((row: Any) => ())
               }
               timeMap += ((index, executionTime))
 


### PR DESCRIPTION
### Why are the changes needed?

`dev/kyuubi-tpcds` has never compiled under Scala 2.13. The snapshot publish workflow (`-Pflink-provided,spark-provided,hive-provided,scala-2.13,spark-4.2,tpcds`) fails with:

```
DataGenerator.scala:609: value par is not a member of Seq[org.apache.kyuubi.tpcds.TableGenerator]
TableGenerator.scala:62: type mismatch; found: scala.collection.mutable.Buffer[String], required: Seq[Any]
Benchmark.scala:267: ... cannot be applied to (ArrayBuffer[ExperimentRun], ...)
Benchmarkable.scala:87: value getStackTraceString is not a member of Throwable
```

plus `Query.scala:90` (`Unit` companion rejected by the 2.13 parser), which was masked by the error limit.

The fixes preserve the original Scala 2.12 semantics:

- `parForeach` helper built on `Future.traverse` keeps table generation concurrent (no new dependency on scala-parallel-collections)
- `.toSeq` conversions are identity on 2.12
- `getStackTrace.mkString("\n", "\n", "\n")` replicates 2.12's `getStackTraceString` exactly, including the leading/trailing newline (verified against 2.12 bytecode)

### How was this patch tested?

```
build/mvn -Pscala-2.13 -Pspark-4.2 -Ptpcds -Pspark-provided -pl dev/kyuubi-tpcds compile
build/mvn -Ptpcds -Pspark-provided -pl dev/kyuubi-tpcds compile   # Scala 2.12 + Spark 3.5
build/mvn -Ptpcds -Pspark-provided -pl dev/kyuubi-tpcds spotless:check
```

Both cross-builds now compile; spotless is clean. No runtime behavior change was intended; the parallel-execution path was smoke-checked for API equivalence only (the generator itself needs a cluster to run end-to-end).

### Was this patch assisted by generative AI tooling?

Assisted-by: GLM 5.3