### PR TITLE
[KYUUBI-7645][SERVER] Fix inaccurate operation state metrics on failed or racing transitions

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/KyuubiOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/KyuubiOperation.scala
@@ -213,7 +213,8 @@ abstract class KyuubiOperation(session: Session) extends AbstractOperation(sessi
 
   if (eventEnabled) EventBus.post(getOperationEvent)
 
-  override def setState(newState: OperationState): Unit = {
+  override def setState(newState: OperationState): Unit = withLockRequired {
+    OperationState.validateTransition(state, newState)
     MetricsSystem.tracing { ms =>
       if (!OperationState.isTerminal(state)) {
         ms.markMeter(MetricRegistry.name(OPERATION_STATE, opType, state.toString.toLowerCase), -1)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix operation state metrics being updated before the actual state transition is validated and applied, which makes metrics inaccurate when a transition fails or races (KYUUBI-7645).

`KyuubiOperation#setState` previously:

1. Updated the metrics meters first (`OPERATION_STATE.<opType>.<oldState>` decremented, `OPERATION_STATE.<opType>.<newState>` and `OPERATION_STATE.<newState>` incremented).
2. Then delegated to `AbstractOperation#setState`, which calls `OperationState.validateTransition(state, newState)` and may throw for stale/invalid transitions.

This caused two problems:

- If `validateTransition` rejected the transition, the meters had already been updated, so metrics diverged from the real operation state.
- Concurrent state transitions for the same operation were not an atomic transition-and-metrics-update sequence, so multiple threads could compute meter updates from the same stale old state.

## How was this patch tested?

Rely on existing CI. The change reuses `AbstractOperation#withLockRequired` (the per-operation `ReentrantLock` already used by `cleanup`/`cancel`/`close`) to make the validate → update metrics → apply transition sequence atomic, and runs `OperationState.validateTransition` before any metrics update.

Closes #7645