### PR TITLE
[KYUUBI #7720][SERVER] Reconcile duplicate-key insert retries

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/MetadataManager.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/MetadataManager.scala
@@ -135,6 +135,18 @@ class MetadataManager extends AbstractService("MetadataManager") {
     }
   }
 
+  // Verifies whether a duplicate-key error on a queued insert retry actually means the
+  // insert already succeeded earlier (e.g. the acknowledgement was lost), by checking
+  // whether a matching row already exists. Used only by the retry loop below, so the
+  // fail-fast contract of insertMetadata() itself is unchanged for direct/foreground calls.
+  private def verifyInsertPostcondition(metadata: Metadata): Boolean = {
+    Option(_metadataStore.getMetadata(metadata.identifier)).exists { existing =>
+      existing.identifier == metadata.identifier &&
+      existing.sessionType == metadata.sessionType &&
+      existing.createTime == metadata.createTime
+    }
+  }
+
   def getBatch(batchId: String): Option[Batch] = {
     getBatchSessionMetadata(batchId).map(buildBatch)
   }
@@ -344,11 +356,30 @@ class MetadataManager extends AbstractService("MetadataManager") {
                     info(s"Retrying metadata requests for $id")
                     var request = ref.metadataRequests.peek()
                     while (request != null) {
-                      request match {
-                        case insert: InsertMetadata =>
-                          insertMetadata(insert.metadata, asyncRetryOnError = false)
-                        case update: UpdateMetadata =>
-                          updateMetadata(update.metadata, asyncRetryOnError = false)
+                      try {
+                        request match {
+                          case insert: InsertMetadata =>
+                            insertMetadata(insert.metadata, asyncRetryOnError = false)
+                          case update: UpdateMetadata =>
+                            updateMetadata(update.metadata, asyncRetryOnError = false)
+                        }
+                      } catch {
+                        // A duplicate-key error while retrying a queued insert means a row
+                        // with this identifier already exists, e.g. the earlier attempt
+                        // actually succeeded but its acknowledgement was lost. Verify the
+                        // postcondition instead of leaving this request stuck at the head
+                        // of the queue forever, which would also block all later requests
+                        // for this session (KYUUBI #7720).
+                        case rethrow: Throwable
+                            if request.isInstanceOf[InsertMetadata] &&
+                              unrecoverableDBErr(rethrow) &&
+                              verifyInsertPostcondition(request.metadata) =>
+                          warn(
+                            s"Insert for ${request.metadata.identifier} returned a " +
+                              "duplicate-key error on retry but a matching row already " +
+                              "exists; treating as idempotent success and removing it " +
+                              "from the retry queue.",
+                            rethrow)
                       }
                       ref.metadataRequests.remove(request)
                       MetricsSystem.tracing(_.markMeter(

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/metadata/MetadataManagerSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/metadata/MetadataManagerSuite.scala
@@ -97,6 +97,30 @@ class MetadataManagerSuite extends KyuubiFunSuite {
     }
   }
 
+  test("[KYUUBI #7720] duplicate-key insert retry does not block the retry queue") {
+    withMetadataManager(Map(
+      METADATA_REQUEST_ASYNC_RETRY_ENABLED.key -> "true",
+      METADATA_REQUEST_RETRY_INTERVAL.key -> "100")) { metadataManager =>
+      val metadata = newMetadata()
+      // Insert the row directly, simulating an earlier attempt that actually succeeded.
+      metadataManager.insertMetadata(metadata)
+
+      // Queue a retry of the *same* insert, simulating a replay whose earlier
+      // acknowledgement was lost. Before the fix, this would throw a duplicate-key
+      // error on every retry attempt and never be removed from the queue.
+      metadataManager.addMetadataRetryRequest(InsertMetadata(metadata))
+      // Queue an unrelated update behind it, to confirm it is no longer blocked.
+      val metadataToUpdate = metadata.copy(state = "RUNNING")
+      metadataManager.addMetadataRetryRequest(UpdateMetadata(metadataToUpdate))
+
+      val retryRef = metadataManager.getMetadataRequestsRetryRef(metadata.identifier)
+      eventually(timeout(3.seconds)) {
+        assert(!retryRef.hasRemainingRequests())
+        assert(metadataManager.getBatch(metadata.identifier).map(_.getState).contains("RUNNING"))
+      }
+    }
+  }
+
   test("async metadata request metrics") {
     withMetadataManager(Map(
       METADATA_REQUEST_ASYNC_RETRY_ENABLED.key -> "true",


### PR DESCRIPTION
### Why are the changes needed?

When a queued `InsertMetadata` retry is replayed by the async retry trigger, it can hit a duplicate-key error if the original insert actually succeeded but its acknowledgement was lost. `insertMetadata` intentionally fails fast on duplicate-key errors, and since the retry loop only caught exceptions around the whole `while` block, this exception escaped before the request could be removed from the queue — leaving it stuck at the head and blocking all later requests for that session indefinitely. This is the same amplification pattern reported in #7708 for updates, but for inserts (raised by @pan3793 during review of #7709).

This patch verifies the postcondition inside the retry loop specifically: if a duplicate-key error occurs while retrying an insert, and a row matching the identifier, session type, and create time already exists, it's treated as an idempotent success and removed from the queue. The fail-fast behavior of `insertMetadata()` itself is unchanged for direct/foreground calls.

Closes #7720.

### How was this patch tested?

Added a regression test verifying that a queued insert retry which hits a duplicate-key error is removed from the queue instead of blocking subsequent requests for the same session.

Ran:
build/mvn test -pl kyuubi-server -am -Pspark-provided,flink-provided,hive-provided -Dtest=none -DwildcardSuites=org.apache.kyuubi.server.metadata.MetadataManagerSuite

### Was this patch assisted by generative AI tooling?

Assisted-by: Claude