### PR TITLE
[KYUUBI #7723][UTIL] Answer false from isClassLoadable when the class fails to link or initialize

### DIFF
--- a/kyuubi-util-scala/src/main/scala/org/apache/kyuubi/util/reflect/ReflectUtils.scala
+++ b/kyuubi-util-scala/src/main/scala/org/apache/kyuubi/util/reflect/ReflectUtils.scala
@@ -22,12 +22,12 @@ import java.util.ServiceLoader
 import scala.collection.JavaConverters._
 import scala.language.existentials
 import scala.reflect.ClassTag
-import scala.util.Try
 
 object ReflectUtils {
 
   /**
-   * Determines whether the provided class is loadable
+   * Determines whether the provided class is loadable, answering false when it cannot
+   * be found, linked, or initialized.
    * @param className the class name
    * @param cl the class loader
    * @return is the class name loadable with the class loader
@@ -35,9 +35,15 @@ object ReflectUtils {
   def isClassLoadable(
       className: String,
       cl: ClassLoader = Thread.currentThread().getContextClassLoader): Boolean =
-    Try {
+    try {
       DynClasses.builder().loader(cl).impl(className).buildChecked()
-    }.isSuccess
+      true
+    } catch {
+      // scala.util.Try does not catch LinkageError, so a class that fails to link or
+      // initialize would escape the probe instead of answering false
+      case _: ClassNotFoundException => false
+      case _: LinkageError => false
+    }
 
   /**
    * get the field value of the given object

--- a/kyuubi-util-scala/src/test/scala/org/apache/kyuubi/util/reflect/ReflectUtilsSuite.scala
+++ b/kyuubi-util-scala/src/test/scala/org/apache/kyuubi/util/reflect/ReflectUtilsSuite.scala
@@ -32,6 +32,15 @@ class ReflectUtilsSuite extends AnyFunSuite {
     assert(!isClassLoadable("org.apache.kyuubi.NonExistClass"))
   }
 
+  test("check class that fails to initialize is not loadable") {
+    // Class.forName reports a failing static initializer as ExceptionInInitializerError,
+    // a LinkageError that Try does not catch; a loadability probe must answer false
+    // instead of letting the error escape
+    // probe by binary name: touching the object reference would run the failing
+    // initialization outside the code under test and abort the suite
+    assert(!isClassLoadable("org.apache.kyuubi.util.reflect.FailingInit$"))
+  }
+
   test("check invokeAs on base class") {
     assertResult("method1")(invokeAs[String](obj1, "method1"))
     assertResult("method2")(invokeAs[String](obj1, "method2"))
@@ -102,4 +111,8 @@ object ObjectA {
 
   def method5(): String = "method5"
   private def method6(): String = "method6"
+}
+
+object FailingInit {
+  throw new IllegalStateException("static init failed")
 }


### PR DESCRIPTION
### Why are the changes needed?

Closes #7723.

`ReflectUtils.isClassLoadable` wrapped its `DynClasses` probe in `scala.util.Try`, which catches only `NonFatal`. The probe resolves the name with `Class.forName(className, true, loader)`, so a class that is present but fails to link or initialize raises a `LinkageError` (`NoClassDefFoundError`, `ExceptionInInitializerError`) rather than a `ClassNotFoundException`. `LinkageError` is not `NonFatal`, so it escaped the probe and crashed the caller instead of answering `false`.

This replaces the `Try` with an explicit `try`/`catch` that answers `false` on `ClassNotFoundException` and `LinkageError`. The two call sites (`Logging` probing the SLF4J bridge, `JDBCMetadataStore` probing the MySQL driver) read the result as a boolean and are only made safer. `OutOfMemoryError`/`StackOverflowError` are `VirtualMachineError`, not `LinkageError`, so they stay fatal exactly as they did under `Try`.

### How was this patch tested?

Added a `ReflectUtilsSuite` case that probes a top-level object whose static initializer throws, by its binary name, and asserts `isClassLoadable` returns `false`. Reverting the production change makes the suite abort as the `ExceptionInInitializerError` escapes, which pins the regression.

```
build/mvn test -pl kyuubi-util-scala -am
build/mvn scalastyle:check spotless:check -pl kyuubi-util-scala -am
```

Module green on Zulu 17.0.18 (22/22), scalastyle 0 errors, spotless clean.

### Was this patch assisted by generative AI tooling?

Assisted-by: Claude Opus 4.8
