### PR TITLE
[KYUUBI #7725][UTIL] Parse two-segment snapshot versions like 1.2-SNAPSHOT correctly

### DIFF
--- a/kyuubi-util-scala/src/main/scala/org/apache/kyuubi/util/SemanticVersion.scala
+++ b/kyuubi-util-scala/src/main/scala/org/apache/kyuubi/util/SemanticVersion.scala
@@ -65,7 +65,7 @@ case class SemanticVersion(majorVersion: Int, minorVersion: Int)
 
 object SemanticVersion {
 
-  private val semanticVersionRegex = """^(\d+)(?:\.(\d+))?(\..*)?$""".r
+  private val semanticVersionRegex = """^(\d+)(?:\.(\d+))?(?:[.-].*)?$""".r
 
   def apply(versionString: String): SemanticVersion = {
     semanticVersionRegex.findFirstMatchIn(versionString) match {

--- a/kyuubi-util-scala/src/test/scala/org/apache/kyuubi/util/SemanticVersionSuite.scala
+++ b/kyuubi-util-scala/src/test/scala/org/apache/kyuubi/util/SemanticVersionSuite.scala
@@ -38,6 +38,14 @@ class SemanticVersionSuite extends AnyFunSuite {
     assert(version.minorVersion === 14)
   }
 
+  test("parse two-segment snapshot version") {
+    val version = SemanticVersion("1.2-SNAPSHOT")
+    assert(version.majorVersion === 1)
+    assert(version.minorVersion === 2)
+    assert(version.isVersionAtLeast("1.1"))
+    assert(version.isVersionAtMost("1.3"))
+  }
+
   test("parse binary version") {
     val version = SemanticVersion("0.9")
     assert(version.majorVersion === 0)


### PR DESCRIPTION
### Why are the changes needed?

Closes #7725.

`SemanticVersion`'s regex made the minor group optional while keeping a trailing group that also starts with `.`:

```
^(\d+)(?:\.(\d+))?(\..*)?$
```

On `"1.2-SNAPSHOT"` the trailing group cannot match the `-`, so the engine backtracks past the minor group and lets the trailing group swallow `.2-SNAPSHOT`. The parse succeeds as `(major=1, minor=0)` with the minor silently dropped, so `isVersionAtLeast`/`isVersionAtMost` compare against the wrong version. This is reachable for Flink development builds (`X.Y-SNAPSHOT` from `EnvironmentInformation.getVersion`, checked in `FlinkEngineUtils.checkFlinkVersion`): a supported `1.20-SNAPSHOT` is rejected with `UnsupportedOperationException`, and an unsupported `2.4-SNAPSHOT` slips through as `2.0`.

Letting the trailing group start with `.` or `-` (`(?:[.-].*)?`) keeps the minor group and lets the suffix be consumed after it, matching how `.4-SNAPSHOT` was already handled following a minor. Capture groups 1 and 2 are unchanged, and the trailing group was never read, so making it non-capturing is safe.

### How was this patch tested?

Added a `SemanticVersionSuite` case asserting `"1.2-SNAPSHOT"` parses to `(1, 2)` and satisfies the `1.1`/`1.3` bounds; it fails on the old regex (minor 0). The existing cases parse identically under both regexes.

```
build/mvn test -pl kyuubi-util-scala -am
build/mvn scalastyle:check spotless:check -pl kyuubi-util-scala -am
```

Module green on Zulu 17.0.18, scalastyle 0 errors, spotless clean.

### Was this patch assisted by generative AI tooling?

Assisted-by: Claude Opus 4.8
