### PR TITLE
[KYUUBI #7727][UTIL] Trim each side of the pair in genKeyValuePair

### DIFF
--- a/kyuubi-util-scala/src/main/scala/org/apache/kyuubi/util/command/CommandLineUtils.scala
+++ b/kyuubi-util-scala/src/main/scala/org/apache/kyuubi/util/command/CommandLineUtils.scala
@@ -35,9 +35,9 @@ object CommandLineUtils {
   val CP = "-cp"
 
   /**
-   * Assemble key value pair with "=" seperator
+   * Assemble key value pair with "=" seperator, trimming each side of the pair
    */
-  def genKeyValuePair(key: String, value: String): String = s"$key=$value".trim
+  def genKeyValuePair(key: String, value: String): String = s"${key.trim}=${value.trim}"
 
   /**
    * Assemble key value pair with config option prefix

--- a/kyuubi-util-scala/src/test/scala/org/apache/kyuubi/util/command/CommandUtilsSuite.scala
+++ b/kyuubi-util-scala/src/test/scala/org/apache/kyuubi/util/command/CommandUtilsSuite.scala
@@ -30,9 +30,27 @@ class CommandUtilsSuite extends AnyFunSuite {
     assertResult("abc=123")(genKeyValuePair("   abc", "123   "))
     assertResult("abc.def=xyz.123")(genKeyValuePair("abc.def", "xyz.123"))
 
+    // trim each side of the pair separately, so a dirty key or value cannot leave
+    // whitespace inside the assembled argument
+    assertResult("abc=123")(genKeyValuePair("abc ", " 123"))
+    assertResult("abc=123")(genKeyValuePair("abc\t", "123"))
+
     assertMatches(genKeyValuePair("abc", "123"), PATTERN_FOR_KEY_VALUE_ARG)
     assertMatches(genKeyValuePair("   abc", "123   "), PATTERN_FOR_KEY_VALUE_ARG)
     assertMatches(genKeyValuePair("abc.def", "xyz.123"), PATTERN_FOR_KEY_VALUE_ARG)
+  }
+
+  test("redact key value argument assembled from a dirty key") {
+    // the assembled pair carries no inner whitespace, so exact-key redaction sees the
+    // clean key; a spaced key name is the shape that slips past the pattern-based
+    // stage for keys like the data agent api key, whose name the default redaction
+    // regex does not match at all
+    val commands = Seq(genKeyValuePair("kyuubi.engine.data.agent.openai.api.key ", "secret"))
+    val redacted = redactConfValues(
+      commands,
+      Set("kyuubi.engine.data.agent.openai.api.key"))
+    assert(redacted.head == "kyuubi.engine.data.agent.openai.api.key=" +
+      REDACTION_REPLACEMENT_TEXT)
   }
 
   test("assemble key value pair with config option") {


### PR DESCRIPTION
### Why are the changes needed?

Closes #7727.

`genKeyValuePair` trimmed only the concatenated string (`s"$key=$value".trim`), so whitespace between the key and value survived: `genKeyValuePair("abc ", "123")` returned `"abc =123"`. `redactConfValues` splits an assembled argument on the first `=` and matches the key against an exact key set, so a spaced key (`"<key> ="`) misses the set and the value is not redacted.

This matters for the Data Agent engine's API key. `kyuubi.engine.data.agent.openai.api.key` is not matched by the default pattern-based redaction, so exact-key redaction is its only guard, and session conf keys are not trimmed on the way to the engine command. A key carrying a trailing space slipped both stages and logged the API key value. Trimming each side (`s"${key.trim}=${value.trim}"`) makes the assembled pair carry no inner whitespace, so the exact-key stage sees the clean key. `Utils.redactCommandLineArgs` also assembles through `genKeyValuePair`, so the same fix closes the hole at both assembly points.

### How was this patch tested?

Added `CommandUtilsSuite` cases: symmetric-trim assertions (`genKeyValuePair("abc ", " 123")` -> `"abc=123"`, including a tab) and a redaction round-trip that assembles a spaced Data Agent api-key argument and asserts `redactConfValues` masks it. Both fail on the old `.trim`.

```
build/mvn test -pl kyuubi-util-scala -am
build/mvn scalastyle:check spotless:check -pl kyuubi-util-scala -am
build/mvn test -pl kyuubi-common -am -DwildcardSuites=org.apache.kyuubi.UtilsSuite
```

`kyuubi-util-scala` green on Zulu 17.0.18 (22/22), scalastyle 0 errors, spotless clean; `kyuubi-common` `UtilsSuite` (which exercises `redactCommandLineArgs`) 14/14.

### Was this patch assisted by generative AI tooling?

Assisted-by: Claude Opus 4.8
