### PR TITLE
[KYUUBI #7729][UTIL] Fail assertFileContent when the file has trailing extra lines

### DIFF
--- a/kyuubi-util-scala/src/test/scala/org/apache/kyuubi/util/AssertionUtils.scala
+++ b/kyuubi-util-scala/src/test/scala/org/apache/kyuubi/util/AssertionUtils.scala
@@ -100,6 +100,12 @@ object AssertionUtils {
           }
           fileLineCount = Math.max(lineNum, fileLineCount)
         }
+      // zip stops at the shorter side, so trailing file lines beyond the expected
+      // content are never compared; count them to fail the length check below
+      while (fileLinesIter.hasNext) {
+        fileLinesIter.next()
+        fileLineCount += 1
+      }
       withClue(s"Line number is not expected. $regenerationHint") {
         assertResult(expectedLinesIter.size)(fileLineCount)(prettifier, pos)
       }

--- a/kyuubi-util-scala/src/test/scala/org/apache/kyuubi/util/AssertionUtilsSuite.scala
+++ b/kyuubi-util-scala/src/test/scala/org/apache/kyuubi/util/AssertionUtilsSuite.scala
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.util
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+
+import org.scalatest.exceptions.TestFailedException
+// scalastyle:off
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.kyuubi.util.AssertionUtils._
+// scalastyle:on
+
+// scalastyle:off
+class AssertionUtilsSuite extends AnyFunSuite {
+// scalastyle:on
+
+  test("assertFileContent fails on trailing extra file lines") {
+    val path = Files.createTempFile("assert-file-content", ".txt")
+    Files.write(path, "first\nsecond\nstale extra\n".getBytes(StandardCharsets.UTF_8))
+    try {
+      val thrown = intercept[TestFailedException] {
+        assertFileContent(path, Seq("first", "second"), "regen.sh")
+      }
+      assert(thrown.getMessage.contains("Line number is not expected"))
+    } finally {
+      Files.deleteIfExists(path)
+    }
+  }
+
+  test("assertFileContent passes on exact content") {
+    val path = Files.createTempFile("assert-file-content", ".txt")
+    Files.write(path, "first\nsecond\n".getBytes(StandardCharsets.UTF_8))
+    try {
+      assertFileContent(path, Seq("first", "second"), "regen.sh")
+    } finally {
+      Files.deleteIfExists(path)
+    }
+  }
+}


### PR DESCRIPTION
### Why are the changes needed?

Closes #7729.

`AssertionUtils.assertFileContent` compares a file against expected lines with `fileLinesIter.zipWithIndex.zip(expectedLinesIter)`. `zip` stops at the shorter side, so file lines beyond the expected content were never compared, and `fileLineCount` only ever reached the number of pairs `zip` produced. The length check `assertResult(expectedLinesIter.size)(fileLineCount)` therefore passed whenever the file was longer, so a golden file with stale trailing lines went unnoticed.

This drains the remaining file lines into `fileLineCount` after the comparison, so the length check sees the file's true length and fails when the file is longer than expected. The equal-length and shorter-file cases are unchanged. Consumers regenerate their golden files from the same source they compare against (`verifyOrRegenerateGoldenFile` writes `toMarkdown` and reads it back), so a correctly regenerated file still round-trips to the same length.

### How was this patch tested?

Added `AssertionUtilsSuite` (the module's first self-test for the assertion helpers): a trailing-extra-line case that must throw `TestFailedException` with the "Line number is not expected" clue, and an exact-content case that must pass. The trailing case stops failing if the drain loop is reverted.

```
build/mvn test -pl kyuubi-util-scala -am
build/mvn scalastyle:check spotless:check -pl kyuubi-util-scala -am
```

Module green on Zulu 17.0.18 (23/23), scalastyle 0 errors, spotless clean.

### Was this patch assisted by generative AI tooling?

Assisted-by: Claude Opus 4.8
