### PR TITLE
[KYUUBI #7731][UTIL] Stop re-labeling invocation failures as missing members in ReflectUtils

### DIFF
--- a/kyuubi-util-scala/src/main/scala/org/apache/kyuubi/util/reflect/ReflectUtils.scala
+++ b/kyuubi-util-scala/src/main/scala/org/apache/kyuubi/util/reflect/ReflectUtils.scala
@@ -48,19 +48,22 @@ object ReflectUtils {
    */
   def getField[T](target: AnyRef, fieldName: String): T = {
     val (clz, obj) = getTargetClass(target)
-    try {
-      val field = DynFields.builder
-        .hiddenImpl(clz, fieldName)
-        .impl(clz, fieldName)
-        .build[T]
-      if (field.isStatic) {
-        field.asStatic.get
-      } else {
-        field.bind(obj).get
+    // only the lookup is re-labeled as a missing field; a failure thrown while
+    // binding or reading the found field keeps its own message
+    val field =
+      try {
+        DynFields.builder
+          .hiddenImpl(clz, fieldName)
+          .impl(clz, fieldName)
+          .build[T]
+      } catch {
+        case e: Exception =>
+          throw new RuntimeException(s"$clz does not have $fieldName field", e)
       }
-    } catch {
-      case e: Exception =>
-        throw new RuntimeException(s"$clz does not have $fieldName field", e)
+    if (field.isStatic) {
+      field.asStatic.get
+    } else {
+      field.bind(obj).get
     }
   }
 
@@ -76,21 +79,24 @@ object ReflectUtils {
   def invokeAs[T](target: AnyRef, methodName: String, args: (Class[_], AnyRef)*): T = {
     val (clz, obj) = getTargetClass(target)
     val argClasses = args.map(_._1)
-    try {
-      val method = DynMethods.builder(methodName)
-        .hiddenImpl(clz, argClasses: _*)
-        .impl(clz, argClasses: _*)
-        .buildChecked
-      if (method.isStatic) {
-        method.asStatic.invoke[T](args.map(_._2): _*)
-      } else {
-        method.bind(obj).invoke[T](args.map(_._2): _*)
+    // only the lookup is re-labeled as a missing method; a failure thrown by the
+    // invoked method itself keeps its own type and message
+    val method =
+      try {
+        DynMethods.builder(methodName)
+          .hiddenImpl(clz, argClasses: _*)
+          .impl(clz, argClasses: _*)
+          .buildChecked
+      } catch {
+        case e: Exception =>
+          throw new RuntimeException(
+            s"$clz does not have $methodName${argClasses.map(_.getName).mkString("(", ", ", ")")}",
+            e)
       }
-    } catch {
-      case e: Exception =>
-        throw new RuntimeException(
-          s"$clz does not have $methodName${argClasses.map(_.getName).mkString("(", ", ", ")")}",
-          e)
+    if (method.isStatic) {
+      method.asStatic.invoke[T](args.map(_._2): _*)
+    } else {
+      method.bind(obj).invoke[T](args.map(_._2): _*)
     }
   }
 

--- a/kyuubi-util-scala/src/test/scala/org/apache/kyuubi/util/reflect/ReflectUtilsSuite.scala
+++ b/kyuubi-util-scala/src/test/scala/org/apache/kyuubi/util/reflect/ReflectUtilsSuite.scala
@@ -78,6 +78,21 @@ class ReflectUtilsSuite extends AnyFunSuite {
     }("class org.apache.kyuubi.util.reflect.ObjectA$ does not have methodNotExists(" +
       "java.lang.String, java.lang.String)")
   }
+
+  test("invokeAs propagates the failure thrown by the invoked method") {
+    // the lookup succeeded and the method ran; re-labeling its failure as
+    // "does not have" points readers at a lookup problem that does not exist
+    interceptContains[IllegalArgumentException](invokeAs[String](obj2, "methodThrows"))(
+      "bad input")
+  }
+
+  test("getField reports the bind failure for an instance field on a class target") {
+    // binding a class target to an instance field fails with the truthful
+    // IllegalArgumentException from the field wrapper, not a missing-field message
+    interceptContains[IllegalArgumentException](getField[String](
+      classOf[ClassA],
+      "field0"))("Cannot bind")
+  }
 }
 
 class ClassA(val field0: String = "field0") {
@@ -94,6 +109,8 @@ class ClassB extends ClassA {
 
   def method3(): String = "method3"
   private def method4(): String = "method4"
+
+  def methodThrows(): String = throw new IllegalArgumentException("bad input")
 }
 
 object ObjectA {


### PR DESCRIPTION
### Why are the changes needed?

Closes #7731.

`ReflectUtils.getField` and `invokeAs` wrapped the whole body in one `try` and rewrote any `Exception` as `RuntimeException(s"$clz does not have ...", e)`. Because `bind`/`get`/`invoke` ran inside that same `try`, a failure thrown by the found field or the invoked method itself was relabeled as a missing member, and the real exception survived only as the cause.

This moves the `try`/`catch` to wrap only the lookup (`DynFields`/`DynMethods` `build`/`buildChecked`). The "does not have" message now applies only when the lookup fails; a failure while binding, reading, or invoking the found member keeps its own type and message.

### How was this patch tested?

Added two `ReflectUtilsSuite` cases: an invoked method that throws `IllegalArgumentException("bad input")` must propagate that exception rather than a "does not have" message, and binding a `Class` target to an instance field must surface the field wrapper's "Cannot bind" `IllegalArgumentException`. Both fail if the catch is widened back over the invocation.

```
build/mvn test -pl kyuubi-util-scala -am
build/mvn scalastyle:check spotless:check -pl kyuubi-util-scala -am
```

Module green on Zulu 17.0.18 (23/23), scalastyle 0 errors, spotless clean.

### Was this patch assisted by generative AI tooling?

Assisted-by: Claude Opus 4.8
