### PR TITLE
[KYUUBI #7733][UTIL] Fall back to ReflectUtils's own loader when the context loader is null

### DIFF
--- a/kyuubi-util-scala/src/main/scala/org/apache/kyuubi/util/reflect/ReflectUtils.scala
+++ b/kyuubi-util-scala/src/main/scala/org/apache/kyuubi/util/reflect/ReflectUtils.scala
@@ -22,12 +22,12 @@ import java.util.ServiceLoader
 import scala.collection.JavaConverters._
 import scala.language.existentials
 import scala.reflect.ClassTag
-import scala.util.Try
 
 object ReflectUtils {
 
   /**
-   * Determines whether the provided class is loadable
+   * Determines whether the provided class is loadable, answering false when it cannot
+   * be found, linked, or initialized.
    * @param className the class name
    * @param cl the class loader
    * @return is the class name loadable with the class loader
@@ -35,9 +35,15 @@ object ReflectUtils {
   def isClassLoadable(
       className: String,
       cl: ClassLoader = Thread.currentThread().getContextClassLoader): Boolean =
-    Try {
+    try {
       DynClasses.builder().loader(cl).impl(className).buildChecked()
-    }.isSuccess
+      true
+    } catch {
+      // scala.util.Try does not catch LinkageError, so a class that fails to link or
+      // initialize would escape the probe instead of answering false
+      case _: ClassNotFoundException => false
+      case _: LinkageError => false
+    }
 
   /**
    * get the field value of the given object

--- a/kyuubi-util-scala/src/main/scala/org/apache/kyuubi/util/reflect/ReflectUtils.scala
+++ b/kyuubi-util-scala/src/main/scala/org/apache/kyuubi/util/reflect/ReflectUtils.scala
@@ -29,14 +29,17 @@ object ReflectUtils {
    * Determines whether the provided class is loadable, answering false when it cannot
    * be found, linked, or initialized.
    * @param className the class name
-   * @param cl the class loader
+   * @param cl the class loader; falls back to ReflectUtils's own loader when null
    * @return is the class name loadable with the class loader
    */
   def isClassLoadable(
       className: String,
-      cl: ClassLoader = Thread.currentThread().getContextClassLoader): Boolean =
+      cl: ClassLoader = Thread.currentThread().getContextClassLoader): Boolean = {
+    // Class.forName resolves through the bootstrap loader only when handed null, so a
+    // thread without a context loader would answer false for any application class
+    val effectiveCl = if (cl == null) getClass.getClassLoader else cl
     try {
-      DynClasses.builder().loader(cl).impl(className).buildChecked()
+      DynClasses.builder().loader(effectiveCl).impl(className).buildChecked()
       true
     } catch {
       // scala.util.Try does not catch LinkageError, so a class that fails to link or
@@ -44,6 +47,7 @@ object ReflectUtils {
       case _: ClassNotFoundException => false
       case _: LinkageError => false
     }
+  }
 
   /**
    * get the field value of the given object

--- a/kyuubi-util-scala/src/test/scala/org/apache/kyuubi/util/reflect/ReflectUtilsSuite.scala
+++ b/kyuubi-util-scala/src/test/scala/org/apache/kyuubi/util/reflect/ReflectUtilsSuite.scala
@@ -41,6 +41,19 @@ class ReflectUtilsSuite extends AnyFunSuite {
     assert(!isClassLoadable("org.apache.kyuubi.util.reflect.FailingInit$"))
   }
 
+  test("check class loadable without a context classloader") {
+    // a thread without a context loader used to resolve through the bootstrap loader
+    // only, answering false for classes that are on the application classpath
+    val original = Thread.currentThread().getContextClassLoader
+    Thread.currentThread().setContextClassLoader(null)
+    try {
+      assert(isClassLoadable(ReflectUtils.getClass.getName))
+      assert(!isClassLoadable("org.apache.kyuubi.NonExistClass"))
+    } finally {
+      Thread.currentThread().setContextClassLoader(original)
+    }
+  }
+
   test("check invokeAs on base class") {
     assertResult("method1")(invokeAs[String](obj1, "method1"))
     assertResult("method2")(invokeAs[String](obj1, "method2"))

--- a/kyuubi-util-scala/src/test/scala/org/apache/kyuubi/util/reflect/ReflectUtilsSuite.scala
+++ b/kyuubi-util-scala/src/test/scala/org/apache/kyuubi/util/reflect/ReflectUtilsSuite.scala
@@ -32,6 +32,15 @@ class ReflectUtilsSuite extends AnyFunSuite {
     assert(!isClassLoadable("org.apache.kyuubi.NonExistClass"))
   }
 
+  test("check class that fails to initialize is not loadable") {
+    // Class.forName reports a failing static initializer as ExceptionInInitializerError,
+    // a LinkageError that Try does not catch; a loadability probe must answer false
+    // instead of letting the error escape
+    // probe by binary name: touching the object reference would run the failing
+    // initialization outside the code under test and abort the suite
+    assert(!isClassLoadable("org.apache.kyuubi.util.reflect.FailingInit$"))
+  }
+
   test("check invokeAs on base class") {
     assertResult("method1")(invokeAs[String](obj1, "method1"))
     assertResult("method2")(invokeAs[String](obj1, "method2"))
@@ -102,4 +111,8 @@ object ObjectA {
 
   def method5(): String = "method5"
   private def method6(): String = "method6"
+}
+
+object FailingInit {
+  throw new IllegalStateException("static init failed")
 }


### PR DESCRIPTION
### Why are the changes needed?

Closes #7733.

Stacked on #7724; its commit is the first of the two here, and the diff reduces to the second commit once #7724 merges.

`ReflectUtils.isClassLoadable` defaults its loader to the thread context classloader. On a thread whose context loader is null, `DynClasses.builder().loader(null)` resolves the name through `Class.forName(name, true, null)`, which delegates to the bootstrap loader. The bootstrap loader sees only JDK classes, so the probe answers `false` for every application class, including Kyuubi's own, even when it is loadable through the loader that defined `ReflectUtils`.

This falls back to `ReflectUtils`'s own classloader when the effective loader is null, matching Spark's `getContextOrSparkClassLoader`. The change is monotonic: a non-null loader behaves exactly as before, and a null loader can only turn a `false` into a `true` (an application class becomes loadable), never the reverse. Repository threads carry a non-null context loader under normal startup, so this is defensive hardening for embedded hosts (a JNI invocation that never sets a context loader, a container framework that clears it) and third-party callers of this public helper.

### How was this patch tested?

Added a `ReflectUtilsSuite` case that sets the thread context loader to null (restored in `finally`) and asserts an application class is loadable while a non-existent one is not. It fails without the fallback, since the bootstrap loader cannot see the class.

```
build/mvn test -pl kyuubi-util-scala -am
build/mvn scalastyle:check spotless:check -pl kyuubi-util-scala -am
```

Module green on Zulu 17.0.18 (23/23), scalastyle 0 errors, spotless clean.

### Was this patch assisted by generative AI tooling?

Assisted-by: Claude Opus 4.8
