### PR TITLE
[SERVER] Simplify engine discovery polling after submission exits

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
@@ -283,7 +283,6 @@ private[kyuubi] class EngineRef(
       builder.validateConf()
       val process = builder.start
       var exitValue: Option[Int] = None
-      var lastApplicationInfo: Option[ApplicationInfo] = None
       while (engineRef.isEmpty) {
         if (exitValue.isEmpty && process.waitFor(1, TimeUnit.SECONDS)) {
           exitValue = Some(process.exitValue())
@@ -315,11 +314,8 @@ private[kyuubi] class EngineRef(
         // even the submit process succeeds, the application might meet failure when initializing,
         // check the engine application state from engine manager and fast fail on engine terminate
         if (engineRef.isEmpty && exitValue.contains(0)) {
+          TimeUnit.SECONDS.sleep(1)
           Option(engineManager).foreach { engineMgr =>
-            if (lastApplicationInfo.isDefined) {
-              TimeUnit.SECONDS.sleep(1)
-            }
-
             val applicationInfo = engineMgr.getApplicationInfo(
               builder.appMgrInfo(),
               engineRefId,
@@ -340,8 +336,6 @@ private[kyuubi] class EngineRef(
                   builder.getError)
               }
             }
-
-            lastApplicationInfo = applicationInfo
           }
         }
       }


### PR DESCRIPTION
### Why are the changes needed?

Query engine information at fixed intervals when the engine starts up, avoid potential issues caused by infinite loops.

This removes the previous-application-info guard and its unused state. The existing process wait remains unchanged while submission is running.

### How was this patch tested?

- `build/mvn test-compile -pl kyuubi-server -am -Pspark-provided,flink-provided,hive-provided`
- Temporary local checks verified polling intervals with no application manager and with unavailable application information; they fail before the change and pass afterward. These checks are not included in the PR.
- `dev/reformat` and `git diff --check`.

### Was this patch assisted by generative AI tooling?

Assisted-by: OpenAI Codex (GPT-6)
